### PR TITLE
fix(crystal): stop reading Grip routes and params out of comments

### DIFF
--- a/spec/functional_test/fixtures/crystal/grip/src/testapp.cr
+++ b/spec/functional_test/fixtures/crystal/grip/src/testapp.cr
@@ -73,7 +73,14 @@ class Application
       end
     end
 
-    get "/health", IndexController
+    # Comments are not routes. Pre-fix the analyzer matched raw source
+    # lines, so each of these became a live endpoint and the
+    # fetch_query_params below became a param on /health.
+    # delete "/purge", IndexController
+    # post "/legacy/import", IndexController, as: :create
+    # ws "/notifications", ChatController
+    get "/health", IndexController # a trailing comment must not break a real route
+    # legacy: context.fetch_query_params["debug"] used to be read here
     ws "/chat", ChatController
   end
 end

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -22,7 +22,15 @@ module Analyzer::Crystal
       last_endpoint = Endpoint.new("", "")
       scope_stack = [] of NamedTuple(prefix: String, indent: Int32)
 
-      lines.each_with_index do |line, index|
+      lines.each_with_index do |raw_line, index|
+        # Grip was the one Crystal analyzer matching routes on raw source:
+        # a comment like `# TODO: add a delete "/users/:id" route` parsed as
+        # a live route, and `context.fetch_query_params["x"]` written in a
+        # comment became a real param. Every sibling analyzer (kemal, amber,
+        # lucky, marten, http) strips first — and this file already did so
+        # for callee collection below, just not here. `strip_comment` keeps
+        # leading whitespace, so the scope-indentation match still lines up.
+        line = Noir::CrystalCalleeExtractor.strip_comment(raw_line)
         details = Details.new(PathInfo.new(path, index + 1))
 
         # Open a scope block, recording its indentation.


### PR DESCRIPTION
## Problem

`Analyzer::Crystal::Grip#analyze_file` matched routes on **raw source lines**. Only `mask_crystal_heredocs` ran first, and that masks heredoc bodies, not `#` comments. So an ordinary comment parsed as a live route:

```crystal
require "grip"

class HomeController < Grip::Controllers::Http
  # TODO: also add a delete "/users/:id" route once auth lands
  def get(context); context; end
end

Grip.define do
  get "/home", HomeController
end
```

```console
$ noir scan ./gripapp     # before
GET /home
DELETE /users/:id         # ← phantom, exists only in the comment
```

`line_to_param` had the same gap: a `context.fetch_query_params["x"]` written inside a comment became a real param on whichever endpoint preceded it.

## Why Grip only

Every sibling Crystal analyzer — `kemal.cr`, `amber.cr`, `lucky.cr`, `marten.cr`, `http.cr` — runs `Noir::CrystalCalleeExtractor.strip_comment` before matching. Grip was the one that didn't, and it already called that helper elsewhere in the same file (line 82, for callee collection) — just not in the route loop. `GRIP_ROUTE_RE` is unanchored and has no comment awareness, so it matched the verb+quoted-string shape wherever it appeared.

## Fix

Strip the comment once per line at the top of the loop. `strip_comment` preserves leading whitespace, so the scope-indentation matching (`SCOPE_END_RE`) still lines up, and it tracks string state, so interpolated routes like `get "#{PREFIX}/items"` are untouched.

Verified against a fixture exercising trailing comments, interpolation, nested scopes and websockets — all still parse; only the commented-out route disappears.

## Found by dogfooding

Scanning noir's own tree reported **19 phantom `crystal_grip` endpoints**, every one sourced from a comment in noir's own Crystal source:

```
DELETE '/DELETE FROM articles WHERE ...'  ← src/analyzer/engines/ruby_engine.cr:104
GET    '/wiki/Home'                       ← src/analyzer/engines/ruby_engine.cr:27
GET    '/x'                               ← src/analyzer/analyzers/crystal/grip.cr:6
GET    '/…'                               ← src/analyzer/analyzers/crystal/kemal.cr:11
...
```

The first one is sourced from the comment in `ruby_engine.cr` that documents *this same bug class* being fixed for Sinatra.

After the fix: `crystal_grip` phantom endpoints = 0, total 3121 → 3102.

Two of the 21 diffs are not removals but tech re-attributions of duplicate `(method, url)` pairs (`js_koa` → `ruby_hanami` / `php_thinkphp`). That is pre-existing nondeterminism from concurrent analyzers racing for attribution on the global method+url dedup — main's own binary produces the same flip on run 2 of 5, unrelated to this change.

## Tests

The grip fixture gains commented-out routes and a commented param alongside a real route with a trailing comment. Expected endpoint list is unchanged, so it is a clean regression: **pre-fix the fixture reports 9 endpoints instead of 6**.

Full suite green: 4149 unit + 22424 functional examples, 0 failures. `crystal tool format --check` and ameba clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)