### PR TITLE
fix(go): stop reading CLI flags and commands out of comments

### DIFF
--- a/spec/functional_test/fixtures/go/cli_cobra/main.go
+++ b/spec/functional_test/fixtures/go/cli_cobra/main.go
@@ -22,11 +22,25 @@ var serveCmd = &cobra.Command{
 	},
 }
 
+// Commented-out registrations are not part of the CLI surface. Pre-fix the
+// analyzer matched raw source, so this became a real `migrate` command.
+// var migrateCmd = &cobra.Command{
+// 	Use:   "migrate",
+// 	Short: "Run migrations",
+// }
+
+/*
+   A block comment is equally not a registration:
+   rootCmd.Flags().StringVar(&dead, "block-flag", "", "")
+*/
+
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "verbose output")
 	serveCmd.Flags().IntVar(&port, "port", 8080, "listen port")
+	// rootCmd.Flags().StringVar(&secret, "secret-token", "", "never registered")
 	viper.BindEnv("api_key", "COBRA_API_KEY")
 	rootCmd.AddCommand(serveCmd)
+	// rootCmd.AddCommand(migrateCmd)
 }
 
 func main() {

--- a/spec/unit_test/analyzer/go_engine_spec.cr
+++ b/spec/unit_test/analyzer/go_engine_spec.cr
@@ -78,4 +78,71 @@ describe Analyzer::Go::GoEngine do
       public_dirs.size.should eq(0)
     end
   end
+
+  describe ".strip_comments" do
+    it "blanks line comments while keeping the line count stable" do
+      source = <<-GO
+        a := 1
+        // rootCmd.Flags().StringVar(&dead, "ghost", "", "")
+        b := 2
+        GO
+
+      stripped = Analyzer::Go::GoEngine.strip_comments(source)
+
+      stripped.lines.size.should eq(source.lines.size)
+      stripped.should_not contain("ghost")
+      stripped.lines[0].should eq("a := 1")
+      stripped.lines[2].should eq("b := 2")
+    end
+
+    it "blanks block comments while keeping the line count stable" do
+      source = <<-GO
+        a := 1
+        /*
+        StringVar(&dead, "ghost", "", "")
+        */
+        b := 2
+        GO
+
+      stripped = Analyzer::Go::GoEngine.strip_comments(source)
+
+      stripped.lines.size.should eq(source.lines.size)
+      stripped.should_not contain("ghost")
+      stripped.lines[4].should eq("b := 2")
+    end
+
+    it "keeps a trailing comment's code but drops the comment" do
+      stripped = Analyzer::Go::GoEngine.strip_comments(%(x := "keep" // "ghost"))
+
+      stripped.should contain("keep")
+      stripped.should_not contain("ghost")
+    end
+
+    # Go raw strings take no escapes and may span newlines, so a `//` or
+    # `/*` inside one is ordinary text — a C-family stripper that only
+    # knows `"` and `'` would truncate the literal here.
+    it "leaves // and /* inside a raw string literal alone" do
+      stripped = Analyzer::Go::GoEngine.strip_comments("x := `keep // this /* and this */`")
+
+      stripped.should eq("x := `keep // this /* and this */`")
+    end
+
+    it "leaves // inside an interpreted string alone" do
+      stripped = Analyzer::Go::GoEngine.strip_comments(%(url := "https://x.example/a//b"))
+
+      stripped.should eq(%(url := "https://x.example/a//b"))
+    end
+
+    it "does not end a string literal on an escaped quote" do
+      stripped = Analyzer::Go::GoEngine.strip_comments(%(x := "a \\" b // still string"))
+
+      stripped.should eq(%(x := "a \\" b // still string"))
+    end
+
+    it "returns the source untouched when it holds no comment markers" do
+      source = %(x := "plain")
+
+      Analyzer::Go::GoEngine.strip_comments(source).should eq(source)
+    end
+  end
 end

--- a/src/analyzer/analyzers/go/cli.cr
+++ b/src/analyzer/analyzers/go/cli.cr
@@ -125,7 +125,11 @@ module Analyzer::Go
         next unless File.exists?(path)
 
         begin
-          content = read_file_content(path)
+          # Blank out comments before any matching: the flag/command
+          # patterns below are shape-based, so a commented-out or merely
+          # documented registration read as a live one. Line numbers are
+          # preserved, so PathInfo stays accurate.
+          content = GoEngine.strip_comments(read_file_content(path))
           next unless cli_evidence?(content)
 
           binary = go_binary_name(modules, path)

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -23,6 +23,79 @@ module Analyzer::Go
       path.split("/").any?(&.starts_with?("_"))
     end
 
+    # Blanks out `//` line comments and `/* */` block comments, replacing
+    # them with spaces so every real line number stays put for PathInfo
+    # reporting. Without this a commented-out call reads as a live one —
+    # a `// serveCmd.Flags().StringVar(&tok, "secret-token", ...)` note
+    # registered a flag that the binary does not accept.
+    #
+    # All three Go string forms are tracked so a `//` or `/*` inside a
+    # literal is never read as a comment opener: interpreted strings
+    # (`"..."`, backslash escapes), rune literals (`'.'`), and raw
+    # strings (`` `...` ``) — the last take no escapes and may span
+    # newlines, which is why a shared C-family stripper is not enough.
+    def self.strip_comments(text : String) : String
+      return text unless text.includes?("//") || text.includes?("/*")
+
+      result = String::Builder.new
+      chars = text.chars
+      i = 0
+      in_string = false
+      string_quote = '\0'
+
+      while i < chars.size
+        c = chars[i]
+
+        if in_string
+          # Raw strings run verbatim to the closing backtick.
+          if string_quote != '`' && c == '\\' && i + 1 < chars.size
+            result << c << chars[i + 1]
+            i += 2
+            next
+          end
+          in_string = false if c == string_quote
+          result << c
+          i += 1
+          next
+        end
+
+        if c == '"' || c == '\'' || c == '`'
+          in_string = true
+          string_quote = c
+          result << c
+          i += 1
+          next
+        end
+
+        if c == '/' && i + 1 < chars.size && chars[i + 1] == '/'
+          while i < chars.size && chars[i] != '\n'
+            result << ' '
+            i += 1
+          end
+          next
+        end
+
+        if c == '/' && i + 1 < chars.size && chars[i + 1] == '*'
+          result << "  "
+          i += 2
+          while i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')
+            result << (chars[i] == '\n' ? '\n' : ' ')
+            i += 1
+          end
+          if i + 1 < chars.size
+            result << "  "
+            i += 2
+          end
+          next
+        end
+
+        result << c
+        i += 1
+      end
+
+      result.to_s
+    end
+
     # --- Tree-sitter group/route pre-pass --------------------------------
     #
     # Does a cross-file fixpoint over every `.go` file in each package


### PR DESCRIPTION
## Problem

The Go CLI analyzer matched its flag and command patterns against **raw source** — `src/analyzer/analyzers/go/cli.cr` had no comment handling at all. So a commented-out or merely documented registration read as a live one:

```go
func init() {
	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "verbose output")
	// someday: serveCmd.Flags().StringVar(&secretToken, "secret-token", "", "secret token")
}
```

```console
$ noir scan ./cobrademo     # before
CLI cli://cobrademo
  ○ flags: verbose, secret-token     # ← secret-token exists only in the comment
```

A commented-out `&cobra.Command{Use: "migrate"}` likewise became a real subcommand endpoint. `MITCHELLH_FLAGVAR_RE` matches the `.XxxVar(&field, "name", ...)` shape shared by cobra, pflag and mitchellh/cli, so this affected all three.

This is the same bug class as #2380 (Grip reading routes out of comments), recurring in a second, independently-implemented analyzer.

## Fix

Adds `GoEngine.strip_comments`, modelled on the equivalent already private to the Java CLI analyzer: comments become spaces so every real line number stays put for `PathInfo` reporting.

Go needs one thing the C-family version does not handle — **raw string literals**. They take no escapes and may span newlines, so a `//` or `/*` inside one is ordinary text that a `"`/`'`-only stripper would truncate at:

```go
rootCmd.Flags().StringVar(&tmpl, "template", `line // not-a-comment /* nor this */`, "")
```

Interpreted strings, rune literals and escaped quotes are tracked too, so a default value like `"https://x.example/a//b"` survives intact. Verified on a fixture exercising all of these plus line and block comments: the 4 real flags are kept, both comment-sourced ones dropped.

## Impact

Detection is otherwise unchanged — all **17 `go_cli` endpoints in noir's own tree are byte-identical** before and after (compared by URL, method and param set).

## Tests

- Functional: the `cli_cobra` fixture gains a commented-out command, a commented-out flag, and a block comment. Expected endpoints are unchanged, so it is a clean regression — **pre-fix it reports 3 endpoints instead of 2** (the phantom `migrate` command).
- Unit: 7 tests for `GoEngine.strip_comments` covering line/block comments with stable line counts, trailing comments, raw strings, interpreted strings with `//`, escaped quotes, and the no-marker fast path.

Full suite green: 4156 unit + 22424 functional examples, 0 failures. `crystal tool format --check` and ameba clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)