### PR TITLE
refactor(specification): give the spec analyzers a shared engine

### DIFF
--- a/src/analyzer/analyzers/specification/apache_httpd.cr
+++ b/src/analyzer/analyzers/specification/apache_httpd.cr
@@ -1,26 +1,16 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class ApacheHttpd < Analyzer
+  class ApacheHttpd < SpecificationEngine
     METHOD_ANY = "ANY"
 
     REDIRECT_STATUSES = Set{"permanent", "temp", "temporary", "seeother", "gone"}
     STATIC_EXTENSIONS = Set{".css", ".js", ".gz", ".br", ".ico", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".woff", ".woff2", ".ttf", ".eot", ".map"}
 
     def analyze
-      spec_files = CodeLocator.instance.all("apache-httpd-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
+      each_spec_file("apache-httpd-spec") do |path|
         content = read_file_content(path)
-        begin
-          process_content(content, path)
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        process_content(content, path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/apisix.cr
+++ b/src/analyzer/analyzers/specification/apisix.cr
@@ -1,18 +1,14 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class Apisix < Analyzer
+  class Apisix < SpecificationEngine
     def analyze
-      locator = CodeLocator.instance
-
-      json_files = locator.all("apisix-json")
-      if json_files.is_a?(Array(String))
-        json_files.each { |path| process_json(path) }
+      each_spec_file("apisix-json") do |path|
+        process_json(path)
       end
 
-      yaml_files = locator.all("apisix-yaml")
-      if yaml_files.is_a?(Array(String))
-        yaml_files.each { |path| process_yaml(path) }
+      each_spec_file("apisix-yaml") do |path|
+        process_yaml(path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/appwrite.cr
+++ b/src/analyzer/analyzers/specification/appwrite.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "./schema_api_common"
 
 module Analyzer::Specification
@@ -10,7 +10,7 @@ module Analyzer::Specification
   # them from `/v1/databases/...` to `/v1/tablesdb/...`. A project uses
   # one naming or the other, so we emit the family matching the keys
   # actually present — emitting both would mean half the output 404s.
-  class Appwrite < Analyzer
+  class Appwrite < SpecificationEngine
     include SchemaApiCommon
 
     ATTRIBUTE_TYPE_HINTS = {
@@ -29,19 +29,9 @@ module Analyzer::Specification
     TAG_SOURCE = "appwrite_analyzer"
 
     def analyze
-      locator = CodeLocator.instance
-      configs = locator.all("appwrite-config")
-      return @result unless configs.is_a?(Array(String))
-
-      configs.each do |path|
-        next unless File.exists?(path)
-        begin
-          content = read_file_content(path)
-          parse_config(content, path)
-        rescue e
-          @logger.debug "Failed to parse Appwrite config #{path}"
-          @logger.debug_sub e
-        end
+      each_spec_file("appwrite-config") do |path|
+        content = read_file_content(path)
+        parse_config(content, path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/asyncapi.cr
+++ b/src/analyzer/analyzers/specification/asyncapi.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
   # AsyncAPI 2.x / 3.x analyzer.
@@ -15,37 +15,19 @@ module Analyzer::Specification
   #
   # The first server's `protocol` (kafka, mqtt, ws, amqp, nats, http, …)
   # is surfaced on the endpoint so DAST consumers can route accordingly.
-  class AsyncApi < Analyzer
+  class AsyncApi < SpecificationEngine
     # Operation keys on `channels` entries (2.x).
     OPERATIONS_2X = {"publish", "subscribe"}
 
     def analyze
-      locator = CodeLocator.instance
-      jsons = locator.all("asyncapi-json")
-      yamls = locator.all("asyncapi-yaml")
-
-      if jsons.is_a?(Array(String))
-        jsons.each do |path|
-          next unless File.exists?(path)
-          details = Details.new(PathInfo.new(path))
-          content = read_file_content(path)
-          process_json(JSON.parse(content), details, path)
-        rescue e
-          @logger.debug "Exception parsing AsyncAPI #{path}"
-          @logger.debug_sub e
-        end
+      each_spec_file_with_details("asyncapi-json") do |path, details|
+        content = read_file_content(path)
+        process_json(JSON.parse(content), details, path)
       end
 
-      if yamls.is_a?(Array(String))
-        yamls.each do |path|
-          next unless File.exists?(path)
-          details = Details.new(PathInfo.new(path))
-          content = read_file_content(path)
-          process_yaml(YAML.parse(content), details, path)
-        rescue e
-          @logger.debug "Exception parsing AsyncAPI #{path}"
-          @logger.debug_sub e
-        end
+      each_spec_file_with_details("asyncapi-yaml") do |path, details|
+        content = read_file_content(path)
+        process_yaml(YAML.parse(content), details, path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/aws_cdk.cr
+++ b/src/analyzer/analyzers/specification/aws_cdk.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class AwsCdk < Analyzer
+  class AwsCdk < SpecificationEngine
     METHOD_ANY = "ANY"
 
     # Variable -> (parent variable | nil, literal path segment)
@@ -21,23 +21,12 @@ module Analyzer::Specification
     PY_METHODS_RE  = /methods\s*=\s*\[([^\]]*)\]/
 
     def analyze
-      spec_files = CodeLocator.instance.all("aws-cdk-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("aws-cdk-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          if path.ends_with?(".py")
-            process_python(content, details)
-          else
-            process_typescript(content, details)
-          end
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
+        if path.ends_with?(".py")
+          process_python(content, details)
+        else
+          process_typescript(content, details)
         end
       end
 

--- a/src/analyzer/analyzers/specification/aws_cloudformation.cr
+++ b/src/analyzer/analyzers/specification/aws_cloudformation.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class AwsCloudformation < Analyzer
+  class AwsCloudformation < SpecificationEngine
     METHOD_ANY            = "ANY"
     SAM_FUNCTION_TYPE     = "AWS::Serverless::Function"
     APIGW_RESOURCE_TYPE   = "AWS::ApiGateway::Resource"
@@ -11,24 +11,13 @@ module Analyzer::Specification
     record ApigwResource, name : String, path_part : String, parent : String?
 
     def analyze
-      spec_files = CodeLocator.instance.all("aws-cloudformation-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("aws-cloudformation-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          resources = parse_resources(path, content)
-          next if resources.empty?
+        resources = parse_resources(path, content)
+        next if resources.empty?
 
-          process_sam(resources, details)
-          process_cloudformation(resources, details)
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        process_sam(resources, details)
+        process_cloudformation(resources, details)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/azure_functions.cr
+++ b/src/analyzer/analyzers/specification/azure_functions.cr
@@ -1,24 +1,13 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class AzureFunctions < Analyzer
+  class AzureFunctions < SpecificationEngine
     METHOD_ANY = "ANY"
 
     def analyze
-      spec_files = CodeLocator.instance.all("azure-functions-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("azure-functions-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          process_doc(JSON.parse(content), path, details)
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        process_doc(JSON.parse(content), path, details)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/bruno.cr
+++ b/src/analyzer/analyzers/specification/bruno.cr
@@ -1,23 +1,14 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class Bruno < Analyzer
+  class Bruno < SpecificationEngine
     HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options"}
 
     def analyze
-      locator = CodeLocator.instance
-      bruno_files = locator.all("bruno-bru")
-
-      bruno_files.each do |bruno_file|
-        next unless File.exists?(bruno_file)
-        begin
-          content = read_file_content(bruno_file)
-          details = Details.new(PathInfo.new(bruno_file))
-          process_bru(content, details)
-        rescue e
-          @logger.debug "Exception processing #{bruno_file}"
-          @logger.debug_sub e
-        end
+      each_spec_file("bruno-bru") do |bruno_file|
+        content = read_file_content(bruno_file)
+        details = Details.new(PathInfo.new(bruno_file))
+        process_bru(content, details)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/burp.cr
+++ b/src/analyzer/analyzers/specification/burp.cr
@@ -1,28 +1,18 @@
 require "base64"
 require "uri"
 require "xml"
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
   # Parses Burp Suite sitemap XML exports (`Target → Site map → right-click →
   # Save items`). Each `<item>` holds an absolute URL, a base64-encoded raw
   # HTTP request, and the response — the request blob is the source of truth
   # for method, path, headers, and body.
-  class Burp < Analyzer
+  class Burp < SpecificationEngine
     def analyze
-      locator = CodeLocator.instance
-      burp_files = locator.all("burp-sitemap")
-      return @result unless burp_files.is_a?(Array(String))
-
-      burp_files.each do |path|
-        next unless File.exists?(path)
-        begin
-          content = read_file_content(path)
-          process_file(content, path)
-        rescue e
-          @logger.debug "Failed to parse Burp sitemap #{path}: #{e.message}"
-          @logger.debug_sub e
-        end
+      each_spec_file("burp-sitemap") do |path|
+        content = read_file_content(path)
+        process_file(content, path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/caddy.cr
+++ b/src/analyzer/analyzers/specification/caddy.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class Caddy < Analyzer
+  class Caddy < SpecificationEngine
     METHOD_ANY = "ANY"
 
     HANDLE_OPEN_RE   = /^handle(_path)?\s+(\S+)\s*\{?/
@@ -15,23 +15,12 @@ module Analyzer::Specification
     SITE_BLOCK_RE    = /^([A-Za-z0-9_.:\/@*?-]+(?:\s*,\s*[A-Za-z0-9_.:\/@*?-]+)*)\s*\{$/
 
     def analyze
-      spec_files = CodeLocator.instance.all("caddy-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("caddy-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          if path.ends_with?(".json")
-            process_json(content, details)
-          else
-            process_caddyfile(content, path, details)
-          end
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
+        if path.ends_with?(".json")
+          process_json(content, details)
+        else
+          process_caddyfile(content, path, details)
         end
       end
 

--- a/src/analyzer/analyzers/specification/caido.cr
+++ b/src/analyzer/analyzers/specification/caido.cr
@@ -1,37 +1,26 @@
 require "base64"
 require "uri"
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class Caido < Analyzer
+  class Caido < SpecificationEngine
     def analyze
-      locator = CodeLocator.instance
-      caido_files = locator.all("caido-json")
-      return @result unless caido_files.is_a?(Array(String))
-
-      caido_files.each do |path|
-        next unless File.exists?(path)
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("caido-json") do |path, details|
         content = read_file_content(path)
 
-        begin
-          data = JSON.parse(content)
-          entries = data.as_a?
-          next unless entries
+        data = JSON.parse(content)
+        entries = data.as_a?
+        next unless entries
 
-          seen = Set(String).new
+        seen = Set(String).new
 
-          entries.each do |entry|
-            begin
-              process_entry(entry, details, seen)
-            rescue e
-              @logger.debug "Exception processing caido entry in #{path}"
-              @logger.debug_sub e
-            end
+        entries.each do |entry|
+          begin
+            process_entry(entry, details, seen)
+          rescue e
+            @logger.debug "Exception processing caido entry in #{path}"
+            @logger.debug_sub e
           end
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
         end
       end
 

--- a/src/analyzer/analyzers/specification/cloudflare_wrangler.cr
+++ b/src/analyzer/analyzers/specification/cloudflare_wrangler.cr
@@ -1,28 +1,17 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "toml"
 
 module Analyzer::Specification
-  class CloudflareWrangler < Analyzer
+  class CloudflareWrangler < SpecificationEngine
     METHOD_ANY = "ANY"
 
     def analyze
-      spec_files = CodeLocator.instance.all("cloudflare-wrangler-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("cloudflare-wrangler-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          if path.ends_with?(".toml")
-            process_toml(content, details)
-          else
-            process_json(content, details)
-          end
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
+        if path.ends_with?(".toml")
+          process_toml(content, details)
+        else
+          process_json(content, details)
         end
       end
 

--- a/src/analyzer/analyzers/specification/directus.cr
+++ b/src/analyzer/analyzers/specification/directus.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../utils/yaml"
 require "./schema_api_common"
 
@@ -7,7 +7,7 @@ module Analyzer::Specification
   # `/items/<collection>`, with the item-level verbs on
   # `/items/<collection>/<id>` and singletons on
   # `/items/<collection>/singleton`.
-  class Directus < Analyzer
+  class Directus < SpecificationEngine
     include SchemaApiCommon
 
     FIELD_TYPE_HINTS = {
@@ -43,19 +43,9 @@ module Analyzer::Specification
     TAG_SOURCE = "directus_analyzer"
 
     def analyze
-      locator = CodeLocator.instance
-      snapshots = locator.all("directus-snapshot")
-      return @result unless snapshots.is_a?(Array(String))
-
-      snapshots.each do |path|
-        next unless File.exists?(path)
-        begin
-          content = read_file_content(path)
-          parse_snapshot(content, path)
-        rescue e
-          @logger.debug "Failed to parse Directus snapshot #{path}"
-          @logger.debug_sub e
-        end
+      each_spec_file("directus-snapshot") do |path|
+        content = read_file_content(path)
+        parse_snapshot(content, path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/envoy.cr
+++ b/src/analyzer/analyzers/specification/envoy.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
   # Extracts HTTP endpoints from Envoy proxy route configuration files
@@ -12,38 +12,16 @@ module Analyzer::Specification
   #   - HTTP method from `match.headers[]` where `name: ":method"`
   #   - An additional endpoint for `route.prefix_rewrite` when it differs
   #     from the matched path
-  class Envoy < Analyzer
+  class Envoy < SpecificationEngine
     def analyze
-      locator = CodeLocator.instance
-
-      yaml_files = locator.all("envoy-yaml")
-      if yaml_files.is_a?(Array(String))
-        yaml_files.each do |path|
-          next unless File.exists?(path)
-          details = Details.new(PathInfo.new(path))
-          content = read_file_content(path)
-          begin
-            process_yaml(YAML.parse(content), details)
-          rescue e
-            @logger.debug "Exception processing #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file_with_details("envoy-yaml") do |path, details|
+        content = read_file_content(path)
+        process_yaml(YAML.parse(content), details)
       end
 
-      json_files = locator.all("envoy-json")
-      if json_files.is_a?(Array(String))
-        json_files.each do |path|
-          next unless File.exists?(path)
-          details = Details.new(PathInfo.new(path))
-          content = read_file_content(path)
-          begin
-            process_json(JSON.parse(content), details)
-          rescue e
-            @logger.debug "Exception processing #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file_with_details("envoy-json") do |path, details|
+        content = read_file_content(path)
+        process_json(JSON.parse(content), details)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/graphql_sdl.cr
+++ b/src/analyzer/analyzers/specification/graphql_sdl.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "./graphql_sdl_parser"
 
 module Analyzer::Specification
@@ -10,21 +10,11 @@ module Analyzer::Specification
   #
   # The SDL grammar itself lives in `GraphqlSdlParser` so other analyzers
   # (Apollo Server inline typeDefs, GraphQL Yoga, etc.) can share it.
-  class GraphqlSdl < Analyzer
+  class GraphqlSdl < SpecificationEngine
     def analyze
-      locator = CodeLocator.instance
-      sdl_files = locator.all("graphql-sdl")
-      return @result unless sdl_files.is_a?(Array(String))
-
-      sdl_files.each do |sdl_file|
-        next unless File.exists?(sdl_file)
-        begin
-          content = read_file_content(sdl_file)
-          GraphqlSdlParser.parse(content, sdl_file).each { |ep| @result << ep }
-        rescue e
-          @logger.debug "GraphQL SDL: failed to parse #{sdl_file}"
-          @logger.debug_sub e
-        end
+      each_spec_file("graphql-sdl") do |sdl_file|
+        content = read_file_content(sdl_file)
+        GraphqlSdlParser.parse(content, sdl_file).each { |ep| @result << ep }
       end
 
       @result

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -1,14 +1,15 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class Grpc < Analyzer
+  class Grpc < SpecificationEngine
     # Represents a parsed protobuf message with its fields
     alias MessageFields = Array(Param)
 
     def analyze
-      locator = CodeLocator.instance
-      proto_files = locator.all("grpc-proto")
-      return @result if proto_files.empty?
+      # `build_message_registry` reads and parses every `.proto` in the
+      # codebase, so bail out before it when the detector registered no
+      # service definitions to resolve against.
+      return @result if CodeLocator.instance.all("grpc-proto").empty?
 
       # Request/response messages are frequently defined in a separate
       # (imported) `.proto`, so resolving params from the service file alone
@@ -16,13 +17,9 @@ module Analyzer::Specification
       # both simple and package-qualified name, and resolve against it.
       registry = build_message_registry
 
-      proto_files.each do |proto_file|
-        begin
-          content = read_file_content(proto_file)
-          parse_proto(content, proto_file, registry)
-        rescue File::NotFoundError
-          @logger.debug "Proto file not found during analysis, skipping: #{proto_file}"
-        end
+      each_spec_file("grpc-proto") do |proto_file|
+        content = read_file_content(proto_file)
+        parse_proto(content, proto_file, registry)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/har.cr
+++ b/src/analyzer/analyzers/specification/har.cr
@@ -1,9 +1,9 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "json"
 require "uri"
 
 module Analyzer::Specification
-  class Har < Analyzer
+  class Har < SpecificationEngine
     STATIC_EXTENSIONS = {
       ".avif", ".bmp", ".css", ".cur", ".eot", ".gif", ".ico", ".jpeg", ".jpg",
       ".js", ".map", ".mjs", ".otf", ".png", ".svg", ".ttf", ".webmanifest",
@@ -34,43 +34,36 @@ module Analyzer::Specification
     }
 
     def analyze
-      locator = CodeLocator.instance
-      har_files = locator.all("har-path")
+      each_spec_file("har-path") do |har_file|
+        data = HAR.from_file(har_file)
+        logger.debug "Open #{har_file} file"
+        data.entries.each do |entry|
+          request_uri = parse_uri(entry.request.url)
+          next unless request_uri
 
-      if har_files.is_a?(Array(String))
-        har_files.each do |har_file|
-          if File.exists?(har_file)
-            data = HAR.from_file(har_file)
-            logger.debug "Open #{har_file} file"
-            data.entries.each do |entry|
-              request_uri = parse_uri(entry.request.url)
-              next unless request_uri
+          path = endpoint_path(request_uri)
+          next unless path
+          next if static_asset_request?(entry, request_uri)
 
-              path = endpoint_path(request_uri)
-              next unless path
-              next if static_asset_request?(entry, request_uri)
+          endpoint = Endpoint.new(path, entry.request.method)
+          add_query_params(endpoint, entry.request, request_uri)
 
-              endpoint = Endpoint.new(path, entry.request.method)
-              add_query_params(endpoint, entry.request, request_uri)
-
-              is_websocket = websocket_request?(entry.request, request_uri)
-              entry.request.headers.each do |header|
-                endpoint.params << Param.new(header.name, header.value, "header")
-              end
-
-              entry.request.cookies.each do |cookie|
-                endpoint.params << Param.new(cookie.name, cookie.value, "cookie")
-              end
-
-              add_post_data_params(endpoint, entry.request)
-
-              details = Details.new(PathInfo.new(har_file, 0))
-              details.status_code = entry.response.status
-              endpoint.details = details
-              endpoint.protocol = "ws" if is_websocket
-              @result << endpoint
-            end
+          is_websocket = websocket_request?(entry.request, request_uri)
+          entry.request.headers.each do |header|
+            endpoint.params << Param.new(header.name, header.value, "header")
           end
+
+          entry.request.cookies.each do |cookie|
+            endpoint.params << Param.new(cookie.name, cookie.value, "cookie")
+          end
+
+          add_post_data_params(endpoint, entry.request)
+
+          details = Details.new(PathInfo.new(har_file, 0))
+          details.status_code = entry.response.status
+          endpoint.details = details
+          endpoint.protocol = "ws" if is_websocket
+          @result << endpoint
         end
       end
 

--- a/src/analyzer/analyzers/specification/hasura.cr
+++ b/src/analyzer/analyzers/specification/hasura.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../utils/yaml"
 require "./graphql_sdl_parser"
 require "./schema_api_common"
@@ -14,7 +14,7 @@ module Analyzer::Specification
   # That yields the fragment URL convention (`/v1/graphql#Query.movies`),
   # a runnable operation document per field, and input-object expansion
   # into dotted params — all of which the SDL analyzer already does.
-  class Hasura < Analyzer
+  class Hasura < SpecificationEngine
     include SchemaApiCommon
 
     GRAPHQL_PATH = "/v1/graphql"
@@ -33,32 +33,12 @@ module Analyzer::Specification
     GRAPHQL_IDENTIFIER = /\A[A-Za-z_][A-Za-z0-9_]*\z/
 
     def analyze
-      locator = CodeLocator.instance
-
-      tables = locator.all("hasura-tables")
-      if tables.is_a?(Array(String))
-        tables.each do |path|
-          next unless File.exists?(path)
-          begin
-            parse_tables(read_file_content(path), path)
-          rescue e
-            @logger.debug "Failed to parse Hasura table metadata #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file("hasura-tables") do |path|
+        parse_tables(read_file_content(path), path)
       end
 
-      rest = locator.all("hasura-rest-endpoints")
-      if rest.is_a?(Array(String))
-        rest.each do |path|
-          next unless File.exists?(path)
-          begin
-            parse_rest_endpoints(read_file_content(path), path)
-          rescue e
-            @logger.debug "Failed to parse Hasura REST endpoints #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file("hasura-rest-endpoints") do |path|
+        parse_rest_endpoints(read_file_content(path), path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/http_file.cr
+++ b/src/analyzer/analyzers/specification/http_file.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../utils/http_symbols"
 require "uri"
 
@@ -13,22 +13,13 @@ module Analyzer::Specification
   # definitions; anything left unresolved in the path is treated as a path
   # parameter (`:var`) rather than literal text. JetBrains response-handler
   # blocks (`> {% ... %}` / `> script.js`) are skipped.
-  class HttpFile < Analyzer
+  class HttpFile < SpecificationEngine
     HTTP_METHODS = ALLOWED_HTTP_METHODS
 
     def analyze
-      locator = CodeLocator.instance
-      http_files = locator.all("http-file")
-
-      http_files.each do |http_file|
-        next unless File.exists?(http_file)
-        begin
-          content = read_file_content(http_file)
-          process_file(content, http_file)
-        rescue e
-          @logger.debug "Exception processing #{http_file}"
-          @logger.debug_sub e
-        end
+      each_spec_file("http-file") do |http_file|
+        content = read_file_content(http_file)
+        process_file(content, http_file)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/insomnia.cr
+++ b/src/analyzer/analyzers/specification/insomnia.cr
@@ -1,40 +1,20 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../utils/http_symbols"
 require "uri"
 
 module Analyzer::Specification
-  class Insomnia < Analyzer
+  class Insomnia < SpecificationEngine
     HTTP_METHODS = ALLOWED_HTTP_METHODS
 
     def analyze
-      locator = CodeLocator.instance
-
-      json_files = locator.all("insomnia-json")
-      if json_files.is_a?(Array(String))
-        json_files.each do |path|
-          next unless File.exists?(path)
-          content = read_file_content(path)
-          begin
-            process_v4(JSON.parse(content), path)
-          rescue e
-            @logger.debug "Exception processing #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file("insomnia-json") do |path|
+        content = read_file_content(path)
+        process_v4(JSON.parse(content), path)
       end
 
-      yaml_files = locator.all("insomnia-yaml")
-      if yaml_files.is_a?(Array(String))
-        yaml_files.each do |path|
-          next unless File.exists?(path)
-          content = read_file_content(path)
-          begin
-            process_v5(YAML.parse(content), path)
-          rescue e
-            @logger.debug "Exception processing #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file("insomnia-yaml") do |path|
+        content = read_file_content(path)
+        process_v5(YAML.parse(content), path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/istio_virtualservice.cr
+++ b/src/analyzer/analyzers/specification/istio_virtualservice.cr
@@ -1,24 +1,13 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class IstioVirtualservice < Analyzer
+  class IstioVirtualservice < SpecificationEngine
     METHOD_ANY = "ANY"
 
     def analyze
-      spec_files = CodeLocator.instance.all("istio-virtualservice-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("istio-virtualservice-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          YAML.parse_all(content).each { |doc| process_doc(doc, details) }
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        YAML.parse_all(content).each { |doc| process_doc(doc, details) }
       end
 
       @result

--- a/src/analyzer/analyzers/specification/k8s_gateway_api.cr
+++ b/src/analyzer/analyzers/specification/k8s_gateway_api.cr
@@ -1,24 +1,13 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class K8sGatewayApi < Analyzer
+  class K8sGatewayApi < SpecificationEngine
     METHOD_ANY = "ANY"
 
     def analyze
-      spec_files = CodeLocator.instance.all("k8s-gateway-api-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("k8s-gateway-api-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          YAML.parse_all(content).each { |doc| process_doc(doc, details) }
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        YAML.parse_all(content).each { |doc| process_doc(doc, details) }
       end
 
       @result

--- a/src/analyzer/analyzers/specification/k8s_ingress.cr
+++ b/src/analyzer/analyzers/specification/k8s_ingress.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class K8sIngress < Analyzer
+  class K8sIngress < SpecificationEngine
     DEFAULT_METHOD     = "GET"
     REWRITE_ANNOTATION = "nginx.ingress.kubernetes.io/rewrite-target"
     DEFAULT_PATH_TYPE  = "ImplementationSpecific"
@@ -12,17 +12,17 @@ module Analyzer::Specification
     HOST_LINE          = /^[ \t-]*host:\s*(.*)$/
 
     def analyze
-      spec_files = CodeLocator.instance.all("k8s-ingress-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("k8s-ingress-spec") do |path, details|
         content = read_file_content(path)
         begin
           YAML.parse_all(content).each { |doc| process_doc(doc, details) }
         rescue e
+          # Kept as an explicit rescue rather than delegating to the engine:
+          # a Helm chart's `templates/ingress.yaml` is a Go template, so
+          # `path: {{ .Values.server.ingress.path }}` is not valid YAML and
+          # the parse legitimately fails. That is the common case, not an
+          # error — fall back to the tolerant line scanner instead of
+          # letting the file be logged and skipped.
           @logger.debug "Exception processing #{path}, falling back to tolerant Ingress template extraction"
           @logger.debug_sub e
           process_template(content, details)

--- a/src/analyzer/analyzers/specification/kamal.cr
+++ b/src/analyzer/analyzers/specification/kamal.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
   # Extracts the externally reachable surface described by a Kamal
@@ -6,26 +6,15 @@ module Analyzer::Specification
   # declares the hosts kamal-proxy serves, the path prefixes it forwards,
   # and the health endpoint it probes on every deploy — all of which are
   # live HTTP routes worth inventorying.
-  class Kamal < Analyzer
+  class Kamal < SpecificationEngine
     DEFAULT_HEALTHCHECK_PATH = "/up"
     APP_METHOD               = "ANY"
     HEALTHCHECK_METHOD       = "GET"
 
     def analyze
-      spec_files = CodeLocator.instance.all("kamal-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("kamal-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          process_config(YAML.parse(content), details)
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        process_config(YAML.parse(content), details)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/kong.cr
+++ b/src/analyzer/analyzers/specification/kong.cr
@@ -1,22 +1,11 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class Kong < Analyzer
+  class Kong < SpecificationEngine
     def analyze
-      spec_files = CodeLocator.instance.all("kong-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("kong-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          process_doc(YAML.parse(content), details)
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        process_doc(YAML.parse(content), details)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/mitmproxy.cr
+++ b/src/analyzer/analyzers/specification/mitmproxy.cr
@@ -1,9 +1,9 @@
 require "uri"
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../utils/tnetstring"
 
 module Analyzer::Specification
-  class Mitmproxy < Analyzer
+  class Mitmproxy < SpecificationEngine
     # mitmproxy's `version` field has changed shape across releases:
     # pre-3.x stored a `[major, minor, patch]` list, while modern
     # versions (3.x through current ≥20) store a single integer. A
@@ -12,18 +12,9 @@ module Analyzer::Specification
     LEGACY_LIST_MIN_MAJOR = 3_i64
 
     def analyze
-      locator = CodeLocator.instance
-      paths = locator.all("mitmproxy-path")
-      return @result unless paths.is_a?(Array(String))
-
-      paths.each do |path|
-        next unless File.exists?(path)
-        begin
-          bytes = read_binary(path)
-          process_file(path, bytes)
-        rescue ex
-          logger.debug "Failed to read mitmproxy flow #{path}: #{ex.message}"
-        end
+      each_spec_file("mitmproxy-path") do |path|
+        bytes = read_binary(path)
+        process_file(path, bytes)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/netlify.cr
+++ b/src/analyzer/analyzers/specification/netlify.cr
@@ -1,22 +1,16 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "toml"
 
 module Analyzer::Specification
-  class Netlify < Analyzer
+  class Netlify < SpecificationEngine
     DEFAULT_METHOD = "ANY"
 
     def analyze
-      locator = CodeLocator.instance
-      redirects_files = locator.all("netlify-redirects")
-      toml_files = locator.all("netlify-toml")
-
-      redirects_files.each do |path|
-        next unless File.exists?(path)
+      each_spec_file("netlify-redirects") do |path|
         parse_redirects_file(path)
       end
 
-      toml_files.each do |path|
-        next unless File.exists?(path)
+      each_spec_file("netlify-toml") do |path|
         parse_toml_file(path)
       end
 

--- a/src/analyzer/analyzers/specification/nginx.cr
+++ b/src/analyzer/analyzers/specification/nginx.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class Nginx < Analyzer
+  class Nginx < SpecificationEngine
     METHOD_ANY = "ANY"
 
     LOCATION_RE     = /^location\s+(?:(=|~\*|~|\^~)\s+)?(\S+)/
@@ -11,20 +11,9 @@ module Analyzer::Specification
     METHOD_BLOCK_RE = /^if\s*\(\s*\$request_method\s*=\s*([A-Z]+)\s*\)/
 
     def analyze
-      spec_files = CodeLocator.instance.all("nginx-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("nginx-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          process_content(content, details)
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        process_content(content, details)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -1,8 +1,8 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../utils/yaml"
 
 module Analyzer::Specification
-  class Oas2 < Analyzer
+  class Oas2 < SpecificationEngine
     HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
 
     # Resolves a `#/definitions/Name` pointer against the spec root.
@@ -312,16 +312,12 @@ module Analyzer::Specification
     end
 
     def analyze
-      locator = CodeLocator.instance
-      swagger_jsons = locator.all("swagger-json")
-      swagger_yamls = locator.all("swagger-yaml")
-
-      if swagger_jsons.is_a?(Array(String))
-        swagger_jsons.each { |path| process_json(path) }
+      each_spec_file("swagger-json") do |path|
+        process_json(path)
       end
 
-      if swagger_yamls.is_a?(Array(String))
-        swagger_yamls.each { |path| process_yaml(path) }
+      each_spec_file("swagger-yaml") do |path|
+        process_yaml(path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -1,9 +1,9 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../utils/yaml"
 require "uri"
 
 module Analyzer::Specification
-  class Oas3 < Analyzer
+  class Oas3 < SpecificationEngine
     HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
 
     def get_base_path(servers : JSON::Any)
@@ -416,48 +416,34 @@ module Analyzer::Specification
     end
 
     def analyze
-      locator = CodeLocator.instance
-      oas3_jsons = locator.all("oas3-json")
-      oas3_yamls = locator.all("oas3-yaml")
+      each_spec_file_with_details("oas3-json") do |oas3_json, details|
+        content = read_file_content(oas3_json)
+        json_obj = JSON.parse(content)
 
-      if oas3_jsons.is_a?(Array(String))
-        oas3_jsons.each do |oas3_json|
-          if File.exists?(oas3_json)
-            details = Details.new(PathInfo.new(oas3_json))
-            content = read_file_content(oas3_json)
-            json_obj = JSON.parse(content)
-
-            base_path = @url
-            begin
-              base_path = get_base_path json_obj["servers"]
-            rescue e
-              @logger.debug "Exception of #{oas3_json}/servers"
-              @logger.debug_sub e
-            end
-
-            process_paths_json(json_obj, base_path, details, oas3_json)
-          end
+        base_path = @url
+        begin
+          base_path = get_base_path json_obj["servers"]
+        rescue e
+          @logger.debug "Exception of #{oas3_json}/servers"
+          @logger.debug_sub e
         end
+
+        process_paths_json(json_obj, base_path, details, oas3_json)
       end
 
-      if oas3_yamls.is_a?(Array(String))
-        oas3_yamls.each do |oas3_yaml|
-          if File.exists?(oas3_yaml)
-            details = Details.new(PathInfo.new(oas3_yaml))
-            content = read_file_content(oas3_yaml)
-            yaml_obj = parse_yaml(content)
+      each_spec_file_with_details("oas3-yaml") do |oas3_yaml, details|
+        content = read_file_content(oas3_yaml)
+        yaml_obj = parse_yaml(content)
 
-            base_path = @url
-            begin
-              base_path = get_base_path yaml_obj["servers"]
-            rescue e
-              @logger.debug "Exception of #{oas3_yaml}/servers"
-              @logger.debug_sub e
-            end
-
-            process_paths_yaml(yaml_obj, base_path, details, oas3_yaml)
-          end
+        base_path = @url
+        begin
+          base_path = get_base_path yaml_obj["servers"]
+        rescue e
+          @logger.debug "Exception of #{oas3_yaml}/servers"
+          @logger.debug_sub e
         end
+
+        process_paths_yaml(yaml_obj, base_path, details, oas3_yaml)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/odata.cr
+++ b/src/analyzer/analyzers/specification/odata.cr
@@ -1,5 +1,5 @@
 require "xml"
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
   # OData CSDL (`$metadata`) describes a service's entity sets,
@@ -8,7 +8,7 @@ module Analyzer::Specification
   # base path is left implicit (`/`) because CSDL doesn't carry the
   # service root — downstream consumers prefix it from their own
   # context.
-  class OData < Analyzer
+  class OData < SpecificationEngine
     EDM_PRIMITIVE_BODY_TYPES = {
       "Edm.String"         => "string",
       "Edm.Boolean"        => "boolean",
@@ -33,19 +33,9 @@ module Analyzer::Specification
     alias Operation = NamedTuple(parameters: Array(NamedTuple(name: String, type: String)), kind: String)
 
     def analyze
-      locator = CodeLocator.instance
-      odata_specs = locator.all("odata-spec")
-      return @result unless odata_specs.is_a?(Array(String))
-
-      odata_specs.each do |path|
-        next unless File.exists?(path)
-        begin
-          content = read_file_content(path)
-          parse_metadata(content, path)
-        rescue e
-          @logger.debug "Failed to parse OData metadata #{path}: #{e.message}"
-          @logger.debug_sub e
-        end
+      each_spec_file("odata-spec") do |path|
+        content = read_file_content(path)
+        parse_metadata(content, path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/openrpc.cr
+++ b/src/analyzer/analyzers/specification/openrpc.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "uri"
 
 module Analyzer::Specification
@@ -18,25 +18,16 @@ module Analyzer::Specification
   # Each endpoint also carries a `jsonrpc_<method>` body param whose value is a
   # ready-to-send JSON-RPC 2.0 request envelope, the same way the GraphQL
   # analyzers attach a `graphql_<operation>_<field>` document param.
-  class OpenRpc < Analyzer
+  class OpenRpc < SpecificationEngine
     # Fallback when the document declares no usable server URL. JSON-RPC has
     # no canonical path the way GraphQL has `/graphql`, so stay at the root
     # rather than inventing one.
     DEFAULT_RPC_PATH = "/"
 
     def analyze
-      locator = CodeLocator.instance
-      jsons = locator.all("openrpc-json")
-      return @result unless jsons.is_a?(Array(String))
-
-      jsons.each do |path|
-        next unless File.exists?(path)
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("openrpc-json") do |path, details|
         content = read_file_content(path)
         process_document(JSON.parse(content), details)
-      rescue e
-        @logger.debug "Exception parsing OpenRPC #{path}"
-        @logger.debug_sub e
       end
 
       @result

--- a/src/analyzer/analyzers/specification/payload_cms.cr
+++ b/src/analyzer/analyzers/specification/payload_cms.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../miniparsers/js_object_config_extractor"
 require "./schema_api_common"
 
@@ -6,7 +6,7 @@ module Analyzer::Specification
   # Payload CMS mounts every collection at `/api/<slug>` and every global
   # at `/api/globals/<slug>`, generating the CRUD verbs plus auth and
   # version route families from flags on the config.
-  class PayloadCms < Analyzer
+  class PayloadCms < SpecificationEngine
     include SchemaApiCommon
 
     FIELD_TYPE_HINTS = {
@@ -45,34 +45,14 @@ module Analyzer::Specification
     TAG_SOURCE         = "payload_cms_analyzer"
 
     def analyze
-      locator = CodeLocator.instance
+      api_prefix = resolve_api_prefix(CodeLocator.instance.all("payload-config"))
 
-      api_prefix = resolve_api_prefix(locator.all("payload-config"))
-
-      collections = locator.all("payload-collection")
-      if collections.is_a?(Array(String))
-        collections.each do |path|
-          next unless File.exists?(path)
-          begin
-            parse_collections(read_file_content(path), path, api_prefix)
-          rescue e
-            @logger.debug "Failed to parse Payload collection #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file("payload-collection") do |path|
+        parse_collections(read_file_content(path), path, api_prefix)
       end
 
-      globals = locator.all("payload-global")
-      if globals.is_a?(Array(String))
-        globals.each do |path|
-          next unless File.exists?(path)
-          begin
-            parse_globals(read_file_content(path), path, api_prefix)
-          rescue e
-            @logger.debug "Failed to parse Payload global #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file("payload-global") do |path|
+        parse_globals(read_file_content(path), path, api_prefix)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/postman.cr
+++ b/src/analyzer/analyzers/specification/postman.cr
@@ -1,28 +1,16 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "uri"
 
 module Analyzer::Specification
-  class Postman < Analyzer
+  class Postman < SpecificationEngine
     def analyze
-      locator = CodeLocator.instance
-      postman_files = locator.all("postman-json")
+      each_spec_file("postman-json") do |postman_file|
+        content = read_file_content(postman_file)
+        json_obj = JSON.parse(content)
 
-      if postman_files.is_a?(Array(String))
-        postman_files.each do |postman_file|
-          if File.exists?(postman_file)
-            content = read_file_content(postman_file)
-            json_obj = JSON.parse(content)
-
-            begin
-              # Process items (requests) in the collection
-              if json_obj["item"]?
-                process_items(json_obj["item"], postman_file, collect_variables(json_obj["variable"]?), "", json_obj["auth"]?)
-              end
-            rescue e
-              @logger.debug "Exception processing #{postman_file}"
-              @logger.debug_sub e
-            end
-          end
+        # Process items (requests) in the collection
+        if json_obj["item"]?
+          process_items(json_obj["item"], postman_file, collect_variables(json_obj["variable"]?), "", json_obj["auth"]?)
         end
       end
 

--- a/src/analyzer/analyzers/specification/raml.cr
+++ b/src/analyzer/analyzers/specification/raml.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class RAML < Analyzer
+  class RAML < SpecificationEngine
     HTTP_METHODS       = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
     INCLUDE_EXTENSIONS = {".raml", ".yaml", ".yml", ".json"}
     alias ResolvedNode = NamedTuple(node: YAML::Any, source_dir: String)
@@ -12,58 +12,54 @@ module Analyzer::Specification
     @libraries = {} of String => ResolvedNode
 
     def analyze
-      locator = CodeLocator.instance
-      raml_specs = locator.all("raml-spec")
+      each_spec_file("raml-spec") do |raml_spec|
+        content = read_file_content(raml_spec)
 
-      if raml_specs.is_a?(Array(String))
-        raml_specs.each do |raml_spec|
-          next unless File.exists?(raml_spec)
-          content = read_file_content(raml_spec)
+        # Only root API documents (`#%RAML 1.0` / `#%RAML 0.8`) describe
+        # endpoints. Fragments — Library, Trait, ResourceType, DataType,
+        # and especially Overlay / Extension — are applied onto a master
+        # API, not served on their own. Analyzing an Extension standalone
+        # emits phantom endpoints (its resources without the master's
+        # baseUri or context), so skip every non-root fragment.
+        next unless raml_root_api?(content)
 
-          # Only root API documents (`#%RAML 1.0` / `#%RAML 0.8`) describe
-          # endpoints. Fragments — Library, Trait, ResourceType, DataType,
-          # and especially Overlay / Extension — are applied onto a master
-          # API, not served on their own. Analyzing an Extension standalone
-          # emits phantom endpoints (its resources without the master's
-          # baseUri or context), so skip every non-root fragment.
-          next unless raml_root_api?(content)
+        details = Details.new(PathInfo.new(raml_spec))
+        yaml_obj = YAML.parse(content)
+        source_dir = File.dirname(raml_spec)
 
-          details = Details.new(PathInfo.new(raml_spec))
-          yaml_obj = YAML.parse(content)
-          source_dir = File.dirname(raml_spec)
+        # A non-mapping root (scalar/array/empty) makes the YAML `[...]?`
+        # lookups below raise "Expected Array or Hash". `each_spec_file`
+        # would catch that and move on, but only after logging it as a
+        # failure — a non-mapping root is an ordinary non-API document, not
+        # an error. Skip it cleanly instead.
+        next unless yaml_obj.as_h?
 
-          # A non-mapping root (scalar/array/empty) makes the YAML `[...]?`
-          # lookups below raise "Expected Array or Hash" and, with no per-spec
-          # rescue, aborts every other RAML spec. Skip it cleanly instead.
-          next unless yaml_obj.as_h?
+        @libraries = collect_libraries(yaml_obj, source_dir)
+        base_path = base_path_from(yaml_obj)
+        default_media = media_types_from(yaml_obj[YAML::Any.new("mediaType")]?)
+        types = yaml_obj[YAML::Any.new("types")]? || YAML::Any.new(nil)
+        schemas = yaml_obj[YAML::Any.new("schemas")]? || YAML::Any.new(nil)
+        resource_types = yaml_obj[YAML::Any.new("resourceTypes")]? || YAML::Any.new(nil)
+        traits = yaml_obj[YAML::Any.new("traits")]? || YAML::Any.new(nil)
 
-          @libraries = collect_libraries(yaml_obj, source_dir)
-          base_path = base_path_from(yaml_obj)
-          default_media = media_types_from(yaml_obj[YAML::Any.new("mediaType")]?)
-          types = yaml_obj[YAML::Any.new("types")]? || YAML::Any.new(nil)
-          schemas = yaml_obj[YAML::Any.new("schemas")]? || YAML::Any.new(nil)
-          resource_types = yaml_obj[YAML::Any.new("resourceTypes")]? || YAML::Any.new(nil)
-          traits = yaml_obj[YAML::Any.new("traits")]? || YAML::Any.new(nil)
-
-          if root = yaml_obj.as_h?
-            root.each do |key, value|
-              key_s = key.to_s
-              next unless key_s.starts_with?("/")
-              walk_resource(
-                value,
-                base_path + key_s,
-                default_media,
-                types,
-                schemas,
-                resource_types,
-                traits,
-                details,
-                raml_spec,
-                source_dir,
-                source_dir,
-                [] of Param
-              )
-            end
+        if root = yaml_obj.as_h?
+          root.each do |key, value|
+            key_s = key.to_s
+            next unless key_s.starts_with?("/")
+            walk_resource(
+              value,
+              base_path + key_s,
+              default_media,
+              types,
+              schemas,
+              resource_types,
+              traits,
+              details,
+              raml_spec,
+              source_dir,
+              source_dir,
+              [] of Param
+            )
           end
         end
       end

--- a/src/analyzer/analyzers/specification/serverless_framework.cr
+++ b/src/analyzer/analyzers/specification/serverless_framework.cr
@@ -1,27 +1,16 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class ServerlessFramework < Analyzer
+  class ServerlessFramework < SpecificationEngine
     METHOD_ANY = "ANY"
 
     def analyze
-      spec_files = CodeLocator.instance.all("serverless-framework-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
-      spec_files.each do |path|
-        next unless File.exists?(path)
-
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("serverless-framework-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          if path.ends_with?(".json")
-            process_doc(JSON.parse(content), details)
-          else
-            process_doc(YAML.parse(content), details)
-          end
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
+        if path.ends_with?(".json")
+          process_doc(JSON.parse(content), details)
+        else
+          process_doc(YAML.parse(content), details)
         end
       end
 

--- a/src/analyzer/analyzers/specification/smithy.cr
+++ b/src/analyzer/analyzers/specification/smithy.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
   # Smithy IDL (https://smithy.io) is AWS's interface definition language.
@@ -6,7 +6,7 @@ module Analyzer::Specification
   # (`@httpLabel`, `@httpHeader`, `@httpQuery`, `@httpPayload`) map
   # directly to Noir endpoints, so we parse them shape-by-shape rather
   # than building a full AST.
-  class Smithy < Analyzer
+  class Smithy < SpecificationEngine
     # Parsed representation of one operation's HTTP binding.
     record HttpBinding, method : String, uri : String, code : Int32?
 
@@ -45,23 +45,13 @@ module Analyzer::Specification
     record InputMember, name : String, param_type : String
 
     def analyze
-      locator = CodeLocator.instance
-      spec_files = locator.all("smithy-spec")
-
       # Two-pass: first collect every structure's member bindings so an
       # `operation` declared above its input structure still resolves.
       structures = {} of String => Array(InputMember)
       operations = [] of NamedTuple(name: String, file: String, line: Int32, binding: HttpBinding, input: String?)
 
-      spec_files.each do |file|
-        begin
-          content = read_file_content(file)
-        rescue File::NotFoundError
-          @logger.debug "Smithy spec not found during analysis, skipping: #{file}"
-          next
-        end
-
-        parse_file(content, file, structures, operations)
+      each_spec_file("smithy-spec") do |file|
+        parse_file(read_file_content(file), file, structures, operations)
       end
 
       operations.each do |op|

--- a/src/analyzer/analyzers/specification/strapi.cr
+++ b/src/analyzer/analyzers/specification/strapi.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../miniparsers/js_object_config_extractor"
 require "./schema_api_common"
 
@@ -9,7 +9,7 @@ module Analyzer::Specification
   #
   # Custom routes declared in `src/api/<name>/routes/*.{ts,js}` are read
   # separately and mounted under the same `/api` prefix.
-  class Strapi < Analyzer
+  class Strapi < SpecificationEngine
     include SchemaApiCommon
 
     ATTRIBUTE_TYPE_HINTS = {
@@ -42,32 +42,12 @@ module Analyzer::Specification
     TAG_SOURCE = "strapi_analyzer"
 
     def analyze
-      locator = CodeLocator.instance
-
-      schemas = locator.all("strapi-schema")
-      if schemas.is_a?(Array(String))
-        schemas.each do |path|
-          next unless File.exists?(path)
-          begin
-            parse_schema(read_file_content(path), path)
-          rescue e
-            @logger.debug "Failed to parse Strapi schema #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file("strapi-schema") do |path|
+        parse_schema(read_file_content(path), path)
       end
 
-      routes = locator.all("strapi-routes")
-      if routes.is_a?(Array(String))
-        routes.each do |path|
-          next unless File.exists?(path)
-          begin
-            parse_routes(read_file_content(path), path)
-          rescue e
-            @logger.debug "Failed to parse Strapi routes #{path}"
-            @logger.debug_sub e
-          end
-        end
+      each_spec_file("strapi-routes") do |path|
+        parse_routes(read_file_content(path), path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/supabase.cr
+++ b/src/analyzer/analyzers/specification/supabase.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "../../../miniparsers/postgres_ddl_parser"
 require "./schema_api_common"
 
@@ -14,7 +14,7 @@ module Analyzer::Specification
   #   * Only exposed schemas are reachable. Supabase migrations routinely
   #     create tables in `auth`, `storage` and `extensions`, none of
   #     which PostgREST serves.
-  class Supabase < Analyzer
+  class Supabase < SpecificationEngine
     include SchemaApiCommon
 
     REST_PREFIX = "/rest/v1"
@@ -35,24 +35,17 @@ module Analyzer::Specification
     MAX_FILTER_PARAMS = 25
 
     def analyze
-      locator = CodeLocator.instance
-      migrations = locator.all("supabase-migration")
-      return @result unless migrations.is_a?(Array(String))
+      # Nothing to apply the DDL to, so skip reading `config.toml` as well.
+      return @result if CodeLocator.instance.all("supabase-migration").empty?
 
-      exposed = exposed_schemas(locator.all("supabase-config"))
+      exposed = exposed_schemas(CodeLocator.instance.all("supabase-config"))
 
       # Migration filenames are `<timestamp>_<name>.sql`, so lexical order
       # is chronological. Applying them in order is what makes a column
       # added in one file and dropped in another come out right.
       state = Noir::PostgresDdlParser::State.new
-      migrations.sort.each do |path|
-        next unless File.exists?(path)
-        begin
-          Noir::PostgresDdlParser.apply(read_file_content(path), path, state)
-        rescue e
-          @logger.debug "Failed to parse Supabase migration #{path}"
-          @logger.debug_sub e
-        end
+      each_spec_file("supabase-migration", sorted: true) do |path|
+        Noir::PostgresDdlParser.apply(read_file_content(path), path, state)
       end
 
       state.tables.each_value do |table|

--- a/src/analyzer/analyzers/specification/terraform.cr
+++ b/src/analyzer/analyzers/specification/terraform.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
   # Extracts HTTP endpoints from Terraform / OpenTofu configurations that
@@ -13,7 +13,7 @@ module Analyzer::Specification
   #     per file.
   #
   # Both HCL (`.tf`) and Terraform JSON (`.tf.json`) inputs are supported.
-  class Terraform < Analyzer
+  class Terraform < SpecificationEngine
     METHOD_ANY   = "ANY"
     HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "ANY"}
 
@@ -39,14 +39,10 @@ module Analyzer::Specification
     record RestNode, name : String, path_part : String, parent : String?
 
     def analyze
-      spec_files = CodeLocator.instance.all("terraform-spec")
-      return @result unless spec_files.is_a?(Array(String))
-
       # Group files by module directory. A REST resource and the method that
       # references it routinely live in different files of the same module.
       by_dir = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
-      spec_files.each do |path|
-        next unless File.exists?(path)
+      each_spec_file("terraform-spec") do |path|
         by_dir[File.dirname(path)] << path
       end
 

--- a/src/analyzer/analyzers/specification/traefik.cr
+++ b/src/analyzer/analyzers/specification/traefik.cr
@@ -1,29 +1,19 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "set"
 
 module Analyzer::Specification
-  class Traefik < Analyzer
+  class Traefik < SpecificationEngine
     def analyze
-      locator = CodeLocator.instance
-      files = locator.all("traefik-spec")
+      # Shared across every file so one route defined in two providers
+      # (a TOML and a YAML dynamic-config pair) is emitted once.
       seen = Set(String).new
 
-      if files.is_a?(Array(String))
-        files.each do |path|
-          next unless File.exists?(path)
-          details = Details.new(PathInfo.new(path))
-          content = read_file_content(path)
-
-          begin
-            if path.ends_with?(".toml")
-              process_toml(content, details, seen)
-            else
-              process_yaml(content, details, seen)
-            end
-          rescue e
-            @logger.debug "Exception processing #{path}"
-            @logger.debug_sub e
-          end
+      each_spec_file_with_details("traefik-spec") do |path, details|
+        content = read_file_content(path)
+        if path.ends_with?(".toml")
+          process_toml(content, details, seen)
+        else
+          process_yaml(content, details, seen)
         end
       end
 

--- a/src/analyzer/analyzers/specification/typespec.cr
+++ b/src/analyzer/analyzers/specification/typespec.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "uri"
 
 module Analyzer::Specification
@@ -7,20 +7,13 @@ module Analyzer::Specification
   # that compose along namespace + interface scopes. This analyzer is a
   # line/block parser (not a full TypeSpec compiler): it walks balanced braces,
   # buffers decorators across newlines, and emits one endpoint per operation.
-  class TypeSpec < Analyzer
+  class TypeSpec < SpecificationEngine
     HTTP_VERB_DECORATORS = {"get", "post", "put", "patch", "delete", "head", "options"}
 
     def analyze
-      locator = CodeLocator.instance
-      typespec_files = locator.all("typespec-spec")
-
-      if typespec_files.is_a?(Array(String))
-        typespec_files.each do |path|
-          next unless File.exists?(path)
-          details = Details.new(PathInfo.new(path))
-          content = read_file_content(path)
-          process_file(content, details, path)
-        end
+      each_spec_file_with_details("typespec-spec") do |path, details|
+        content = read_file_content(path)
+        process_file(content, details, path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/vercel.cr
+++ b/src/analyzer/analyzers/specification/vercel.cr
@@ -1,26 +1,15 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class Vercel < Analyzer
+  class Vercel < SpecificationEngine
     ROUTING_GROUP_KEYS = {"beforeFiles", "afterFiles", "fallback"}
     PATTERN_CHARS      = {'*', '^', '$', '(', ')', '[', ']', '{', '}', '|', '+', '?', '\\'}
     METHOD_ANY         = "ANY"
 
     def analyze
-      locator = CodeLocator.instance
-      config_files = locator.all("vercel-spec")
-      return @result unless config_files.is_a?(Array(String))
-
-      config_files.each do |path|
-        next unless File.exists?(path)
-        details = Details.new(PathInfo.new(path))
+      each_spec_file_with_details("vercel-spec") do |path, details|
         content = read_file_content(path)
-        begin
-          process_config(JSON.parse(content), details)
-        rescue e
-          @logger.debug "Exception processing #{path}"
-          @logger.debug_sub e
-        end
+        process_config(JSON.parse(content), details)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/wsdl.cr
+++ b/src/analyzer/analyzers/specification/wsdl.cr
@@ -1,9 +1,9 @@
 require "xml"
 require "uri"
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 
 module Analyzer::Specification
-  class WSDL < Analyzer
+  class WSDL < SpecificationEngine
     SOAP12_NS        = "http://schemas.xmlsoap.org/wsdl/soap12/"
     MAX_IMPORT_DEPTH = 8
 
@@ -15,19 +15,9 @@ module Analyzer::Specification
     alias PartRef = NamedTuple(name: String, ref: String, is_element: Bool)
 
     def analyze
-      locator = CodeLocator.instance
-      wsdl_specs = locator.all("wsdl-spec")
-      return @result unless wsdl_specs.is_a?(Array(String))
-
-      wsdl_specs.each do |path|
-        next unless File.exists?(path)
-        begin
-          content = read_file_content(path)
-          parse_wsdl(content, path)
-        rescue e
-          @logger.debug "Failed to parse WSDL #{path}: #{e.message}"
-          @logger.debug_sub e
-        end
+      each_spec_file("wsdl-spec") do |path|
+        content = read_file_content(path)
+        parse_wsdl(content, path)
       end
 
       @result

--- a/src/analyzer/analyzers/specification/zap_sites_tree.cr
+++ b/src/analyzer/analyzers/specification/zap_sites_tree.cr
@@ -1,29 +1,16 @@
-require "../../../models/analyzer"
+require "../../engines/specification_engine"
 require "uri"
 
 module Analyzer::Specification
-  class ZapSitesTree < Analyzer
+  class ZapSitesTree < SpecificationEngine
     def analyze
-      locator = CodeLocator.instance
-      sites_trees = locator.all("zap-sites-tree")
+      each_spec_file_with_details("zap-sites-tree") do |sites_tree, details|
+        content = read_file_content(sites_tree)
+        yaml_obj = YAML.parse(content)
 
-      if sites_trees.is_a?(Array(String))
-        sites_trees.each do |sites_tree|
-          if File.exists?(sites_tree)
-            details = Details.new(PathInfo.new(sites_tree))
-            content = read_file_content(sites_tree)
-            yaml_obj = YAML.parse(content)
-
-            begin
-              children = yaml_obj.as_a
-              children.each do |child|
-                process_node(child, details)
-              end
-            rescue e
-              @logger.debug "Exception of #{sites_tree}/paths"
-              @logger.debug_sub e
-            end
-          end
+        children = yaml_obj.as_a
+        children.each do |child|
+          process_node(child, details)
         end
       end
 

--- a/src/analyzer/engines/specification_engine.cr
+++ b/src/analyzer/engines/specification_engine.cr
@@ -1,0 +1,83 @@
+require "../../models/analyzer"
+require "../../models/code_locator"
+
+module Analyzer::Specification
+  # Base for the specification-format analyzers (OpenAPI, Postman, HAR,
+  # Terraform, k8s manifests, proxy exports, …).
+  #
+  # They do not walk the file tree the way the language engines do. The
+  # detector recognises a document and pushes its path into `CodeLocator`
+  # under a key, and the analyzer later drains that key. Forty-odd
+  # analyzers each open-coded the same drain:
+  #
+  #     locator = CodeLocator.instance
+  #     files = locator.all("some-key")
+  #     return @result unless files.is_a?(Array(String))
+  #     files.each do |path|
+  #       next unless File.exists?(path)
+  #       begin
+  #         ...
+  #       rescue e
+  #         @logger.debug "..."
+  #         @logger.debug_sub e
+  #       end
+  #     end
+  #
+  # with just enough variation between copies that some dropped the
+  # existence check, some dropped the per-file rescue (letting one
+  # malformed document abort every remaining file for that analyzer), and
+  # the log wording differed everywhere. `each_spec_file` is that drain,
+  # once.
+  abstract class SpecificationEngine < Analyzer
+    # Yield every registered path for `key`, skipping paths that no longer
+    # resolve and containing per-file failures.
+    #
+    # The `File.exists?` check is load-bearing, not a leftover. Unlike the
+    # language engines — whose paths come from the extension index rebuilt
+    # per scan — these keys are never cleared at the start of a scan
+    # (`detect_techs` clears only `file_map` and the mobile keys, and
+    # `clear_all` runs only between the two halves of a `--diff` run). A
+    # second scan in the same process therefore still sees the first
+    # scan's registrations, and dropping the check would turn stale
+    # entries into read errors.
+    #
+    # Failures are contained per file: a malformed document is logged and
+    # skipped so the remaining files for that analyzer still produce
+    # endpoints.
+    #
+    # `sorted` yields in lexical path order. Only pass it where order is part
+    # of the format's meaning — Supabase migrations are named
+    # `<timestamp>_<name>.sql`, so lexical order is chronological and a column
+    # added in one file and dropped in another only comes out right if they
+    # are applied in sequence. Registration order is otherwise whatever the
+    # concurrent detector walk produced, so relying on it silently would be a
+    # bug.
+    protected def each_spec_file(key : String, sorted : Bool = false, &block : String -> Nil) : Nil
+      # No `is_a?(Array(String))` guard: `CodeLocator#all` is typed to return
+      # `Array(String)`, so the copies of that check in the old analyzers were
+      # always true and only read as though `all` might hand back something
+      # else.
+      paths = CodeLocator.instance.all(key)
+      paths = paths.sort if sorted
+
+      paths.each do |path|
+        next unless File.exists?(path)
+
+        begin
+          block.call(path)
+        rescue e
+          logger.debug "#{self.class} failed to process #{path}"
+          logger.debug_sub e
+        end
+      end
+    end
+
+    # `each_spec_file` plus the `Details` almost every caller builds from
+    # the path as its first statement.
+    protected def each_spec_file_with_details(key : String, &block : String, Details -> Nil) : Nil
+      each_spec_file(key) do |path|
+        block.call(path, Details.new(PathInfo.new(path)))
+      end
+    end
+  end
+end


### PR DESCRIPTION
The 45 specification analyzers do not walk the file tree the way the language engines do. The detector recognises a document and pushes its path into `CodeLocator` under a key; the analyzer later drains that key. Every one of them open-coded the same drain:

```crystal
locator = CodeLocator.instance
files = locator.all("some-key")
return @result unless files.is_a?(Array(String))
files.each do |path|
  next unless File.exists?(path)
  begin
    ...
  rescue e
    @logger.debug "..."
    @logger.debug_sub e
  end
end
```

Forty-odd near-copies drifted the way near-copies do:

- some dropped the existence check
- some dropped the per-file rescue, so **one malformed document aborted every remaining file for that analyzer** — `postman` and `oas2` parsed outside their own `begin`/`rescue`
- the log wording differed everywhere
- the `is_a?(Array(String))` guard was dead in all of them: `CodeLocator#all` is typed to return `Array(String)`

`SpecificationEngine#each_spec_file` is that drain, once. The whole family now extends it — nothing under `specification/` inherits `Analyzer` directly any more. `each_spec_file_with_details` folds in the `Details` that 18 of the 43 drain blocks were building by hand as their first statement.

**`File.exists?` moves into the engine rather than being dropped.** Unlike the language engines — whose paths come from the extension index, rebuilt per scan — these keys are never cleared at the start of a scan (`detect_techs` clears only `file_map` and the mobile keys; `clear_all` runs only between the halves of a `--diff` run), so a second scan in the same process still sees the first scan's registrations. Load-bearing, not a leftover.

## Deliberately not folded in

| analyzer | why |
|---|---|
| `k8s_ingress` | its rescue is not logging — it falls back to a tolerant line scanner, because a Helm chart's `templates/ingress.yaml` is a Go template and failing to parse as YAML is the normal case there |
| `oas2` / `oas3` | inner `begin`/`rescue` around the `servers` lookup must survive |
| `grpc` | early return kept: `build_message_registry` reads every `.proto` in the codebase |
| `supabase` | early return kept (no migrations → do not read `config.toml`), and passes `sorted: true` — migration filenames are `<timestamp>_<name>.sql`, so applying them out of order gets the column state wrong. Registration order is otherwise whatever the concurrent detector walk produced |

## Behaviour change

In the safe direction: analyzers that previously had no per-file rescue now get one, so a single bad document no longer costs the remaining files. Log wording is now uniform, which loses `mitmproxy`'s and `smithy`'s bespoke messages.

## Verification

Detection-neutral, measured rather than assumed: base (`origin/main`) and this branch, both built `--release`, scanned **all 661 functional-test fixture directories** with `--include-path`. Normalised endpoint output (method, url, params, technology, tags) is identical in every one, with no empty results masking a difference.

```
crystal spec spec/unit_test         4,161 examples, 0 failures
crystal spec spec/functional_test  22,432 examples, 0 failures
crystal tool format --check         clean
ameba                               725 files, 0 failures
```

net **−391 lines** (443 insertions, 834 deletions across 46 files)

> Caught during review, worth calling out: the first pass of this migration silently dropped `k8s_ingress`'s Helm fallback, because the script treated every `rescue` as removable logging. The unit suite caught it. I then audited all 45 files for rescue bodies containing non-logging statements — `k8s_ingress` was the only one.