### PR TITLE
fix(techs): link the tech registries and repair two live drifts

### DIFF
--- a/docs/content/usage/supported/specification/index.ko.md
+++ b/docs/content/usage/supported/specification/index.ko.md
@@ -37,7 +37,6 @@ sort_by = "weight"
 | Directus (schema snapshot) | JSON | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ✗ | ✗ |
 | Envoy | JSON | ☑️ | ☑️ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Envoy | YAML | ☑️ | ☑️ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| GraphQL | GRAPHQL | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | GraphQL SDL | GRAPHQL_SDL | ☑️ | ☑️ | ✗ | ✗ | ☑️ | ✗ | ✗ |
 | Grpc | PROTOBUF | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ✗ | ✗ |
 | HAR | JSON | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
@@ -78,5 +77,6 @@ sort_by = "weight"
 | TypeSpec | TYPESPEC | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | Vercel | JSON | ☑️ | ☑️ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Wsdl | XML | ☑️ | ☑️ | ✗ | ✗ | ☑️ | ☑️ | ✗ |
+| Zap Sites Tree | YAML | ☑️ | ☑️ | ✗ | ✗ | ☑️ | ✗ | ✗ |
 | iOS (Info.plist) | PLIST | ☑️ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | mitmproxy Flow | TNETSTRING | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |

--- a/docs/content/usage/supported/specification/index.md
+++ b/docs/content/usage/supported/specification/index.md
@@ -37,7 +37,6 @@ Beyond source code analysis, Noir can parse API and data specification formats s
 | Directus (schema snapshot) | JSON | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ✗ | ✗ |
 | Envoy | JSON | ☑️ | ☑️ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Envoy | YAML | ☑️ | ☑️ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| GraphQL | GRAPHQL | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | GraphQL SDL | GRAPHQL_SDL | ☑️ | ☑️ | ✗ | ✗ | ☑️ | ✗ | ✗ |
 | Grpc | PROTOBUF | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ✗ | ✗ |
 | HAR | JSON | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
@@ -78,5 +77,6 @@ Beyond source code analysis, Noir can parse API and data specification formats s
 | TypeSpec | TYPESPEC | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |
 | Vercel | JSON | ☑️ | ☑️ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Wsdl | XML | ☑️ | ☑️ | ✗ | ✗ | ☑️ | ☑️ | ✗ |
+| Zap Sites Tree | YAML | ☑️ | ☑️ | ✗ | ✗ | ☑️ | ✗ | ✗ |
 | iOS (Info.plist) | PLIST | ☑️ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | mitmproxy Flow | TNETSTRING | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ | ☑️ |

