### PR TITLE
perf: cut scan time 1.4-4.4x by removing redundant reads, scans and parses

### DIFF
--- a/scripts/detector_scan_cost.cr
+++ b/scripts/detector_scan_cost.cr
@@ -1,0 +1,98 @@
+# Times every detector's `detect` over a real codebase, so detector-side
+# content-scanning work can be prioritised by measured cost instead of by
+# counting `includes?` calls (most of which sit behind a cheap basename
+# gate and never run).
+#
+#   crystal run --release scripts/detector_scan_cost.cr -- <path> [<path>...]
+require "yaml"
+require "../src/detector/detector"
+require "../src/utils/media_filter"
+require "../src/utils/text_file"
+
+options = {
+  "base"    => YAML::Any.new([YAML::Any.new(ARGV[0]? || ".")]),
+  "debug"   => YAML::Any.new(false),
+  "verbose" => YAML::Any.new(false),
+  "color"   => YAML::Any.new(false),
+  "nolog"   => YAML::Any.new(true),
+}
+
+detectors = [] of Detector
+{% for sub in Detector.all_subclasses %}
+  {% unless sub.abstract? %}
+    instance = {{ sub }}.new(options)
+    instance.set_name
+    detectors << instance
+  {% end %}
+{% end %}
+
+# Collect the file set the detect phase would see.
+paths = [] of String
+ARGV.each do |root|
+  stack = [root]
+  until stack.empty?
+    dir = stack.pop
+    begin
+      Dir.each_child(dir) do |entry|
+        full = File.join(dir, entry)
+        info = File.info?(full, follow_symlinks: false)
+        next if info.nil?
+        if info.directory?
+          next if DETECTOR_IGNORED_DIR_NAMES.includes?(entry)
+          stack << full
+          next
+        end
+        next unless info.file?
+        next if MediaFilter.skip_check(full, info: info, sniff_binary: false)
+        paths << full
+      end
+    rescue
+      next
+    end
+  end
+end
+
+contents = {} of String => String
+total_bytes = 0_i64
+paths.each do |path|
+  content = Noir::TextFile.read(path)
+  next if content.to_slice.includes?(0_u8)
+  contents[path] = content
+  total_bytes += content.bytesize
+rescue
+  next
+end
+
+STDERR.puts "corpus: #{contents.size} files, #{total_bytes // 1024} KB"
+
+# Two passes: the first warms the page/branch state, the second is scored.
+timings = {} of String => Time::Span
+applied = Hash(String, Int32).new(0)
+scanned = Hash(String, Int64).new(0_i64)
+
+2.times do |round|
+  detectors.each do |detector|
+    hits = 0
+    bytes = 0_i64
+    elapsed = Time.measure do
+      contents.each do |path, content|
+        next unless detector.applicable?(path)
+        hits += 1
+        bytes += content.bytesize
+        detector.detect(path, content)
+      end
+    end
+    next unless round == 1
+    timings[detector.name] = elapsed
+    applied[detector.name] = hits
+    scanned[detector.name] = bytes
+  end
+end
+
+puts "#{"detector".ljust(30)} #{"ms".rjust(9)} #{"files".rjust(7)} #{"MB seen".rjust(9)}"
+timings.to_a.sort_by { |(_, span)| -span.total_milliseconds }.first(40).each do |name, span|
+  puts "#{name.ljust(30)} #{span.total_milliseconds.round(1).to_s.rjust(9)} " \
+       "#{applied[name].to_s.rjust(7)} #{(scanned[name] / 1_048_576.0).round(1).to_s.rjust(9)}"
+end
+puts "-" * 60
+puts "#{"TOTAL".ljust(30)} #{timings.values.sum(&.total_milliseconds).round(1).to_s.rjust(9)}"

--- a/src/ai_context/source_reader.cr
+++ b/src/ai_context/source_reader.cr
@@ -1,3 +1,5 @@
+require "../utils/text_file"
+
 module NoirAIContext
   # Reads source files once (cached per path) and extracts the
   # contextual snippets the augmentor attaches to AIContext entries:
@@ -185,7 +187,7 @@ module NoirAIContext
         return cached
       end
 
-      lines = File.read(path, encoding: "utf-8", invalid: :skip).split("\n")
+      lines = Noir::TextFile.read(path).split("\n")
       @file_cache[path] = lines
       lines
     rescue

--- a/src/ai_context/source_reader.cr
+++ b/src/ai_context/source_reader.cr
@@ -1,3 +1,4 @@
+require "../models/code_locator"
 require "../utils/text_file"
 
 module NoirAIContext
@@ -187,7 +188,11 @@ module NoirAIContext
         return cached
       end
 
-      lines = Noir::TextFile.read(path).split("\n")
+      # The detector already read and cached almost every file of the
+      # scan; going back to disk here paid a second open per file the
+      # augmentor touches.
+      content = CodeLocator.instance.content_for(path) || Noir::TextFile.read(path)
+      lines = content.split("\n")
       @file_cache[path] = lines
       lines
     rescue

--- a/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
+++ b/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../../models/endpoint"
 require "json"
 require "log"
+require "../../../utils/text_file"
 
 # Parses GraphQL *operation documents* (`query Foo { ... }`,
 # `mutation Bar { ... }`, `subscription Baz { ... }`) carried in `.graphql`