--- a/spec/unit_test/techs/registry_integrity_spec.cr
+++ b/spec/unit_test/techs/registry_integrity_spec.cr
@@ -1,0 +1,93 @@
+require "../../spec_helper"
+require "../../../src/utils/*"
+require "../../../src/techs/techs"
+require "../../../src/detector/detector"
+require "../../../src/analyzer/analyzer"
+require "../../../src/models/logger"
+
+# Tech identity lives in five hand-maintained lists with no compile-time
+# linkage between them:
+#
+#   * `NoirTechs::TECHS`                 — the user-facing catalog behind
+#                                          `noir list techs`, `-t`,
+#                                          `--only-techs`, `--exclude-techs`
+#   * `define_analyzers` (analyzer.cr)   — tech -> analyzer
+#   * `build_detector_list` (detector.cr)— tech -> detector
+#   * `CALLEE_SUPPORTED_TECHS`           — `--include-callee` capability
+#   * `AI_CONTEXT_GUARD_SUPPORTED_TECHS` — `--ai-context guards` capability
+#
+# Nothing forced them to agree, and they drifted in both directions:
+# `zap_sites_tree` shipped a working analyzer *and* detector but no catalog
+# entry, so all three tech-selection flags rejected a technology noir
+# actually supports and `noir list techs` never mentioned it; `:graphql` sat
+# in the catalog with neither an analyzer nor a detector behind it, and its
+# `"graphql"` alias shadowed lookups that belong to `graphql_sdl`.
+#
+# These specs are that missing linkage. A tech added to one list but not the
+# others fails here rather than shipping as a silent capability gap.
+
+# Analyzers that intentionally have no detector and no catalog entry.
+DYNAMIC_ANALYZER_TECHS = Set{
+  # Activated by `--ai-provider`, never by file detection. Kept out of the
+  # catalog so it is not offered as a `-t` target.
+  "ai",
+}
+
+private def sorted(names) : Array(String)
+  names.to_a.sort
+end
+
+describe "tech registry integrity" do
+  logger = NoirLogger.new(false, false, false, true)
+
+  catalog = NoirTechs.techs.keys.map(&.to_s).to_set
+  analyzers = initialize_analyzers(logger).keys.to_set - DYNAMIC_ANALYZER_TECHS
+  detectors = build_detector_list(create_test_options).map(&.name).to_set
+
+  it "gives every analyzer a catalog entry" do
+    # Without one, `-t <tech>` / `--only-techs <tech>` / `--exclude-techs
+    # <tech>` all reject the name and `noir list techs` omits it.
+    orphans = analyzers - catalog
+    fail "analyzers with no NoirTechs::TECHS entry: #{sorted(orphans)}" unless orphans.empty?
+  end
+
+  it "gives every detector a catalog entry" do
+    orphans = detectors - catalog
+    fail "detectors with no NoirTechs::TECHS entry: #{sorted(orphans)}" unless orphans.empty?
+  end
+
+  it "backs every catalog entry with an analyzer" do
+    # A catalog entry with no analyzer advertises a capability that cannot
+    # produce endpoints.
+    phantoms = catalog - analyzers
+    fail "NoirTechs::TECHS entries with no analyzer: #{sorted(phantoms)}" unless phantoms.empty?
+  end
+
+  it "backs every catalog entry with a detector" do
+    phantoms = catalog - detectors
+    fail "NoirTechs::TECHS entries with no detector: #{sorted(phantoms)}" unless phantoms.empty?
+  end
+
+  it "registers each detector name exactly once" do
+    names = build_detector_list(create_test_options).map(&.name)
+    dupes = names.tally.select { |_, count| count > 1 }.keys
+    fail "detector names registered more than once: #{sorted(dupes)}" unless dupes.empty?
+  end
+
+  it "names only real techs in CALLEE_SUPPORTED_TECHS" do
+    unknown = NoirTechs::CALLEE_SUPPORTED_TECHS.to_set - catalog
+    fail "CALLEE_SUPPORTED_TECHS names unknown techs: #{sorted(unknown)}" unless unknown.empty?
+  end
+
+  it "names only real techs in AI_CONTEXT_GUARD_SUPPORTED_TECHS" do
+    unknown = NoirTechs::AI_CONTEXT_GUARD_SUPPORTED_TECHS.to_set - catalog
+    fail "AI_CONTEXT_GUARD_SUPPORTED_TECHS names unknown techs: #{sorted(unknown)}" unless unknown.empty?
+  end
+
+  it "resolves every catalog key through similar_to_tech" do
+    # `similar_to_tech` is the single gate every tech-selection flag passes
+    # through. A key it cannot round-trip is unreachable from the CLI.
+    unresolvable = catalog.reject { |tech| NoirTechs.similar_to_tech(tech) == tech }
+    fail "catalog keys similar_to_tech cannot resolve: #{sorted(unresolvable)}" unless unresolvable.empty?
+  end
+end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -248,11 +248,15 @@ def detector_build_applicable_lookup(detectors : Array(Detector)) : Proc(String,
   end
 end
 
-def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), passive_scans : Array(PassiveScan), logger : NoirLogger)
-  techs = [] of String
-  passive_result = [] of PassiveScanResult
+# The complete detector registry, constructed fresh per scan.
+#
+# Extracted from `detect_techs` so the registry is enumerable outside the
+# scan path. `spec/unit_test/techs/registry_integrity_spec.cr` walks it to
+# prove every detector name has a matching `NoirTechs::TECHS` entry — the
+# linkage that `zap_sites_tree` (detector + analyzer, no TECHS entry) had
+# silently lost.
+def build_detector_list(options : Hash(String, YAML::Any)) : Array(Detector)
   detector_list = [] of Detector
-  mutex = Mutex.new
 
   # Define detectors
   define_detectors([
@@ -498,6 +502,15 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
     Zig::Httpz,
     Zig::Tokamak,
   ])
+
+  detector_list
+end
+
+def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), passive_scans : Array(PassiveScan), logger : NoirLogger)
+  techs = [] of String
+  passive_result = [] of PassiveScanResult
+  detector_list = build_detector_list(options)
+  mutex = Mutex.new
 
   # Handle --only-techs: filter detector_list to only specified techs
   only_techs_value = options["only_techs"]?.to_s

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -1617,6 +1617,28 @@ module NoirTechs
         },
       },
     },
+    # The analyzer walks the exported node tree and emits `url` + `method`,
+    # plus the `data` string split into `form` params. The query string is
+    # dropped with the rest of the URI (only `uri.path` is kept), and the
+    # export carries no header or cookie record — hence body-only params.
+    #
+    # No bare `"zap"` alias: `zig_zap` already owns it, and a duplicate
+    # would resolve by TECHS iteration order rather than by intent.
+    :zap_sites_tree => {
+      :format    => ["YAML"],
+      :similar   => ["zap_sites_tree", "zap-sites-tree", "zap-sitemap", "zap_sitemap", "zaproxy", "owasp-zap"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => false,
+          :path   => false,
+          :body   => true,
+          :header => false,
+          :cookie => false,
+        },
+      },
+    },
     :java_cli => {
       :framework => "CLI (picocli / args4j / JCommander / commons-cli / airline / JOpt Simple)",
       :language  => "Java",
@@ -2850,24 +2872,16 @@ module NoirTechs
         },
       },
     },
-    :graphql => {
-      :format    => ["GRAPHQL"],
-      :similar   => ["graphql", ".graphql"],
-      :supported => {
-        :endpoint => true,
-        :method   => true,
-        :params   => {
-          :query  => true,
-          :path   => true,
-          :body   => true,
-          :header => true,
-          :cookie => true,
-        },
-      },
-    },
+    # `:graphql` used to sit here with no analyzer and no detector behind it
+    # — a catalog entry that advertised support nothing could deliver, and
+    # whose `"graphql"` / `".graphql"` aliases resolved to that dead end
+    # instead of to the analyzer that really reads those files. The aliases
+    # moved onto `graphql_sdl`, whose detector already claims `.graphql`
+    # (see `Detector::Specification::GraphqlSdl#applicable?`), so `-t
+    # graphql` now selects a tech that produces endpoints.
     :graphql_sdl => {
       :format    => ["GRAPHQL_SDL"],
-      :similar   => ["graphql_sdl", "graphql-sdl", "graphql_schema", ".graphqls"],
+      :similar   => ["graphql_sdl", "graphql-sdl", "graphql_schema", ".graphqls", "graphql", ".graphql"],
       :supported => {
         :endpoint => true,
         :method   => true,


### PR DESCRIPTION
Tech identity lives in five hand-maintained lists with no linkage between them — `NoirTechs::TECHS`, `define_analyzers`, the detector list, `CALLEE_SUPPORTED_TECHS`, `AI_CONTEXT_GUARD_SUPPORTED_TECHS`. Nothing made them agree, and they had drifted in **both** directions.

## The two drifts

### `zap_sites_tree` — real support the CLI refuses to acknowledge

The analyzer and detector both exist and work. There was no `TECHS` entry, and every tech-selection flag resolves through `NoirTechs.similar_to_tech`, so all three rejected it:

```
$ noir -t zap_sites_tree              -> ERROR: unknown tech "zap_sites_tree"
$ noir --only-techs zap_sites_tree    -> ERROR: unknown tech "zap_sites_tree"
$ noir --exclude-techs zap_sites_tree -> ERROR: unknown tech "zap_sites_tree"
$ noir list techs | grep zap          -> (nothing)
```

ZAP sites-tree exports were scanned only by accident of auto-detection — users could not select, exclude, or even see the technology, and it was missing from the supported-formats docs.

The catalog entry now describes what the analyzer actually emits, verified against `spec/functional_test/fixtures/specification/zap`: `url` + `method`, with the `data` string split into `form` params. The query string is dropped along with the rest of the URI (only `uri.path` is kept) and the export carries no header or cookie record, so params are body-only.

No bare `"zap"` alias — `zig_zap` already owns that name, and a duplicate would resolve by `TECHS` iteration order rather than by intent.

After:

```
$ noir --only-techs zap_sites_tree ...    -> 7 endpoints
$ noir --exclude-techs zap_sites_tree ... -> 0 endpoints
```

### `:graphql` — a catalog entry with nothing behind it

No analyzer, no detector. Worse, its `"graphql"` / `".graphql"` aliases resolved to that dead end instead of to `graphql_sdl`, whose detector already claims `.graphql` (`Detector::Specification::GraphqlSdl#applicable?`). The aliases move onto `graphql_sdl` and the phantom entry is gone, so `-t graphql` keeps working and now selects a tech that actually produces endpoints.

## The linkage

`define_detectors([...])` was inline inside `detect_techs`, so the detector registry could not be enumerated without running a scan. It moves into `build_detector_list(options)`.

`spec/unit_test/techs/registry_integrity_spec.cr` then asserts the linkage in both directions:

- every analyzer / detector has a catalog entry (catches `zap_sites_tree`)
- every catalog entry has an analyzer and a detector (catches `:graphql`)
- no duplicate detector names
- `CALLEE_SUPPORTED_TECHS` / `AI_CONTEXT_GUARD_SUPPORTED_TECHS` name only real techs
- every catalog key round-trips through `similar_to_tech` — the gate all three flags pass through

A tech added to one list but not the others now fails CI instead of shipping as a silent capability gap.

## Noted, not changed

16 aliases are ambiguous across techs (`argparse` -> cpp_cli/lua_cli/python_cli, `spring` -> java_spring/kotlin_spring, `play` -> scala_play/java_play, ...). Most are genuine cross-language library-name collisions, so a hard CI failure would force churn on cases that are arguably correct. Left alone deliberately; worth a separate decision.

## Verification

- `crystal spec spec/unit_test` — 4,169 examples, 0 failures
- `crystal spec spec/functional_test` — 22,432 examples, 0 failures
- `crystal tool format --check` clean, ameba 727 files / 0 failures
- `just dsup` regenerated the supported-formats docs; the diff is exactly this change (GraphQL row out, Zap Sites Tree row in) with no unrelated drift