@@ -184,7 +185,7 @@ FileAnalyzer.add_hook(->(path : String, _url : String) : Array(Endpoint) {
   return [] of Endpoint unless path.ends_with?(".graphql") || path.ends_with?(".gql")
 
   begin
-    file_content = File.read(path, encoding: "utf-8", invalid: :skip)
+    file_content = Noir::TextFile.read(path)
   rescue ex
     Log.debug { "GraphQL Analyzer: Error reading file #{path}: #{ex.message} (#{ex.class})" }
     return [] of Endpoint # Return empty if read fails

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -18,6 +18,10 @@ module Analyzer::Go
     # calls would otherwise surface as chi routes).
     IMPORT_MARKER = "github.com/go-chi/chi"
 
+    # Whole-file gates, run on every `.go` in the tree.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+    MOUNT_CALL_RE    = /\.Mount\(/
+
     def analyze
       result = [] of Endpoint
 
@@ -40,7 +44,7 @@ module Analyzer::Go
           package_files[dir] << scan_path
 
           content = read_file_content(scan_path)
-          chi_dirs << dir if content.includes?(IMPORT_MARKER)
+          chi_dirs << dir if content_matches?(content, IMPORT_MARKER_RE)
           # Cache contents for every Go file in the package — the
           # cross-file callee map and Mount-expansion walker both
           # need handler/helper functions that live in non-chi
@@ -59,7 +63,7 @@ module Analyzer::Go
           # (qualified by receiver type for methods, so a same-named
           # `Routes()` on another type — or a top-level router builder
           # also named `Routes()` — is not skipped by accident).
-          next unless content.includes?(".Mount(")
+          next unless content_matches?(content, MOUNT_CALL_RE)
           content.each_line do |scan_line|
             next unless scan_line.includes?(".Mount(")
             if target = parse_mount_target(scan_line)
@@ -131,7 +135,7 @@ module Analyzer::Go
                 next if GoEngine.go_test_file?(path)
                 if File.exists?(path)
                   content = file_contents_cache[path]? || read_file_content(path)
-                  next unless content.includes?(IMPORT_MARKER)
+                  next unless content_matches?(content, IMPORT_MARKER_RE)
                   lines = file_lines_cache[path]? || content.lines
 
                   dir = File.dirname(path)

--- a/src/analyzer/analyzers/go/cli.cr
+++ b/src/analyzer/analyzers/go/cli.cr
@@ -31,6 +31,16 @@ module Analyzer::Go
     # precompiled `Regex.union` (PCRE2 JIT) checks all nine in a single pass.
     FRAMEWORK_IMPORTS_RE = Regex.union(FRAMEWORK_IMPORTS)
 
+    # Per-framework matchers for the scan dispatch below, which asks the
+    # same questions again once `cli_evidence?` has let a file through.
+    KONG_IMPORT_RE       = Regex.union("github.com/alecthomas/kong")
+    KINGPIN_IMPORT_RE    = Regex.union("github.com/alecthomas/kingpin", "gopkg.in/alecthomas/kingpin.v2")
+    MITCHELLH_IMPORT_RE  = Regex.union("github.com/mitchellh/cli")
+    STRUCT_TAG_IMPORT_RE = Regex.union("alexflint/go-arg", "jessevdk/go-flags")
+    FLAG_IMPORT_RE       = /"flag"/
+    FLAG_PARSE_RE        = /flag\.Parse\(/
+    OS_ARGS_RE           = /os\.Args/
+
     # --- builtin flag / argv -------------------------------------------------
     # The flag name is always the FIRST quoted string in the call: the `*Var`
     # forms put the destination pointer (unquoted) first, then the name.
@@ -150,15 +160,15 @@ module Analyzer::Go
             emit_stdlib, has_cli_parse)
           scan_struct_tags(content, path, root_url, endpoints)
 
-          if content.includes?("github.com/alecthomas/kong")
+          if content_matches?(content, KONG_IMPORT_RE)
             scan_kong(lines, path, root_url, endpoints, kong_cmd_type_urls(lines, root_url))
           end
 
-          if content.includes?("github.com/alecthomas/kingpin") || content.includes?("gopkg.in/alecthomas/kingpin.v2")
+          if content_matches?(content, KINGPIN_IMPORT_RE)
             scan_kingpin(lines, path, endpoints, kingpin_cmd_urls(lines, root_url))
           end
 
-          if content.includes?("github.com/mitchellh/cli")
+          if content_matches?(content, MITCHELLH_IMPORT_RE)
             scan_mitchellh(lines, path, root_url, endpoints)
           end
         rescue e
@@ -174,11 +184,11 @@ module Analyzer::Go
     # A file is part of the CLI surface when it imports a CLI framework or
     # uses the stdlib flag package / os.Args directly.
     private def cli_evidence?(content : String) : Bool
-      return true if content.matches?(FRAMEWORK_IMPORTS_RE)
-      return true if content.includes?("\"flag\"") &&
-                     (content.matches?(BUILTIN_FLAG_RE) || content.includes?("flag.Parse(") ||
-                     content.matches?(BUILTIN_ARG_RE) || content.matches?(BUILTIN_ARGS_RE))
-      content.matches?(OS_ARG_INDEX_RE)
+      return true if content_matches?(content, FRAMEWORK_IMPORTS_RE)
+      return true if content_matches?(content, FLAG_IMPORT_RE) &&
+                     (content_matches?(content, BUILTIN_FLAG_RE) || content_matches?(content, FLAG_PARSE_RE) ||
+                     content_matches?(content, BUILTIN_ARG_RE) || content_matches?(content, BUILTIN_ARGS_RE))
+      content_matches?(content, OS_ARG_INDEX_RE)
     end
 
     # Five markers OR-ed as a standalone boolean gate for `cli_parse_point?`
@@ -201,9 +211,9 @@ module Analyzer::Go
       # precisely (struct tag / .Envar() / scoped Run() body) — they
       # deliberately don't opt into the raw root-level os.Getenv fallback
       # below, which would double-attribute (or mis-scope) those reads.
-      return true if content.matches?(CLI_PARSE_POINT_RE)
-      return true if content.matches?(OS_ARG_INDEX_RE)
-      content.includes?("os.Args")
+      return true if content_matches?(content, CLI_PARSE_POINT_RE)
+      return true if content_matches?(content, OS_ARG_INDEX_RE)
+      content_matches?(content, OS_ARGS_RE)
     end
 
     private def go_binary_name(modules : Array(Tuple(String, String)), path : String) : String
@@ -384,7 +394,7 @@ module Analyzer::Go
     # follow-up).
     private def scan_struct_tags(content : String, path : String, root_url : String,
                                  endpoints : Hash(String, Endpoint))
-      return unless content.includes?("alexflint/go-arg") || content.includes?("jessevdk/go-flags")
+      return unless content_matches?(content, STRUCT_TAG_IMPORT_RE)
 
       content.each_line.with_index do |line, index|
         line_no = index + 1

--- a/src/analyzer/analyzers/go/connect_rpc.cr
+++ b/src/analyzer/analyzers/go/connect_rpc.cr
@@ -17,7 +17,12 @@ module Analyzer::Go
   # file that registers the handler instead of (or in addition to)
   # the proto file.
   class ConnectRpc < GoEngine
-    IMPORT_MARKER         = "connectrpc.com/connect"
+    IMPORT_MARKER = "connectrpc.com/connect"
+
+    # Whole-file gates, run on every `.go` in the tree.
+    IMPORT_MARKER_RE      = Regex.union(IMPORT_MARKER)
+    PROCEDURE_MARKER_RE   = /Procedure/
+    IMPORT_OR_HANDLER_RE  = Regex.union(IMPORT_MARKER, "ServiceHandler(")
     HANDLER_NAME_REGEX    = /New(\w+ServiceHandler)\s*\(/
     CONNECT_CONTENT_TYPES = "application/proto, application/json, application/connect+proto, application/connect+json"
 
@@ -71,8 +76,8 @@ module Analyzer::Go
         next if GoEngine.go_test_file?(path)
         begin
           content = read_file_content(path)
-          next unless content.includes?(IMPORT_MARKER)
-          next unless content.includes?("Procedure")
+          next unless content_matches?(content, IMPORT_MARKER_RE)
+          next unless content_matches?(content, PROCEDURE_MARKER_RE)
 
           kinds = {} of String => String
           content.scan(HANDLER_KIND_REGEX) do |m|
@@ -124,7 +129,7 @@ module Analyzer::Go
           next if GoEngine.go_test_file?(path)
           base_path = configured_base_for(path)
           content = read_file_content(path)
-          next unless content.includes?(IMPORT_MARKER) || content.includes?("ServiceHandler(")
+          next unless content_matches?(content, IMPORT_OR_HANDLER_RE)
           content.each_line.with_index do |line, index|
             if match = line.match(HANDLER_NAME_REGEX)
               handler_name = match[1]

--- a/src/analyzer/analyzers/javascript/cli.cr
+++ b/src/analyzer/analyzers/javascript/cli.cr
@@ -109,6 +109,12 @@ module Analyzer::Javascript
     # OR-of-includes? it replaces.
     CLI_MARKERS_RE = Regex.union("commander", "yargs", "cac", "meow", "minimist", "clipanion", "@oclif", "sade", "parseArgs", "Deno.args", "Bun.argv")
 
+    # Two more OR-ed pairs of whole-file scans, collapsed the same way:
+    # the evidence gate every JS/TS file passes through, and the
+    # web-framework veto that decides whether env reads are emitted.
+    CLI_EVIDENCE_RE = Regex.union(CLI_MARKERS_RE, ARGV_SLICE, LIB_IMPORT_ONLY_RE)
+    WEB_EVIDENCE_RE = Regex.union(WEB_FRAMEWORK_RE, WEB_LISTEN_RE)
+
     def analyze
       package_names = collect_package_names
       endpoints = {} of String => Endpoint
@@ -126,7 +132,7 @@ module Analyzer::Javascript
               binary = js_binary_name(package_names, path)
               root_url = "cli://#{binary}"
               lines = content.lines
-              emit_env = !(content.matches?(WEB_FRAMEWORK_RE) || content.matches?(WEB_LISTEN_RE))
+              emit_env = !content_matches?(content, WEB_EVIDENCE_RE)
 
               scan(lines, path, root_url, endpoints, emit_env)
             rescue e
@@ -143,8 +149,7 @@ module Analyzer::Javascript
     end
 
     private def cli_evidence?(content : String) : Bool
-      content.matches?(CLI_MARKERS_RE) || content.matches?(ARGV_SLICE) ||
-        content.matches?(LIB_IMPORT_ONLY_RE)
+      content_matches?(content, CLI_EVIDENCE_RE)
     end
 
     private def js_test_or_vendor?(path : String) : Bool

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -3,6 +3,7 @@ require "../../../../utils/js_literal_scanner"
 require "../../../../utils/path_scope"
 require "../../../../utils/url_path"
 require "../express_constants"
+require "../../../../utils/text_file"
 
 module Analyzer::Javascript
   # RouterMountScanner handles the two-pass scanning process for Express router mounts.
@@ -69,7 +70,7 @@ module Analyzer::Javascript
       file_contexts : Hash(String, FileContext),
       global_deferred_mounts : Array(Tuple(String, String, String, String)),
     )
-      content = CodeLocator.instance.content_for(main_file) || File.read(main_file, encoding: "utf-8", invalid: :skip)
+      content = CodeLocator.instance.content_for(main_file) || Noir::TextFile.read(main_file)
 
       # Cheap pre-filter: every code path in this scanner is downstream
       # of a `.use(...)` or `.route(...)` call (literal mount, no-prefix
@@ -652,7 +653,7 @@ module Analyzer::Javascript
       return false unless File.file?(file_path)
 
       begin
-        content = CodeLocator.instance.content_for(file_path) || File.read(file_path, encoding: "utf-8", invalid: :skip)
+        content = CodeLocator.instance.content_for(file_path) || Noir::TextFile.read(file_path)
         # Look for common route definition patterns
         # Matches: router.get(, router.post(, .get(, .post(, etc.
         content.matches?(/\.(get|post|put|delete|patch|all|head|options)\s*\(/)

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -4,6 +4,7 @@ require "../../../llm/adapter"
 require "../../../llm/prompt"
 require "../../../llm/prompt_overrides"
 require "../../../llm/cache"
+require "../../../utils/text_file"
 
 module Analyzer::AI
   # Unified AI analyzer that uses a provider-agnostic LLM adapter.
@@ -144,7 +145,7 @@ module Analyzer::AI
         next if File.directory?(path) || File.symlink?(path) || ignore_extensions.includes?(File.extname(path))
 
         relative_path = get_relative_path(base_path, path)
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = Noir::TextFile.read(path)
         files << {relative_path, content}
       end
       files
@@ -595,7 +596,7 @@ module Analyzer::AI
       return "ERROR: file '#{path}' is outside base paths or does not exist." if resolved.nil?
       return "ERROR: '#{path}' is a directory. Use list_directory instead." if File.directory?(resolved)
 
-      content = File.read(resolved, encoding: "utf-8", invalid: :skip)
+      content = Noir::TextFile.read(resolved)
       return "FILE #{agent_relative_path(resolved)}\n#{content}" if content.bytesize <= AGENT_MAX_READ_BYTES
 
       half = AGENT_MAX_READ_BYTES // 2

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -1,4 +1,5 @@
 require "../../engines/python_engine"
+require "../../../utils/text_file"
 
 module Analyzer::Python
   class Tornado < PythonEngine
@@ -658,7 +659,7 @@ module Analyzer::Python
     private def read_file_content(file_path : ::String) : ::String
       return @file_content_cache[file_path] if @file_content_cache.has_key?(file_path)
       content = begin
-        CodeLocator.instance.content_for(file_path) || File.read(file_path, encoding: "utf-8", invalid: :skip)
+        CodeLocator.instance.content_for(file_path) || Noir::TextFile.read(file_path)
       rescue e : IO::Error
         @logger.debug "Failed to read file: #{file_path} (#{e.message})"
         ""

--- a/src/analyzer/analyzers/ruby/cli.cr
+++ b/src/analyzer/analyzers/ruby/cli.cr
@@ -87,6 +87,17 @@ module Analyzer::Ruby
     # instead of up to four naive substring scans.
     CLI_EVIDENCE_MARKERS_RE = Regex.union("OptionParser.new", "GLI::App", "TTY::Option", "Commander::Methods")
 
+    SLOP_CALL = /\bSlop\.(?:parse|new)\b/
+
+    # `cli_evidence?` is the gate every `.rb` in the tree passes through,
+    # and it OR-ed seven separate whole-file scans. One union is the same
+    # predicate in a single pass; the individual patterns are still needed
+    # below, where each one sets its own flag.
+    CLI_EVIDENCE_RE = Regex.union(
+      THOR_SUBCLASS, CLI_EVIDENCE_MARKERS_RE, SLOP_CALL,
+      ARGV_INDEX, OPTIMIST_CALL, CLAMP_SUBCLASS, DRY_CLI_MARKER,
+    )
+
     def analyze
       endpoints = {} of String => Endpoint
 
@@ -102,11 +113,11 @@ module Analyzer::Ruby
             binary = ruby_binary_name(content, path)
             root_url = "cli://#{binary}"
             lines = content.lines
-            thor = content.matches?(THOR_SUBCLASS)
-            clamp = content.matches?(CLAMP_SUBCLASS)
-            dry_cli = content.matches?(DRY_CLI_MARKER)
-            optimist = content.matches?(OPTIMIST_CALL)
-            emit_env = !content.matches?(WEB_FRAMEWORK_RE)
+            thor = content_matches?(content, THOR_SUBCLASS)
+            clamp = content_matches?(content, CLAMP_SUBCLASS)
+            dry_cli = content_matches?(content, DRY_CLI_MARKER)
+            optimist = content_matches?(content, OPTIMIST_CALL)
+            emit_env = !content_matches?(content, WEB_FRAMEWORK_RE)
 
             scan(lines, path, root_url, endpoints, thor, emit_env, clamp, dry_cli, optimist)
           rescue e
@@ -122,13 +133,7 @@ module Analyzer::Ruby
     end
 
     private def cli_evidence?(content : String) : Bool
-      content.matches?(THOR_SUBCLASS) ||
-        content.matches?(CLI_EVIDENCE_MARKERS_RE) ||
-        content.matches?(/\bSlop\.(?:parse|new)\b/) ||
-        content.matches?(ARGV_INDEX) ||
-        content.matches?(OPTIMIST_CALL) ||
-        content.matches?(CLAMP_SUBCLASS) ||
-        content.matches?(DRY_CLI_MARKER)
+      content_matches?(content, CLI_EVIDENCE_RE)
     end
 
     private def ruby_binary_name(content : String, path : String) : String

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -241,8 +241,12 @@ module Analyzer::Go
     # the file that calls `router.GET(...)` may not import Gin/Echo itself.
     def framework_package_dirs(file_contents : Hash(String, String), import_marker : String) : Set(String)
       dirs = Set(String).new
+      # Compiled once for the whole sweep — this walks every cached `.go`
+      # source, and one JIT-compiled scan beats `includes?`'s Rabin-Karp
+      # walk per file.
+      marker = Regex.union(import_marker)
       file_contents.each do |path, content|
-        dirs << File.dirname(path) if content.includes?(import_marker)
+        dirs << File.dirname(path) if content.matches?(marker, options: Noir::TextFile::MATCH_OPTIONS)
       end
       dirs
     end
@@ -251,10 +255,10 @@ module Analyzer::Go
     # import Gin/Echo for `*gin.Context` / `echo.Context`, but they cannot emit
     # endpoints unless they contain a route/static registration call.
     def go_route_source_candidate?(content : String, extra_methods : Array(String)) : Bool
-      return true if content.matches?(GO_HTTP_ROUTE_CALL_RE)
+      return true if content.matches?(GO_HTTP_ROUTE_CALL_RE, options: Noir::TextFile::MATCH_OPTIONS)
       extra_methods.any? do |method|
         method_regex = @extra_method_regexes[method] ||= /\.#{Regex.escape(method)}\s*\(/
-        content.matches?(method_regex)
+        content.matches?(method_regex, options: Noir::TextFile::MATCH_OPTIONS)
       end
     end
 

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -236,17 +236,23 @@ module Analyzer::Go
     # instead of rebuilding them for every candidate file.
     @extra_method_regexes = Hash(String, Regex).new
 
+    # One compiled matcher per framework import marker. Each analyzer
+    # passes a single `IMPORT_MARKER` constant, so the cardinality here is
+    # one entry; the Hash just keeps the memo honest if that changes.
+    @import_marker_regexes = Hash(String, Regex).new
+
+    private def import_marker_regex(import_marker : String) : Regex
+      @import_marker_regexes[import_marker] ||= Regex.union(import_marker)
+    end
+
     # Per-package directories that import a target framework. Some real
     # projects hide the concrete framework type behind a local interface, so
     # the file that calls `router.GET(...)` may not import Gin/Echo itself.
     def framework_package_dirs(file_contents : Hash(String, String), import_marker : String) : Set(String)
       dirs = Set(String).new
-      # Compiled once for the whole sweep — this walks every cached `.go`
-      # source, and one JIT-compiled scan beats `includes?`'s Rabin-Karp
-      # walk per file.
-      marker = Regex.union(import_marker)
+      marker = import_marker_regex(import_marker)
       file_contents.each do |path, content|
-        dirs << File.dirname(path) if content.matches?(marker, options: Noir::TextFile::MATCH_OPTIONS)
+        dirs << File.dirname(path) if content_matches?(content, marker)
       end
       dirs
     end
@@ -255,10 +261,10 @@ module Analyzer::Go
     # import Gin/Echo for `*gin.Context` / `echo.Context`, but they cannot emit
     # endpoints unless they contain a route/static registration call.
     def go_route_source_candidate?(content : String, extra_methods : Array(String)) : Bool
-      return true if content.matches?(GO_HTTP_ROUTE_CALL_RE, options: Noir::TextFile::MATCH_OPTIONS)
+      return true if content_matches?(content, GO_HTTP_ROUTE_CALL_RE)
       extra_methods.any? do |method|
         method_regex = @extra_method_regexes[method] ||= /\.#{Regex.escape(method)}\s*\(/
-        content.matches?(method_regex, options: Noir::TextFile::MATCH_OPTIONS)
+        content_matches?(content, method_regex)
       end
     end
 
@@ -267,7 +273,7 @@ module Analyzer::Go
                                           framework_dirs : Set(String),
                                           import_marker : String,
                                           extra_methods : Array(String)) : Bool
-      return false unless content.includes?(import_marker) || framework_dirs.includes?(dir)
+      return false unless content_matches?(content, import_marker_regex(import_marker)) || framework_dirs.includes?(dir)
       go_route_source_candidate?(content, extra_methods)
     end
 

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -50,13 +50,26 @@ module Analyzer::Ruby
     # root so noir's own fixture tree under `spec/functional_test/fixtures`
     # is not accidentally skipped when the fixture directory itself is the
     # base path.
+    # Exact translation of the three-way check this replaces:
+    # `relative == dir` and `relative.starts_with?("#{dir}/")` collapse to
+    # the leading branch, `relative.includes?("/#{dir}/")` to the second.
+    # Deliberately NOT `(?:\A|\/)dir(?:\/|\z)`, which would also match a
+    # trailing segment (`app/spec`) the old chain rejected.
+    #
+    # The chain built two interpolated Strings per directory per call —
+    # 18 allocations on every Ruby file, for every whole-tree Ruby
+    # analyzer — before scanning for each of them separately.
+    RUBY_NON_PRODUCTION_PATH_RE = begin
+      alternation = RUBY_NON_PRODUCTION_DIRS.join("|") { |dir| Regex.escape(dir) }
+      Regex.new("\\A(?:#{alternation})(?:/|\\z)|/(?:#{alternation})/")
+    end
+
     protected def ruby_non_production_path?(path : String) : Bool
       return true if RubyEngine.ruby_test_path?(path)
 
-      relative = ruby_relative_path(path).gsub('\\', '/')
-      RUBY_NON_PRODUCTION_DIRS.any? do |dir|
-        relative == dir || relative.starts_with?("#{dir}/") || relative.includes?("/#{dir}/")
-      end
+      relative = ruby_relative_path(path)
+      relative = relative.gsub('\\', '/') if relative.includes?('\\')
+      relative.matches?(RUBY_NON_PRODUCTION_PATH_RE)
     end
 
     private def ruby_relative_path(path : String) : String

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -5,6 +5,7 @@ require "../techs/techs.cr" # Added to define NoirTechs
 require "../passive_scan/detect.cr"
 require "wait_group"
 require "../utils/media_filter"
+require "../utils/text_file"
 require "yaml"
 
 macro define_detectors(detectors)
@@ -118,7 +119,7 @@ def detector_add_android_source_prefixes_from_dir(dir : String, prefixes : Array
   return unless File.exists?(manifest_path)
 
   begin
-    content = File.read(manifest_path, encoding: "utf-8", invalid: :skip)
+    content = Noir::TextFile.read(manifest_path)
     return unless content.includes?("<manifest")
   rescue File::NotFoundError | File::AccessDeniedError
     return
@@ -728,13 +729,13 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
                 # Keep the path visible to analyzers without paying to
                 # read/cache content that neither detection nor passive
                 # scan will inspect. Analyzer reads still fall back to
-                # File.read when a file was not cached here.
+                # a disk read when a file was not cached here.
                 locator.push("file_map", full_path)
                 skipped_content_reads += 1
                 next
               end
 
-              content = File.read(full_path, encoding: "utf-8", invalid: :skip)
+              content = Noir::TextFile.read(full_path)
               if content.to_slice.includes?(0_u8)
                 logger.debug "Skipping #{full_path}: binary content (file is text-extension but bytes look binary)"
                 skipped_files += 1

--- a/src/detector/detectors/asp/classic.cr
+++ b/src/detector/detectors/asp/classic.cr
@@ -13,9 +13,9 @@ module Detector::Asp
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
 
-      return true if file_contents.matches?(DIRECTIVE_RE)
-      return true if file_contents.matches?(SERVER_SCRIPT_RE)
-      return true if file_contents.matches?(SCRIPT_DELIMITER_RE) && file_contents.matches?(INTRINSIC_RE)
+      return true if content_matches?(file_contents, DIRECTIVE_RE)
+      return true if content_matches?(file_contents, SERVER_SCRIPT_RE)
+      return true if content_matches?(file_contents, SCRIPT_DELIMITER_RE) && content_matches?(file_contents, INTRINSIC_RE)
 
       false
     end

--- a/src/detector/detectors/aspnet/webforms.cr
+++ b/src/detector/detectors/aspnet/webforms.cr
@@ -19,14 +19,14 @@ module Detector::Aspnet
       return false unless applicable?(filename)
 
       if MARKUP_EXTENSIONS.includes?(File.extname(filename).downcase)
-        return true if file_contents.matches?(DIRECTIVE_RE)
-        return true if file_contents.matches?(RUNAT_RE)
+        return true if content_matches?(file_contents, DIRECTIVE_RE)
+        return true if content_matches?(file_contents, RUNAT_RE)
         return false
       end
 
       # `.cs` / `.vb` only count as WebForms when they are page code-behind;
       # otherwise every ASP.NET Core project would match.
-      file_contents.matches?(CODEBEHIND_RE)
+      content_matches?(file_contents, CODEBEHIND_RE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/cfml/coldbox.cr
+++ b/src/detector/detectors/cfml/coldbox.cr
@@ -16,9 +16,9 @@ module Detector::Cfml
         return true
       end
 
-      return true if file_contents.matches?(NAMESPACE_RE)
-      return true if base == "moduleconfig.cfc" && file_contents.matches?(MODULE_RE)
-      return true if base == "routes.cfm" && file_contents.matches?(ROUTER_DSL_RE)
+      return true if content_matches?(file_contents, NAMESPACE_RE)
+      return true if base == "moduleconfig.cfc" && content_matches?(file_contents, MODULE_RE)
+      return true if base == "routes.cfm" && content_matches?(file_contents, ROUTER_DSL_RE)
 
       false
     end

--- a/src/detector/detectors/cfml/fw1.cr
+++ b/src/detector/detectors/cfml/fw1.cr
@@ -11,9 +11,9 @@ module Detector::Cfml
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
 
-      return true if file_contents.matches?(BASE_RE)
-      return true if file_contents.matches?(ROUTES_RE)
-      return true if file_contents.matches?(SETTINGS_RE)
+      return true if content_matches?(file_contents, BASE_RE)
+      return true if content_matches?(file_contents, ROUTES_RE)
+      return true if content_matches?(file_contents, SETTINGS_RE)
 
       false
     end

--- a/src/detector/detectors/cfml/pure.cr
+++ b/src/detector/detectors/cfml/pure.cr
@@ -13,9 +13,9 @@ module Detector::Cfml
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
 
-      return true if file_contents.matches?(TAG_MARKERS_RE)
-      return true if file_contents.matches?(SCRIPT_FUNCTION_RE)
-      return true if file_contents.matches?(SCRIPT_COMPONENT_RE)
+      return true if content_matches?(file_contents, TAG_MARKERS_RE)
+      return true if content_matches?(file_contents, SCRIPT_FUNCTION_RE)
+      return true if content_matches?(file_contents, SCRIPT_COMPONENT_RE)
 
       false
     end

--- a/src/detector/detectors/cfml/taffy.cr
+++ b/src/detector/detectors/cfml/taffy.cr
@@ -12,9 +12,9 @@ module Detector::Cfml
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
 
-      return true if file_contents.matches?(URI_ATTRIBUTE_RE)
-      return true if file_contents.matches?(RESOURCE_BASE_RE)
-      return true if file_contents.matches?(API_BASE_RE)
+      return true if content_matches?(file_contents, URI_ATTRIBUTE_RE)
+      return true if content_matches?(file_contents, RESOURCE_BASE_RE)
+      return true if content_matches?(file_contents, API_BASE_RE)
 
       false
     end

--- a/src/detector/detectors/cfml/wheels.cr
+++ b/src/detector/detectors/cfml/wheels.cr
@@ -12,11 +12,11 @@ module Detector::Cfml
       return false unless applicable?(filename)
 
       if File.basename(filename).downcase == "routes.cfm"
-        return true if file_contents.matches?(MAPPER_RE)
-        return true if file_contents.matches?(DSL_RE)
+        return true if content_matches?(file_contents, MAPPER_RE)
+        return true if content_matches?(file_contents, DSL_RE)
       end
 
-      file_contents.matches?(NAMESPACE_RE)
+      content_matches?(file_contents, NAMESPACE_RE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/clojure/cli.cr
+++ b/src/detector/detectors/clojure/cli.cr
@@ -12,7 +12,7 @@ module Detector::Clojure
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/cpp/cli.cr
+++ b/src/detector/detectors/cpp/cli.cr
@@ -18,10 +18,10 @@ module Detector::Cpp
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless EXTS.any? { |ext| filename.ends_with?(ext) }
-      file_contents.matches?(CLI11) || file_contents.matches?(GETOPT) ||
-        file_contents.matches?(CXXOPTS) || file_contents.matches?(BOOST_PO) ||
-        file_contents.matches?(GFLAGS) || file_contents.matches?(ABSL_FLAG) ||
-        file_contents.matches?(ARGPARSE)
+      content_matches?(file_contents, CLI11) || content_matches?(file_contents, GETOPT) ||
+        content_matches?(file_contents, CXXOPTS) || content_matches?(file_contents, BOOST_PO) ||
+        content_matches?(file_contents, GFLAGS) || content_matches?(file_contents, ABSL_FLAG) ||
+        content_matches?(file_contents, ARGPARSE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/crystal/cli.cr
+++ b/src/detector/detectors/crystal/cli.cr
@@ -9,7 +9,7 @@ module Detector::Crystal
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cr")
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/csharp/aspnet_core_minimal_api.cr
+++ b/src/detector/detectors/csharp/aspnet_core_minimal_api.cr
@@ -6,8 +6,8 @@ module Detector::CSharp
       return false unless filename.ends_with?(".cs")
       return false if file_contents.includes?("ICarterModule")
 
-      has_http_map = file_contents.matches?(/\.\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)\s*\(/)
-      has_generic_map = file_contents.matches?(/\.\s*Map\s*\(/) && minimal_api_context?(file_contents)
+      has_http_map = content_matches?(file_contents, /\.\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)\s*\(/)
+      has_generic_map = content_matches?(file_contents, /\.\s*Map\s*\(/) && minimal_api_context?(file_contents)
 
       has_http_map || has_generic_map
     end

--- a/src/detector/detectors/csharp/cli.cr
+++ b/src/detector/detectors/csharp/cli.cr
@@ -16,9 +16,9 @@ module Detector::CSharp
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cs")
-      return true if file_contents.matches?(CLI_LIB) || file_contents.matches?(LIB_USAGE)
-      return false if file_contents.matches?(WEB_HOST)
-      file_contents.matches?(MAIN_ARGS) || file_contents.matches?(GET_ARGS)
+      return true if content_matches?(file_contents, CLI_LIB) || content_matches?(file_contents, LIB_USAGE)
+      return false if content_matches?(file_contents, WEB_HOST)
+      content_matches?(file_contents, MAIN_ARGS) || content_matches?(file_contents, GET_ARGS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/csharp/httplistener.cr
+++ b/src/detector/detectors/csharp/httplistener.cr
@@ -6,8 +6,8 @@ module Detector::CSharp
       return false unless filename.ends_with?(".cs")
       return false unless file_contents.includes?("HttpListener")
 
-      file_contents.matches?(/\bnew\s+HttpListener\s*\(/) ||
-        file_contents.matches?(/\bnew\s+System\.Net\.HttpListener\s*\(/) ||
+      content_matches?(file_contents, /\bnew\s+HttpListener\s*\(/) ||
+        content_matches?(file_contents, /\bnew\s+System\.Net\.HttpListener\s*\(/) ||
         file_contents.includes?(".Prefixes.Add") ||
         file_contents.includes?(".GetContext") ||
         file_contents.includes?("GetContextAsync")

--- a/src/detector/detectors/csharp/signalr.cr
+++ b/src/detector/detectors/csharp/signalr.cr
@@ -10,7 +10,7 @@ module Detector::CSharp
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cs")
-      file_contents.matches?(SIGNALR_MARKER)
+      content_matches?(file_contents, SIGNALR_MARKER)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/dart/cli.cr
+++ b/src/detector/detectors/dart/cli.cr
@@ -9,7 +9,7 @@ module Detector::Dart
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".dart")
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/elixir/cli.cr
+++ b/src/detector/detectors/elixir/cli.cr
@@ -8,7 +8,7 @@ module Detector::Elixir
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ex") || filename.ends_with?(".exs")
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/elixir/phoenix.cr
+++ b/src/detector/detectors/elixir/phoenix.cr
@@ -31,7 +31,7 @@ module Detector::Elixir
       # isn't in scope (e.g. `--include-path` runs over `lib/` only).
       if filename.ends_with?(".ex") || filename.ends_with?(".exs")
         return file_contents.includes?("Phoenix.Router") ||
-          file_contents.matches?(ROUTER_USE_REGEX)
+          content_matches?(file_contents, ROUTER_USE_REGEX)
       end
 
       false

--- a/src/detector/detectors/elixir/phoenix_channel.cr
+++ b/src/detector/detectors/elixir/phoenix_channel.cr
@@ -11,7 +11,7 @@ module Detector::Elixir
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ex") || filename.ends_with?(".exs")
-      file_contents.matches?(CHANNEL_MARKER)
+      content_matches?(file_contents, CHANNEL_MARKER)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/erlang/cowboy.cr
+++ b/src/detector/detectors/erlang/cowboy.cr
@@ -10,14 +10,14 @@ module Detector::Erlang
       base = File.basename(filename)
 
       if base == "rebar.config" || filename.ends_with?(".app.src") || base == "erlang.mk"
-        return true if file_contents.matches?(/(?:^|[\s,{"])cowboy(?:_[a-z]+)?(?=$|[\s,}"])/)
+        return true if content_matches?(file_contents, /(?:^|[\s,{"])cowboy(?:_[a-z]+)?(?=$|[\s,}"])/)
       end
 
       return false unless filename.ends_with?(".erl") || filename.ends_with?(".hrl")
 
       return true if file_contents.includes?("cowboy_router:compile")
       return true if file_contents.includes?("cowboy:start_clear") || file_contents.includes?("cowboy:start_tls")
-      return true if file_contents.matches?(/-(?:behaviour|behavior)\s*\(\s*cowboy_(?:handler|rest|loop|websocket)\s*\)/)
+      return true if content_matches?(file_contents, /-(?:behaviour|behavior)\s*\(\s*cowboy_(?:handler|rest|loop|websocket)\s*\)/)
       return true if file_contents.includes?("cowboy_req:")
 
       false

--- a/src/detector/detectors/erlang/elli.cr
+++ b/src/detector/detectors/erlang/elli.cr
@@ -6,12 +6,12 @@ module Detector::Erlang
       base = File.basename(filename)
 
       if base == "rebar.config" || filename.ends_with?(".app.src") || base == "erlang.mk"
-        return true if file_contents.matches?(/(?:^|[\s,{"])elli(?:_[a-z]+)?(?=$|[\s,}"])/)
+        return true if content_matches?(file_contents, /(?:^|[\s,{"])elli(?:_[a-z]+)?(?=$|[\s,}"])/)
       end
 
       return false unless filename.ends_with?(".erl") || filename.ends_with?(".hrl")
 
-      return true if file_contents.matches?(/-(?:behaviour|behavior)\s*\(\s*elli_handler\s*\)/)
+      return true if content_matches?(file_contents, /-(?:behaviour|behavior)\s*\(\s*elli_handler\s*\)/)
       return true if file_contents.includes?("elli_request:")
       return true if file_contents.includes?("elli:start_link")
 

--- a/src/detector/detectors/gleam/wisp.cr
+++ b/src/detector/detectors/gleam/wisp.cr
@@ -6,13 +6,13 @@ module Detector::Gleam
       base = File.basename(filename)
 
       if base == "gleam.toml" || base == "manifest.toml"
-        return true if file_contents.matches?(/^\s*wisp\s*=/m)
-        return true if file_contents.matches?(/name\s*=\s*"wisp"/)
+        return true if content_matches?(file_contents, /^\s*wisp\s*=/m)
+        return true if content_matches?(file_contents, /name\s*=\s*"wisp"/)
       end
 
       return false unless filename.ends_with?(".gleam")
 
-      return true if file_contents.matches?(/^\s*import\s+wisp(?:\/[a-z_]+)?(?:\s|\.|$)/m)
+      return true if content_matches?(file_contents, /^\s*import\s+wisp(?:\/[a-z_]+)?(?:\s|\.|$)/m)
       return true if file_contents.includes?("wisp.path_segments")
 
       false

--- a/src/detector/detectors/go/cli.cr
+++ b/src/detector/detectors/go/cli.cr
@@ -21,6 +21,13 @@ module Detector::Go
       "gopkg.in/alecthomas/kingpin.v2",
     ]
 
+    # Single-pass union of the library markers above. The `any? includes?`
+    # chain walked every non-CLI `.go` file nine times over.
+    CLI_LIBRARY_MARKER = Regex.union(CLI_LIBRARY_MARKERS)
+
+    # The stdlib `flag` import line.
+    FLAG_IMPORT = /"flag"/
+
     # A real call into the stdlib `flag` package (not just the bare token
     # "flag", which appears in unrelated identifiers/comments).
     BUILTIN_FLAG_USE = /\bflag\.(?:Parse|Args?|NArg|String(?:Var)?|Int(?:64)?(?:Var)?|Uint(?:64)?(?:Var)?|Bool(?:Var)?|Float64(?:Var)?|Duration(?:Var)?|Var)\s*\(/
@@ -35,14 +42,14 @@ module Detector::Go
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".go") || File.basename(filename) == "go.mod"
-      return true if CLI_LIBRARY_MARKERS.any? { |marker| file_contents.includes?(marker) }
+      return true if content_matches?(file_contents, CLI_LIBRARY_MARKER)
 
       # go.mod has no flag/argv usage of its own; only the library markers
       # above qualify it.
       return false unless filename.ends_with?(".go")
-      return false if file_contents.matches?(HTTP_LISTEN)
-      return true if file_contents.includes?("\"flag\"") && file_contents.matches?(BUILTIN_FLAG_USE)
-      return true if file_contents.matches?(ARGV_INDEX)
+      return false if content_matches?(file_contents, HTTP_LISTEN)
+      return true if content_matches?(file_contents, FLAG_IMPORT) && content_matches?(file_contents, BUILTIN_FLAG_USE)
+      return true if content_matches?(file_contents, ARGV_INDEX)
 
       false
     end

--- a/src/detector/detectors/go/connect_rpc.cr
+++ b/src/detector/detectors/go/connect_rpc.cr
@@ -4,11 +4,15 @@ module Detector::Go
   class ConnectRpc < Detector
     IMPORT_MARKER = "connectrpc.com/connect"
 
+    # One JIT-compiled scan per file instead of a Rabin-Karp walk;
+    # every `.go` in the tree reaches this marker check.
+    IMPORT_PATTERN = Regex.union(IMPORT_MARKER)
+
     def detect(filename : String, file_contents : String) : Bool
-      if filename.includes?("go.mod") && file_contents.includes?(IMPORT_MARKER)
+      if filename.includes?("go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
         return true
       end
-      if filename.ends_with?(".go") && file_contents.includes?(IMPORT_MARKER)
+      if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
         return true
       end
       false

--- a/src/detector/detectors/go/gf.cr
+++ b/src/detector/detectors/go/gf.cr
@@ -4,13 +4,17 @@ module Detector::Go
   class Gf < Detector
     IMPORT_MARKER = "github.com/gogf/gf"
 
+    # One JIT-compiled scan per file instead of a Rabin-Karp walk;
+    # every `.go` in the tree reaches this marker check.
+    IMPORT_PATTERN = Regex.union(IMPORT_MARKER)
+
     # Detect from `go.mod` (whole-repo scans) AND any `.go` file that
     # imports GoFrame, so a sub-directory whose `go.mod` lives higher up
     # is still recognized when scanned on its own. The analyzer re-gates
     # every file on the same marker, so this can't over-extract.
     def detect(filename : String, file_contents : String) : Bool
-      return true if (filename.includes? "go.mod") && file_contents.includes?(IMPORT_MARKER)
-      return true if filename.ends_with?(".go") && file_contents.includes?(IMPORT_MARKER)
+      return true if (filename.includes? "go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
+      return true if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
       false
     end
 

--- a/src/detector/detectors/go/go_restful.cr
+++ b/src/detector/detectors/go/go_restful.cr
@@ -4,13 +4,17 @@ module Detector::Go
   class GoRestful < Detector
     IMPORT_MARKER = "github.com/emicklei/go-restful"
 
+    # One JIT-compiled scan per file instead of a Rabin-Karp walk;
+    # every `.go` in the tree reaches this marker check.
+    IMPORT_PATTERN = Regex.union(IMPORT_MARKER)
+
     # Detect from `go.mod` (whole-repo scans) AND any `.go` file that
     # imports go-restful, so a sub-directory whose `go.mod` lives higher up
     # is still recognized when scanned on its own. The analyzer re-gates
     # every file on the same marker, so this can't over-extract.
     def detect(filename : String, file_contents : String) : Bool
-      return true if (filename.includes? "go.mod") && file_contents.includes?(IMPORT_MARKER)
-      return true if filename.ends_with?(".go") && file_contents.includes?(IMPORT_MARKER)
+      return true if (filename.includes? "go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
+      return true if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
       false
     end
 

--- a/src/detector/detectors/go/gozero.cr
+++ b/src/detector/detectors/go/gozero.cr
@@ -4,14 +4,18 @@ module Detector::Go
   class GoZero < Detector
     IMPORT_MARKER = "github.com/zeromicro/go-zero"
 
+    # One JIT-compiled scan per file instead of a Rabin-Karp walk;
+    # every `.go` in the tree reaches this marker check.
+    IMPORT_PATTERN = Regex.union(IMPORT_MARKER)
+
     # Detect from `go.mod` (whole-repo scans) AND any `.go` file that
     # imports go-zero. The `.go` path lets a microservice sub-directory
     # (e.g. `service/order/api`, whose `go.mod` lives at the monorepo
     # root) still be recognized when scanned on its own. The analyzer
     # re-gates every file on the same marker, so this can't over-extract.
     def detect(filename : String, file_contents : String) : Bool
-      return true if (filename.includes? "go.mod") && file_contents.includes?(IMPORT_MARKER)
-      return true if filename.ends_with?(".go") && file_contents.includes?(IMPORT_MARKER)
+      return true if (filename.includes? "go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
+      return true if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
       false
     end
 

--- a/src/detector/detectors/go/http.cr
+++ b/src/detector/detectors/go/http.cr
@@ -11,8 +11,8 @@ module Detector::Go
       # - Direct "http.HandleFunc(" / "http.Handle(" for the default serve mux case
       #   (the "http." qualifier prevents catching r.HandleFunc in chi/mux/etc).
       file_contents.includes?("NewServeMux") ||
-        file_contents.matches?(/http\.HandleFunc\s*\(/) ||
-        file_contents.matches?(/http\.Handle\s*\(\s*["`\/]/)
+        content_matches?(file_contents, /http\.HandleFunc\s*\(/) ||
+        content_matches?(file_contents, /http\.Handle\s*\(\s*["`\/]/)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/go/huma.cr
+++ b/src/detector/detectors/go/huma.cr
@@ -6,14 +6,12 @@ module Detector::Go
     # go.mod require line is the strongest signal; individual
     # .go files import the package directly so we also catch
     # standalone scans where go.mod isn't in the base path.
+    IMPORT_PATTERN = Regex.union("github.com/danielgtaylor/huma")
+
     def detect(filename : String, file_contents : String) : Bool
-      if filename.includes?("go.mod") && file_contents.includes?("github.com/danielgtaylor/huma")
-        true
-      elsif filename.ends_with?(".go") && file_contents.includes?("github.com/danielgtaylor/huma")
-        true
-      else
-        false
-      end
+      return false unless filename.includes?("go.mod") || filename.ends_with?(".go")
+
+      content_matches?(file_contents, IMPORT_PATTERN)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/go/iris.cr
+++ b/src/detector/detectors/go/iris.cr
@@ -4,13 +4,17 @@ module Detector::Go
   class Iris < Detector
     IMPORT_MARKER = "github.com/kataras/iris"
 
+    # One JIT-compiled scan per file instead of a Rabin-Karp walk;
+    # every `.go` in the tree reaches this marker check.
+    IMPORT_PATTERN = Regex.union(IMPORT_MARKER)
+
     # Detect from `go.mod` (whole-repo scans) AND any `.go` file that
     # imports Iris, so a sub-directory whose `go.mod` lives higher up is
     # still recognized when scanned on its own. The analyzer re-gates
     # every file on the same marker, so this can't over-extract.
     def detect(filename : String, file_contents : String) : Bool
-      return true if (filename.includes? "go.mod") && file_contents.includes?(IMPORT_MARKER)
-      return true if filename.ends_with?(".go") && file_contents.includes?(IMPORT_MARKER)
+      return true if (filename.includes? "go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
+      return true if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
       false
     end
 

--- a/src/detector/detectors/groovy/cli.cr
+++ b/src/detector/detectors/groovy/cli.cr
@@ -10,7 +10,7 @@ module Detector::Groovy
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".groovy")
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/haskell/cli.cr
+++ b/src/detector/detectors/haskell/cli.cr
@@ -16,7 +16,7 @@ module Detector::Haskell
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".hs") || filename.ends_with?(".lhs")
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/java/cli.cr
+++ b/src/detector/detectors/java/cli.cr
@@ -27,7 +27,7 @@ module Detector::Java
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".java")
       return true if LIB_IMPORTS.any? { |marker| file_contents.includes?(marker) }
-      file_contents.matches?(USAGE)
+      content_matches?(file_contents, USAGE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/java/jsp.cr
+++ b/src/detector/detectors/java/jsp.cr
@@ -23,7 +23,7 @@ module Detector::Java
       end
 
       if filename.ends_with?(".xml")
-        return false unless file_contents.matches?(XML_MARKER)
+        return false unless content_matches?(file_contents, XML_MARKER)
         xml_without_comments = file_contents.gsub(/<!--.*?-->/m, "")
         return xml_without_comments.includes?("<jsp-file>") ||
           !!xml_without_comments.match(/<servlet-class>\s*[^<]*\bJspServlet\b[^<]*<\/servlet-class>/)

--- a/src/detector/detectors/java/wicket.cr
+++ b/src/detector/detectors/java/wicket.cr
@@ -2,19 +2,15 @@ require "../../../models/detector"
 
 module Detector::Java
   class Wicket < Detector
-    def detect(filename : String, file_contents : String) : Bool
-      if filename.ends_with?(".java")
-        return true if file_contents.includes?("org.apache.wicket")
-        return true if file_contents.includes?("extends WebApplication")
-        return true if file_contents.includes?("@MountPath")
-      end
+    SOURCE_MARKERS = Regex.union("org.apache.wicket", "extends WebApplication", "@MountPath")
+    BUILD_MARKERS  = Regex.union("org.apache.wicket", "wicket-core", "wicket-auth-roles", "wicketstuff")
 
-      build_file?(filename) && (
-        file_contents.includes?("org.apache.wicket") ||
-          file_contents.includes?("wicket-core") ||
-          file_contents.includes?("wicket-auth-roles") ||
-          file_contents.includes?("wicketstuff")
-      )
+    def detect(filename : String, file_contents : String) : Bool
+      # `build_file?` never matches `.java`, so the source markers decide
+      # the answer outright for those.
+      return content_matches?(file_contents, SOURCE_MARKERS) if filename.ends_with?(".java")
+
+      build_file?(filename) && content_matches?(file_contents, BUILD_MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/adonisjs.cr
+++ b/src/detector/detectors/javascript/adonisjs.cr
@@ -2,13 +2,14 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Adonisjs < Detector
+    PACKAGE_MARKERS = Regex.union("@adonisjs/core", "\"adonis-") # legacy adonis-* packages
+    SOURCE_MARKERS  = Regex.union("@adonisjs/core", "@ioc:Adonis")
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
       # `package.json` listing AdonisJS as a dependency.
-      if base == "package.json" &&
-         (file_contents.includes?("@adonisjs/core") ||
-         file_contents.includes?("\"adonis-")) # legacy adonis-* packages
+      if base == "package.json" && content_matches?(file_contents, PACKAGE_MARKERS)
         return true
       end
 
@@ -20,8 +21,7 @@ module Detector::Javascript
       # service-locator router or the v5 IoC alias.
       if (filename.ends_with?(".ts") || filename.ends_with?(".js") ||
          filename.ends_with?(".mjs")) &&
-         (file_contents.includes?("@adonisjs/core") ||
-         file_contents.includes?("@ioc:Adonis"))
+         content_matches?(file_contents, SOURCE_MARKERS)
         return true
       end
 

--- a/src/detector/detectors/javascript/apollo.cr
+++ b/src/detector/detectors/javascript/apollo.cr
@@ -20,7 +20,7 @@ module Detector::Javascript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      file_contents.matches?(SIGNAL)
+      content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/cli.cr
+++ b/src/detector/detectors/javascript/cli.cr
@@ -19,11 +19,11 @@ module Detector::Javascript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      file_contents.matches?(CLI_LIB_IMPORT) ||
-        file_contents.matches?(PARSE_ARGS) ||
-        file_contents.matches?(DENO_ARGS) ||
-        file_contents.matches?(BUN_ARGV) ||
-        file_contents.matches?(ARGV_SLICE)
+      content_matches?(file_contents, CLI_LIB_IMPORT) ||
+        content_matches?(file_contents, PARSE_ARGS) ||
+        content_matches?(file_contents, DENO_ARGS) ||
+        content_matches?(file_contents, BUN_ARGV) ||
+        content_matches?(file_contents, ARGV_SLICE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/elysia.cr
+++ b/src/detector/detectors/javascript/elysia.cr
@@ -2,11 +2,17 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Elysia < Detector
+    PACKAGE_MARKER = /"elysia"/
+    SOURCE_MARKERS = Regex.union(
+      "from 'elysia'", "from \"elysia\"",
+      "require('elysia')", "require(\"elysia\")",
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
       # `package.json` listing elysia as a dependency.
-      if base == "package.json" && file_contents.includes?("\"elysia\"")
+      if base == "package.json" && content_matches?(file_contents, PACKAGE_MARKER)
         return true
       end
 
@@ -18,10 +24,7 @@ module Detector::Javascript
                           filename.ends_with?(".js") ||
                           filename.ends_with?(".mjs")
 
-      file_contents.includes?("from 'elysia'") ||
-        file_contents.includes?("from \"elysia\"") ||
-        file_contents.includes?("require('elysia')") ||
-        file_contents.includes?("require(\"elysia\")")
+      content_matches?(file_contents, SOURCE_MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/express.cr
+++ b/src/detector/detectors/javascript/express.cr
@@ -14,7 +14,7 @@ module Detector::Javascript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") || filename.ends_with?(".cjs")
-      file_contents.matches?(SIGNAL)
+      content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/fastify.cr
+++ b/src/detector/detectors/javascript/fastify.cr
@@ -14,7 +14,7 @@ module Detector::Javascript
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") ||
                           filename.ends_with?(".jsx") || filename.ends_with?(".tsx") || filename.ends_with?(".cjs")
-      file_contents.matches?(SIGNAL)
+      content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/fresh.cr
+++ b/src/detector/detectors/javascript/fresh.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Fresh < Detector
+    FRESH_MARKER = /\$fresh\//
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -9,19 +11,19 @@ module Detector::Javascript
       # canonical signals are `deno.json` / `deno.jsonc` referencing
       # `$fresh/` and `fresh.config.{ts,js}` files.
       if base == "fresh.config.ts" || base == "fresh.config.js" ||
-         base == "main.ts" && file_contents.includes?("$fresh/")
+         base == "main.ts" && content_matches?(file_contents, FRESH_MARKER)
         return true
       end
 
       if (base == "deno.json" || base == "deno.jsonc") &&
-         file_contents.includes?("$fresh/")
+         content_matches?(file_contents, FRESH_MARKER)
         return true
       end
 
       # Source-side: Fresh handlers / pages import from `$fresh/`.
       if (filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
          filename.ends_with?(".js") || filename.ends_with?(".jsx")) &&
-         file_contents.includes?("$fresh/")
+         content_matches?(file_contents, FRESH_MARKER)
         return true
       end
 

--- a/src/detector/detectors/javascript/graphql_yoga.cr
+++ b/src/detector/detectors/javascript/graphql_yoga.cr
@@ -21,7 +21,7 @@ module Detector::Javascript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      file_contents.matches?(SIGNAL)
+      content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/hapi.cr
+++ b/src/detector/detectors/javascript/hapi.cr
@@ -2,16 +2,18 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Hapi < Detector
+    MARKERS = Regex.union(
+      "@hapi/hapi",
+      "require('hapi')", "require(\"hapi\")",
+      "from 'hapi'", "from \"hapi\"",
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".js") ||
                           filename.ends_with?(".mjs") ||
                           filename.ends_with?(".cjs") ||
                           filename.ends_with?(".ts")
-      file_contents.includes?("@hapi/hapi") ||
-        file_contents.includes?("require('hapi')") ||
-        file_contents.includes?("require(\"hapi\")") ||
-        file_contents.includes?("from 'hapi'") ||
-        file_contents.includes?("from \"hapi\"")
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/hono.cr
+++ b/src/detector/detectors/javascript/hono.cr
@@ -11,7 +11,7 @@ module Detector::Javascript
 
     def detect(filename : String, file_contents : String) : Bool
       [".js", ".mjs", ".ts", ".jsx", ".tsx", ".cjs"].any? { |ext| filename.ends_with?(ext) } &&
-        file_contents.matches?(SIGNAL)
+        content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/http.cr
+++ b/src/detector/detectors/javascript/http.cr
@@ -15,15 +15,15 @@ module Detector::Javascript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless source_file?(filename)
-      return false unless file_contents.matches?(CORE_HTTP_IMPORT)
-      return false unless file_contents.matches?(CREATE_SERVER_SIGNAL)
+      return false unless content_matches?(file_contents, CORE_HTTP_IMPORT)
+      return false unless content_matches?(file_contents, CREATE_SERVER_SIGNAL)
 
       # Adapter use such as `createServer(yoga)` imports node:http but has no
       # direct request branching. Keep js_http scoped to the bare stdlib router
       # shape requested in #2144.
-      file_contents.matches?(METHOD_REF) &&
-        file_contents.matches?(URL_REF) &&
-        file_contents.matches?(PATH_LITERAL)
+      content_matches?(file_contents, METHOD_REF) &&
+        content_matches?(file_contents, URL_REF) &&
+        content_matches?(file_contents, PATH_LITERAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/koa.cr
+++ b/src/detector/detectors/javascript/koa.cr
@@ -14,7 +14,7 @@ module Detector::Javascript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts")
-      file_contents.matches?(SIGNAL)
+      content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/nestjs.cr
+++ b/src/detector/detectors/javascript/nestjs.cr
@@ -15,7 +15,7 @@ module Detector::Javascript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".js") || filename.ends_with?(".jsx")
-      file_contents.matches?(SIGNAL)
+      content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/nextjs.cr
+++ b/src/detector/detectors/javascript/nextjs.cr
@@ -49,7 +49,7 @@ module Detector::Javascript
       if (filename.ends_with?(".js") || filename.ends_with?(".jsx") ||
          filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
          filename.ends_with?(".mjs")) &&
-         file_contents.matches?(NEXT_IMPORT)
+         content_matches?(file_contents, NEXT_IMPORT)
         return true
       end
 

--- a/src/detector/detectors/javascript/nitro.cr
+++ b/src/detector/detectors/javascript/nitro.cr
@@ -17,7 +17,7 @@ module Detector::Javascript
 
       # Check for Nitro imports and patterns in JS/TS files
       if (filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") || filename.ends_with?(".cjs")) &&
-         file_contents.matches?(SIGNAL)
+         content_matches?(file_contents, SIGNAL)
         return true
       end
 

--- a/src/detector/detectors/javascript/nuxtjs.cr
+++ b/src/detector/detectors/javascript/nuxtjs.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nuxtjs < Detector
+    EVENT_HANDLER = /defineEventHandler/
+
     # Single precompiled alternation — one PCRE2 scan instead of six.
     SIGNAL = Regex.union(
       /require\(['"]nuxt['"]\)/,
@@ -20,7 +22,7 @@ module Detector::Javascript
 
       # Check for Nuxt imports and patterns in JS/TS files
       if (filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts")) &&
-         file_contents.matches?(SIGNAL)
+         content_matches?(file_contents, SIGNAL)
         return true
       end
 
@@ -34,7 +36,7 @@ module Detector::Javascript
       if (filename.includes?("/server/api/") || filename.includes?("/server/routes/")) &&
          (filename.ends_with?(".js") || filename.ends_with?(".ts") ||
          filename.ends_with?(".mjs") || filename.ends_with?(".mts")) &&
-         file_contents.includes?("defineEventHandler")
+         content_matches?(file_contents, EVENT_HANDLER)
         return true
       end
 

--- a/src/detector/detectors/javascript/remix.cr
+++ b/src/detector/detectors/javascript/remix.cr
@@ -2,6 +2,9 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Remix < Detector
+    PACKAGE_MARKER = /@remix-run\//
+    VITE_MARKER    = /@remix-run\/dev/
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -14,14 +17,14 @@ module Detector::Javascript
         return true
       end
 
-      if base == "package.json" && file_contents.includes?("@remix-run/")
+      if base == "package.json" && content_matches?(file_contents, PACKAGE_MARKER)
         return true
       end
 
       # `vite.config.*` carrying `@remix-run/dev` confirms a
       # Remix 2 / Vite project even when package.json is far away.
       if (base.starts_with?("vite.config.") || base.starts_with?("remix.")) &&
-         file_contents.includes?("@remix-run/dev")
+         content_matches?(file_contents, VITE_MARKER)
         return true
       end
 
@@ -30,7 +33,7 @@ module Detector::Javascript
       if (filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
          filename.ends_with?(".js") || filename.ends_with?(".jsx") ||
          filename.ends_with?(".mjs")) &&
-         file_contents.includes?("@remix-run/")
+         content_matches?(file_contents, PACKAGE_MARKER)
         return true
       end
 

--- a/src/detector/detectors/javascript/restify.cr
+++ b/src/detector/detectors/javascript/restify.cr
@@ -2,13 +2,16 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Restify < Detector
+    # `.js` accepts either quoting of the require; `.ts` only the double-quoted
+    # form, which is how this detector has always behaved.
+    JS_MARKERS = Regex.union("require('restify')", "require(\"restify\")")
+    TS_MARKER  = /require\("restify"\)/
+
     def detect(filename : String, file_contents : String) : Bool
-      if (filename.ends_with? ".js") && (file_contents.includes? "require('restify')")
-        true
-      elsif (filename.ends_with? ".js") && (file_contents.includes? "require(\"restify\")")
-        true
-      elsif (filename.ends_with? ".ts") && (file_contents.includes? "require(\"restify\")")
-        true
+      if filename.ends_with?(".js")
+        content_matches?(file_contents, JS_MARKERS)
+      elsif filename.ends_with?(".ts")
+        content_matches?(file_contents, TS_MARKER)
       else
         false
       end

--- a/src/detector/detectors/javascript/socketio.cr
+++ b/src/detector/detectors/javascript/socketio.cr
@@ -12,14 +12,18 @@ module Detector::Javascript
       /require\(\s*['"]socket\.io['"]\s*\)/,
     )
 
+    PACKAGE_MARKER = /"socket\.io"\s*:/
+    NEW_SERVER     = /new Server\(/
+    ON_CALL        = /\.on\(/
+
     def detect(filename : String, file_contents : String) : Bool
       if File.basename(filename) == "package.json"
-        return file_contents.matches?(/"socket\.io"\s*:/)
+        return content_matches?(file_contents, PACKAGE_MARKER)
       end
 
       return false unless source_file?(filename)
-      return true if file_contents.matches?(SIGNAL)
-      file_contents.includes?("new Server(") && file_contents.includes?(".on(")
+      return true if content_matches?(file_contents, SIGNAL)
+      content_matches?(file_contents, NEW_SERVER) && content_matches?(file_contents, ON_CALL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/kotlin/cli.cr
+++ b/src/detector/detectors/kotlin/cli.cr
@@ -10,7 +10,7 @@ module Detector::Kotlin
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".kt")
-      LIB_IMPORTS.any? { |marker| file_contents.includes?(marker) } || file_contents.matches?(USAGE)
+      LIB_IMPORTS.any? { |marker| file_contents.includes?(marker) } || content_matches?(file_contents, USAGE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/lua/cli.cr
+++ b/src/detector/detectors/lua/cli.cr
@@ -9,7 +9,7 @@ module Detector::Lua
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".lua")
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/perl/cli.cr
+++ b/src/detector/detectors/perl/cli.cr
@@ -9,7 +9,7 @@ module Detector::Perl
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/php/cli.cr
+++ b/src/detector/detectors/php/cli.cr
@@ -27,12 +27,12 @@ module Detector::Php
     # PCRE2's fast scan, which the wide alternation defeats.
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".php")
-      file_contents.matches?(USE_SF_CONSOLE) || file_contents.matches?(SF_COMMAND) ||
-        file_contents.matches?(AS_COMMAND) || file_contents.matches?(LARAVEL_ZERO) ||
-        file_contents.matches?(CLIMATE) || file_contents.matches?(MINICLI) ||
-        file_contents.matches?(GETOPT) || file_contents.matches?(ARGV_INDEX) ||
-        file_contents.matches?(ARTISAN_SIGNATURE) || file_contents.matches?(ROBO_MARKER) ||
-        file_contents.matches?(WP_ADD_COMMAND) || file_contents.matches?(WP_COMMAND_CLASS)
+      content_matches?(file_contents, USE_SF_CONSOLE) || content_matches?(file_contents, SF_COMMAND) ||
+        content_matches?(file_contents, AS_COMMAND) || content_matches?(file_contents, LARAVEL_ZERO) ||
+        content_matches?(file_contents, CLIMATE) || content_matches?(file_contents, MINICLI) ||
+        content_matches?(file_contents, GETOPT) || content_matches?(file_contents, ARGV_INDEX) ||
+        content_matches?(file_contents, ARTISAN_SIGNATURE) || content_matches?(file_contents, ROBO_MARKER) ||
+        content_matches?(file_contents, WP_ADD_COMMAND) || content_matches?(file_contents, WP_COMMAND_CLASS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/php/wordpress.cr
+++ b/src/detector/detectors/php/wordpress.cr
@@ -74,7 +74,7 @@ module Detector::Php
         # `admin_post_` substring also occurs in Symfony/Laravel route
         # names like `admin_post_edit`, so anchor to the call syntax
         # rather than matching the prefix anywhere in the file.
-        return true if file_contents.matches?(/add_action\s*\(\s*['"](?:wp_ajax_|admin_post_)/)
+        return true if content_matches?(file_contents, /add_action\s*\(\s*['"](?:wp_ajax_|admin_post_)/)
       end
 
       false

--- a/src/detector/detectors/python/cli.cr
+++ b/src/detector/detectors/python/cli.cr
@@ -14,7 +14,7 @@ module Detector::Python
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
-      file_contents.matches?(CLI_IMPORT_RE)
+      content_matches?(file_contents, CLI_IMPORT_RE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/r/plumber.cr
+++ b/src/detector/detectors/r/plumber.cr
@@ -6,15 +6,15 @@ module Detector::R
       return false unless filename.ends_with?(".R") || filename.ends_with?(".r")
 
       # plumber library import
-      return true if file_contents.matches?(/library\s*\(\s*plumber\s*\)/)
-      return true if file_contents.matches?(/require\s*\(\s*plumber\s*\)/)
+      return true if content_matches?(file_contents, /library\s*\(\s*plumber\s*\)/)
+      return true if content_matches?(file_contents, /require\s*\(\s*plumber\s*\)/)
       return true if file_contents.includes?("plumber::")
 
       # Plumber annotations
-      return true if file_contents.matches?(/^\s*#\*\s*@(?:get|post|put|delete|patch|head|options|apiTitle|apiDescription|param|serializer)\b/mi)
+      return true if content_matches?(file_contents, /^\s*#\*\s*@(?:get|post|put|delete|patch|head|options|apiTitle|apiDescription|param|serializer)\b/mi)
 
       # Programmatic plumber routing functions
-      return true if file_contents.matches?(/\bpr_(?:get|post|put|delete|patch|head|options|handle|mount)\b/i)
+      return true if content_matches?(file_contents, /\bpr_(?:get|post|put|delete|patch|head|options|handle|mount)\b/i)
 
       false
     end

--- a/src/detector/detectors/ruby/actioncable.cr
+++ b/src/detector/detectors/ruby/actioncable.cr
@@ -10,7 +10,7 @@ module Detector::Ruby
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".rb") || filename.ends_with?(".ru")
-      file_contents.matches?(ACTIONCABLE_MARKER)
+      content_matches?(file_contents, ACTIONCABLE_MARKER)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/ruby/cli.cr
+++ b/src/detector/detectors/ruby/cli.cr
@@ -40,7 +40,7 @@ module Detector::Ruby
       end
 
       return false unless filename.ends_with?(".rb")
-      file_contents.matches?(CLI_MARKER)
+      content_matches?(file_contents, CLI_MARKER)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/ruby/grape.cr
+++ b/src/detector/detectors/ruby/grape.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Grape < Detector
+    # `"< Grape::API"` was a separate probe, but it contains `"Grape::API"`
+    # so it can never match anything the shorter literal misses.
+    SOURCE_MARKERS = Regex.union("Grape::API", /require\s+['"]grape['"]/)
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.includes?("Gemfile")
         return true if gemfile_dependency?(file_contents, "grape")
@@ -12,9 +16,7 @@ module Detector::Ruby
       end
 
       if filename.ends_with?(".rb")
-        return true if file_contents.includes?("Grape::API")
-        return true if file_contents.includes?("< Grape::API")
-        return true if file_contents.matches?(/require\s+['"]grape['"]/)
+        return true if content_matches?(file_contents, SOURCE_MARKERS)
       end
 
       false

--- a/src/detector/detectors/ruby/roda.cr
+++ b/src/detector/detectors/ruby/roda.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Roda < Detector
+    SOURCE_MARKERS = Regex.union(/<\s*Roda\b/, "Roda.route", /require\s+['"]roda['"]/)
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.includes?("Gemfile")
         return true if gemfile_dependency?(file_contents, "roda")
@@ -12,9 +14,7 @@ module Detector::Ruby
       end
 
       if filename.ends_with?(".rb")
-        return true if file_contents =~ /<\s*Roda\b/
-        return true if file_contents.includes?("Roda.route")
-        return true if file_contents =~ /require\s+['"]roda['"]/
+        return true if content_matches?(file_contents, SOURCE_MARKERS)
       end
 
       false

--- a/src/detector/detectors/ruby/webrick.cr
+++ b/src/detector/detectors/ruby/webrick.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Webrick < Detector
+    MARKERS = Regex.union("WEBrick", "webrick", "mount_proc", "AbstractServlet")
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".rb") || filename.ends_with?(".ru")
 
@@ -10,12 +12,7 @@ module Detector::Ruby
       # tech counts from incidental "webrick" mentions in Gemfiles of other
       # Ruby frameworks (e.g. rackup using webrick in a sinatra/rails Gemfile).
       # Mirrors python_http_server and crystal_http design.
-      return true if file_contents.includes?("WEBrick")
-      return true if file_contents.includes?("webrick")
-      return true if file_contents.includes?("mount_proc")
-      return true if file_contents.includes?("AbstractServlet")
-
-      false
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/rust/cli.cr
+++ b/src/detector/detectors/rust/cli.cr
@@ -30,13 +30,13 @@ module Detector::Rust
     def detect(filename : String, file_contents : String) : Bool
       if File.basename(filename) == "Cargo.toml"
         return file_contents.includes?("dependencies") &&
-          file_contents.matches?(CARGO_CLI_DEP)
+          content_matches?(file_contents, CARGO_CLI_DEP)
       end
 
       return false unless filename.ends_with?(".rs")
-      return true if file_contents.matches?(SOURCE_MARKER)
+      return true if content_matches?(file_contents, SOURCE_MARKER)
       # `Command::new(` alone is clap-builder only when clap is in use.
-      return true if file_contents.includes?("clap") && file_contents.matches?(BUILDER_CMD)
+      return true if file_contents.includes?("clap") && content_matches?(file_contents, BUILDER_CMD)
 
       false
     end

--- a/src/detector/detectors/scala/cli.cr
+++ b/src/detector/detectors/scala/cli.cr
@@ -8,7 +8,7 @@ module Detector::Scala
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".scala") || filename.ends_with?(".sc")
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/specification/apisix.cr
+++ b/src/detector/detectors/specification/apisix.cr
@@ -101,9 +101,9 @@ module Detector::Specification
     PAYLOAD_MARKER = /\bupstream_id\b|\bplugins\b/
 
     private def apisix_candidate?(content : String) : Bool
-      content.matches?(ROUTES_MARKER) &&
-        content.matches?(URI_MARKER) &&
-        content.matches?(PAYLOAD_MARKER)
+      content_matches?(content, ROUTES_MARKER) &&
+        content_matches?(content, URI_MARKER) &&
+        content_matches?(content, PAYLOAD_MARKER)
     end
   end
 end

--- a/src/detector/detectors/specification/appwrite.cr
+++ b/src/detector/detectors/specification/appwrite.cr
@@ -21,7 +21,7 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless file_contents.matches?(PROJECT_ID_MARKER)
+      return false unless content_matches?(file_contents, PROJECT_ID_MARKER)
 
       data = json_any?(file_contents)
       return false unless data

--- a/src/detector/detectors/specification/asyncapi.cr
+++ b/src/detector/detectors/specification/asyncapi.cr
@@ -5,9 +5,12 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class AsyncApi < Detector
+    # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate.
+    ASYNCAPI_MARKER = /asyncapi/
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
-      return false unless file_contents.includes?("asyncapi")
+      return false unless content_matches?(file_contents, ASYNCAPI_MARKER)
 
       if filename.ends_with?(".json")
         begin

--- a/src/detector/detectors/specification/aws_cdk.cr
+++ b/src/detector/detectors/specification/aws_cdk.cr
@@ -3,14 +3,17 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class AwsCdk < Detector
-    TS_JS_HINTS  = ["aws-cdk-lib", "@aws-cdk/aws-apigateway", "@aws-cdk/aws-apigatewayv2"]
-    PYTHON_HINTS = ["from aws_cdk", "import aws_cdk", "aws_cdk.aws_apigateway"]
+    # Every `.ts`/`.js`/`.py` in the tree reaches these gates, so each was
+    # walking the whole corpus three (hints) plus six (constructs) times.
+    TS_JS_HINT_MARKER  = Regex.union("aws-cdk-lib", "@aws-cdk/aws-apigateway", "@aws-cdk/aws-apigatewayv2")
+    PYTHON_HINT_MARKER = Regex.union("from aws_cdk", "import aws_cdk", "aws_cdk.aws_apigateway")
+    API_CONSTRUCT      = Regex.union("RestApi", "HttpApi", "addResource", "add_resource", "addRoutes", "add_routes")
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
 
-      hints = filename.ends_with?(".py") ? PYTHON_HINTS : TS_JS_HINTS
-      return false unless hints.any? { |h| file_contents.includes?(h) }
+      hints = filename.ends_with?(".py") ? PYTHON_HINT_MARKER : TS_JS_HINT_MARKER
+      return false unless content_matches?(file_contents, hints)
 
       # Require at least one CDK API surface construct so we don't fire on
       # CDK utility files that contain imports but no endpoint declarations.
@@ -36,9 +39,7 @@ module Detector::Specification
     end
 
     private def cdk_api_construct?(content : String) : Bool
-      content.includes?("RestApi") || content.includes?("HttpApi") ||
-        content.includes?("addResource") || content.includes?("add_resource") ||
-        content.includes?("addRoutes") || content.includes?("add_routes")
+      content_matches?(content, API_CONSTRUCT)
     end
   end
 end

--- a/src/detector/detectors/specification/aws_cloudformation.cr
+++ b/src/detector/detectors/specification/aws_cloudformation.cr
@@ -7,6 +7,10 @@ module Detector::Specification
   class AwsCloudformation < Detector
     SAM_TRANSFORM = "AWS::Serverless-2016-10-31"
 
+    # Every `.yml`/`.yaml`/`.json` in the tree reaches this gate, so the
+    # two-`includes?` chain it replaces was walking the whole corpus twice.
+    CANDIDATE_MARKER = Regex.union("AWSTemplateFormatVersion", SAM_TRANSFORM)
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
 
@@ -84,7 +88,7 @@ module Detector::Specification
     end
 
     private def cloudformation_candidate?(content : String) : Bool
-      content.includes?("AWSTemplateFormatVersion") || content.includes?(SAM_TRANSFORM)
+      content_matches?(content, CANDIDATE_MARKER)
     end
   end
 end

--- a/src/detector/detectors/specification/bruno.cr
+++ b/src/detector/detectors/specification/bruno.cr
@@ -7,7 +7,7 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".bru")
-      return false unless file_contents.matches?(BLOCK_HEADER)
+      return false unless content_matches?(file_contents, BLOCK_HEADER)
 
       locator = CodeLocator.instance
       locator.push("bruno-bru", filename)

--- a/src/detector/detectors/specification/caddy.cr
+++ b/src/detector/detectors/specification/caddy.cr
@@ -6,6 +6,11 @@ module Detector::Specification
   class Caddy < Detector
     CADDYFILE_NAMES = {"Caddyfile", "caddyfile"}
 
+    # Every `.json` in the tree reaches these guards. Both must match, so
+    # they stay separate probes rather than a union.
+    APPS_MARKER     = /"apps"/
+    HTTP_APP_MARKER = /"http"/
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
 
@@ -43,7 +48,7 @@ module Detector::Specification
       # JSON-format Caddy configs always nest the HTTP app under
       # `apps.http`. Use that shape as the discriminator so we don't
       # claim every JSON file that happens to be in the tree.
-      content.includes?("\"apps\"") && content.includes?("\"http\"")
+      content_matches?(content, APPS_MARKER) && content_matches?(content, HTTP_APP_MARKER)
     end
   end
 end

--- a/src/detector/detectors/specification/caido.cr
+++ b/src/detector/detectors/specification/caido.cr
@@ -4,6 +4,15 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Caido < Detector
+    # Every `.json` in the tree reaches these guards. The first four must
+    # all match, so they stay separate probes; only the last pair is an
+    # alternation.
+    HOST_MARKER        = /"host"/
+    METHOD_MARKER      = /"method"/
+    PATH_MARKER        = /"path"/
+    RAW_MARKER         = /"raw"/
+    TLS_OR_PORT_MARKER = Regex.union("\"is_tls\"", "\"port\"")
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".json")
       return false unless caido_json_candidate?(file_contents)
@@ -51,11 +60,11 @@ module Detector::Specification
     end
 
     private def caido_json_candidate?(content : String) : Bool
-      content.includes?("\"host\"") &&
-        content.includes?("\"method\"") &&
-        content.includes?("\"path\"") &&
-        content.includes?("\"raw\"") &&
-        (content.includes?("\"is_tls\"") || content.includes?("\"port\""))
+      content_matches?(content, HOST_MARKER) &&
+        content_matches?(content, METHOD_MARKER) &&
+        content_matches?(content, PATH_MARKER) &&
+        content_matches?(content, RAW_MARKER) &&
+        content_matches?(content, TLS_OR_PORT_MARKER)
     end
   end
 end

--- a/src/detector/detectors/specification/directus.cr
+++ b/src/detector/detectors/specification/directus.cr
@@ -21,7 +21,7 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless file_contents.matches?(SNAPSHOT_MARKER)
+      return false unless content_matches?(file_contents, SNAPSHOT_MARKER)
 
       data = yaml_any?(file_contents)
       return false unless data

--- a/src/detector/detectors/specification/envoy.cr
+++ b/src/detector/detectors/specification/envoy.cr
@@ -5,8 +5,13 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Envoy < Detector
+    # Every `.yaml`/`.yml`/`.json` in the tree reaches these gates.
+    VIRTUAL_HOSTS_MARKER = /virtual_hosts/
+    DOMAINS_MARKER       = /domains/
+
     def detect(filename : String, file_contents : String) : Bool
-      return false unless file_contents.includes?("virtual_hosts") && file_contents.includes?("domains")
+      return false unless content_matches?(file_contents, VIRTUAL_HOSTS_MARKER) &&
+                          content_matches?(file_contents, DOMAINS_MARKER)
 
       if filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         if (data = yaml_any?(file_contents)) && find_virtual_hosts_yaml(data)

--- a/src/detector/detectors/specification/grpc.cr
+++ b/src/detector/detectors/specification/grpc.cr
@@ -10,7 +10,7 @@ module Detector::Specification
     SERVICE_BLOCK = /\bservice\s+\w+\s*\{/
 
     def detect(filename : String, file_contents : String) : Bool
-      if filename.ends_with?(".proto") && file_contents.matches?(SERVICE_BLOCK)
+      if filename.ends_with?(".proto") && content_matches?(file_contents, SERVICE_BLOCK)
         CodeLocator.instance.push("grpc-proto", filename)
         return true
       end

--- a/src/detector/detectors/specification/har.cr
+++ b/src/detector/detectors/specification/har.cr
@@ -6,6 +6,11 @@ require "har"
 
 module Detector::Specification
   class Har < Detector
+    # Every `.json` in the tree reaches these guards. Both must match, so
+    # they stay separate probes rather than a union.
+    LOG_MARKER     = /"log"/
+    ENTRIES_MARKER = /"entries"/
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".har") || (filename.ends_with? ".json")
         if filename.ends_with?(".har") || har_json_candidate?(file_contents)
@@ -39,7 +44,7 @@ module Detector::Specification
     end
 
     private def har_json_candidate?(content : String) : Bool
-      content.includes?("\"log\"") && content.includes?("\"entries\"")
+      content_matches?(content, LOG_MARKER) && content_matches?(content, ENTRIES_MARKER)
     end
   end
 end

--- a/src/detector/detectors/specification/hasura.cr
+++ b/src/detector/detectors/specification/hasura.cr
@@ -65,7 +65,7 @@ module Detector::Specification
     end
 
     private def detect_rest_endpoints(filename : String, file_contents : String) : Bool
-      return false unless file_contents.matches?(REST_MARKER)
+      return false unless content_matches?(file_contents, REST_MARKER)
 
       data = yaml_any?(file_contents)
       return false unless data
@@ -84,8 +84,8 @@ module Detector::Specification
     end
 
     private def detect_tables(filename : String, file_contents : String) : Bool
-      return false unless file_contents.matches?(TABLE_MARKER)
-      return false unless file_contents.matches?(HASURA_VOCABULARY)
+      return false unless content_matches?(file_contents, TABLE_MARKER)
+      return false unless content_matches?(file_contents, HASURA_VOCABULARY)
 
       data = yaml_any?(file_contents)
       return false unless data

--- a/src/detector/detectors/specification/http_file.cr
+++ b/src/detector/detectors/specification/http_file.cr
@@ -12,7 +12,7 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless file_contents.matches?(REQUEST_LINE)
+      return false unless content_matches?(file_contents, REQUEST_LINE)
 
       locator = CodeLocator.instance
       locator.push("http-file", filename)

--- a/src/detector/detectors/specification/insomnia.cr
+++ b/src/detector/detectors/specification/insomnia.cr
@@ -5,10 +5,16 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Insomnia < Detector
+    # Every `.json`/`.yaml`/`.yml` in the tree reaches these gates.
+    EXPORT_FORMAT_MARKER = /"__export_format"/
+    TYPE_FIELD_MARKER    = /"_type"/
+    INSOMNIA_HOST_MARKER = /\.insomnia\.rest\//
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
       if filename.ends_with?(".json")
-        return false unless file_contents.includes?("\"__export_format\"") && file_contents.includes?("\"_type\"")
+        return false unless content_matches?(file_contents, EXPORT_FORMAT_MARKER) &&
+                            content_matches?(file_contents, TYPE_FIELD_MARKER)
 
         begin
           data = JSON.parse(file_contents)
@@ -23,7 +29,7 @@ module Detector::Specification
           logger.debug "Insomnia JSON detection failed for #{filename}: #{e}"
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-        return false unless file_contents.includes?(".insomnia.rest/")
+        return false unless content_matches?(file_contents, INSOMNIA_HOST_MARKER)
 
         begin
           data = YAML.parse(file_contents)

--- a/src/detector/detectors/specification/istio_virtualservice.cr
+++ b/src/detector/detectors/specification/istio_virtualservice.cr
@@ -6,6 +6,11 @@ module Detector::Specification
   class IstioVirtualservice < Detector
     ISTIO_API_PREFIX = "networking.istio.io/"
 
+    # Every `.yaml`/`.yml` in the tree reaches these guards. Both must
+    # match, so they stay separate probes rather than a union.
+    ISTIO_API_PREFIX_MARKER     = /networking\.istio\.io\//
+    VIRTUAL_SERVICE_KIND_MARKER = /kind: VirtualService/
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       # Substring guard first: the full `YAML.parse_all` below only runs on
@@ -40,7 +45,7 @@ module Detector::Specification
     end
 
     private def virtual_service_present?(content : String) : Bool
-      content.includes?(ISTIO_API_PREFIX) && content.includes?("kind: VirtualService")
+      content_matches?(content, ISTIO_API_PREFIX_MARKER) && content_matches?(content, VIRTUAL_SERVICE_KIND_MARKER)
     end
   end
 end

--- a/src/detector/detectors/specification/k8s_gateway_api.cr
+++ b/src/detector/detectors/specification/k8s_gateway_api.cr
@@ -6,6 +6,11 @@ module Detector::Specification
   class K8sGatewayApi < Detector
     GATEWAY_API_PREFIX = "gateway.networking.k8s.io/"
 
+    # Every `.yaml`/`.yml` in the tree reaches these guards. Both must
+    # match, so they stay separate probes rather than a union.
+    GATEWAY_API_PREFIX_MARKER = /gateway\.networking\.k8s\.io\//
+    HTTP_ROUTE_KIND_MARKER    = /kind: HTTPRoute/
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       # Substring guard first: the full `YAML.parse_all` below only runs on
@@ -40,7 +45,7 @@ module Detector::Specification
     end
 
     private def route_present?(content : String) : Bool
-      content.includes?(GATEWAY_API_PREFIX) && content.includes?("kind: HTTPRoute")
+      content_matches?(content, GATEWAY_API_PREFIX_MARKER) && content_matches?(content, HTTP_ROUTE_KIND_MARKER)
     end
   end
 end

--- a/src/detector/detectors/specification/k8s_ingress.cr
+++ b/src/detector/detectors/specification/k8s_ingress.cr
@@ -6,6 +6,9 @@ module Detector::Specification
   class K8sIngress < Detector
     INGRESS_API_VERSION_PREFIXES = ["networking.k8s.io/", "extensions/v1beta1"]
 
+    # Every `.yml`/`.yaml` in the tree reaches this gate.
+    INGRESS_API_VERSION_MARKER = Regex.union(INGRESS_API_VERSION_PREFIXES)
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       return false unless ingress_markers_present?(file_contents)
@@ -43,7 +46,7 @@ module Detector::Specification
     end
 
     private def ingress_markers_present?(content : String) : Bool
-      return false unless INGRESS_API_VERSION_PREFIXES.any? { |prefix| content.includes?(prefix) }
+      return false unless content_matches?(content, INGRESS_API_VERSION_MARKER)
 
       has_api_version = false
       has_kind = false

--- a/src/detector/detectors/specification/kong.cr
+++ b/src/detector/detectors/specification/kong.cr
@@ -14,7 +14,7 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless file_contents.matches?(KONG_MARKER)
+      return false unless content_matches?(file_contents, KONG_MARKER)
       return false unless data = yaml_any?(file_contents)
 
       begin

--- a/src/detector/detectors/specification/nginx.cr
+++ b/src/detector/detectors/specification/nginx.cr
@@ -40,7 +40,7 @@ module Detector::Specification
     end
 
     private def nginx_shape?(content : String) : Bool
-      return false unless content.matches?(SHAPE_GUARD)
+      return false unless content_matches?(content, SHAPE_GUARD)
 
       # Include fragments often contain only `location` blocks, so scan
       # executable directives instead of requiring a top-level server/http block.

--- a/src/detector/detectors/specification/oas2.cr
+++ b/src/detector/detectors/specification/oas2.cr
@@ -5,9 +5,12 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Oas2 < Detector
+    # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate.
+    SWAGGER_MARKER = /swagger/
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
-      return false unless file_contents.includes?("swagger")
+      return false unless content_matches?(file_contents, SWAGGER_MARKER)
 
       if filename.ends_with?(".json")
         begin

--- a/src/detector/detectors/specification/oas3.cr
+++ b/src/detector/detectors/specification/oas3.cr
@@ -5,9 +5,12 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Oas3 < Detector
+    # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate.
+    OPENAPI_MARKER = /openapi/
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
-      return false unless file_contents.includes?("openapi")
+      return false unless content_matches?(file_contents, OPENAPI_MARKER)
 
       if filename.ends_with?(".json")
         begin

--- a/src/detector/detectors/specification/payload_cms.cr
+++ b/src/detector/detectors/specification/payload_cms.cr
@@ -36,23 +36,23 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless file_contents.matches?(PAYLOAD_MARKER)
+      return false unless content_matches?(file_contents, PAYLOAD_MARKER)
 
       detected = false
 
-      if file_contents.matches?(COLLECTION_MARKER) &&
-         file_contents.matches?(SLUG_MARKER) && file_contents.matches?(FIELDS_MARKER)
+      if content_matches?(file_contents, COLLECTION_MARKER) &&
+         content_matches?(file_contents, SLUG_MARKER) && content_matches?(file_contents, FIELDS_MARKER)
         CodeLocator.instance.push("payload-collection", filename)
         detected = true
       end
 
-      if file_contents.matches?(GLOBAL_MARKER) &&
-         file_contents.matches?(SLUG_MARKER) && file_contents.matches?(FIELDS_MARKER)
+      if content_matches?(file_contents, GLOBAL_MARKER) &&
+         content_matches?(file_contents, SLUG_MARKER) && content_matches?(file_contents, FIELDS_MARKER)
         CodeLocator.instance.push("payload-global", filename)
         detected = true
       end
 
-      if file_contents.matches?(BUILD_CONFIG)
+      if content_matches?(file_contents, BUILD_CONFIG)
         CodeLocator.instance.push("payload-config", filename)
         detected = true
       end

--- a/src/detector/detectors/specification/postman.cr
+++ b/src/detector/detectors/specification/postman.cr
@@ -4,6 +4,11 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Postman < Detector
+    # Every `.json` in the tree reaches this guard.
+    CANDIDATE_MARKER = Regex.union(
+      "schema.getpostman.com", "schema.postman.com", "\"_postman_id\"",
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
       if filename.ends_with?(".json") && postman_json_candidate?(file_contents)
@@ -45,9 +50,7 @@ module Detector::Specification
     end
 
     private def postman_json_candidate?(content : String) : Bool
-      content.includes?("schema.getpostman.com") ||
-        content.includes?("schema.postman.com") ||
-        content.includes?("\"_postman_id\"")
+      content_matches?(content, CANDIDATE_MARKER)
     end
   end
 end

--- a/src/detector/detectors/specification/raml.cr
+++ b/src/detector/detectors/specification/raml.cr
@@ -4,10 +4,13 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class RAML < Detector
+    # Every `.raml`/`.yaml`/`.yml` in the tree reaches this guard.
+    RAML_MARKER = /\#%RAML/
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
       if filename.ends_with?(".raml") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-        if file_contents.includes?("#%RAML")
+        if content_matches?(file_contents, RAML_MARKER)
           # `valid_yaml?` already proves the content parses; the previous
           # second `YAML.parse` (result discarded) doubled the cost for
           # nothing.

--- a/src/detector/detectors/specification/strapi.cr
+++ b/src/detector/detectors/specification/strapi.cr
@@ -59,7 +59,7 @@ module Detector::Specification
     end
 
     private def detect_schema(filename : String, file_contents : String) : Bool
-      return false unless file_contents.matches?(SCHEMA_MARKER)
+      return false unless content_matches?(file_contents, SCHEMA_MARKER)
 
       data = json_any?(file_contents)
       return false unless data
@@ -79,8 +79,8 @@ module Detector::Specification
     end
 
     private def detect_routes(filename : String, file_contents : String) : Bool
-      core_router = file_contents.matches?(CORE_ROUTER_MARKER)
-      custom = file_contents.matches?(ROUTE_MARKER) && file_contents.matches?(ROUTE_HANDLER)
+      core_router = content_matches?(file_contents, CORE_ROUTER_MARKER)
+      custom = content_matches?(file_contents, ROUTE_MARKER) && content_matches?(file_contents, ROUTE_HANDLER)
       return false unless core_router || custom
 
       CodeLocator.instance.push("strapi-routes", filename)

--- a/src/detector/detectors/specification/supabase.cr
+++ b/src/detector/detectors/specification/supabase.cr
@@ -39,10 +39,10 @@ module Detector::Specification
         return true
       end
 
-      return false unless file_contents.matches?(DDL_MARKER)
+      return false unless content_matches?(file_contents, DDL_MARKER)
 
       unless supabase_directory?(path)
-        return false unless file_contents.matches?(SUPABASE_FINGERPRINT)
+        return false unless content_matches?(file_contents, SUPABASE_FINGERPRINT)
       end
 
       CodeLocator.instance.push("supabase-migration", filename)

--- a/src/detector/detectors/specification/traefik.cr
+++ b/src/detector/detectors/specification/traefik.cr
@@ -18,7 +18,7 @@ module Detector::Specification
 
       if filename.ends_with?(".toml")
         check = file_contents.includes?("[http.routers.") && file_contents.includes?("rule")
-      elsif (filename.ends_with?(".yaml") || filename.ends_with?(".yml")) && file_contents.matches?(YAML_MARKER)
+      elsif (filename.ends_with?(".yaml") || filename.ends_with?(".yml")) && content_matches?(file_contents, YAML_MARKER)
         if data = yaml_any?(file_contents)
           begin
             check = traefik_dynamic_config?(data) ||

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -5,13 +5,16 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class ZapSitesTree < Detector
+    # Every `.yaml`/`.yml` in the tree reaches this guard.
+    SITES_MARKER = /Sites/
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
       # The accepted shape requires a "node" value containing "Sites", so
       # the literal must appear in the raw document — guard before the full
       # parse (this detector is non-idempotent and previously parsed every
       # YAML file of the scan twice).
-      if applicable?(filename) && file_contents.includes?("Sites") && (data = yaml_any?(file_contents))
+      if applicable?(filename) && content_matches?(file_contents, SITES_MARKER) && (data = yaml_any?(file_contents))
         begin
           if data[0]["node"].as_s.includes? "Sites"
             check = true
@@ -31,7 +34,7 @@ module Detector::Specification
       # export filenames are chosen by the user at export time — an export
       # saved as `zap_export.yaml` or `target.yaml` would be dropped with
       # no diagnostic. The expensive work (`yaml_any?`) is already gated
-      # in `detect` by the `includes?("Sites")` content guard, so the name
+      # in `detect` by the `SITES_MARKER` content guard, so the name
       # gate only saved a substring scan and bought that at the price of a
       # silent false negative.
       filename.ends_with?(".yaml") || filename.ends_with?(".yml")

--- a/src/detector/detectors/swift/cli.cr
+++ b/src/detector/detectors/swift/cli.cr
@@ -14,9 +14,9 @@ module Detector::Swift
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".swift")
-      file_contents.includes?("import ArgumentParser") || file_contents.matches?(PARSABLE) ||
-        file_contents.matches?(WRAPPERS) || file_contents.matches?(SWIFTCLI) ||
-        file_contents.matches?(COMMANDER) || file_contents.matches?(CMDLINE)
+      file_contents.includes?("import ArgumentParser") || content_matches?(file_contents, PARSABLE) ||
+        content_matches?(file_contents, WRAPPERS) || content_matches?(file_contents, SWIFTCLI) ||
+        content_matches?(file_contents, COMMANDER) || content_matches?(file_contents, CMDLINE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/typescript/nestjs.cr
+++ b/src/detector/detectors/typescript/nestjs.cr
@@ -15,7 +15,7 @@ module Detector::Typescript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx")
-      file_contents.matches?(SIGNAL)
+      content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/typescript/tanstack_router.cr
+++ b/src/detector/detectors/typescript/tanstack_router.cr
@@ -16,7 +16,7 @@ module Detector::Typescript
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx")
-      file_contents.matches?(SIGNAL)
+      content_matches?(file_contents, SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/typescript/trpc.cr
+++ b/src/detector/detectors/typescript/trpc.cr
@@ -25,7 +25,7 @@ module Detector::Typescript
         return file_contents.includes?("\"@trpc/server\"") || file_contents.includes?("\"@trpc/next\"")
       end
 
-      if file_contents.matches?(SIGNAL)
+      if content_matches?(file_contents, SIGNAL)
         return true
       end
 

--- a/src/detector/detectors/zig/cli.cr
+++ b/src/detector/detectors/zig/cli.cr
@@ -9,7 +9,7 @@ module Detector::Zig
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".zig")
-      file_contents.matches?(MARKERS)
+      content_matches?(file_contents, MARKERS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/zig/httpz.cr
+++ b/src/detector/detectors/zig/httpz.cr
@@ -6,7 +6,7 @@ module Detector::Zig
       return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"httpz\")")
 
       if File.basename(filename) == "build.zig.zon"
-        return true if file_contents.matches?(/\.httpz\s*=\s*\.\{/)
+        return true if content_matches?(file_contents, /\.httpz\s*=\s*\.\{/)
         return true if file_contents.includes?("karlseguin/http.zig")
       end
 

--- a/src/detector/detectors/zig/jetzig.cr
+++ b/src/detector/detectors/zig/jetzig.cr
@@ -9,7 +9,7 @@ module Detector::Zig
       # The Zig package manifest declares a `.jetzig` dependency. `.zon`
       # uses dot-prefixed field names, so match the dependency key.
       if File.basename(filename) == "build.zig.zon"
-        return true if file_contents.matches?(/\.jetzig\s*=\s*\.\{/)
+        return true if content_matches?(file_contents, /\.jetzig\s*=\s*\.\{/)
         return true if file_contents.includes?("jetzig-framework/jetzig")
       end
 

--- a/src/detector/detectors/zig/tokamak.cr
+++ b/src/detector/detectors/zig/tokamak.cr
@@ -6,7 +6,7 @@ module Detector::Zig
       return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"tokamak\")")
 
       if File.basename(filename) == "build.zig.zon"
-        return true if file_contents.matches?(/\.tokamak\s*=\s*\.\{/)
+        return true if content_matches?(file_contents, /\.tokamak\s*=\s*\.\{/)
         return true if file_contents.includes?("cztomsik/tokamak")
       end
 

--- a/src/detector/detectors/zig/zap.cr
+++ b/src/detector/detectors/zig/zap.cr
@@ -6,7 +6,7 @@ module Detector::Zig
       return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"zap\")")
 
       if File.basename(filename) == "build.zig.zon"
-        return true if file_contents.matches?(/\.zap\s*=\s*\.\{/)
+        return true if content_matches?(file_contents, /\.zap\s*=\s*\.\{/)
         return true if file_contents.includes?("zigzap/zap")
       end
 

--- a/src/miniparsers/go_callee_extractor.cr
+++ b/src/miniparsers/go_callee_extractor.cr
@@ -1,4 +1,5 @@
 require "../ext/tree_sitter/tree_sitter"
+require "./extraction_result_cache"
 
 # Tree-sitter-backed Go 1-hop callee extractor. Parallels
 # `Noir::PythonCalleeExtractor` but works at the AST level — Go can't
@@ -120,25 +121,106 @@ module Noir::GoCalleeExtractor
     package_method_bodies[dir]? || Hash(String, Array(FunctionBody)).new
   end
 
+  # Process-wide memo for the two top-level-declaration tables.
+  #
+  # A Go scan asks for these tables from several directions: the callee
+  # pass (`GoEngine#collect_package_*`), the request-param pass
+  # (`GoRequestParamExtractor#package_*_for_dirs`), and once per Go
+  # framework analyzer that survived detection — each over the same
+  # `CodeLocator` content. Measured on a gitea checkout: 1734 Go parses
+  # for 680 distinct sources, 2.55 parses per file, some files 8 times.
+  #
+  # Both tables come out of one `each_named_child` walk, so a miss on
+  # either fills both (via `store_capped`, which `fetch` cannot do
+  # without parsing twice). Keys include `file_path` because it is baked
+  # into every `FunctionBody`, so two identical files at different paths
+  # must not share an entry.
+  @@function_bodies_memo = Hash(UInt64, Hash(String, FunctionBody)).new
+  @@function_bodies_order = [] of UInt64
+  @@method_bodies_memo = Hash(UInt64, Hash(String, Array(FunctionBody))).new
+  @@method_bodies_order = [] of UInt64
+  @@bodies_memo_mutex = Mutex.new
+  @@bodies_clearer_registered = false
+
+  private def ensure_bodies_clearer_registered : Nil
+    return if @@bodies_clearer_registered
+    @@bodies_memo_mutex.synchronize do
+      return if @@bodies_clearer_registered
+      Noir::ExtractionResultCache.register_clearer do
+        @@bodies_memo_mutex.synchronize do
+          @@function_bodies_memo.clear
+          @@function_bodies_order.clear
+          @@method_bodies_memo.clear
+          @@method_bodies_order.clear
+        end
+      end
+      @@bodies_clearer_registered = true
+    end
+  end
+
   # Returns top-level function declarations in `source`, keyed by name.
   # `file_path` is recorded on each `FunctionBody` so callees emitted by
   # later re-parsing can report a useful path.
+  #
+  # Callers treat the result as read-only (they copy entries into their
+  # own per-directory maps), which is what lets it be shared.
   def collect_function_bodies(source : String, file_path : String) : Hash(String, FunctionBody)
-    bodies = Hash(String, FunctionBody).new
+    collect_top_level_bodies(source, file_path)[0]
+  end
+
+  # Collects top-level `method_declaration` bodies keyed by method name.
+  # The value is a list because a name can be defined on several receiver
+  # types in one package; callers that need an unambiguous resolution
+  # should require `size == 1`. Used to attach callees to controller-style
+  # routes whose handler is referenced by method name only.
+  def collect_method_bodies(source : String, file_path : String) : Hash(String, Array(FunctionBody))
+    collect_top_level_bodies(source, file_path)[1]
+  end
+
+  # One parse, both tables, memoized.
+  private def collect_top_level_bodies(source : String,
+                                       file_path : String) : Tuple(Hash(String, FunctionBody), Hash(String, Array(FunctionBody)))
+    ensure_bodies_clearer_registered
+    fn_key = Noir::ExtractionResultCache.key(source, "go_fn_bodies", file_path)
+    method_key = Noir::ExtractionResultCache.key(source, "go_method_bodies", file_path)
+
+    @@bodies_memo_mutex.synchronize do
+      cached_fns = @@function_bodies_memo[fn_key]?
+      cached_methods = @@method_bodies_memo[method_key]?
+      return {cached_fns, cached_methods} if cached_fns && cached_methods
+    end
+
+    functions = Hash(String, FunctionBody).new
+    methods = Hash(String, Array(FunctionBody)).new
+
     Noir::TreeSitter.parse_go(source) do |root|
       Noir::TreeSitter.each_named_child(root) do |child|
-        next unless Noir::TreeSitter.node_type(child) == "function_declaration"
+        node_type = Noir::TreeSitter.node_type(child)
+        next unless node_type == "function_declaration" || node_type == "method_declaration"
         name_node = Noir::TreeSitter.field(child, "name")
         next unless name_node
         name = Noir::TreeSitter.node_text(name_node, source)
-        bodies[name] ||= FunctionBody.new(
+        body = FunctionBody.new(
           Noir::TreeSitter.node_text(child, source),
           file_path,
           Noir::TreeSitter.node_start_row(child),
         )
+        if node_type == "function_declaration"
+          functions[name] ||= body
+        else
+          (methods[name] ||= [] of FunctionBody) << body
+        end
       end
     end
-    bodies
+
+    @@bodies_memo_mutex.synchronize do
+      functions = Noir::ExtractionResultCache.store_capped(
+        @@function_bodies_memo, @@function_bodies_order, fn_key, functions)
+      methods = Noir::ExtractionResultCache.store_capped(
+        @@method_bodies_memo, @@method_bodies_order, method_key, methods)
+    end
+
+    {functions, methods}
   end
 
   # Like `callees_for_routes`, but returns an empty map immediately when
@@ -774,29 +856,6 @@ module Noir::GoCalleeExtractor
   def callees_in_body(fn : FunctionBody,
                       external_functions : Hash(String, FunctionBody) = Hash(String, FunctionBody).new) : Array(Tuple(String, String, Int32))
     calls_in_external(fn, external_functions)
-  end
-
-  # Collects top-level `method_declaration` bodies keyed by method name.
-  # The value is a list because a name can be defined on several receiver
-  # types in one package; callers that need an unambiguous resolution
-  # should require `size == 1`. Used to attach callees to controller-style
-  # routes whose handler is referenced by method name only.
-  def collect_method_bodies(source : String, file_path : String) : Hash(String, Array(FunctionBody))
-    bodies = Hash(String, Array(FunctionBody)).new
-    Noir::TreeSitter.parse_go(source) do |root|
-      Noir::TreeSitter.each_named_child(root) do |child|
-        next unless Noir::TreeSitter.node_type(child) == "method_declaration"
-        name_node = Noir::TreeSitter.field(child, "name")
-        next unless name_node
-        name = Noir::TreeSitter.node_text(name_node, source)
-        (bodies[name] ||= [] of FunctionBody) << FunctionBody.new(
-          Noir::TreeSitter.node_text(child, source),
-          file_path,
-          Noir::TreeSitter.node_start_row(child),
-        )
-      end
-    end
-    bodies
   end
 
   # Render a callee's textual name. Identifiers come back verbatim;

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -1,3 +1,5 @@
+require "../utils/text_file"
+
 module Noir
   # Shared file-level import-graph traversal for cross-file route /
   # DTO resolution.
@@ -317,11 +319,11 @@ module Noir::ImportGraph::Python
   # `app_base_path` anchors the dotted path for absolute imports;
   # `file_path`'s directory anchors relative imports. Pass
   # `content` when the caller already has the file in hand to
-  # skip the second `File.read`.
+  # skip the second disk read.
   def self.find_imported_modules(app_base_path : String,
                                  file_path : String,
                                  content : String? = nil) : Hash(String, Tuple(String, Int32))
-    content = File.read(file_path, encoding: "utf-8", invalid: :skip) if content.nil?
+    content = Noir::TextFile.read(file_path) if content.nil?
 
     file_base_path = file_path
     file_base_path = File.dirname(file_path) if file_path.ends_with? ".py"

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -3,6 +3,7 @@ require "../models/endpoint"
 require "../models/code_locator"
 require "./import_graph"
 require "./java_route_extractor_ts"
+require "../utils/text_file"
 
 module Noir
   # Tree-sitter-backed parameter extractor for Java/Spring.
@@ -1294,10 +1295,10 @@ module Noir
     private def file_body(file : String) : String
       # Detector pre-warms a content cache for every scanned file
       # (size-bounded). Sibling/parent DTO files often live in that
-      # cache already — `nil` falls back to a fresh `File.read` for
+      # cache already — `nil` falls back to a fresh disk read for
       # files outside the budget.
       CodeLocator.instance.content_for(file) ||
-        File.read(file, encoding: "utf-8", invalid: :skip)
+        Noir::TextFile.read(file)
     end
 
     private def absorb!(result : Index,

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -6,6 +6,7 @@ require "../models/code_locator"
 require "../utils/url_path"
 require "../utils/js_literal_scanner"
 require "../analyzer/analyzers/javascript/express_constants"
+require "../utils/text_file"
 
 module Noir
   # JSRouteExtractor provides a unified interface for extracting routes from JavaScript files
@@ -22,7 +23,7 @@ module Noir
       return [] of Endpoint unless File.exists?(file_path)
 
       begin
-        content = content || File.read(file_path, encoding: "utf-8", invalid: :skip)
+        content = content || Noir::TextFile.read(file_path)
 
         # Cheap pre-filter: every shape the JSParser knows about ends
         # in a verb call (`x.get(`, `.post(`, ...), a Fastify/Restify
@@ -336,24 +337,20 @@ module Noir
     # contains no shape the JS parser knows how to emit (any verb
     # invocation pattern like `.get(`/`.post(`/... or Fastify/Restify
     # `.route(`, plus Express-style mounts `.use(` which feed into the
-    # cross-file router prefix table). Substring-checking is millions
-    # of times cheaper than tokenizing the file.
-    PARSER_ROUTE_CALL_HINTS = [
-      ".get(", ".post(", ".put(", ".delete(", ".patch(",
-      ".options(", ".head(", ".all(",
-      ".route(", ".register(", ".use(",
-      ".get (", ".post (", ".put (", ".delete (", ".patch (",
-      ".options (", ".head (", ".all (",
-      ".route (", ".register (", ".use (",
-    ]
-
+    # cross-file router prefix table). Matching is millions of times
+    # cheaper than tokenizing the file.
     BRACKET_ROUTE_CALL_PATTERN  = /\[\s*['"](?:get|post|put|delete|del|patch|options|head|all)['"]\s*\]\s*\(/i
     FLEXIBLE_ROUTE_CALL_PATTERN = /\.(?:\s|\n|\r)*(?:get|post|put|delete|del|patch|options|head|all|route|register|use)(?:\s|\n|\r)*\(/i
 
+    # A 22-literal `includes?` pre-pass used to run ahead of these two
+    # patterns (`".get("`, `".get ("`, ... for each verb). Every one of
+    # those literals is `.` + verb + optional space + `(`, which
+    # `FLEXIBLE_ROUTE_CALL_PATTERN` already matches with zero or one
+    # whitespace character — so the pre-pass could never change the
+    # result, and each miss cost 22 Rabin-Karp walks of the whole file.
     def self.route_call_candidate?(content : String) : Bool
-      PARSER_ROUTE_CALL_HINTS.any? { |hint| content.includes?(hint) } ||
-        content.matches?(BRACKET_ROUTE_CALL_PATTERN) ||
-        content.matches?(FLEXIBLE_ROUTE_CALL_PATTERN)
+      content.matches?(BRACKET_ROUTE_CALL_PATTERN, options: Noir::TextFile::MATCH_OPTIONS) ||
+        content.matches?(FLEXIBLE_ROUTE_CALL_PATTERN, options: Noir::TextFile::MATCH_OPTIONS)
     end
 
     # Byte length above which a single source line is considered "long".
@@ -681,15 +678,33 @@ module Noir
     # from 'react'`, and skipping them on that basis dropped every such
     # route. The test-stub *library* markers (msw/supertest/...) and path/
     # filename markers still apply in both modes.
+    # Precompiled unions of the marker lists above. `Regex.union` escapes
+    # every String argument, so each is exactly the `any? includes?` it
+    # replaces — but the content lists are long (72 test-stub libraries,
+    # 32 client frameworks, 26 server libraries), and every JS/TS file in
+    # the tree used to be walked once per literal.
+    TEST_STUB_FILENAME_MARKER    = Regex.union(TEST_STUB_FILENAME_MARKERS)
+    STRICT_TEST_PATH_MARKER      = Regex.union(STRICT_TEST_PATH_MARKERS)
+    TEST_STUB_PATH_MARKER        = Regex.union(TEST_STUB_PATH_MARKERS)
+    TEST_STUB_LIBRARY_MARKER     = Regex.union(TEST_STUB_LIBRARY_MARKERS)
+    CLIENT_SIDE_FRAMEWORK_MARKER = Regex.union(CLIENT_SIDE_FRAMEWORK_MARKERS)
+    HTTP_SERVER_LIBRARY_MARKER   = Regex.union(HTTP_SERVER_LIBRARY_MARKERS)
+
     def self.test_stub_only?(file_path : String, content : String,
                              include_client_frameworks : Bool = true) : Bool
-      return true if TEST_STUB_FILENAME_MARKERS.any? { |m| file_path.includes?(m) }
-      return true if STRICT_TEST_PATH_MARKERS.any? { |m| file_path.includes?(m) }
-      has_library = TEST_STUB_LIBRARY_MARKERS.any? { |m| content.includes?(m) } ||
-                    (include_client_frameworks && CLIENT_SIDE_FRAMEWORK_MARKERS.any? { |m| content.includes?(m) })
-      has_path_marker = TEST_STUB_PATH_MARKERS.any? { |m| file_path.includes?(m) }
+      return true if file_path.matches?(TEST_STUB_FILENAME_MARKER)
+      return true if file_path.matches?(STRICT_TEST_PATH_MARKER)
+      has_library = content_matches?(content, TEST_STUB_LIBRARY_MARKER) ||
+                    (include_client_frameworks && content_matches?(content, CLIENT_SIDE_FRAMEWORK_MARKER))
+      has_path_marker = file_path.matches?(TEST_STUB_PATH_MARKER)
       return false unless has_library || has_path_marker
-      HTTP_SERVER_LIBRARY_MARKERS.none? { |m| content.includes?(m) }
+      !content_matches?(content, HTTP_SERVER_LIBRARY_MARKER)
+    end
+
+    # Match against file content, which always came from a
+    # `Noir::TextFile.read` (directly or via the detector's cache).
+    private def self.content_matches?(content : String, markers : Regex) : Bool
+      markers.matches?(content, options: Noir::TextFile::MATCH_OPTIONS)
     end
 
     # Import markers for the five frameworks whose analyzers call
@@ -777,20 +792,30 @@ module Noir
     # disambiguate on, so narrowing further is left as follow-up scope
     # (a confirmed package.json dependency or cross-file mount signal
     # would be needed to resolve those).
+    # Per-framework precompiled unions of the two tables above: the
+    # framework's own import markers, and the markers of every *other*
+    # shared-extractor framework. Together with the sibling union this
+    # turns the up-to-44-literal `includes?` walk below into three
+    # matches. Five analyzers call this on every JS/TS file, so the old
+    # shape scanned some trees over 200 times per file.
+    OWN_EXTRACTOR_MARKER = SHARED_EXTRACTOR_FRAMEWORK_MARKERS
+      .transform_values { |markers| Regex.union(markers) }
+
+    OTHER_EXTRACTOR_MARKER = SHARED_EXTRACTOR_FRAMEWORK_MARKERS.keys.to_h do |framework|
+      others = SHARED_EXTRACTOR_FRAMEWORK_MARKERS
+        .reject { |other, _| other == framework }
+        .values
+        .flatten
+      {framework, Regex.union(others)}
+    end
+
+    SIBLING_FRAMEWORK_MARKER = Regex.union(OTHER_FRAMEWORK_MARKERS.values.flatten)
+
     def self.other_shared_extractor_framework?(content : String, framework : Symbol) : Bool
-      own_markers = SHARED_EXTRACTOR_FRAMEWORK_MARKERS[framework]
-      return false if own_markers.any? { |m| content.includes?(m) }
+      return false if content_matches?(content, OWN_EXTRACTOR_MARKER[framework])
+      return true if content_matches?(content, OTHER_EXTRACTOR_MARKER[framework])
 
-      SHARED_EXTRACTOR_FRAMEWORK_MARKERS.each do |other, markers|
-        next if other == framework
-        return true if markers.any? { |m| content.includes?(m) }
-      end
-
-      OTHER_FRAMEWORK_MARKERS.each do |_, markers|
-        return true if markers.any? { |m| content.includes?(m) }
-      end
-
-      false
+      content_matches?(content, SIBLING_FRAMEWORK_MARKER)
     end
 
     def self.attach_callees(endpoint : Endpoint,
@@ -1350,6 +1375,11 @@ module Noir
     # analyzer walks all `.js`/`.ts` files) doesn't pick up another
     # framework's static declaration and re-emit it under the wrong tech.
     # `nil` runs every pattern (back-compat for un-scoped callers).
+    STATIC_MOUNT_MARKER = Regex.union(
+      ".use(", ".use (", ".register(", ".register (",
+      "ServeStaticModule.forRoot", "serveStatic",
+    )
+
     def self.extract_static_paths(content : String, framework : Symbol? = nil) : Array(Hash(String, String))
       static_paths = [] of Hash(String, String)
 
@@ -1358,10 +1388,7 @@ module Noir
       # `ServeStaticModule.forRoot(...)`, or Restify `serveStatic(...)`.
       # Files without any of those markers cannot host one — skip the
       # regex scans on the vast majority of JS/TS files.
-      return static_paths unless content.includes?(".use(") || content.includes?(".use (") ||
-                                 content.includes?(".register(") || content.includes?(".register (") ||
-                                 content.includes?("ServeStaticModule.forRoot") ||
-                                 content.includes?("serveStatic")
+      return static_paths unless content_matches?(content, STATIC_MOUNT_MARKER)
 
       # Bundled/minified assets occasionally carry a `.use(`/`.register(`
       # substring from packed library code; never run the static-mount

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -2,6 +2,7 @@ require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "../models/code_locator"
 require "./import_graph"
+require "../utils/text_file"
 
 module Noir
   # Tree-sitter-backed parameter extractor for Kotlin Spring.
@@ -1388,7 +1389,7 @@ module Noir
 
     private def file_body(file : String) : String
       CodeLocator.instance.content_for(file) ||
-        File.read(file, encoding: "utf-8", invalid: :skip)
+        Noir::TextFile.read(file)
     end
 
     private def absorb!(result : Index,

--- a/src/miniparsers/python.cr
+++ b/src/miniparsers/python.cr
@@ -1,6 +1,7 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../utils/parser_limit"
 require "./import_graph"
+require "../utils/text_file"
 
 # Python source-file parser used by the Flask analyzer to resolve
 # routing-relevant globals (Blueprint / Namespace / Api instances)
@@ -401,7 +402,7 @@ class PythonParser
   private def get_or_create_parser(pyfile : String) : PythonParser?
     return @parsers[pyfile] if @parsers.has_key?(pyfile)
 
-    content = File.read(pyfile, encoding: "utf-8", invalid: :skip)
+    content = Noir::TextFile.read(pyfile)
     sub = PythonParser.new(pyfile, content, @parsers, @visited.dup, depth: @depth + 1)
     @parsers[pyfile] = sub
     sub

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -5,6 +5,7 @@ require "../miniparsers/kotlin_callee_extractor"
 require "../miniparsers/java_callee_extractor"
 require "../miniparsers/swift_callee_extractor"
 require "../miniparsers/objc_callee_extractor"
+require "../utils/text_file"
 
 # Post-analysis pass that links mobile deep-link endpoints (produced by the
 # config-file analyzers from AndroidManifest.xml) to the source code that
@@ -186,7 +187,7 @@ module NoirMobileLinker
     cached = CodeLocator.instance.content_for(path)
     return cached if cached
     return unless File.exists?(path)
-    File.read(path, encoding: "utf-8", invalid: :skip)
+    Noir::TextFile.read(path)
   end
 
   private def self.android_handler_info(simple : String, path : String, lang : Symbol,

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -4,6 +4,7 @@ require "./file_helper"
 require "wait_group"
 require "../utils/media_filter"
 require "../utils/path_scope"
+require "../utils/text_file"
 require "../utils/utils"
 
 class Analyzer
@@ -64,7 +65,7 @@ class Analyzer
 
   # Prefer the detector-populated cache over a fresh disk read. On
   # cache miss (budget exhausted, cache cleared between runs, path
-  # not registered via register_file) falls back to `File.read`.
+  # not registered via register_file) falls back to a disk read.
   #
   # Analyzers migrating from direct `File.read(path, ...)` calls
   # should use this helper so the second read of files the detector
@@ -72,7 +73,7 @@ class Analyzer
   def read_file_content(path : String) : String
     cached = CodeLocator.instance.content_for(path)
     return cached if cached
-    File.read(path, encoding: "utf-8", invalid: :skip)
+    Noir::TextFile.read(path)
   end
 
   # Callees feed `--include-callee` (direct output) and `--ai-context`

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -76,6 +76,21 @@ class Analyzer
     Noir::TextFile.read(path)
   end
 
+  # Whether `content` matches `markers`, skipping PCRE2's per-call UTF-8
+  # revalidation. Analyzer content always comes from `read_file_content`
+  # (or the detector cache it reads through), so the subject is
+  # known-valid UTF-8 — see `Noir::TextFile::MATCH_OPTIONS`.
+  #
+  # Use this in place of a chain of `String#includes?` over whole file
+  # content: `String#includes?` runs Rabin-Karp per marker, while one
+  # precompiled `Regex.union` of the same literals is the same predicate
+  # in a single JIT-compiled pass. A single `includes?` on a short string
+  # (one source line, a path segment) is not worth converting — the win
+  # scales with the size of the subject.
+  def content_matches?(content : String, markers : Regex) : Bool
+    markers.matches?(content, options: Noir::TextFile::MATCH_OPTIONS)
+  end
+
   # Callees feed `--include-callee` (direct output) and `--ai-context`
   # (aggregated review context). Analyzers should consult this before
   # running their callee extractor so the work is skipped on default

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -1,4 +1,5 @@
 require "./logger"
+require "../utils/text_file"
 require "../utils/utils"
 require "yaml"
 
@@ -82,6 +83,32 @@ class Detector
     true
   end
 
+  # Detector content always arrives from `Noir::TextFile.read`, so the
+  # subject is known-valid UTF-8 and PCRE2's per-call revalidation is
+  # skippable. See `Noir::TextFile::MATCH_OPTIONS`.
+  CONTENT_MATCH_OPTIONS = Noir::TextFile::MATCH_OPTIONS
+
+  # Whether any alternative of a precompiled `Regex.union` appears in
+  # `file_contents`. With a union of plain literals this is exactly
+  # OR-ing `String#includes?` over the same literals — `Regex.union`
+  # escapes every String argument — but it costs one pass instead of N.
+  #
+  # `String#includes?` runs Rabin-Karp: a rolling hash over every byte
+  # position, restarted for each marker. PCRE2 JIT-compiles the union
+  # into a program that skips ahead on a start-byte bitmap. Measured on
+  # a 467 KB locale file against four non-matching markers: 2.16 ms of
+  # chained `includes?` versus 26 µs here (82x). Even a single marker
+  # over 300 small Ruby files is 13x, so the win is not a big-file
+  # artifact.
+  #
+  # Use this for the marker sweep at the top of `detect`. A union is not
+  # a substitute for a real pattern: keep purpose-built regexes as they
+  # are, and keep a single `includes?` that merely gates an expensive
+  # parse (there the substring check is the cheap half, not the cost).
+  def content_matches?(file_contents : String, markers : Regex) : Bool
+    markers.matches?(file_contents, options: CONTENT_MATCH_OPTIONS)
+  end
+
   # Per-gem regex memos for `gemfile_dependency?`/`gemspec_dependency?`.
   # The interpolated literals used to recompile on every call — the Ruby
   # CLI detector alone probes 8 gems against every Gemfile/gemspec, and
@@ -100,7 +127,7 @@ class Detector
     re = @@dependency_res_mutex.synchronize do
       @@gemfile_dependency_res[gem_name] ||= /\bgem\s*\(?\s*['"]#{Regex.escape(gem_name)}['"]/
     end
-    file_contents.matches?(re)
+    content_matches?(file_contents, re)
   end
 
   # Tolerant matcher for a gemspec runtime dependency on `<name>`, in
@@ -112,7 +139,7 @@ class Detector
     re = @@dependency_res_mutex.synchronize do
       @@gemspec_dependency_res[gem_name] ||= /\badd(?:_runtime)?_dependency\s*\(?\s*['"]#{Regex.escape(gem_name)}['"]/
     end
-    file_contents.matches?(re)
+    content_matches?(file_contents, re)
   end
 
   getter name, logger

--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -2,6 +2,7 @@ require "./tagger"
 require "./endpoint"
 require "./code_locator"
 require "./file_helper"
+require "../utils/text_file"
 
 struct SourceContext
   property path : String
@@ -87,7 +88,14 @@ class FrameworkTagger < Tagger
       return cached
     end
 
-    content = File.read(path)
+    # Prefer the detector's content cache, which by this point holds
+    # almost every file of the scan — the bare `File.read` this replaces
+    # paid a second open for every file any tagger looked at. Analyzers
+    # already read through the same cache (`Analyzer#read_file_content`),
+    # so this also stops taggers being the one component that sees raw
+    # bytes: on a file with invalid UTF-8 they now get the same
+    # `invalid: :skip` text everything else works from.
+    content = CodeLocator.instance.content_for(path) || Noir::TextFile.read(path)
     @file_cache[path] = content
     content
   rescue ex

--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -18,12 +18,14 @@ class FrameworkTagger < Tagger
   @base_path : String
   @base_paths : Array(String)
   @file_cache : Hash(String, String)
+  @lines_cache : Hash(String, Array(String))
 
   def initialize(options : Hash(String, YAML::Any))
     super
     @base_paths = resolve_base_paths(options)
     @base_path = @base_paths.first
     @file_cache = Hash(String, String).new
+    @lines_cache = Hash(String, Array(String)).new
   end
 
   # `base` is built as a flat Array(YAML::Any) and `-b PATH` / positional
@@ -91,6 +93,28 @@ class FrameworkTagger < Tagger
   rescue ex
     @logger.debug "FrameworkTagger: Failed to read file #{path}: #{ex.message}"
     nil
+  end
+
+  # `read_file` split on newlines, cached alongside it.
+  #
+  # Taggers walk backwards from an endpoint's line looking for decorators,
+  # middleware and guard blocks, so they need the file as lines. They ask
+  # once per endpoint (really once per code path per endpoint), which meant
+  # re-splitting the same controller for every action it defines: on a
+  # Rails app that was the single most expensive thing the `-T` pass did.
+  #
+  # The returned array is shared, so treat it as read-only.
+  def read_file_lines(path : String) : Array(String)?
+    if cached = @lines_cache[path]?
+      return cached
+    end
+
+    content = read_file(path)
+    return if content.nil?
+
+    lines = content.split("\n")
+    @lines_cache[path] = lines
+    lines
   end
 
   # Static-asset file extensions. A route ending in one of these serves a

--- a/src/tagger/framework_taggers/crystal/crystal_auth.cr
+++ b/src/tagger/framework_taggers/crystal/crystal_auth.cr
@@ -52,10 +52,8 @@ class CrystalAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/csharp/aspnet_auth.cr
+++ b/src/tagger/framework_taggers/csharp/aspnet_auth.cr
@@ -44,10 +44,8 @@ class AspnetAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/elixir/elixir_auth.cr
+++ b/src/tagger/framework_taggers/elixir/elixir_auth.cr
@@ -106,10 +106,8 @@ class ElixirAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -123,10 +123,8 @@ class GoAuthTagger < FrameworkTagger
   private def check_endpoint(endpoint : Endpoint)
     # Check route definition for inline middleware
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
 

--- a/src/tagger/framework_taggers/go/go_security.cr
+++ b/src/tagger/framework_taggers/go/go_security.cr
@@ -166,10 +166,8 @@ class GoSecurityTagger < FrameworkTagger
   # Phase 2: tag each endpoint from inline route middleware + group scopes.
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       next if line_num < 1 || line_num > lines.size

--- a/src/tagger/framework_taggers/java/java_misc_auth.cr
+++ b/src/tagger/framework_taggers/java/java_misc_auth.cr
@@ -50,10 +50,8 @@ class JavaMiscAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/javascript/express_auth.cr
+++ b/src/tagger/framework_taggers/javascript/express_auth.cr
@@ -53,10 +53,8 @@ class ExpressAuthTagger < FrameworkTagger
     extensions.each do |ext|
       files = collect_files_by_extension(ext)
       files.each do |file|
-        content = read_file(file)
-        next if content.nil?
-
-        lines = content.split("\n")
+        lines = read_file_lines(file)
+        next if lines.nil?
         lines.each do |line|
           stripped = line.strip
 
@@ -83,10 +81,8 @@ class ExpressAuthTagger < FrameworkTagger
   private def check_endpoint(endpoint : Endpoint)
     # Check route definition line for auth patterns
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
 

--- a/src/tagger/framework_taggers/javascript/hono_auth.cr
+++ b/src/tagger/framework_taggers/javascript/hono_auth.cr
@@ -51,10 +51,8 @@ class HonoAuthTagger < FrameworkTagger
     extensions.each do |ext|
       files = collect_files_by_extension(ext)
       files.each do |file|
-        content = read_file(file)
-        next if content.nil?
-
-        lines = content.split("\n")
+        lines = read_file_lines(file)
+        next if lines.nil?
         lines.each do |line|
           stripped = line.strip
 
@@ -97,10 +95,8 @@ class HonoAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/javascript/js_misc_auth.cr
+++ b/src/tagger/framework_taggers/javascript/js_misc_auth.cr
@@ -60,10 +60,8 @@ class JsMiscAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       line_idx = line_num - 1

--- a/src/tagger/framework_taggers/javascript/nestjs_auth.cr
+++ b/src/tagger/framework_taggers/javascript/nestjs_auth.cr
@@ -56,10 +56,8 @@ class NestjsAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/kotlin/ktor_auth.cr
+++ b/src/tagger/framework_taggers/kotlin/ktor_auth.cr
@@ -93,10 +93,8 @@ class KtorAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/perl/perl_auth.cr
+++ b/src/tagger/framework_taggers/perl/perl_auth.cr
@@ -59,10 +59,8 @@ class PerlAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       next if line_num < 1 || line_num > lines.size

--- a/src/tagger/framework_taggers/php/php_auth.cr
+++ b/src/tagger/framework_taggers/php/php_auth.cr
@@ -95,10 +95,8 @@ class PhpAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/python/fastapi_auth.cr
+++ b/src/tagger/framework_taggers/python/fastapi_auth.cr
@@ -48,10 +48,8 @@ class FastAPIAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
 

--- a/src/tagger/framework_taggers/python/flask_auth.cr
+++ b/src/tagger/framework_taggers/python/flask_auth.cr
@@ -41,10 +41,8 @@ class FlaskAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/python/python_misc_auth.cr
+++ b/src/tagger/framework_taggers/python/python_misc_auth.cr
@@ -40,10 +40,8 @@ class PythonMiscAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/ruby/rails_security.cr
+++ b/src/tagger/framework_taggers/ruby/rails_security.cr
@@ -69,10 +69,8 @@ class RailsSecurityTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we read

--- a/src/tagger/framework_taggers/ruby/ruby_auth.cr
+++ b/src/tagger/framework_taggers/ruby/ruby_auth.cr
@@ -83,10 +83,8 @@ class RubyAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/rust/rust_auth.cr
+++ b/src/tagger/framework_taggers/rust/rust_auth.cr
@@ -154,10 +154,8 @@ class RustAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
 

--- a/src/tagger/framework_taggers/scala/scala_auth.cr
+++ b/src/tagger/framework_taggers/scala/scala_auth.cr
@@ -51,10 +51,8 @@ class ScalaAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/tagger/framework_taggers/swift/swift_auth.cr
+++ b/src/tagger/framework_taggers/swift/swift_auth.cr
@@ -52,10 +52,8 @@ class SwiftAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
-      content = read_file(path_info.path)
-      next if content.nil?
-
-      lines = content.split("\n")
+      lines = read_file_lines(path_info.path)
+      next if lines.nil?
       line_num = path_info.line
       next if line_num.nil?
       # Skip stale/out-of-range line refs: a line beyond the content we

--- a/src/utils/text_file.cr
+++ b/src/utils/text_file.cr
@@ -1,0 +1,42 @@
+require "file"
+
+# UTF-8 text reads for the scan pipeline.
+module Noir::TextFile
+  # Reads `path` as UTF-8 text, dropping invalid byte sequences.
+  #
+  # `File.read(path, encoding: "utf-8", invalid: :skip)` routes the whole
+  # file through `IO::Decoder` and libiconv even though the requested
+  # conversion is UTF-8 to UTF-8. That costs ~4.5x a plain read and
+  # allocates ~12x as much (a decode buffer per chunk on top of the
+  # result). Source trees are overwhelmingly valid UTF-8 already, so read
+  # the bytes straight and only pay for the transcode when they are not.
+  #
+  # The result is byte-identical either way. On valid input the decode is
+  # the identity — it strips no BOM and translates no newlines — and
+  # invalid input still goes through the same `invalid: :skip` decode that
+  # dropped the bad sequences before. The fallback decodes the bytes
+  # already in hand rather than re-reading the file, so a file that
+  # changes mid-scan cannot yield a half-and-half result.
+  def self.read(path : String) : String
+    content = File.read(path)
+    return content if content.valid_encoding?
+    decode(content)
+  end
+
+  # `invalid: :skip` decode of bytes already in memory.
+  def self.decode(content : String) : String
+    io = IO::Memory.new(content.to_slice)
+    io.set_encoding("utf-8", invalid: :skip)
+    io.gets_to_end
+  end
+
+  # Match options for a subject that came from `read` (or from the
+  # detector's content cache, which `read` fills).
+  #
+  # PCRE2 revalidates its whole subject as UTF-8 on every match call, and
+  # on a large file that validation dominates the match — measured at
+  # ~3.4x the cost of the match itself. `read` guarantees valid UTF-8, so
+  # the re-check is pure overhead. Only pass this for strings that came
+  # through `read`, or for slices of one taken at character boundaries.
+  MATCH_OPTIONS = Regex::MatchOptions::NO_UTF_CHECK
+end


### PR DESCRIPTION
## Summary

Detection-neutral performance work, profile-driven with `sample` on three real
codebases. Every change keeps output byte-identical; the speed comes from
removing redundant work, not from narrowing what noir looks at.

| corpus | default | `--include callee` | `-T --ai-context` |
| --- | --- | --- | --- |
| gitea (Go, 58 MB) | 2.08s → **1.46s** (1.42x) | 5.01s → **2.21s** (2.27x) | 6.11s → **2.97s** (2.06x) |
| strapi (JS/TS, 122 MB) | 2.92s → **0.66s** (4.42x) | 3.37s → **1.11s** (3.04x) | 3.40s → **1.12s** (3.04x) |
| discourse (Rails+JS, 314 MB) | 3.58s → **1.16s** (3.09x) | 3.60s → **1.19s** (3.03x) | 4.32s → **1.38s** (3.13x) |

The detect phase alone drops from 4161 ms to 1445 ms of serial work over the
three corpora.

## What was actually slow

**Reading files went through libiconv.** Every read used
`File.read(path, encoding: "utf-8", invalid: :skip)`. Crystal only bypasses
`IO::Decoder` when `invalid` is nil, so passing `:skip` routed the whole file
through libiconv for a UTF-8-to-UTF-8 conversion: 4.5x the time and 12x the
allocation of a plain read, on every file of every scan. `Noir::TextFile.read`
now reads the bytes straight and only transcodes when `valid_encoding?` says it
must.

**`String#includes?` is Rabin-Karp.** A rolling hash over every byte position,
restarted per marker — so a chain of them walks the file once per literal. One
precompiled `Regex.union` of the same literals is the same predicate (`Regex.union`
escapes String arguments) in one JIT-compiled pass: 12–82x faster depending on
marker count. On top of that, PCRE2 revalidates its whole subject as UTF-8 on
every match call, worth another 3.4x; content always comes from a validated read,
so that check is skippable.

**The same Go file was parsed up to 14 times.** Three callers want the same two
top-level declaration tables, and `collect_function_bodies` /
`collect_method_bodies` each parsed independently even though both tables fall
out of one walk. They now share one parse through the existing
`Noir::ExtractionResultCache`. With `--include callee`: 10877 parses → 4082,
63 MB → 25 MB, and peak RSS *drops* 178 MB → 145 MB.

**Taggers re-split every file per endpoint.** `read_file` cached content but
each tagger re-split it inside its per-endpoint loop, so a Rails controller was
split once per action it defines, then again for the next tagger — 466 of ~1500
samples on the `-T` path, ahead of file I/O.

**Two components bypassed the content cache.** Framework taggers and the
AI-context source reader went to disk for files the detector had already cached
(discourse: 18366 files / 94 MB against a 512 MB budget). Reading through
`CodeLocator` cuts opens on that path by a third, and stops taggers being the
one component matching against raw bytes on invalid-UTF-8 files.

Also removed: a 22-literal `includes?` pre-pass in `route_call_candidate?` that
could never change its own result (every hint is already matched by the regex it
was OR-ed with).

## How the targets were picked

Counting `includes?` calls per detector ranks the wrong files — most sit behind
a cheap basename gate and never run. `scripts/detector_scan_cost.cr` (added here)
instantiates every `Detector.all_subclasses`, walks a real corpus the way the
detect phase does, and times `applicable?` + `detect` per detector. The
conversions in this PR are the top of that measured ranking, not of a grep.

## Test plan

Run after **every** commit in this PR:

- `just test` — 4161 unit + 22432 functional, 0 failures
- `just check` — `crystal tool format --check` + ameba over 1812 files, 0 failures
- `typos .` — clean
- `crystal build --no-codegen` on each commit individually, so the history bisects
- **Output parity vs `main`**, byte-for-byte: gitea / strapi / discourse in three
  modes (`-f json -T`, `-f plain --include path,techs,callee --ai-context`,
  `--passive-scan`), plus a per-endpoint tag diff under `-T --ai-context`
- **Output parity per fixture**: all 661 directories under
  `spec/functional_test/fixtures/*/*` scanned individually and diffed. Scanning
  the whole fixture tree as one project is *not* a valid comparison — unrelated
  fixtures collide on the same url+method and the dedup keeps whichever analyzer
  finished first, so `main` disagrees with itself run to run.

Equivalence of the riskier rewrites was checked directly against the old code
rather than only end-to-end:

- the read path, on 15 crafted inputs (BOM, lone continuation byte, truncated
  sequence, overlong encoding, surrogate half, latin-1, UTF-16 BOM, embedded NUL,
  CRLF, empty) plus all 3236 files under `spec/`
- `ruby_non_production_path?`, over 162 paths covering every directory in bare,
  prefix, nested, trailing, doubled and decoy (`specx`, `xspec`) form
