### PR TITLE
refactor(detector): declare detectors with a `detector_for` macro

### DIFF
--- a/spec/unit_test/detector/applicable_lookup_fidelity_spec.cr
+++ b/spec/unit_test/detector/applicable_lookup_fidelity_spec.cr
@@ -5,10 +5,16 @@ require "../../../src/models/detector"
 # Instantiate every concrete Detector subclass. Using `all_subclasses`
 # rather than a hand-written list is deliberate: a new detector joins
 # this sweep automatically, so it cannot silently regress the memo.
+#
+# Restricted to the `Detector::` namespace, which is where every production
+# detector lives. `crystal spec` compiles the whole suite into one binary, so
+# `all_subclasses` also sees the throwaway subclasses other spec files define
+# to exercise the base class (`detector_for_spec.cr`) — and because those are
+# file-private, naming them here does not even compile.
 private def every_detector(options) : Array(Detector)
   detectors = [] of Detector
   {% for sub in Detector.all_subclasses %}
-    {% unless sub.abstract? %}
+    {% if !sub.abstract? && sub.name.starts_with?("Detector::") %}
       detector = {{ sub }}.new(options)
       detector.set_name
       detectors << detector.as(Detector)

--- a/spec/unit_test/detector/detector_for_spec.cr
+++ b/spec/unit_test/detector/detector_for_spec.cr
@@ -1,0 +1,124 @@
+require "../../spec_helper"
+require "../../../src/detector/detector"
+require "../../../src/models/detector"
+
+# `detector_for` replaced the hand-written `set_name` / `applicable?` /
+# `idempotent?` trio that every one of the 241 detectors carried. These specs
+# pin the macro's expansion, and the sweep at the bottom pins the invariant
+# that made the macro worth introducing: the tech name is declared exactly
+# once per detector, so `Class.tech_name` and the instance's `name` can never
+# disagree.
+
+private class ExtOnlyDetector < Detector
+  detector_for "spec_ext_only", extensions: %w[.foo .bar]
+end
+
+private class BasenameDetector < Detector
+  detector_for "spec_basename", basenames: %w[config.toml Makefile]
+end
+
+private class MixedDetector < Detector
+  detector_for "spec_mixed", extensions: %w[.zz], basenames: %w[zz.mod], idempotent: false
+end
+
+private class DirSegmentDetector < Detector
+  detector_for "spec_dir_segment", path_segments: %w[/metadata/]
+end
+
+private class BareSubstringDetector < Detector
+  detector_for "spec_bare_substring", path_segments: %w[zz.mod]
+end
+
+private class NameOnlyDetector < Detector
+  detector_for "spec_name_only"
+end
+
+describe "detector_for" do
+  options = create_test_options
+
+  it "declares the tech name for both the instance and the class" do
+    detector = ExtOnlyDetector.new(options)
+    detector.set_name
+    detector.name.should eq "spec_ext_only"
+    ExtOnlyDetector.tech_name.should eq "spec_ext_only"
+  end
+
+  it "gates on every declared extension and nothing else" do
+    detector = ExtOnlyDetector.new(options)
+    detector.applicable?("a/b/thing.foo").should be_true
+    detector.applicable?("thing.bar").should be_true
+    detector.applicable?("thing.baz").should be_false
+    detector.applicable?("foo").should be_false
+  end
+
+  it "compares basenames rather than substrings" do
+    detector = BasenameDetector.new(options)
+    detector.applicable?("deep/dir/config.toml").should be_true
+    detector.applicable?("Makefile").should be_true
+    # A substring gate would wrongly accept these.
+    detector.applicable?("config.toml.bak").should be_false
+    detector.applicable?("dir/config.tomlx").should be_false
+  end
+
+  it "ORs extensions and basenames together" do
+    detector = MixedDetector.new(options)
+    detector.applicable?("x/y.zz").should be_true
+    detector.applicable?("x/zz.mod").should be_true
+    detector.applicable?("x/y.qq").should be_false
+  end
+
+  it "carries idempotent: false through, and defaults to true" do
+    MixedDetector.new(options).idempotent?.should be_false
+    ExtOnlyDetector.new(options).idempotent?.should be_true
+  end
+
+  # The reason `path_segments` exists as its own key. `applicable?` is
+  # memoized by basename, so a directory gate that does not declare itself
+  # path-sensitive is silently dropped — the way the Hasura `metadata/**`
+  # gate was lost.
+  it "derives path_sensitive? from a segment that names a directory" do
+    detector = DirSegmentDetector.new(options)
+    detector.path_sensitive?.should be_true
+    detector.applicable?("app/metadata/tables.yaml").should be_true
+    detector.applicable?("tables.yaml").should be_false
+  end
+
+  # A separator-free term is a plain substring test over the whole path, and
+  # `detector_path_sensitive?`'s probe does not flag those: it compares
+  # `applicable?("a/b/c/zz.mod")` with `applicable?("zz.mod")`, which agree.
+  # Declaring them sensitive would drop the detector out of the basename memo
+  # for no correctness gain.
+  it "leaves a separator-free substring term basename-memoizable" do
+    detector = BareSubstringDetector.new(options)
+    detector.path_sensitive?.should be_false
+    detector.applicable?("a/b/c/zz.mod").should eq detector.applicable?("zz.mod")
+  end
+
+  it "emits no gate when only a name is declared" do
+    detector = NameOnlyDetector.new(options)
+    NameOnlyDetector.tech_name.should eq "spec_name_only"
+    # Falls through to Detector's permissive default.
+    detector.applicable?("anything.at.all").should be_true
+  end
+end
+
+describe "detector identity" do
+  it "declares each real detector's name exactly once" do
+    options = create_test_options
+    mismatched = [] of String
+
+    # `Detector::` is the production namespace — see the same filter in
+    # applicable_lookup_fidelity_spec.cr for why the sweep is scoped.
+    {% for sub in Detector.all_subclasses %}
+      {% if !sub.abstract? && sub.name.starts_with?("Detector::") %}
+        detector = {{ sub }}.new(options)
+        detector.set_name
+        unless detector.name == {{ sub }}.tech_name
+          mismatched << "{{ sub }}: name=#{detector.name} tech_name=#{{{ sub }}.tech_name}"
+        end
+      {% end %}
+    {% end %}
+
+    fail "detectors whose instance name and class tech_name disagree: #{mismatched}" unless mismatched.empty?
+  end
+end

--- a/src/detector/detectors/asp/classic.cr
+++ b/src/detector/detectors/asp/classic.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Asp
   class Classic < Detector
+    detector_for "asp_classic", extensions: %w[.asp .asa .inc]
+
     # `<%@ LANGUAGE="VBSCRIPT" %>` page directive, the ASP intrinsic
     # objects, and server-side <script> blocks. `.aspx` is a different
     # extension entirely, so there is no overlap with WebForms.
@@ -18,14 +20,6 @@ module Detector::Asp
       return true if content_matches?(file_contents, SCRIPT_DELIMITER_RE) && content_matches?(file_contents, INTRINSIC_RE)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".asp") || filename.ends_with?(".asa") || filename.ends_with?(".inc")
-    end
-
-    def set_name
-      @name = "asp_classic"
     end
   end
 end

--- a/src/detector/detectors/aspnet/webforms.cr
+++ b/src/detector/detectors/aspnet/webforms.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Aspnet
   class WebForms < Detector
+    detector_for "aspnet_webforms"
+
     # `<%@ Page %>` / `<%@ Control %>` / `<%@ WebHandler %>` /
     # `<%@ WebService %>` directives, and the `runat="server"` marker that
     # every WebForms control carries. Directives routinely span several
@@ -35,10 +37,6 @@ module Detector::Aspnet
 
       # Only code-behind siblings, never arbitrary sources.
       filename.downcase.matches?(/\.(?:aspx|ascx|ashx|asmx|master)\.(?:cs|vb)\z/)
-    end
-
-    def set_name
-      @name = "aspnet_webforms"
     end
   end
 end

--- a/src/detector/detectors/cfml/coldbox.cr
+++ b/src/detector/detectors/cfml/coldbox.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cfml
   class Coldbox < Detector
+    detector_for "cfml_coldbox", extensions: %w[.cfc .cfm]
+
     # The router DSL and the ColdBox base classes. `coldbox.system` is the
     # framework namespace every ColdBox application references.
     ROUTER_DSL_RE = /(?<![\w.])(?:addRoute|resources)\s*\(|\.\s*to(?:Handler|View|Redirect|Response|ModuleRouting)\s*\(/i
@@ -21,14 +23,6 @@ module Detector::Cfml
       return true if base == "routes.cfm" && content_matches?(file_contents, ROUTER_DSL_RE)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cfc") || filename.ends_with?(".cfm")
-    end
-
-    def set_name
-      @name = "cfml_coldbox"
     end
   end
 end

--- a/src/detector/detectors/cfml/fw1.cr
+++ b/src/detector/detectors/cfml/fw1.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cfml
   class Fw1 < Detector
+    detector_for "cfml_fw1", extensions: %w[.cfc]
+
     # Applications extend `framework.one`; the routes array and the
     # framework settings struct are the other unambiguous markers.
     BASE_RE     = /extends\s*=\s*["']framework\.one["']/i
@@ -16,14 +18,6 @@ module Detector::Cfml
       return true if content_matches?(file_contents, SETTINGS_RE)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cfc")
-    end
-
-    def set_name
-      @name = "cfml_fw1"
     end
   end
 end

--- a/src/detector/detectors/cfml/pure.cr
+++ b/src/detector/detectors/cfml/pure.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cfml
   class Pure < Detector
+    detector_for "cfml_pure", extensions: %w[.cfm .cfc .cfml]
+
     # CFML tag markers. Tags are case-insensitive and may be written with
     # or without a closing slash, so match the opening `<cfxxx` prefix only.
     TAG_MARKERS_RE = /<cf(?:component|function|argument|script|set|output|query|param|return|invoke|http|location|include)\b/i
@@ -18,14 +20,6 @@ module Detector::Cfml
       return true if content_matches?(file_contents, SCRIPT_COMPONENT_RE)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cfm") || filename.ends_with?(".cfc") || filename.ends_with?(".cfml")
-    end
-
-    def set_name
-      @name = "cfml_pure"
     end
   end
 end

--- a/src/detector/detectors/cfml/taffy.cr
+++ b/src/detector/detectors/cfml/taffy.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cfml
   class Taffy < Detector
+    detector_for "cfml_taffy", extensions: %w[.cfc .cfm]
+
     # The `taffy:uri` / `taffy_uri` resource attribute, or a component
     # extending Taffy's resource base. `taffy.core.api` appears in the
     # application's index.cfm.
@@ -17,14 +19,6 @@ module Detector::Cfml
       return true if content_matches?(file_contents, API_BASE_RE)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cfc") || filename.ends_with?(".cfm")
-    end
-
-    def set_name
-      @name = "cfml_taffy"
     end
   end
 end

--- a/src/detector/detectors/cfml/wheels.cr
+++ b/src/detector/detectors/cfml/wheels.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cfml
   class Wheels < Detector
+    detector_for "cfml_wheels", extensions: %w[.cfm .cfc]
+
     # The `mapper()` chain in config/routes.cfm, and the framework's own
     # namespace used by application components.
     MAPPER_RE    = /(?<![\w.])mapper\s*\(\s*\)\s*(?:\/\/[^\n]*\n\s*)*\./i
@@ -17,14 +19,6 @@ module Detector::Cfml
       end
 
       content_matches?(file_contents, NAMESPACE_RE)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cfm") || filename.ends_with?(".cfc")
-    end
-
-    def set_name
-      @name = "cfml_wheels"
     end
   end
 end

--- a/src/detector/detectors/clojure/cli.cr
+++ b/src/detector/detectors/clojure/cli.cr
@@ -8,19 +8,13 @@ module Detector::Clojure
   # web apps and services, so it only annotates params on a `cli://`
   # endpoint one of the markers below already established.
   class Cli < Detector
+    detector_for "clojure_cli", extensions: %w[.clj .cljs .cljc]
+
     MARKERS = /clojure\.tools\.cli\b|\(\s*(?:[\w.-]+\/)?parse-opts\b|\bcli-matic\b|\*command-line-args\*|\bbabashka\.cli\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".clj") || filename.ends_with?(".cljs") || filename.ends_with?(".cljc")
-    end
-
-    def set_name
-      @name = "clojure_cli"
     end
   end
 end

--- a/src/detector/detectors/clojure/compojure.cr
+++ b/src/detector/detectors/clojure/compojure.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Clojure
   class Compojure < Detector
+    detector_for "clojure_compojure",
+      extensions: %w[.clj .cljs .cljc .edn],
+      basenames: %w[project.clj deps.edn]
+
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
     PROJECT_FILES      = {"project.clj", "deps.edn"}
 
@@ -22,14 +26,6 @@ module Detector::Clojure
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".clj") || filename.ends_with?(".cljs") || filename.ends_with?(".cljc") || filename.ends_with?(".edn") || File.basename(filename) == "project.clj" || File.basename(filename) == "deps.edn"
-    end
-
-    def set_name
-      @name = "clojure_compojure"
     end
   end
 end

--- a/src/detector/detectors/clojure/pedestal.cr
+++ b/src/detector/detectors/clojure/pedestal.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Clojure
   class Pedestal < Detector
+    detector_for "clojure_pedestal",
+      extensions: %w[.clj .cljs .cljc .edn],
+      basenames: %w[project.clj deps.edn]
+
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
     PROJECT_FILES      = {"project.clj", "deps.edn"}
 
@@ -25,14 +29,6 @@ module Detector::Clojure
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".clj") || filename.ends_with?(".cljs") || filename.ends_with?(".cljc") || filename.ends_with?(".edn") || File.basename(filename) == "project.clj" || File.basename(filename) == "deps.edn"
-    end
-
-    def set_name
-      @name = "clojure_pedestal"
     end
   end
 end

--- a/src/detector/detectors/clojure/reitit.cr
+++ b/src/detector/detectors/clojure/reitit.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Clojure
   class Reitit < Detector
+    detector_for "clojure_reitit",
+      extensions: %w[.clj .cljs .cljc .edn],
+      basenames: %w[project.clj deps.edn]
+
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
     PROJECT_FILES      = {"project.clj", "deps.edn"}
 
@@ -23,14 +27,6 @@ module Detector::Clojure
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".clj") || filename.ends_with?(".cljs") || filename.ends_with?(".cljc") || filename.ends_with?(".edn") || File.basename(filename) == "project.clj" || File.basename(filename) == "deps.edn"
-    end
-
-    def set_name
-      @name = "clojure_reitit"
     end
   end
 end

--- a/src/detector/detectors/clojure/ring.cr
+++ b/src/detector/detectors/clojure/ring.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Clojure
   class Ring < Detector
+    detector_for "clojure_ring",
+      extensions: %w[.clj .cljs .cljc .edn],
+      basenames: %w[project.clj deps.edn]
+
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
     PROJECT_FILES      = {"project.clj", "deps.edn"}
 
@@ -34,14 +38,6 @@ module Detector::Clojure
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".clj") || filename.ends_with?(".cljs") || filename.ends_with?(".cljc") || filename.ends_with?(".edn") || File.basename(filename) == "project.clj" || File.basename(filename) == "deps.edn"
-    end
-
-    def set_name
-      @name = "clojure_ring"
     end
   end
 end

--- a/src/detector/detectors/cpp/cli.cr
+++ b/src/detector/detectors/cpp/cli.cr
@@ -7,6 +7,8 @@ module Detector::Cpp
   # `main(int argc, char** argv)`, which every C++ program (servers
   # included) has.
   class Cli < Detector
+    detector_for "cpp_cli"
+
     EXTS      = [".cpp", ".cc", ".cxx", ".c++", ".hpp", ".hh", ".hxx"]
     CLI11     = /\bCLI::App\b|include\s*[<"]CLI\/CLI\.hpp/
     GETOPT    = /\bgetopt(?:_long)?\s*\(|\bstruct\s+option\b/
@@ -26,10 +28,6 @@ module Detector::Cpp
 
     def applicable?(filename : String) : Bool
       EXTS.any? { |ext| filename.ends_with?(ext) }
-    end
-
-    def set_name
-      @name = "cpp_cli"
     end
   end
 end

--- a/src/detector/detectors/cpp/crow.cr
+++ b/src/detector/detectors/cpp/crow.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cpp
   class Crow < Detector
+    detector_for "cpp_crow", extensions: %w[.cpp .cc .cxx .c .h .hpp .hxx]
+
     CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"]
 
     def detect(filename : String, file_contents : String) : Bool
@@ -17,14 +19,6 @@ module Detector::Cpp
       return true if file_contents.includes?("CROW_ROUTE(")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cpp") || filename.ends_with?(".cc") || filename.ends_with?(".cxx") || filename.ends_with?(".c") || filename.ends_with?(".h") || filename.ends_with?(".hpp") || filename.ends_with?(".hxx")
-    end
-
-    def set_name
-      @name = "cpp_crow"
     end
   end
 end

--- a/src/detector/detectors/cpp/drogon.cr
+++ b/src/detector/detectors/cpp/drogon.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cpp
   class Drogon < Detector
+    detector_for "cpp_drogon", extensions: %w[.cpp .cc .cxx .c .h .hpp .hxx]
+
     DROGON_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp"]
 
     def detect(filename : String, file_contents : String) : Bool
@@ -18,14 +20,6 @@ module Detector::Cpp
       return true if file_contents.includes?("find_package(Drogon") || file_contents.includes?("find_package(drogon")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cpp") || filename.ends_with?(".cc") || filename.ends_with?(".cxx") || filename.ends_with?(".c") || filename.ends_with?(".h") || filename.ends_with?(".hpp") || filename.ends_with?(".hxx")
-    end
-
-    def set_name
-      @name = "cpp_drogon"
     end
   end
 end

--- a/src/detector/detectors/cpp/httplib.cr
+++ b/src/detector/detectors/cpp/httplib.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cpp
   class Httplib < Detector
+    detector_for "cpp_httplib"
+
     CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"]
 
     def detect(filename : String, file_contents : String) : Bool
@@ -20,10 +22,6 @@ module Detector::Cpp
 
     def applicable?(filename : String) : Bool
       CPP_EXTENSIONS.any? { |ext| filename.ends_with?(ext) } || filename.ends_with?(".c")
-    end
-
-    def set_name
-      @name = "cpp_httplib"
     end
   end
 end

--- a/src/detector/detectors/cpp/oatpp.cr
+++ b/src/detector/detectors/cpp/oatpp.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Cpp
   class Oatpp < Detector
+    detector_for "cpp_oatpp"
+
     CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"]
 
     def detect(filename : String, file_contents : String) : Bool
@@ -17,10 +19,6 @@ module Detector::Cpp
 
     def applicable?(filename : String) : Bool
       CPP_EXTENSIONS.any? { |ext| filename.ends_with?(ext) } || filename.ends_with?(".c")
-    end
-
-    def set_name
-      @name = "cpp_oatpp"
     end
   end
 end

--- a/src/detector/detectors/crystal/amber.cr
+++ b/src/detector/detectors/crystal/amber.cr
@@ -2,18 +2,12 @@ require "../../../models/detector"
 
 module Detector::Crystal
   class Amber < Detector
+    detector_for "crystal_amber", extensions: %w[.cr], basenames: %w[shard.yml shard.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("shard.yml")
 
       file_contents.includes?("amberframework/amber")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
-    end
-
-    def set_name
-      @name = "crystal_amber"
     end
   end
 end

--- a/src/detector/detectors/crystal/cli.cr
+++ b/src/detector/detectors/crystal/cli.cr
@@ -5,19 +5,13 @@ module Detector::Crystal
   # indexing, or a CLI shard (clim, admiral, commander). Never gates on bare
   # ENV (ubiquitous in Crystal web apps).
   class Cli < Detector
+    detector_for "crystal_cli", extensions: %w[.cr]
+
     MARKERS = /\bOptionParser\.(?:parse|new)\b|\bARGV\s*\[\s*\d+\s*\]|<\s*Clim\b|<\s*Admiral::Command\b|\bCommander::Command\b|\brequire\s+"(?:clim|admiral|commander)"/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cr")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cr")
-    end
-
-    def set_name
-      @name = "crystal_cli"
     end
   end
 end

--- a/src/detector/detectors/crystal/grip.cr
+++ b/src/detector/detectors/crystal/grip.cr
@@ -2,18 +2,12 @@ require "../../../models/detector"
 
 module Detector::Crystal
   class Grip < Detector
+    detector_for "crystal_grip", extensions: %w[.cr], basenames: %w[shard.yml shard.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("shard.yml")
 
       file_contents.includes?("grip-framework/grip")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
-    end
-
-    def set_name
-      @name = "crystal_grip"
     end
   end
 end

--- a/src/detector/detectors/crystal/http.cr
+++ b/src/detector/detectors/crystal/http.cr
@@ -2,17 +2,11 @@ require "../../../models/detector"
 
 module Detector::Crystal
   class Http < Detector
+    detector_for "crystal_http", extensions: %w[.cr], basenames: %w[shard.yml shard.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cr")
       file_contents.includes?("http/server") || file_contents.includes?("HTTP::Server")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
-    end
-
-    def set_name
-      @name = "crystal_http"
     end
   end
 end

--- a/src/detector/detectors/crystal/kemal.cr
+++ b/src/detector/detectors/crystal/kemal.cr
@@ -2,19 +2,13 @@ require "../../../models/detector"
 
 module Detector::Crystal
   class Kemal < Detector
+    detector_for "crystal_kemal", extensions: %w[.cr], basenames: %w[shard.yml shard.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       check = filename.includes?("shard.yml")
       check = check && file_contents.includes?("kemalcr/kemal")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
-    end
-
-    def set_name
-      @name = "crystal_kemal"
     end
   end
 end

--- a/src/detector/detectors/crystal/lucky.cr
+++ b/src/detector/detectors/crystal/lucky.cr
@@ -2,18 +2,12 @@ require "../../../models/detector"
 
 module Detector::Crystal
   class Lucky < Detector
+    detector_for "crystal_lucky", extensions: %w[.cr], basenames: %w[shard.yml shard.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("shard.yml")
 
       file_contents.includes?("luckyframework/lucky")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
-    end
-
-    def set_name
-      @name = "crystal_lucky"
     end
   end
 end

--- a/src/detector/detectors/crystal/marten.cr
+++ b/src/detector/detectors/crystal/marten.cr
@@ -2,18 +2,12 @@ require "../../../models/detector"
 
 module Detector::Crystal
   class Marten < Detector
+    detector_for "crystal_marten", extensions: %w[.cr], basenames: %w[shard.yml shard.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("shard.yml")
 
       file_contents.includes?("martenframework/marten")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
-    end
-
-    def set_name
-      @name = "crystal_marten"
     end
   end
 end

--- a/src/detector/detectors/csharp/aspnet_core_minimal_api.cr
+++ b/src/detector/detectors/csharp/aspnet_core_minimal_api.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::CSharp
   class AspNetCoreMinimalApi < Detector
+    detector_for "cs_aspnet_core_minimal_api", extensions: %w[.cs]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cs")
       return false if file_contents.includes?("ICarterModule")
@@ -10,14 +12,6 @@ module Detector::CSharp
       has_generic_map = content_matches?(file_contents, /\.\s*Map\s*\(/) && minimal_api_context?(file_contents)
 
       has_http_map || has_generic_map
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cs")
-    end
-
-    def set_name
-      @name = "cs_aspnet_core_minimal_api"
     end
 
     private def minimal_api_context?(file_contents : String) : Bool

--- a/src/detector/detectors/csharp/aspnet_core_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_core_mvc.cr
@@ -2,6 +2,13 @@ require "../../../models/detector"
 
 module Detector::CSharp
   class AspNetCoreMvc < Detector
+    # Side effect: registers `Program.cs` / similar paths in
+    # `CodeLocator` for the analyzer. Must keep running after first
+    # match.
+    detector_for "cs_aspnet_core_mvc",
+      extensions: %w[.cs .csproj .vbproj .sln .config],
+      idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       is_csproj = filename.ends_with?(".csproj")
       is_program_file = filename.ends_with?("Program.cs") || filename.ends_with?("Startup.cs")
@@ -31,21 +38,6 @@ module Detector::CSharp
       end
 
       detected
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cs") || filename.ends_with?(".csproj") || filename.ends_with?(".vbproj") || filename.ends_with?(".sln") || filename.ends_with?(".config")
-    end
-
-    def set_name
-      @name = "cs_aspnet_core_mvc"
-    end
-
-    # Side effect: registers `Program.cs` / similar paths in
-    # `CodeLocator` for the analyzer. Must keep running after first
-    # match.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/csharp/aspnet_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_mvc.cr
@@ -2,6 +2,14 @@ require "../../../models/detector"
 
 module Detector::CSharp
   class AspNetMvc < Detector
+    # `check_routeconfig` records every `RouteConfig.cs` path it
+    # sees into `CodeLocator` for the analyzer to consume. Skipping
+    # this detector after its first match would lose the
+    # registration on subsequent files.
+    detector_for "cs_aspnet_mvc",
+      extensions: %w[.cs .csproj .vbproj .sln .config],
+      idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       check_routeconfig filename, file_contents
 
@@ -16,22 +24,6 @@ module Detector::CSharp
         locator = CodeLocator.instance
         locator.set("cs-apinet-mvc-routeconfig", filename)
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cs") || filename.ends_with?(".csproj") || filename.ends_with?(".vbproj") || filename.ends_with?(".sln") || filename.ends_with?(".config")
-    end
-
-    def set_name
-      @name = "cs_aspnet_mvc"
-    end
-
-    # `check_routeconfig` records every `RouteConfig.cs` path it
-    # sees into `CodeLocator` for the analyzer to consume. Skipping
-    # this detector after its first match would lose the
-    # registration on subsequent files.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/csharp/carter.cr
+++ b/src/detector/detectors/csharp/carter.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::CSharp
   class Carter < Detector
+    detector_for "cs_carter", extensions: %w[.cs .csproj .props .targets]
+
     # Detects Carter (https://github.com/CarterCommunity/Carter), a
     # module library for ASP.NET Core minimal APIs. Carter projects
     # are also ASP.NET Core projects, so the surrounding
@@ -18,15 +20,6 @@ module Detector::CSharp
 
       return false unless filename.ends_with?(".cs")
       file_contents.includes?("using Carter") || file_contents.includes?("ICarterModule")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cs") || filename.ends_with?(".csproj") ||
-        filename.ends_with?(".props") || filename.ends_with?(".targets")
-    end
-
-    def set_name
-      @name = "cs_carter"
     end
   end
 end

--- a/src/detector/detectors/csharp/cli.cr
+++ b/src/detector/detectors/csharp/cli.cr
@@ -8,6 +8,8 @@ module Detector::CSharp
   # CLI analyzer. A web host (ASP.NET / HttpListener) suppresses the builtin
   # signals so a server's `Main`/env reads don't masquerade as a CLI.
   class Cli < Detector
+    detector_for "cs_cli", extensions: %w[.cs]
+
     CLI_LIB   = /\busing\s+(?:System\.CommandLine|CommandLine|CliFx|Spectre\.Console\.Cli|McMaster\.Extensions\.CommandLineUtils|Cocona)\b/
     LIB_USAGE = /\bnew\s+RootCommand\s*\(|\bnew\s+CommandApp\b|\bCliApplicationBuilder\s*\(|\bParser\.Default\.ParseArguments\b|\[\s*Verb\s*\(|\[\s*CommandOption\s*\(|\[\s*CommandArgument\s*\(|\bCommandLineApplication\.Execute\b|\[\s*Subcommand\s*\(|\bCoconaApp\.(?:Create|Run)\b/
     WEB_HOST  = /\bWebApplication\.(?:Create(?:Builder|SlimBuilder|EmptyBuilder)?|CreateDefault)\b|\bnew\s+HttpListener\b|\.MapGet\s*\(|\.MapPost\s*\(|\.MapControllers\s*\(|\[\s*ApiController\s*\]|:\s*ControllerBase\b|\bHost\.CreateDefaultBuilder\b/
@@ -19,14 +21,6 @@ module Detector::CSharp
       return true if content_matches?(file_contents, CLI_LIB) || content_matches?(file_contents, LIB_USAGE)
       return false if content_matches?(file_contents, WEB_HOST)
       content_matches?(file_contents, MAIN_ARGS) || content_matches?(file_contents, GET_ARGS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cs")
-    end
-
-    def set_name
-      @name = "cs_cli"
     end
   end
 end

--- a/src/detector/detectors/csharp/fastendpoints.cr
+++ b/src/detector/detectors/csharp/fastendpoints.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::CSharp
   class FastEndpoints < Detector
+    detector_for "cs_fastendpoints", extensions: %w[.cs .csproj]
+
     def detect(filename : String, file_contents : String) : Bool
       is_csproj = filename.ends_with?(".csproj")
       is_cs = filename.ends_with?(".cs")
@@ -17,14 +19,6 @@ module Detector::CSharp
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cs") || filename.ends_with?(".csproj")
-    end
-
-    def set_name
-      @name = "cs_fastendpoints"
     end
   end
 end

--- a/src/detector/detectors/csharp/httplistener.cr
+++ b/src/detector/detectors/csharp/httplistener.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::CSharp
   class HttpListener < Detector
+    detector_for "cs_httplistener", extensions: %w[.cs]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cs")
       return false unless file_contents.includes?("HttpListener")
@@ -11,14 +13,6 @@ module Detector::CSharp
         file_contents.includes?(".Prefixes.Add") ||
         file_contents.includes?(".GetContext") ||
         file_contents.includes?("GetContextAsync")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cs")
-    end
-
-    def set_name
-      @name = "cs_httplistener"
     end
   end
 end

--- a/src/detector/detectors/csharp/signalr.cr
+++ b/src/detector/detectors/csharp/signalr.cr
@@ -6,19 +6,13 @@ module Detector::CSharp
   # mount. Gates the SignalR analyzer, which emits hub methods as `ws://`
   # realtime endpoints.
   class SignalR < Detector
+    detector_for "cs_signalr", extensions: %w[.cs]
+
     SIGNALR_MARKER = /Microsoft\.AspNetCore\.SignalR\b|\bMapHub\s*</
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cs")
       content_matches?(file_contents, SIGNALR_MARKER)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".cs")
-    end
-
-    def set_name
-      @name = "cs_signalr"
     end
   end
 end

--- a/src/detector/detectors/dart/alfred.cr
+++ b/src/detector/detectors/dart/alfred.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Dart
   class Alfred < Detector
+    detector_for "dart_alfred", extensions: %w[.dart], basenames: %w[pubspec.yaml pubspec.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -16,14 +18,6 @@ module Detector::Dart
       return true if file_contents.includes?("package:alfred/")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".dart") || File.basename(filename) == "pubspec.yaml" || File.basename(filename) == "pubspec.lock"
-    end
-
-    def set_name
-      @name = "dart_alfred"
     end
   end
 end

--- a/src/detector/detectors/dart/angel3.cr
+++ b/src/detector/detectors/dart/angel3.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Dart
   class Angel3 < Detector
+    detector_for "dart_angel3", extensions: %w[.dart], basenames: %w[pubspec.yaml pubspec.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -17,14 +19,6 @@ module Detector::Dart
       return true if file_contents.includes?("package:angel_framework/")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".dart") || File.basename(filename) == "pubspec.yaml" || File.basename(filename) == "pubspec.lock"
-    end
-
-    def set_name
-      @name = "dart_angel3"
     end
   end
 end

--- a/src/detector/detectors/dart/cli.cr
+++ b/src/detector/detectors/dart/cli.cr
@@ -5,19 +5,13 @@ module Detector::Dart
   # CommandRunner), dcli, or `main(List<String> args)` + args indexing. Never
   # gates on bare Platform.environment (shelf/dart_frog config).
   class Cli < Detector
+    detector_for "dart_cli", extensions: %w[.dart]
+
     MARKERS = /package:args\/|package:dcli\/|\bArgParser\s*\(|\bCommandRunner\b|\bextends\s+Command\b|main\s*\(\s*List<String>/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".dart")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".dart")
-    end
-
-    def set_name
-      @name = "dart_cli"
     end
   end
 end

--- a/src/detector/detectors/dart/dart_frog.cr
+++ b/src/detector/detectors/dart/dart_frog.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Dart
   class DartFrog < Detector
+    detector_for "dart_frog", extensions: %w[.dart], basenames: %w[pubspec.yaml pubspec.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -26,14 +28,6 @@ module Detector::Dart
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".dart") || File.basename(filename) == "pubspec.yaml" || File.basename(filename) == "pubspec.lock"
-    end
-
-    def set_name
-      @name = "dart_frog"
     end
   end
 end

--- a/src/detector/detectors/dart/get_server.cr
+++ b/src/detector/detectors/dart/get_server.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Dart
   class GetServer < Detector
+    detector_for "dart_get_server", extensions: %w[.dart], basenames: %w[pubspec.yaml pubspec.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -16,14 +18,6 @@ module Detector::Dart
       return true if file_contents.includes?("package:get_server/")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".dart") || File.basename(filename) == "pubspec.yaml" || File.basename(filename) == "pubspec.lock"
-    end
-
-    def set_name
-      @name = "dart_get_server"
     end
   end
 end

--- a/src/detector/detectors/dart/http.cr
+++ b/src/detector/detectors/dart/http.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Dart
   class Http < Detector
+    detector_for "dart_http", extensions: %w[.dart]
+
     DART_IO_IMPORT_RE = /^\s*import\s+['"]dart:io['"]/m
 
     def detect(filename : String, file_contents : String) : Bool
@@ -9,14 +11,6 @@ module Detector::Dart
       return false unless file_contents.match(DART_IO_IMPORT_RE)
 
       file_contents.includes?("HttpServer") || file_contents.includes?("HttpRequest")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".dart")
-    end
-
-    def set_name
-      @name = "dart_http"
     end
   end
 end

--- a/src/detector/detectors/dart/serverpod.cr
+++ b/src/detector/detectors/dart/serverpod.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Dart
   class Serverpod < Detector
+    detector_for "dart_serverpod", extensions: %w[.dart], basenames: %w[pubspec.yaml pubspec.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -18,14 +20,6 @@ module Detector::Dart
       return true if file_contents.match(/\bextends\s+(StreamingEndpoint|Endpoint)\b/)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".dart") || File.basename(filename) == "pubspec.yaml" || File.basename(filename) == "pubspec.lock"
-    end
-
-    def set_name
-      @name = "dart_serverpod"
     end
   end
 end

--- a/src/detector/detectors/dart/shelf.cr
+++ b/src/detector/detectors/dart/shelf.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Dart
   class Shelf < Detector
+    detector_for "dart_shelf", extensions: %w[.dart], basenames: %w[pubspec.yaml pubspec.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -20,14 +22,6 @@ module Detector::Dart
       return true if file_contents.includes?("package:shelf/shelf.dart") && file_contents.includes?("Router(")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".dart") || File.basename(filename) == "pubspec.yaml" || File.basename(filename) == "pubspec.lock"
-    end
-
-    def set_name
-      @name = "dart_shelf"
     end
   end
 end

--- a/src/detector/detectors/elixir/bandit.cr
+++ b/src/detector/detectors/elixir/bandit.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Elixir
   class Bandit < Detector
+    detector_for "elixir_bandit", extensions: %w[.ex .exs], basenames: %w[mix.exs]
+
     def detect(filename : String, file_contents : String) : Bool
       basename = File.basename(filename)
 
@@ -25,14 +27,6 @@ module Detector::Elixir
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ex") || filename.ends_with?(".exs") || File.basename(filename) == "mix.exs"
-    end
-
-    def set_name
-      @name = "elixir_bandit"
     end
   end
 end

--- a/src/detector/detectors/elixir/cli.cr
+++ b/src/detector/detectors/elixir/cli.cr
@@ -4,19 +4,13 @@ module Detector::Elixir
   # Detects Elixir command-line apps via OptionParser, System.argv, or the
   # optimus library. Never gates on bare System.get_env (Phoenix config).
   class Cli < Detector
+    detector_for "elixir_cli", extensions: %w[.ex .exs]
+
     MARKERS = /\bOptionParser\.(?:parse|parse!|next)\b|\bSystem\.argv\b|\bOptimus\.new!?\b|\buse\s+Optimus\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ex") || filename.ends_with?(".exs")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ex") || filename.ends_with?(".exs")
-    end
-
-    def set_name
-      @name = "elixir_cli"
     end
   end
 end

--- a/src/detector/detectors/elixir/phoenix.cr
+++ b/src/detector/detectors/elixir/phoenix.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Elixir
   class Phoenix < Detector
+    detector_for "elixir_phoenix", extensions: %w[.ex .exs], basenames: %w[mix.exs]
+
     # Phoenix routers rarely write `use Phoenix.Router` directly; the
     # generated convention is `use MyAppWeb, :router`, where the
     # `:router` clause of the app's `*_web.ex` macro injects
@@ -35,14 +37,6 @@ module Detector::Elixir
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ex") || filename.ends_with?(".exs") || File.basename(filename) == "mix.exs"
-    end
-
-    def set_name
-      @name = "elixir_phoenix"
     end
   end
 end

--- a/src/detector/detectors/elixir/phoenix_channel.cr
+++ b/src/detector/detectors/elixir/phoenix_channel.cr
@@ -7,19 +7,13 @@ module Detector::Elixir
   # `handle_in` events as `ws://` realtime endpoints. Runs alongside the
   # Phoenix (HTTP router) detector — the two cover different surfaces.
   class PhoenixChannel < Detector
+    detector_for "elixir_phoenix_channel", extensions: %w[.ex .exs]
+
     CHANNEL_MARKER = /\buse\s+Phoenix\.Channel\b|\buse\s+[A-Z][\w.]*\s*,\s*:channel\b|\bchannel\s+["'][^"']+["']\s*,\s*[A-Z]/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ex") || filename.ends_with?(".exs")
       content_matches?(file_contents, CHANNEL_MARKER)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ex") || filename.ends_with?(".exs")
-    end
-
-    def set_name
-      @name = "elixir_phoenix_channel"
     end
   end
 end

--- a/src/detector/detectors/elixir/plug.cr
+++ b/src/detector/detectors/elixir/plug.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Elixir
   class Plug < Detector
+    detector_for "elixir_plug", extensions: %w[.ex .exs], basenames: %w[mix.exs]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check if this is a mix.exs file with Plug dependency
       if filename.includes?("mix.exs")
@@ -20,14 +22,6 @@ module Detector::Elixir
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ex") || filename.ends_with?(".exs") || File.basename(filename) == "mix.exs"
-    end
-
-    def set_name
-      @name = "elixir_plug"
     end
   end
 end

--- a/src/detector/detectors/erlang/cowboy.cr
+++ b/src/detector/detectors/erlang/cowboy.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Erlang
   class Cowboy < Detector
+    detector_for "erlang_cowboy",
+      extensions: %w[.erl .hrl .app.src],
+      basenames: %w[rebar.config erlang.mk]
+
     # Elixir projects pull Cowboy in through `plug_cowboy`, but their
     # routes live in Phoenix/Plug routers that the Elixir analyzers
     # already own. Restricting the manifest check to Erlang's own build
@@ -21,17 +25,6 @@ module Detector::Erlang
       return true if file_contents.includes?("cowboy_req:")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".erl") || filename.ends_with?(".hrl") ||
-        filename.ends_with?(".app.src") ||
-        File.basename(filename) == "rebar.config" ||
-        File.basename(filename) == "erlang.mk"
-    end
-
-    def set_name
-      @name = "erlang_cowboy"
     end
   end
 end

--- a/src/detector/detectors/erlang/elli.cr
+++ b/src/detector/detectors/erlang/elli.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Erlang
   class Elli < Detector
+    detector_for "erlang_elli",
+      extensions: %w[.erl .hrl .app.src],
+      basenames: %w[rebar.config erlang.mk]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -16,17 +20,6 @@ module Detector::Erlang
       return true if file_contents.includes?("elli:start_link")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".erl") || filename.ends_with?(".hrl") ||
-        filename.ends_with?(".app.src") ||
-        File.basename(filename) == "rebar.config" ||
-        File.basename(filename) == "erlang.mk"
-    end
-
-    def set_name
-      @name = "erlang_elli"
     end
   end
 end

--- a/src/detector/detectors/fsharp/giraffe.cr
+++ b/src/detector/detectors/fsharp/giraffe.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Fsharp
   class Giraffe < Detector
+    detector_for "fs_giraffe",
+      extensions: %w[.fs .fsx .fsproj .csproj],
+      basenames: %w[paket.dependencies]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -24,14 +28,6 @@ module Detector::Fsharp
                      file_contents.match(/\b(?:route|routef|routeCi|subRoute|subRouteCi|subRoutef|choose)\s+/)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".fs") || filename.ends_with?(".fsx") || filename.ends_with?(".fsproj") || filename.ends_with?(".csproj") || File.basename(filename) == "paket.dependencies"
-    end
-
-    def set_name
-      @name = "fs_giraffe"
     end
   end
 end

--- a/src/detector/detectors/gleam/wisp.cr
+++ b/src/detector/detectors/gleam/wisp.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Gleam
   class Wisp < Detector
+    detector_for "gleam_wisp", extensions: %w[.gleam], basenames: %w[gleam.toml manifest.toml]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -16,16 +18,6 @@ module Detector::Gleam
       return true if file_contents.includes?("wisp.path_segments")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".gleam") ||
-        File.basename(filename) == "gleam.toml" ||
-        File.basename(filename) == "manifest.toml"
-    end
-
-    def set_name
-      @name = "gleam_wisp"
     end
   end
 end

--- a/src/detector/detectors/go/beego.cr
+++ b/src/detector/detectors/go/beego.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Beego < Detector
+    detector_for "go_beego", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "github.com/beego/beego")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_beego"
     end
   end
 end

--- a/src/detector/detectors/go/chi.cr
+++ b/src/detector/detectors/go/chi.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Chi < Detector
+    detector_for "go_chi", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "github.com/go-chi/chi")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_chi"
     end
   end
 end

--- a/src/detector/detectors/go/cli.cr
+++ b/src/detector/detectors/go/cli.cr
@@ -7,6 +7,8 @@ module Detector::Go
   # `os.Args` directly. Gates the Go CLI analyzer, which surfaces the argv /
   # flag / env attack surface as `cli://` endpoints.
   class Cli < Detector
+    detector_for "go_cli", extensions: %w[.go], basenames: %w[go.mod]
+
     # CLI framework import paths. Presence of any of these — in go.mod or a
     # source import block — is a strong, unambiguous CLI signal.
     CLI_LIBRARY_MARKERS = [
@@ -52,14 +54,6 @@ module Detector::Go
       return true if content_matches?(file_contents, ARGV_INDEX)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".go") || File.basename(filename) == "go.mod"
-    end
-
-    def set_name
-      @name = "go_cli"
     end
   end
 end

--- a/src/detector/detectors/go/connect_rpc.cr
+++ b/src/detector/detectors/go/connect_rpc.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class ConnectRpc < Detector
+    detector_for "go_connect_rpc", extensions: %w[.go], path_segments: %w[go.mod]
+
     IMPORT_MARKER = "connectrpc.com/connect"
 
     # One JIT-compiled scan per file instead of a Rabin-Karp walk;
@@ -16,14 +18,6 @@ module Detector::Go
         return true
       end
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_connect_rpc"
     end
   end
 end

--- a/src/detector/detectors/go/echo.cr
+++ b/src/detector/detectors/go/echo.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Echo < Detector
+    detector_for "go_echo", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "github.com/labstack/echo")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_echo"
     end
   end
 end

--- a/src/detector/detectors/go/fasthttp.cr
+++ b/src/detector/detectors/go/fasthttp.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class Fasthttp < Detector
+    detector_for "go_fasthttp", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") &&
          (file_contents.includes? "github.com/valyala/fasthttp") &&
@@ -10,14 +12,6 @@ module Detector::Go
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_fasthttp"
     end
   end
 end

--- a/src/detector/detectors/go/fiber.cr
+++ b/src/detector/detectors/go/fiber.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Fiber < Detector
+    detector_for "go_fiber", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "github.com/gofiber/fiber")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_fiber"
     end
   end
 end

--- a/src/detector/detectors/go/gf.cr
+++ b/src/detector/detectors/go/gf.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class Gf < Detector
+    detector_for "go_gf", extensions: %w[.go], path_segments: %w[go.mod]
+
     IMPORT_MARKER = "github.com/gogf/gf"
 
     # One JIT-compiled scan per file instead of a Rabin-Karp walk;
@@ -16,14 +18,6 @@ module Detector::Go
       return true if (filename.includes? "go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
       return true if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_gf"
     end
   end
 end

--- a/src/detector/detectors/go/gin.cr
+++ b/src/detector/detectors/go/gin.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Gin < Detector
+    detector_for "go_gin", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "github.com/gin-gonic/gin")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_gin"
     end
   end
 end

--- a/src/detector/detectors/go/go_restful.cr
+++ b/src/detector/detectors/go/go_restful.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class GoRestful < Detector
+    detector_for "go_restful", extensions: %w[.go], path_segments: %w[go.mod]
+
     IMPORT_MARKER = "github.com/emicklei/go-restful"
 
     # One JIT-compiled scan per file instead of a Rabin-Karp walk;
@@ -16,14 +18,6 @@ module Detector::Go
       return true if (filename.includes? "go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
       return true if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_restful"
     end
   end
 end

--- a/src/detector/detectors/go/goyave.cr
+++ b/src/detector/detectors/go/goyave.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Goyave < Detector
+    detector_for "go_goyave", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "goyave.dev/goyave")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_goyave"
     end
   end
 end

--- a/src/detector/detectors/go/gozero.cr
+++ b/src/detector/detectors/go/gozero.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class GoZero < Detector
+    detector_for "go_gozero", extensions: %w[.go], path_segments: %w[go.mod]
+
     IMPORT_MARKER = "github.com/zeromicro/go-zero"
 
     # One JIT-compiled scan per file instead of a Rabin-Karp walk;
@@ -17,14 +19,6 @@ module Detector::Go
       return true if (filename.includes? "go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
       return true if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_gozero"
     end
   end
 end

--- a/src/detector/detectors/go/hertz.cr
+++ b/src/detector/detectors/go/hertz.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Hertz < Detector
+    detector_for "go_hertz", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "github.com/cloudwego/hertz")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_hertz"
     end
   end
 end

--- a/src/detector/detectors/go/http.cr
+++ b/src/detector/detectors/go/http.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class Http < Detector
+    detector_for "go_http", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".go")
       return false unless file_contents.includes?("net/http")
@@ -13,14 +15,6 @@ module Detector::Go
       file_contents.includes?("NewServeMux") ||
         content_matches?(file_contents, /http\.HandleFunc\s*\(/) ||
         content_matches?(file_contents, /http\.Handle\s*\(\s*["`\/]/)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".go") || filename.includes?("go.mod")
-    end
-
-    def set_name
-      @name = "go_http"
     end
   end
 end

--- a/src/detector/detectors/go/httprouter.cr
+++ b/src/detector/detectors/go/httprouter.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Httprouter < Detector
+    detector_for "go_httprouter", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "github.com/julienschmidt/httprouter")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_httprouter"
     end
   end
 end

--- a/src/detector/detectors/go/huma.cr
+++ b/src/detector/detectors/go/huma.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class Huma < Detector
+    detector_for "go_huma", extensions: %w[.go], path_segments: %w[go.mod]
+
     # Huma v2 ships under `github.com/danielgtaylor/huma/v2`. A
     # go.mod require line is the strongest signal; individual
     # .go files import the package directly so we also catch
@@ -12,14 +14,6 @@ module Detector::Go
       return false unless filename.includes?("go.mod") || filename.ends_with?(".go")
 
       content_matches?(file_contents, IMPORT_PATTERN)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_huma"
     end
   end
 end

--- a/src/detector/detectors/go/iris.cr
+++ b/src/detector/detectors/go/iris.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class Iris < Detector
+    detector_for "go_iris", extensions: %w[.go], path_segments: %w[go.mod]
+
     IMPORT_MARKER = "github.com/kataras/iris"
 
     # One JIT-compiled scan per file instead of a Rabin-Karp walk;
@@ -16,14 +18,6 @@ module Detector::Go
       return true if (filename.includes? "go.mod") && content_matches?(file_contents, IMPORT_PATTERN)
       return true if filename.ends_with?(".go") && content_matches?(file_contents, IMPORT_PATTERN)
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_iris"
     end
   end
 end

--- a/src/detector/detectors/go/mux.cr
+++ b/src/detector/detectors/go/mux.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Go
   class Mux < Detector
+    detector_for "go_mux", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.includes? "go.mod") && (file_contents.includes? "github.com/gorilla/mux")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_mux"
     end
   end
 end

--- a/src/detector/detectors/go/pocketbase.cr
+++ b/src/detector/detectors/go/pocketbase.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Go
   class Pocketbase < Detector
+    detector_for "go_pocketbase", extensions: %w[.go], path_segments: %w[go.mod]
+
     # Pocketbase apps are full Go programs that import the
     # framework's own `tools/router` package. The framework repo
     # itself self-references via the same path so the marker
@@ -14,14 +16,6 @@ module Detector::Go
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.includes?("go.mod") || filename.ends_with?(".go")
-    end
-
-    def set_name
-      @name = "go_pocketbase"
     end
   end
 end

--- a/src/detector/detectors/groovy/cli.cr
+++ b/src/detector/detectors/groovy/cli.cr
@@ -6,19 +6,13 @@ module Detector::Groovy
   # constructs/imports only (never a bare generic token) so unrelated code
   # doesn't light this up. Never gates on bare System.getenv (Grails config).
   class Cli < Detector
+    detector_for "groovy_cli", extensions: %w[.groovy]
+
     MARKERS = /\bnew\s+CliBuilder\b|\bCliBuilder\s*\(|@picocli|@Command\b|\bimport\s+com\.beust\.jcommander\b|\bnew\s+JCommander\s*\(|\bJCommander\.newBuilder\s*\(|\bimport\s+org\.apache\.commons\.cli\b|\bOption\.builder\s*\(/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".groovy")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".groovy")
-    end
-
-    def set_name
-      @name = "groovy_cli"
     end
   end
 end

--- a/src/detector/detectors/groovy/grails.cr
+++ b/src/detector/detectors/groovy/grails.cr
@@ -2,6 +2,12 @@ require "../../../models/detector"
 
 module Detector::Groovy
   class Grails < Detector
+    # Memo safety: `applicable?` consults the path
+    # (/grails-app/ gate), not just the basename.
+    detector_for "groovy_grails",
+      extensions: %w[.groovy .gsp .gradle .gradle.kts .java .yml .yaml .xml],
+      path_segments: %w[/grails-app/]
+
     GRADLE_FILES = {"build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"}
 
     def detect(filename : String, file_contents : String) : Bool
@@ -42,20 +48,6 @@ module Detector::Groovy
       return true if file_contents.includes?("import grails.")
 
       false
-    end
-
-    # Memo safety: `applicable?` consults the path
-    # (/grails-app/ gate), not just the basename.
-    def path_sensitive? : Bool
-      true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".groovy") || filename.ends_with?(".gsp") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".java") || filename.ends_with?(".yml") || filename.ends_with?(".yaml") || filename.ends_with?(".xml") || filename.includes?("/grails-app/")
-    end
-
-    def set_name
-      @name = "groovy_grails"
     end
   end
 end

--- a/src/detector/detectors/haskell/cli.cr
+++ b/src/detector/detectors/haskell/cli.cr
@@ -6,6 +6,8 @@ module Detector::Haskell
   # Turtle.Options. Never gates on bare getEnv/lookupEnv (Scotty/Servant
   # config).
   class Cli < Detector
+    detector_for "haskell_cli", extensions: %w[.hs .lhs]
+
     # Turtle re-exports Turtle.Options from the top-level Turtle module,
     # which is used pervasively for plain shell scripting too, so gate on
     # either the qualified submodule import or an explicit `options` name
@@ -17,14 +19,6 @@ module Detector::Haskell
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".hs") || filename.ends_with?(".lhs")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".hs") || filename.ends_with?(".lhs")
-    end
-
-    def set_name
-      @name = "haskell_cli"
     end
   end
 end

--- a/src/detector/detectors/haskell/scotty.cr
+++ b/src/detector/detectors/haskell/scotty.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Haskell
   class Scotty < Detector
+    detector_for "haskell_scotty",
+      extensions: %w[.hs .cabal .dhall],
+      basenames: %w[stack.yaml package.yaml]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -17,14 +21,6 @@ module Detector::Haskell
       return true if file_contents.match(/\bscottyApp\s/) || file_contents.includes?("scottyOpts")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".hs") || filename.ends_with?(".cabal") || filename.ends_with?(".dhall") || File.basename(filename) == "stack.yaml" || File.basename(filename) == "package.yaml"
-    end
-
-    def set_name
-      @name = "haskell_scotty"
     end
   end
 end

--- a/src/detector/detectors/haskell/servant.cr
+++ b/src/detector/detectors/haskell/servant.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Haskell
   class Servant < Detector
+    detector_for "haskell_servant",
+      extensions: %w[.hs .cabal .dhall],
+      basenames: %w[stack.yaml package.yaml]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -17,14 +21,6 @@ module Detector::Haskell
       return true if file_contents.includes?(":<|>") && file_contents.includes?(":>")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".hs") || filename.ends_with?(".cabal") || filename.ends_with?(".dhall") || File.basename(filename) == "stack.yaml" || File.basename(filename) == "package.yaml"
-    end
-
-    def set_name
-      @name = "haskell_servant"
     end
   end
 end

--- a/src/detector/detectors/haskell/yesod.cr
+++ b/src/detector/detectors/haskell/yesod.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Haskell
   class Yesod < Detector
+    detector_for "haskell_yesod",
+      extensions: %w[.hs .cabal .dhall],
+      basenames: %w[stack.yaml package.yaml]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -20,14 +24,6 @@ module Detector::Haskell
       return true if file_contents.includes?("parseRoutesFile")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".hs") || filename.ends_with?(".cabal") || filename.ends_with?(".dhall") || File.basename(filename) == "stack.yaml" || File.basename(filename) == "package.yaml"
-    end
-
-    def set_name
-      @name = "haskell_yesod"
     end
   end
 end

--- a/src/detector/detectors/java/armeria.cr
+++ b/src/detector/detectors/java/armeria.cr
@@ -2,6 +2,9 @@ require "../../../models/detector"
 
 module Detector::Java
   class Armeria < Detector
+    detector_for "java_armeria",
+      extensions: %w[pom.xml build.gradle build.gradle.kts settings.gradle.kts]
+
     def detect(filename : String, file_contents : String) : Bool
       if (
            (filename.includes? "pom.xml") || (filename.includes? "build.gradle") ||
@@ -11,17 +14,6 @@ module Detector::Java
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?("pom.xml") ||
-        filename.ends_with?("build.gradle") ||
-        filename.ends_with?("build.gradle.kts") ||
-        filename.ends_with?("settings.gradle.kts")
-    end
-
-    def set_name
-      @name = "java_armeria"
     end
   end
 end

--- a/src/detector/detectors/java/cli.cr
+++ b/src/detector/detectors/java/cli.cr
@@ -6,6 +6,8 @@ module Detector::Java
   # `main(String[] args)` / `System.getenv`, which every Java app (web
   # servers included) has.
   class Cli < Detector
+    detector_for "java_cli", extensions: %w[.java]
+
     LIB_IMPORTS = [
       "picocli.",
       "org.kohsuke.args4j",
@@ -28,14 +30,6 @@ module Detector::Java
       return false unless filename.ends_with?(".java")
       return true if LIB_IMPORTS.any? { |marker| file_contents.includes?(marker) }
       content_matches?(file_contents, USAGE)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_cli"
     end
   end
 end

--- a/src/detector/detectors/java/dropwizard.cr
+++ b/src/detector/detectors/java/dropwizard.cr
@@ -2,17 +2,11 @@ require "../../../models/detector"
 
 module Detector::Java
   class Dropwizard < Detector
+    detector_for "java_dropwizard", extensions: %w[.java]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".java")
       file_contents.includes?("io.dropwizard")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_dropwizard"
     end
   end
 end

--- a/src/detector/detectors/java/httpserver.cr
+++ b/src/detector/detectors/java/httpserver.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Java
   class HttpServer < Detector
+    detector_for "java_httpserver", extensions: %w[.java]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".java")
       # JDK built-in HTTP server. The `com.sun.net.httpserver` package
@@ -12,14 +14,6 @@ module Detector::Java
       # trip the analyzer with nothing to extract.
       return false unless file_contents.includes?("com.sun.net.httpserver")
       file_contents.includes?("createContext")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_httpserver"
     end
   end
 end

--- a/src/detector/detectors/java/javalin.cr
+++ b/src/detector/detectors/java/javalin.cr
@@ -2,17 +2,11 @@ require "../../../models/detector"
 
 module Detector::Java
   class Javalin < Detector
+    detector_for "java_javalin", extensions: %w[.java]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".java")
       file_contents.includes?("io.javalin")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_javalin"
     end
   end
 end

--- a/src/detector/detectors/java/jaxrs.cr
+++ b/src/detector/detectors/java/jaxrs.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Java
   class JaxRs < Detector
+    detector_for "java_jaxrs", extensions: %w[.java]
+
     # Frameworks that ride on JAX-RS but ship their own detector.
     # Quarkus / Dropwizard projects should report as that specific
     # framework, not as plain JAX-RS.
@@ -25,14 +27,6 @@ module Detector::Java
       return false if DERIVATIVE_MARKERS.any? { |marker| file_contents.includes?(marker) }
       return false if derivative_project?(filename)
       file_contents.includes?("jakarta.ws.rs") || file_contents.includes?("javax.ws.rs")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_jaxrs"
     end
 
     private def derivative_project?(filename : String) : Bool

--- a/src/detector/detectors/java/jsp.cr
+++ b/src/detector/detectors/java/jsp.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Java
   class Jsp < Detector
+    detector_for "java_jsp", extensions: %w[.jsp .java .xml]
+
     # Necessary-condition guard for the `.xml` branch: comment stripping
     # only removes text, so a marker absent from the raw content is also
     # absent from the stripped copy — the whole-file `gsub` allocation can
@@ -30,14 +32,6 @@ module Detector::Java
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".jsp") || filename.ends_with?(".java") || filename.ends_with?(".xml")
-    end
-
-    def set_name
-      @name = "java_jsp"
     end
   end
 end

--- a/src/detector/detectors/java/micronaut.cr
+++ b/src/detector/detectors/java/micronaut.cr
@@ -2,17 +2,11 @@ require "../../../models/detector"
 
 module Detector::Java
   class Micronaut < Detector
+    detector_for "java_micronaut", extensions: %w[.java]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".java")
       file_contents.includes?("io.micronaut") || file_contents.includes?("micronaut.io")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_micronaut"
     end
   end
 end

--- a/src/detector/detectors/java/play.cr
+++ b/src/detector/detectors/java/play.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Java
   class Play < Detector
+    detector_for "java_play", extensions: %w[.java routes routes.conf]
+
     def detect(filename : String, file_contents : String) : Bool
       # Detect Play Framework by Java-specific indicators
       if filename.ends_with?(".java")
@@ -24,16 +26,6 @@ module Detector::Java
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java") ||
-        filename.ends_with?("routes") ||
-        filename.ends_with?("routes.conf")
-    end
-
-    def set_name
-      @name = "java_play"
     end
   end
 end

--- a/src/detector/detectors/java/quarkus.cr
+++ b/src/detector/detectors/java/quarkus.cr
@@ -2,17 +2,11 @@ require "../../../models/detector"
 
 module Detector::Java
   class Quarkus < Detector
+    detector_for "java_quarkus", extensions: %w[.java]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".java")
       file_contents.includes?("io.quarkus") || file_contents.includes?("quarkus.io")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_quarkus"
     end
   end
 end

--- a/src/detector/detectors/java/spark.cr
+++ b/src/detector/detectors/java/spark.cr
@@ -2,19 +2,13 @@ require "../../../models/detector"
 
 module Detector::Java
   class Spark < Detector
+    detector_for "java_spark", extensions: %w[.java]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".java")
       file_contents.includes?("spark.Spark") ||
         file_contents.includes?("import spark.") ||
         file_contents.includes?("import static spark.")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_spark"
     end
   end
 end

--- a/src/detector/detectors/java/spring.cr
+++ b/src/detector/detectors/java/spring.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Java
   class Spring < Detector
+    detector_for "java_spring", extensions: %w[.java]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".java") && (file_contents.includes? "org.springframework")
         return true
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java")
-    end
-
-    def set_name
-      @name = "java_spring"
     end
   end
 end

--- a/src/detector/detectors/java/struts2.cr
+++ b/src/detector/detectors/java/struts2.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Java
   class Struts2 < Detector
+    detector_for "java_struts2", extensions: %w[.java .xml .gradle .gradle.kts .properties]
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.ends_with?(".java")
         return true if file_contents.includes?("org.apache.struts2")
@@ -28,18 +30,6 @@ module Detector::Java
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java") ||
-        filename.ends_with?(".xml") ||
-        filename.ends_with?(".gradle") ||
-        filename.ends_with?(".gradle.kts") ||
-        filename.ends_with?(".properties")
-    end
-
-    def set_name
-      @name = "java_struts2"
     end
   end
 end

--- a/src/detector/detectors/java/vertx.cr
+++ b/src/detector/detectors/java/vertx.cr
@@ -2,6 +2,9 @@ require "../../../models/detector"
 
 module Detector::Java
   class Vertx < Detector
+    detector_for "java_vertx",
+      extensions: %w[.java pom.xml build.gradle build.gradle.kts settings.gradle.kts]
+
     def detect(filename : String, file_contents : String) : Bool
       if (
            (filename.ends_with?("pom.xml")) || (filename.ends_with?("build.gradle")) ||
@@ -11,18 +14,6 @@ module Detector::Java
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".java") ||
-        filename.ends_with?("pom.xml") ||
-        filename.ends_with?("build.gradle") ||
-        filename.ends_with?("build.gradle.kts") ||
-        filename.ends_with?("settings.gradle.kts")
-    end
-
-    def set_name
-      @name = "java_vertx"
     end
   end
 end

--- a/src/detector/detectors/java/wicket.cr
+++ b/src/detector/detectors/java/wicket.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Java
   class Wicket < Detector
+    detector_for "java_wicket"
+
     SOURCE_MARKERS = Regex.union("org.apache.wicket", "extends WebApplication", "@MountPath")
     BUILD_MARKERS  = Regex.union("org.apache.wicket", "wicket-core", "wicket-auth-roles", "wicketstuff")
 
@@ -15,10 +17,6 @@ module Detector::Java
 
     def applicable?(filename : String) : Bool
       filename.ends_with?(".java") || build_file?(filename)
-    end
-
-    def set_name
-      @name = "java_wicket"
     end
 
     private def build_file?(filename : String) : Bool

--- a/src/detector/detectors/javascript/adonisjs.cr
+++ b/src/detector/detectors/javascript/adonisjs.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Adonisjs < Detector
+    detector_for "js_adonisjs",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     PACKAGE_MARKERS = Regex.union("@adonisjs/core", "\"adonis-") # legacy adonis-* packages
     SOURCE_MARKERS  = Regex.union("@adonisjs/core", "@ioc:Adonis")
 
@@ -26,14 +30,6 @@ module Detector::Javascript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_adonisjs"
     end
   end
 end

--- a/src/detector/detectors/javascript/apollo.cr
+++ b/src/detector/detectors/javascript/apollo.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Apollo < Detector
+    detector_for "js_apollo", extensions: %w[.js .mjs .cjs .jsx .ts .tsx]
+
     # Apollo Server v4 ships as `@apollo/server`; legacy v2/v3 use the
     # `apollo-server` / `apollo-server-*` family. `ApolloServer` shows up
     # in both, so a literal-name match catches plain `import { ApolloServer }`
@@ -21,16 +23,6 @@ module Detector::Javascript
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") ||
-        filename.ends_with?(".cjs") || filename.ends_with?(".jsx") ||
-        filename.ends_with?(".ts") || filename.ends_with?(".tsx")
-    end
-
-    def set_name
-      @name = "js_apollo"
     end
   end
 end

--- a/src/detector/detectors/javascript/astro.cr
+++ b/src/detector/detectors/javascript/astro.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Astro < Detector
+    detector_for "js_astro",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     def detect(filename : String, file_contents : String) : Bool
       # `.astro` files are unmistakable.
       return true if filename.ends_with?(".astro")
@@ -20,14 +24,6 @@ module Detector::Javascript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_astro"
     end
   end
 end

--- a/src/detector/detectors/javascript/cli.cr
+++ b/src/detector/detectors/javascript/cli.cr
@@ -8,6 +8,8 @@ module Detector::Javascript
   # `process.argv.slice(2)` parse. Gates the JS CLI analyzer. Bare
   # `process.argv` / `process.env` are too common to qualify.
   class Cli < Detector
+    detector_for "js_cli"
+
     CLI_LIB_IMPORT = /(?:require\s*\(\s*|from\s+)['"](?:commander|yargs(?:\/(?:yargs|helpers))?|cac|meow|minimist|mri|arg|clipanion|@oclif\/(?:core|command)|sade|gluegun|command-line-args|getopts|citty)['"]/
 
     PARSE_ARGS = /\bparseArgs\s*\(\s*\{/
@@ -28,10 +30,6 @@ module Detector::Javascript
 
     def applicable?(filename : String) : Bool
       SOURCE_EXTS.any? { |ext| filename.ends_with?(ext) }
-    end
-
-    def set_name
-      @name = "js_cli"
     end
   end
 end

--- a/src/detector/detectors/javascript/elysia.cr
+++ b/src/detector/detectors/javascript/elysia.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Elysia < Detector
+    detector_for "js_elysia",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     PACKAGE_MARKER = /"elysia"/
     SOURCE_MARKERS = Regex.union(
       "from 'elysia'", "from \"elysia\"",
@@ -25,14 +29,6 @@ module Detector::Javascript
                           filename.ends_with?(".mjs")
 
       content_matches?(file_contents, SOURCE_MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_elysia"
     end
   end
 end

--- a/src/detector/detectors/javascript/express.cr
+++ b/src/detector/detectors/javascript/express.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Express < Detector
+    detector_for "js_express",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     # Single precompiled alternation — one PCRE2 scan over the file
     # instead of up to four separate `.match` passes. Regex.union wraps
     # each branch verbatim, so the boolean result is identical.
@@ -15,14 +19,6 @@ module Detector::Javascript
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") || filename.ends_with?(".cjs")
       content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_express"
     end
   end
 end

--- a/src/detector/detectors/javascript/fastify.cr
+++ b/src/detector/detectors/javascript/fastify.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Fastify < Detector
+    detector_for "js_fastify",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     # Single precompiled alternation — one PCRE2 scan instead of five.
     SIGNAL = Regex.union(
       /require\(['"]fastify['"]\)/,
@@ -15,14 +19,6 @@ module Detector::Javascript
       return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") ||
                           filename.ends_with?(".jsx") || filename.ends_with?(".tsx") || filename.ends_with?(".cjs")
       content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_fastify"
     end
   end
 end

--- a/src/detector/detectors/javascript/fresh.cr
+++ b/src/detector/detectors/javascript/fresh.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Fresh < Detector
+    detector_for "js_fresh",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     FRESH_MARKER = /\$fresh\//
 
     def detect(filename : String, file_contents : String) : Bool
@@ -28,14 +32,6 @@ module Detector::Javascript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_fresh"
     end
   end
 end

--- a/src/detector/detectors/javascript/graphql_yoga.cr
+++ b/src/detector/detectors/javascript/graphql_yoga.cr
@@ -7,6 +7,8 @@ module Detector::Javascript
   # runtimes. The `createYoga` factory is the universal entry point, so
   # a literal-name match also covers wrapper helpers that re-export it.
   class GraphqlYoga < Detector
+    detector_for "js_graphql_yoga", extensions: %w[.js .mjs .cjs .jsx .ts .tsx]
+
     SIGNALS = [
       /from\s+['"]graphql-yoga(?:\/[^'"]*)?['"]/,
       /require\(['"]graphql-yoga(?:\/[^'"]*)?['"]\)/,
@@ -22,16 +24,6 @@ module Detector::Javascript
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") ||
-        filename.ends_with?(".cjs") || filename.ends_with?(".jsx") ||
-        filename.ends_with?(".ts") || filename.ends_with?(".tsx")
-    end
-
-    def set_name
-      @name = "js_graphql_yoga"
     end
   end
 end

--- a/src/detector/detectors/javascript/hapi.cr
+++ b/src/detector/detectors/javascript/hapi.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Hapi < Detector
+    detector_for "js_hapi", extensions: %w[.js .mjs .cjs .jsx .ts .tsx], basenames: %w[package.json]
+
     MARKERS = Regex.union(
       "@hapi/hapi",
       "require('hapi')", "require(\"hapi\")",
@@ -14,14 +16,6 @@ module Detector::Javascript
                           filename.ends_with?(".cjs") ||
                           filename.ends_with?(".ts")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_hapi"
     end
   end
 end

--- a/src/detector/detectors/javascript/hono.cr
+++ b/src/detector/detectors/javascript/hono.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Hono < Detector
+    detector_for "js_hono", extensions: %w[.js .mjs .cjs .jsx .ts .tsx], basenames: %w[package.json]
+
     # Single precompiled alternation — one PCRE2 scan instead of three.
     SIGNAL = Regex.union(
       /require\(['"]hono['"]\)/,
@@ -12,14 +14,6 @@ module Detector::Javascript
     def detect(filename : String, file_contents : String) : Bool
       [".js", ".mjs", ".ts", ".jsx", ".tsx", ".cjs"].any? { |ext| filename.ends_with?(ext) } &&
         content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_hono"
     end
   end
 end

--- a/src/detector/detectors/javascript/http.cr
+++ b/src/detector/detectors/javascript/http.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Http < Detector
+    detector_for "js_http"
+
     CORE_HTTP_IMPORT = Regex.union(
       /require\s*\(\s*['"](?:node:)?https?['"]\s*\)/,
       /from\s+['"](?:node:)?https?['"]/,
@@ -28,10 +30,6 @@ module Detector::Javascript
 
     def applicable?(filename : String) : Bool
       source_file?(filename) || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_http"
     end
 
     private def source_file?(filename : String) : Bool

--- a/src/detector/detectors/javascript/koa.cr
+++ b/src/detector/detectors/javascript/koa.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Koa < Detector
+    detector_for "js_koa", extensions: %w[.js .mjs .cjs .jsx .ts .tsx], basenames: %w[package.json]
+
     # Single precompiled alternation — one PCRE2 scan instead of six.
     SIGNAL = Regex.union(
       /require\(['"]koa['"]\)/,
@@ -15,14 +17,6 @@ module Detector::Javascript
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts")
       content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_koa"
     end
   end
 end

--- a/src/detector/detectors/javascript/nestjs.cr
+++ b/src/detector/detectors/javascript/nestjs.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nestjs < Detector
+    detector_for "js_nestjs",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     # Single precompiled alternation — one PCRE2 scan instead of seven.
     SIGNAL = Regex.union(
       /require\(['"]@nestjs\/core['"]\)/,
@@ -16,14 +20,6 @@ module Detector::Javascript
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".js") || filename.ends_with?(".jsx")
       content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_nestjs"
     end
   end
 end

--- a/src/detector/detectors/javascript/nextjs.cr
+++ b/src/detector/detectors/javascript/nextjs.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nextjs < Detector
+    detector_for "js_nextjs",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     # Single-pass union of the four Next.js import forms (`require("next")`,
     # `require("next/...")`, `from "next"`, `from "next/..."`) — previously
     # four separate whole-file scans per JS/TS source.
@@ -54,14 +58,6 @@ module Detector::Javascript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_nextjs"
     end
 
     private def next_js_content_signal?(content : String) : Bool

--- a/src/detector/detectors/javascript/nitro.cr
+++ b/src/detector/detectors/javascript/nitro.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nitro < Detector
+    detector_for "js_nitro",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     # Single precompiled alternation — one PCRE2 scan instead of three.
     SIGNAL = Regex.union(
       /require\(['"]nitropack['"]\)/,
@@ -22,14 +26,6 @@ module Detector::Javascript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_nitro"
     end
   end
 end

--- a/src/detector/detectors/javascript/nuxtjs.cr
+++ b/src/detector/detectors/javascript/nuxtjs.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nuxtjs < Detector
+    detector_for "js_nuxtjs",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     EVENT_HANDLER = /defineEventHandler/
 
     # Single precompiled alternation — one PCRE2 scan instead of six.
@@ -41,14 +45,6 @@ module Detector::Javascript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_nuxtjs"
     end
   end
 end

--- a/src/detector/detectors/javascript/remix.cr
+++ b/src/detector/detectors/javascript/remix.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Remix < Detector
+    detector_for "js_remix",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     PACKAGE_MARKER = /@remix-run\//
     VITE_MARKER    = /@remix-run\/dev/
 
@@ -38,14 +42,6 @@ module Detector::Javascript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_remix"
     end
   end
 end

--- a/src/detector/detectors/javascript/restify.cr
+++ b/src/detector/detectors/javascript/restify.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Restify < Detector
+    detector_for "js_restify",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     # `.js` accepts either quoting of the require; `.ts` only the double-quoted
     # form, which is how this detector has always behaved.
     JS_MARKERS = Regex.union("require('restify')", "require(\"restify\")")
@@ -15,14 +19,6 @@ module Detector::Javascript
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_restify"
     end
   end
 end

--- a/src/detector/detectors/javascript/socketio.cr
+++ b/src/detector/detectors/javascript/socketio.cr
@@ -7,6 +7,8 @@ module Detector::Javascript
   # with `.on(` usage. Gates the Socket.IO analyzer, which emits inbound
   # `socket.on` events as `ws://` realtime endpoints.
   class SocketIO < Detector
+    detector_for "js_socketio"
+
     SIGNAL = Regex.union(
       /from\s+['"]socket\.io['"]/,
       /require\(\s*['"]socket\.io['"]\s*\)/,
@@ -28,10 +30,6 @@ module Detector::Javascript
 
     def applicable?(filename : String) : Bool
       source_file?(filename) || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_socketio"
     end
 
     private def source_file?(filename : String) : Bool

--- a/src/detector/detectors/javascript/sveltekit.cr
+++ b/src/detector/detectors/javascript/sveltekit.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Sveltekit < Detector
+    detector_for "js_sveltekit",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -30,14 +34,6 @@ module Detector::Javascript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "js_sveltekit"
     end
   end
 end

--- a/src/detector/detectors/kotlin/cli.cr
+++ b/src/detector/detectors/kotlin/cli.cr
@@ -5,20 +5,14 @@ module Detector::Kotlin
   # picocli imports or their constructs — NOT on bare `fun main(args)`, which
   # Spring Boot and most Kotlin apps have.
   class Cli < Detector
+    detector_for "kotlin_cli", extensions: %w[.kt]
+
     LIB_IMPORTS = ["com.github.ajalt.clikt", "kotlinx.cli", "picocli.CommandLine"]
     USAGE       = /:\s*CliktCommand\b|\bArgParser\s*\(/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".kt")
       LIB_IMPORTS.any? { |marker| file_contents.includes?(marker) } || content_matches?(file_contents, USAGE)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".kt")
-    end
-
-    def set_name
-      @name = "kotlin_cli"
     end
   end
 end

--- a/src/detector/detectors/kotlin/http4k.cr
+++ b/src/detector/detectors/kotlin/http4k.cr
@@ -2,17 +2,11 @@ require "../../../models/detector"
 
 module Detector::Kotlin
   class Http4k < Detector
+    detector_for "kotlin_http4k", extensions: %w[.kt]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".kt")
       file_contents.includes?("org.http4k")
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".kt")
-    end
-
-    def set_name
-      @name = "kotlin_http4k"
     end
   end
 end

--- a/src/detector/detectors/kotlin/ktor.cr
+++ b/src/detector/detectors/kotlin/ktor.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Kotlin
   class Ktor < Detector
+    detector_for "kotlin_ktor", extensions: %w[.kt]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".kt") && (file_contents.includes? "io.ktor")
         return true
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".kt")
-    end
-
-    def set_name
-      @name = "kotlin_ktor"
     end
   end
 end

--- a/src/detector/detectors/kotlin/spring.cr
+++ b/src/detector/detectors/kotlin/spring.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Kotlin
   class Spring < Detector
+    detector_for "kotlin_spring", extensions: %w[.kt]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".kt") && (file_contents.includes? "org.springframework")
         return true
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".kt")
-    end
-
-    def set_name
-      @name = "kotlin_spring"
     end
   end
 end

--- a/src/detector/detectors/lua/cli.cr
+++ b/src/detector/detectors/lua/cli.cr
@@ -5,19 +5,13 @@ module Detector::Lua
   # (lua_cliargs) library, or explicit `arg` indexing. Never gates on bare
   # os.getenv (lapis/lor config).
   class Cli < Detector
+    detector_for "lua_cli", extensions: %w[.lua]
+
     MARKERS = /\brequire\s*\(?\s*['"]argparse['"]|\bargparse\s*\(|\barg\s*\[\s*\d+\s*\]|\brequire\s*\(?\s*['"]cliargs['"]/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".lua")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".lua")
-    end
-
-    def set_name
-      @name = "lua_cli"
     end
   end
 end

--- a/src/detector/detectors/lua/lapis.cr
+++ b/src/detector/detectors/lua/lapis.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Lua
   class Lapis < Detector
+    detector_for "lua_lapis", extensions: %w[.lua .moon .rockspec]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -26,14 +28,6 @@ module Detector::Lua
       return true if file_contents.match(/extends\s+lapis\.Application/)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".lua") || filename.ends_with?(".moon") || filename.ends_with?(".rockspec")
-    end
-
-    def set_name
-      @name = "lua_lapis"
     end
   end
 end

--- a/src/detector/detectors/lua/lor.cr
+++ b/src/detector/detectors/lua/lor.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Lua
   class Lor < Detector
+    detector_for "lua_lor", extensions: %w[.lua .moon .rockspec]
+
     def detect(filename : String, file_contents : String) : Bool
       # `*.rockspec` (LuaRocks manifest) declaring the `lor` dependency.
       if filename.ends_with?(".rockspec") &&
@@ -19,14 +21,6 @@ module Detector::Lua
       return true if file_contents.match(/=\s*lor\s*\(\s*\)/)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".lua") || filename.ends_with?(".moon") || filename.ends_with?(".rockspec")
-    end
-
-    def set_name
-      @name = "lua_lor"
     end
   end
 end

--- a/src/detector/detectors/mobile/android.cr
+++ b/src/detector/detectors/mobile/android.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Mobile
   class Android < Detector
+    # Registers AndroidManifest.xml paths in `CodeLocator`.
+    detector_for "android", basenames: %w[AndroidManifest.xml], idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       if File.basename(filename) == "AndroidManifest.xml" && file_contents.includes?("<manifest")
         locator = CodeLocator.instance
@@ -10,19 +13,6 @@ module Detector::Mobile
         return true
       end
 
-      false
-    end
-
-    def applicable?(filename : String) : Bool
-      File.basename(filename) == "AndroidManifest.xml"
-    end
-
-    def set_name
-      @name = "android"
-    end
-
-    # Registers AndroidManifest.xml paths in `CodeLocator`.
-    def idempotent? : Bool
       false
     end
   end

--- a/src/detector/detectors/mobile/ios.cr
+++ b/src/detector/detectors/mobile/ios.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Mobile
   class Ios < Detector
+    # Registers Info.plist / .entitlements paths in `CodeLocator`.
+    detector_for "ios", extensions: %w[.plist .entitlements], idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       locator = CodeLocator.instance
 
@@ -16,19 +19,6 @@ module Detector::Mobile
         return true
       end
 
-      false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".plist") || filename.ends_with?(".entitlements")
-    end
-
-    def set_name
-      @name = "ios"
-    end
-
-    # Registers Info.plist / .entitlements paths in `CodeLocator`.
-    def idempotent? : Bool
       false
     end
   end

--- a/src/detector/detectors/mobile/well_known.cr
+++ b/src/detector/detectors/mobile/well_known.cr
@@ -14,6 +14,10 @@ module Detector::Mobile
   # JSON blob doesn't register. Both file types feed the single
   # `well_known_applinks` analyzer via the CodeLocator.
   class WellKnown < Detector
+    # Registers assetlinks.json / apple-app-site-association paths in
+    # `CodeLocator`, so it must run on every candidate file.
+    detector_for "well_known_applinks", idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       basename = File.basename(filename)
       locator = CodeLocator.instance
@@ -34,16 +38,6 @@ module Detector::Mobile
     def applicable?(filename : String) : Bool
       basename = File.basename(filename)
       basename == "assetlinks.json" || aasa_basename?(basename)
-    end
-
-    def set_name
-      @name = "well_known_applinks"
-    end
-
-    # Registers assetlinks.json / apple-app-site-association paths in
-    # `CodeLocator`, so it must run on every candidate file.
-    def idempotent? : Bool
-      false
     end
 
     private def aasa_basename?(basename : String) : Bool

--- a/src/detector/detectors/perl/catalyst.cr
+++ b/src/detector/detectors/perl/catalyst.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Perl
   class Catalyst < Detector
+    detector_for "perl_catalyst"
+
     def detect(filename : String, file_contents : String) : Bool
       if dependency_manifest?(filename)
         return file_contents.includes?("Catalyst") ||
@@ -27,10 +29,6 @@ module Detector::Perl
 
     def applicable?(filename : String) : Bool
       perl_source?(filename) || dependency_manifest?(filename)
-    end
-
-    def set_name
-      @name = "perl_catalyst"
     end
 
     private def perl_source?(filename : String) : Bool

--- a/src/detector/detectors/perl/cli.cr
+++ b/src/detector/detectors/perl/cli.cr
@@ -5,19 +5,13 @@ module Detector::Perl
   # MooseX::Getopt, Getopt::Long::Descriptive, MooX::Options, or explicit
   # @ARGV indexing. Never gates on bare %ENV (Mojolicious/Dancer2 config).
   class Cli < Detector
+    detector_for "perl_cli", extensions: %w[.pl .pm .t]
+
     MARKERS = /\buse\s+Getopt::(?:Long|Std)\b|\bGetOptions\s*\(|\bgetopts?\s*\(|\buse\s+App::Cmd\b|\bMooseX::Getopt\b|\$ARGV\s*\[\s*\d+\s*\]|\buse\s+Getopt::Long::Descriptive\b|\bdescribe_options\s*\(|\buse\s+MooX::Options\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".pl") || filename.ends_with?(".pm") || filename.ends_with?(".t")
-    end
-
-    def set_name
-      @name = "perl_cli"
     end
   end
 end

--- a/src/detector/detectors/perl/dancer2.cr
+++ b/src/detector/detectors/perl/dancer2.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Perl
   class Dancer2 < Detector
+    detector_for "perl_dancer2"
+
     def detect(filename : String, file_contents : String) : Bool
       if dependency_manifest?(filename)
         return file_contents.includes?("Dancer2")
@@ -25,10 +27,6 @@ module Detector::Perl
 
     def applicable?(filename : String) : Bool
       perl_source?(filename) || dependency_manifest?(filename)
-    end
-
-    def set_name
-      @name = "perl_dancer2"
     end
 
     private def perl_source?(filename : String) : Bool

--- a/src/detector/detectors/perl/mojolicious.cr
+++ b/src/detector/detectors/perl/mojolicious.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Perl
   class Mojolicious < Detector
+    detector_for "perl_mojolicious",
+      extensions: %w[.pl .pm .psgi .t],
+      basenames: %w[cpanfile Makefile.PL dist.ini META.json META.yml]
+
     def detect(filename : String, file_contents : String) : Bool
       # Dependency manifests
       if filename.ends_with?("cpanfile") ||
@@ -23,14 +27,6 @@ module Detector::Perl
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".pl") || filename.ends_with?(".pm") || filename.ends_with?(".psgi") || filename.ends_with?(".t") || File.basename(filename) == "cpanfile" || File.basename(filename) == "Makefile.PL" || File.basename(filename) == "dist.ini" || File.basename(filename) == "META.json" || File.basename(filename) == "META.yml"
-    end
-
-    def set_name
-      @name = "perl_mojolicious"
     end
   end
 end

--- a/src/detector/detectors/php/cakephp.cr
+++ b/src/detector/detectors/php/cakephp.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class CakePHP < Detector
+    detector_for "php_cakephp",
+      extensions: %w[.php .phtml],
+      basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for composer.json with CakePHP dependency
       if filename.ends_with?("composer.json") && file_contents.includes?("cakephp/cakephp")
@@ -21,14 +25,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_cakephp"
     end
   end
 end

--- a/src/detector/detectors/php/cli.cr
+++ b/src/detector/detectors/php/cli.cr
@@ -8,6 +8,8 @@ module Detector::Php
   # (`WP_CLI::add_command` / `WP_CLI_Command`), or builtin getopt / $argv
   # indexing.
   class Cli < Detector
+    detector_for "php_cli", extensions: %w[.php]
+
     USE_SF_CONSOLE    = /\buse\s+Symfony\\Component\\Console\b/
     SF_COMMAND        = /\bclass\s+\w+\s+extends\s+(?:\\?Symfony\\Component\\Console\\Command\\)?Command\b/
     AS_COMMAND        = /#\[\s*AsCommand\b/
@@ -33,14 +35,6 @@ module Detector::Php
         content_matches?(file_contents, GETOPT) || content_matches?(file_contents, ARGV_INDEX) ||
         content_matches?(file_contents, ARTISAN_SIGNATURE) || content_matches?(file_contents, ROBO_MARKER) ||
         content_matches?(file_contents, WP_ADD_COMMAND) || content_matches?(file_contents, WP_COMMAND_CLASS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php")
-    end
-
-    def set_name
-      @name = "php_cli"
     end
   end
 end

--- a/src/detector/detectors/php/codeigniter.cr
+++ b/src/detector/detectors/php/codeigniter.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class CodeIgniter < Detector
+    detector_for "php_codeigniter",
+      extensions: %w[.php .phtml],
+      basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       # composer.json with CodeIgniter dependency
       if filename.ends_with?("composer.json") &&
@@ -46,14 +50,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_codeigniter"
     end
   end
 end

--- a/src/detector/detectors/php/drupal.cr
+++ b/src/detector/detectors/php/drupal.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class Drupal < Detector
+    detector_for "php_drupal",
+      extensions: %w[.php .module .install .theme .profile .inc .yml .yaml],
+      basenames: %w[composer.json]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -48,18 +52,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".module") ||
-        filename.ends_with?(".install") || filename.ends_with?(".theme") ||
-        filename.ends_with?(".profile") || filename.ends_with?(".inc") ||
-        filename.ends_with?(".yml") || filename.ends_with?(".yaml") ||
-        File.basename(filename) == "composer.json"
-    end
-
-    def set_name
-      @name = "php_drupal"
     end
   end
 end

--- a/src/detector/detectors/php/hyperf.cr
+++ b/src/detector/detectors/php/hyperf.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class Hyperf < Detector
+    detector_for "php_hyperf",
+      extensions: %w[.php .phtml],
+      basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.ends_with?("composer.json") && (file_contents.includes?("hyperf/hyperf") ||
          file_contents.includes?("hyperf/framework") ||
@@ -19,14 +23,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_hyperf"
     end
   end
 end

--- a/src/detector/detectors/php/laminas.cr
+++ b/src/detector/detectors/php/laminas.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class Laminas < Detector
+    detector_for "php_laminas",
+      extensions: %w[.php .phtml],
+      basenames: %w[composer.json composer.lock]
+
     LAMINAS_PACKAGES = [
       "laminas/laminas-mvc",
       "laminas/laminas-router",
@@ -33,14 +37,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_laminas"
     end
   end
 end

--- a/src/detector/detectors/php/laravel.cr
+++ b/src/detector/detectors/php/laravel.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class Laravel < Detector
+    detector_for "php_laravel",
+      extensions: %w[.php .phtml],
+      basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for composer.json with Laravel dependencies
       if filename.ends_with?("composer.json") && file_contents.includes?("laravel/framework")
@@ -42,14 +46,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_laravel"
     end
   end
 end

--- a/src/detector/detectors/php/lumen.cr
+++ b/src/detector/detectors/php/lumen.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class Lumen < Detector
+    detector_for "php_lumen",
+      extensions: %w[.php .phtml],
+      basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       # composer.json explicitly pulling in lumen-framework is the strongest signal.
       if filename.ends_with?("composer.json") && file_contents.includes?("laravel/lumen-framework")
@@ -21,14 +25,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_lumen"
     end
   end
 end

--- a/src/detector/detectors/php/magento.cr
+++ b/src/detector/detectors/php/magento.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Php
   class Magento < Detector
+    detector_for "php_magento", extensions: %w[.php .xml], basenames: %w[composer.json]
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
 
@@ -47,15 +49,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".xml") ||
-        File.basename(filename) == "composer.json"
-    end
-
-    def set_name
-      @name = "php_magento"
     end
   end
 end

--- a/src/detector/detectors/php/mautic.cr
+++ b/src/detector/detectors/php/mautic.cr
@@ -6,6 +6,8 @@ module Detector::Php
   # => ['name' => ['path' => '/x', 'controller' => '...']]]`) rather than
   # Symfony attributes/annotations — so the Symfony analyzer finds nothing.
   class Mautic < Detector
+    detector_for "php_mautic", extensions: %w[.php], basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       if File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
         return true if file_contents.includes?(%("mautic/core-lib"))
@@ -18,14 +20,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_mautic"
     end
   end
 end

--- a/src/detector/detectors/php/php.cr
+++ b/src/detector/detectors/php/php.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Php
   class Php < Detector
+    detector_for "php_pure", extensions: %w[.php .phtml], basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".php")
 
@@ -9,14 +11,6 @@ module Detector::Php
       check = check || file_contents.includes?("?>")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_pure"
     end
   end
 end

--- a/src/detector/detectors/php/slim.cr
+++ b/src/detector/detectors/php/slim.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Php
   class Slim < Detector
+    detector_for "php_slim", extensions: %w[.php .phtml], basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.ends_with?("composer.json") && file_contents.includes?("slim/slim")
         return true
@@ -15,14 +17,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_slim"
     end
   end
 end

--- a/src/detector/detectors/php/symfony.cr
+++ b/src/detector/detectors/php/symfony.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class Symfony < Detector
+    detector_for "php_symfony",
+      extensions: %w[.php .phtml],
+      basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for composer.json with Symfony dependencies
       if filename.ends_with?("composer.json") && file_contents.includes?("symfony/")
@@ -30,14 +34,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_symfony"
     end
   end
 end

--- a/src/detector/detectors/php/thinkphp.cr
+++ b/src/detector/detectors/php/thinkphp.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Php
   class ThinkPHP < Detector
+    detector_for "php_thinkphp",
+      extensions: %w[.php .phtml],
+      basenames: %w[composer.json composer.lock think]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for composer.json with ThinkPHP dependency
       if filename.ends_with?("composer.json") && file_contents.includes?("topthink/framework")
@@ -31,14 +35,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock" || File.basename(filename) == "think"
-    end
-
-    def set_name
-      @name = "php_thinkphp"
     end
   end
 end

--- a/src/detector/detectors/php/wordpress.cr
+++ b/src/detector/detectors/php/wordpress.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Php
   class Wordpress < Detector
+    detector_for "php_wordpress", extensions: %w[.php .phtml], basenames: %w[composer.json]
+
     # Strong, WordPress-specific source markers. A generic PHP file that
     # merely calls `add_action` is not enough — we require a marker that
     # is effectively unique to WordPress core/plugin/theme code so we do
@@ -78,14 +80,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json"
-    end
-
-    def set_name
-      @name = "php_wordpress"
     end
   end
 end

--- a/src/detector/detectors/php/yii.cr
+++ b/src/detector/detectors/php/yii.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Php
   class Yii < Detector
+    detector_for "php_yii", extensions: %w[.php .phtml], basenames: %w[composer.json composer.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for composer.json with Yii2 dependency
       if filename.ends_with?("composer.json") && file_contents.includes?("yiisoft/yii2")
@@ -35,14 +37,6 @@ module Detector::Php
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-    end
-
-    def set_name
-      @name = "php_yii"
     end
   end
 end

--- a/src/detector/detectors/python/aiohttp.cr
+++ b/src/detector/detectors/python/aiohttp.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class Aiohttp < Detector
+    detector_for "python_aiohttp", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -9,14 +11,6 @@ module Detector::Python
       has_import = file_contents.match(/(^|\n)\s*import\s+aiohttp(\s|,|$|\.)/)
 
       !!(has_from_import || has_import)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_aiohttp"
     end
   end
 end

--- a/src/detector/detectors/python/bottle.cr
+++ b/src/detector/detectors/python/bottle.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class Bottle < Detector
+    detector_for "python_bottle", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -10,14 +12,6 @@ module Detector::Python
       has_import = file_contents.match(/(^|\n)\s*import\s+bottle(\s|,|$)/)
 
       !!(has_from_import || has_import)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_bottle"
     end
   end
 end

--- a/src/detector/detectors/python/cli.cr
+++ b/src/detector/detectors/python/cli.cr
@@ -10,19 +10,13 @@ module Detector::Python
   # (sys.argv) is far too common to treat as CLI evidence on its own, so it
   # is only honored inside the analyzer when paired with a `__main__` guard.
   class Cli < Detector
+    detector_for "python_cli", extensions: %w[.py]
+
     CLI_IMPORT_RE = /(?:^|\n)\s*(?:import|from)\s+(?:argparse|click|typer|fire|docopt|getopt|absl|cleo)\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
       content_matches?(file_contents, CLI_IMPORT_RE)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_cli"
     end
   end
 end

--- a/src/detector/detectors/python/django.cr
+++ b/src/detector/detectors/python/django.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class Django < Detector
+    detector_for "python_django", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -10,14 +12,6 @@ module Detector::Python
       has_import = file_contents.match(/(^|\n)\s*import\s+django(\s|,|$)/)
 
       !!(has_from_import || has_import)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_django"
     end
   end
 end

--- a/src/detector/detectors/python/django_ninja.cr
+++ b/src/detector/detectors/python/django_ninja.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class DjangoNinja < Detector
+    detector_for "python_django_ninja", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -16,14 +18,6 @@ module Detector::Python
       has_import = file_contents.match(/(^|\n)\s*import\s+ninja(\s|,|\.|$)/)
 
       !!(has_from_import || has_import)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_django_ninja"
     end
   end
 end

--- a/src/detector/detectors/python/falcon.cr
+++ b/src/detector/detectors/python/falcon.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class Falcon < Detector
+    detector_for "python_falcon", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -11,14 +13,6 @@ module Detector::Python
       has_import = file_contents.match(/(^|\n)\s*import\s+falcon(\s|,|$|\.)/)
 
       !!(has_from_import || has_import)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_falcon"
     end
   end
 end

--- a/src/detector/detectors/python/fastapi.cr
+++ b/src/detector/detectors/python/fastapi.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Python
   class FastAPI < Detector
+    detector_for "python_fastapi", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".py") && (file_contents.includes?("from fastapi") || file_contents.includes?("import fastapi"))
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_fastapi"
     end
   end
 end

--- a/src/detector/detectors/python/flask.cr
+++ b/src/detector/detectors/python/flask.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class Flask < Detector
+    detector_for "python_flask", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -13,14 +15,6 @@ module Detector::Python
       has_appbuilder_import = file_contents.match(/(^|\n)\s*(?:from|import)\s+flask_appbuilder\b/)
 
       !!(has_from_import || has_import || has_appbuilder_import)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_flask"
     end
   end
 end

--- a/src/detector/detectors/python/http_server.cr
+++ b/src/detector/detectors/python/http_server.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class HttpServer < Detector
+    detector_for "python_http_server", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -15,14 +17,6 @@ module Detector::Python
       return true if file_contents.includes?("HTTPServer")
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_http_server"
     end
   end
 end

--- a/src/detector/detectors/python/litestar.cr
+++ b/src/detector/detectors/python/litestar.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Python
   class Litestar < Detector
+    detector_for "python_litestar", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".py") && (file_contents.includes?("from litestar") || file_contents.includes?("import litestar"))
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_litestar"
     end
   end
 end

--- a/src/detector/detectors/python/pyramid.cr
+++ b/src/detector/detectors/python/pyramid.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class Pyramid < Detector
+    detector_for "python_pyramid", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -9,14 +11,6 @@ module Detector::Python
       has_import = file_contents.match(/(^|\n)\s*import\s+pyramid(\s|,|\.|$)/)
 
       !!(has_from_import || has_import)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_pyramid"
     end
   end
 end

--- a/src/detector/detectors/python/quart.cr
+++ b/src/detector/detectors/python/quart.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Python
   class Quart < Detector
+    detector_for "python_quart", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
@@ -14,14 +16,6 @@ module Detector::Python
       has_import = file_contents.match(/(^|\n)\s*import\s+quart(\s|,|$)/)
 
       !!(has_from_import || has_import)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_quart"
     end
   end
 end

--- a/src/detector/detectors/python/robyn.cr
+++ b/src/detector/detectors/python/robyn.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Python
   class Robyn < Detector
+    detector_for "python_robyn", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".py") && (file_contents.includes?("from robyn") || file_contents.includes?("import robyn"))
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_robyn"
     end
   end
 end

--- a/src/detector/detectors/python/sanic.cr
+++ b/src/detector/detectors/python/sanic.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Python
   class Sanic < Detector
+    detector_for "python_sanic", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".py") && (file_contents.includes? "from sanic")
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_sanic"
     end
   end
 end

--- a/src/detector/detectors/python/starlette.cr
+++ b/src/detector/detectors/python/starlette.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Python
   class Starlette < Detector
+    detector_for "python_starlette", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".py") && (file_contents.includes?("from starlette") || file_contents.includes?("import starlette"))
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_starlette"
     end
   end
 end

--- a/src/detector/detectors/python/tornado.cr
+++ b/src/detector/detectors/python/tornado.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Python
   class Tornado < Detector
+    detector_for "python_tornado", extensions: %w[.py]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".py") && (file_contents.includes?("import tornado") || file_contents.includes?("from tornado"))
         true
       else
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "python_tornado"
     end
   end
 end

--- a/src/detector/detectors/r/plumber.cr
+++ b/src/detector/detectors/r/plumber.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::R
   class Plumber < Detector
+    detector_for "r_plumber", extensions: %w[.R .r]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".R") || filename.ends_with?(".r")
 
@@ -17,14 +19,6 @@ module Detector::R
       return true if content_matches?(file_contents, /\bpr_(?:get|post|put|delete|patch|head|options|handle|mount)\b/i)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".R") || filename.ends_with?(".r")
-    end
-
-    def set_name
-      @name = "r_plumber"
     end
   end
 end

--- a/src/detector/detectors/ruby/actioncable.cr
+++ b/src/detector/detectors/ruby/actioncable.cr
@@ -6,19 +6,13 @@ module Detector::Ruby
   # connection, or a `mount ActionCable.server` route. Gates the Action Cable
   # analyzer, which emits channel actions as `ws://` realtime endpoints.
   class ActionCable < Detector
+    detector_for "ruby_actioncable", extensions: %w[.rb .ru]
+
     ACTIONCABLE_MARKER = /<\s*ApplicationCable::Channel\b|<\s*ActionCable::Channel::Base\b|<\s*ActionCable::Connection::Base\b|\bmount\s+ActionCable\.server\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".rb") || filename.ends_with?(".ru")
       content_matches?(file_contents, ACTIONCABLE_MARKER)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") || filename.ends_with?(".ru")
-    end
-
-    def set_name
-      @name = "ruby_actioncable"
     end
   end
 end

--- a/src/detector/detectors/ruby/cli.cr
+++ b/src/detector/detectors/ruby/cli.cr
@@ -8,6 +8,8 @@ module Detector::Ruby
   # bare `ENV[...]` or a plain `ARGV` reference (without an index) is too
   # common in web apps to qualify.
   class Cli < Detector
+    detector_for "ruby_cli"
+
     CLI_GEMS = ["thor", "gli", "slop", "tty-option", "commander", "optimist", "clamp", "dry-cli"]
 
     REQUIRE_OPTPARSE = /\brequire\s+["']optparse["']/
@@ -46,10 +48,6 @@ module Detector::Ruby
     def applicable?(filename : String) : Bool
       base = File.basename(filename)
       filename.ends_with?(".rb") || filename.ends_with?(".gemspec") || base == "Gemfile"
-    end
-
-    def set_name
-      @name = "ruby_cli"
     end
   end
 end

--- a/src/detector/detectors/ruby/grape.cr
+++ b/src/detector/detectors/ruby/grape.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Grape < Detector
+    detector_for "ruby_grape", extensions: %w[.rb .ru .gemspec], basenames: %w[Gemfile Gemfile.lock]
+
     # `"< Grape::API"` was a separate probe, but it contains `"Grape::API"`
     # so it can never match anything the shorter literal misses.
     SOURCE_MARKERS = Regex.union("Grape::API", /require\s+['"]grape['"]/)
@@ -20,14 +22,6 @@ module Detector::Ruby
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") || filename.ends_with?(".ru") || filename.ends_with?(".gemspec") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
-    end
-
-    def set_name
-      @name = "ruby_grape"
     end
   end
 end

--- a/src/detector/detectors/ruby/hanami.cr
+++ b/src/detector/detectors/ruby/hanami.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Hanami < Detector
+    detector_for "ruby_hanami",
+      extensions: %w[.rb .ru .gemspec],
+      basenames: %w[Gemfile Gemfile.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.includes?("Gemfile")
         return gemfile_dependency?(file_contents, "hanami")
@@ -17,18 +21,6 @@ module Detector::Ruby
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") ||
-        filename.ends_with?(".ru") ||
-        filename.ends_with?(".gemspec") ||
-        File.basename(filename) == "Gemfile" ||
-        File.basename(filename) == "Gemfile.lock"
-    end
-
-    def set_name
-      @name = "ruby_hanami"
     end
   end
 end

--- a/src/detector/detectors/ruby/rails.cr
+++ b/src/detector/detectors/ruby/rails.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Rails < Detector
+    detector_for "ruby_rails", extensions: %w[.rb .ru .gemspec], basenames: %w[Gemfile Gemfile.lock]
+
     # Modern Rails apps frequently skip the umbrella `rails` dependency and
     # pull the individual frameworks they actually use (railties +
     # actionpack + activerecord + ...). Treat `railties` as a unique marker
@@ -22,18 +24,6 @@ module Detector::Ruby
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") ||
-        filename.ends_with?(".ru") ||
-        filename.ends_with?(".gemspec") ||
-        File.basename(filename) == "Gemfile" ||
-        File.basename(filename) == "Gemfile.lock"
-    end
-
-    def set_name
-      @name = "ruby_rails"
     end
   end
 end

--- a/src/detector/detectors/ruby/roda.cr
+++ b/src/detector/detectors/ruby/roda.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Roda < Detector
+    detector_for "ruby_roda", extensions: %w[.rb .ru .gemspec], basenames: %w[Gemfile Gemfile.lock]
+
     SOURCE_MARKERS = Regex.union(/<\s*Roda\b/, "Roda.route", /require\s+['"]roda['"]/)
 
     def detect(filename : String, file_contents : String) : Bool
@@ -18,14 +20,6 @@ module Detector::Ruby
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") || filename.ends_with?(".ru") || filename.ends_with?(".gemspec") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
-    end
-
-    def set_name
-      @name = "ruby_roda"
     end
   end
 end

--- a/src/detector/detectors/ruby/sinatra.cr
+++ b/src/detector/detectors/ruby/sinatra.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Sinatra < Detector
+    detector_for "ruby_sinatra",
+      extensions: %w[.rb .ru .gemspec],
+      basenames: %w[Gemfile Gemfile.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.includes?("Gemfile")
         return gemfile_dependency?(file_contents, "sinatra")
@@ -14,18 +18,6 @@ module Detector::Ruby
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") ||
-        filename.ends_with?(".ru") ||
-        filename.ends_with?(".gemspec") ||
-        File.basename(filename) == "Gemfile" ||
-        File.basename(filename) == "Gemfile.lock"
-    end
-
-    def set_name
-      @name = "ruby_sinatra"
     end
   end
 end

--- a/src/detector/detectors/ruby/webrick.cr
+++ b/src/detector/detectors/ruby/webrick.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Webrick < Detector
+    detector_for "ruby_webrick", extensions: %w[.rb .ru]
+
     MARKERS = Regex.union("WEBrick", "webrick", "mount_proc", "AbstractServlet")
 
     def detect(filename : String, file_contents : String) : Bool
@@ -13,14 +15,6 @@ module Detector::Ruby
       # Ruby frameworks (e.g. rackup using webrick in a sinatra/rails Gemfile).
       # Mirrors python_http_server and crystal_http design.
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") || filename.ends_with?(".ru")
-    end
-
-    def set_name
-      @name = "ruby_webrick"
     end
   end
 end

--- a/src/detector/detectors/rust/actix_web.cr
+++ b/src/detector/detectors/rust/actix_web.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class ActixWeb < Detector
+    detector_for "rust_actix_web", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_actix_web"
     end
   end
 end

--- a/src/detector/detectors/rust/axum.cr
+++ b/src/detector/detectors/rust/axum.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Axum < Detector
+    detector_for "rust_axum", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_axum"
     end
   end
 end

--- a/src/detector/detectors/rust/cli.cr
+++ b/src/detector/detectors/rust/cli.cr
@@ -6,6 +6,8 @@ module Detector::Rust
   # parser / uses `std::env::args()`. Gates the Rust CLI analyzer. Bare
   # `std::env::var(...)` (config reads, common in web crates) does not qualify.
   class Cli < Detector
+    detector_for "rust_cli", extensions: %w[.rs], basenames: %w[Cargo.toml]
+
     CLI_CRATES = ["clap", "structopt", "argh", "bpaf", "pico-args", "getopts"]
     # Single-pass alternation over CLI_CRATES — the previous per-crate
     # interpolated literal recompiled (and rescanned) once per crate for
@@ -39,14 +41,6 @@ module Detector::Rust
       return true if file_contents.includes?("clap") && content_matches?(file_contents, BUILDER_CMD)
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml"
-    end
-
-    def set_name
-      @name = "rust_cli"
     end
   end
 end

--- a/src/detector/detectors/rust/gotham.cr
+++ b/src/detector/detectors/rust/gotham.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Gotham < Detector
+    detector_for "rust_gotham", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_gotham"
     end
   end
 end

--- a/src/detector/detectors/rust/loco.cr
+++ b/src/detector/detectors/rust/loco.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Loco < Detector
+    detector_for "rust_loco", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_loco"
     end
   end
 end

--- a/src/detector/detectors/rust/poem.cr
+++ b/src/detector/detectors/rust/poem.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Poem < Detector
+    detector_for "rust_poem", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = !check.nil? && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_poem"
     end
   end
 end

--- a/src/detector/detectors/rust/rocket.cr
+++ b/src/detector/detectors/rust/rocket.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Rocket < Detector
+    detector_for "rust_rocket", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       check = filename.includes?("Cargo.toml")
       check = check && file_contents.includes?("rocket")
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_rocket"
     end
   end
 end

--- a/src/detector/detectors/rust/rwf.cr
+++ b/src/detector/detectors/rust/rwf.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Rwf < Detector
+    detector_for "rust_rwf", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_rwf"
     end
   end
 end

--- a/src/detector/detectors/rust/salvo.cr
+++ b/src/detector/detectors/rust/salvo.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Salvo < Detector
+    detector_for "rust_salvo", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_salvo"
     end
   end
 end

--- a/src/detector/detectors/rust/tide.cr
+++ b/src/detector/detectors/rust/tide.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Tide < Detector
+    detector_for "rust_tide", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_tide"
     end
   end
 end

--- a/src/detector/detectors/rust/warp.cr
+++ b/src/detector/detectors/rust/warp.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Rust
   class Warp < Detector
+    detector_for "rust_warp", extensions: %w[.rs], basenames: %w[Cargo.toml Cargo.lock]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Cargo.toml")
 
@@ -9,14 +11,6 @@ module Detector::Rust
       check = check && file_contents.includes?("dependencies")
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
-    end
-
-    def set_name
-      @name = "rust_warp"
     end
   end
 end

--- a/src/detector/detectors/scala/akka.cr
+++ b/src/detector/detectors/scala/akka.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Scala
   class Akka < Detector
+    detector_for "scala_akka", extensions: %w[.scala .sbt], basenames: %w[build.sbt]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".scala") && (file_contents.includes? "akka.http")
         return true
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
-    end
-
-    def set_name
-      @name = "scala_akka"
     end
   end
 end

--- a/src/detector/detectors/scala/cli.cr
+++ b/src/detector/detectors/scala/cli.cr
@@ -4,19 +4,13 @@ module Detector::Scala
   # Detects Scala command-line apps via scopt, decline, mainargs, Scallop, or
   # com.twitter.app. Never gates on bare sys.env (Akka/Play config).
   class Cli < Detector
+    detector_for "scala_cli", extensions: %w[.scala .sc]
+
     MARKERS = /\bscopt\b|\bOParser\b|\bcom\.monovore\.decline\b|\bimport\s+com\.monovore\.decline|\bOpts\.(?:option|flag|argument|arguments)\b|\bmainargs\b|@main\b|\borg\.rogach\.scallop\b|\bScallopConf\b|\bcom\.twitter\.app\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".scala") || filename.ends_with?(".sc")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".scala") || filename.ends_with?(".sc")
-    end
-
-    def set_name
-      @name = "scala_cli"
     end
   end
 end

--- a/src/detector/detectors/scala/http4s.cr
+++ b/src/detector/detectors/scala/http4s.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Scala
   class Http4s < Detector
+    detector_for "scala_http4s", extensions: %w[.scala .sbt], basenames: %w[build.sbt]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
 
@@ -10,14 +12,6 @@ module Detector::Scala
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
-    end
-
-    def set_name
-      @name = "scala_http4s"
     end
   end
 end

--- a/src/detector/detectors/scala/play.cr
+++ b/src/detector/detectors/scala/play.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Scala
   class Play < Detector
+    detector_for "scala_play", extensions: %w[.scala .sbt], basenames: %w[build.sbt]
+
     def detect(filename : String, file_contents : String) : Bool
       # Detect Play Framework by Scala-specific indicators
       if filename.ends_with?(".scala")
@@ -23,14 +25,6 @@ module Detector::Scala
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
-    end
-
-    def set_name
-      @name = "scala_play"
     end
   end
 end

--- a/src/detector/detectors/scala/scalatra.cr
+++ b/src/detector/detectors/scala/scalatra.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Scala
   class Scalatra < Detector
+    detector_for "scala_scalatra", extensions: %w[.scala .sbt], basenames: %w[build.sbt]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".scala") && (file_contents.includes?("org.scalatra") || file_contents.includes?("ScalatraServlet"))
         return true
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
-    end
-
-    def set_name
-      @name = "scala_scalatra"
     end
   end
 end

--- a/src/detector/detectors/scala/tapir.cr
+++ b/src/detector/detectors/scala/tapir.cr
@@ -2,20 +2,14 @@ require "../../../models/detector"
 
 module Detector::Scala
   class Tapir < Detector
+    detector_for "scala_tapir", extensions: %w[.scala .sbt], basenames: %w[build.sbt]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".scala") && (file_contents.includes?("sttp.tapir") || file_contents.includes?("import tapir."))
         return true
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
-    end
-
-    def set_name
-      @name = "scala_tapir"
     end
   end
 end

--- a/src/detector/detectors/scala/zio_http.cr
+++ b/src/detector/detectors/scala/zio_http.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Scala
   class ZioHttp < Detector
+    detector_for "scala_zio_http", extensions: %w[.scala .sbt], basenames: %w[build.sbt]
+
     def detect(filename : String, file_contents : String) : Bool
       if (filename.ends_with? ".scala") && (
            file_contents.includes?("zio.http") ||
@@ -11,14 +13,6 @@ module Detector::Scala
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
-    end
-
-    def set_name
-      @name = "scala_zio_http"
     end
   end
 end

--- a/src/detector/detectors/specification/apache_httpd.cr
+++ b/src/detector/detectors/specification/apache_httpd.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class ApacheHttpd < Detector
+    # Registers each Apache config path in `CodeLocator`.
+    detector_for "apache_httpd", idempotent: false
+
     HTACCESS          = ".htaccess"
     APACHE_DIRECTIVES = [
       "<VirtualHost",
@@ -40,15 +43,6 @@ module Detector::Specification
       base = File.basename(filename)
       return true if base == HTACCESS
       apache_conf?(filename) && !nginx_only?(filename)
-    end
-
-    def set_name
-      @name = "apache_httpd"
-    end
-
-    # Registers each Apache config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     # Avoid claiming nginx-only fragments by name to prevent the

--- a/src/detector/detectors/specification/apisix.cr
+++ b/src/detector/detectors/specification/apisix.cr
@@ -5,6 +5,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Apisix < Detector
+    # Registers every APISIX route config path in `CodeLocator`.
+    detector_for "apisix", extensions: %w[.json .yaml .yml], idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.ends_with?(".json")
         return false unless apisix_candidate?(file_contents)
@@ -26,19 +29,6 @@ module Detector::Specification
 
       false
     rescue
-      false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".json") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "apisix"
-    end
-
-    # Registers every APISIX route config path in `CodeLocator`.
-    def idempotent? : Bool
       false
     end
 

--- a/src/detector/detectors/specification/appwrite.cr
+++ b/src/detector/detectors/specification/appwrite.cr
@@ -8,6 +8,9 @@ module Detector::Specification
   # `appwrite.config.json` from v6). The server generates the whole
   # REST surface from that file, so it is the only thing to read.
   class Appwrite < Detector
+    # Registers each config path in `CodeLocator`.
+    detector_for "appwrite", idempotent: false
+
     CONFIG_FILENAMES = {"appwrite.json", "appwrite.config.json"}
 
     # `projectId` is mandatory in every Appwrite config and is the
@@ -40,15 +43,6 @@ module Detector::Specification
     # unrelated `.json`.
     def applicable?(filename : String) : Bool
       CONFIG_FILENAMES.includes?(File.basename(filename))
-    end
-
-    def set_name
-      @name = "appwrite"
-    end
-
-    # Registers each config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/asyncapi.cr
+++ b/src/detector/detectors/specification/asyncapi.cr
@@ -5,6 +5,10 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class AsyncApi < Detector
+    # Registers every AsyncAPI spec path in `CodeLocator` for the
+    # analyzer pass. Must keep running after first match.
+    detector_for "asyncapi", extensions: %w[.json .yaml .yml], idempotent: false
+
     # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate.
     ASYNCAPI_MARKER = /asyncapi/
 
@@ -39,20 +43,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".json") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "asyncapi"
-    end
-
-    # Registers every AsyncAPI spec path in `CodeLocator` for the
-    # analyzer pass. Must keep running after first match.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/aws_cdk.cr
+++ b/src/detector/detectors/specification/aws_cdk.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class AwsCdk < Detector
+    # Registers each CDK source path in `CodeLocator`.
+    detector_for "aws_cdk", extensions: %w[.ts .tsx .js .mjs .py], idempotent: false
+
     # Every `.ts`/`.js`/`.py` in the tree reaches these gates, so each was
     # walking the whole corpus three (hints) plus six (constructs) times.
     TS_JS_HINT_MARKER  = Regex.union("aws-cdk-lib", "@aws-cdk/aws-apigateway", "@aws-cdk/aws-apigatewayv2")
@@ -21,21 +24,6 @@ module Detector::Specification
 
       CodeLocator.instance.push("aws-cdk-spec", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
-        filename.ends_with?(".js") || filename.ends_with?(".mjs") ||
-        filename.ends_with?(".py")
-    end
-
-    def set_name
-      @name = "aws_cdk"
-    end
-
-    # Registers each CDK source path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def cdk_api_construct?(content : String) : Bool

--- a/src/detector/detectors/specification/aws_cloudformation.cr
+++ b/src/detector/detectors/specification/aws_cloudformation.cr
@@ -5,6 +5,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class AwsCloudformation < Detector
+    # Registers each template path in `CodeLocator`.
+    detector_for "aws_cloudformation", extensions: %w[.yaml .yml .json], idempotent: false
+
     SAM_TRANSFORM = "AWS::Serverless-2016-10-31"
 
     # Every `.yml`/`.yaml`/`.json` in the tree reaches this gate, so the
@@ -22,19 +25,6 @@ module Detector::Specification
 
       CodeLocator.instance.push("aws-cloudformation-spec", filename) if detected
       detected
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml") || filename.ends_with?(".json")
-    end
-
-    def set_name
-      @name = "aws_cloudformation"
-    end
-
-    # Registers each template path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def detect_yaml(content : String) : Bool

--- a/src/detector/detectors/specification/azure_functions.cr
+++ b/src/detector/detectors/specification/azure_functions.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class AzureFunctions < Detector
+    # Registers each function.json path in `CodeLocator`.
+    detector_for "azure_functions", idempotent: false
+
     FUNCTION_JSON = "function.json"
 
     def detect(filename : String, file_contents : String) : Bool
@@ -19,15 +22,6 @@ module Detector::Specification
 
     def applicable?(filename : String) : Bool
       File.basename(filename) == FUNCTION_JSON
-    end
-
-    def set_name
-      @name = "azure_functions"
-    end
-
-    # Registers each function.json path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/bruno.cr
+++ b/src/detector/detectors/specification/bruno.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Bruno < Detector
+    # Registers Bruno `.bru` paths in `CodeLocator`.
+    detector_for "bruno", extensions: %w[.bru], idempotent: false
+
     BLOCK_HEADER = /^[ \t]*(meta|get|post|put|patch|delete|head|options)[ \t]*\{/m
 
     def detect(filename : String, file_contents : String) : Bool
@@ -12,19 +15,6 @@ module Detector::Specification
       locator = CodeLocator.instance
       locator.push("bruno-bru", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".bru")
-    end
-
-    def set_name
-      @name = "bruno"
-    end
-
-    # Registers Bruno `.bru` paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/burp.cr
+++ b/src/detector/detectors/specification/burp.cr
@@ -7,6 +7,11 @@ module Detector::Specification
   # single detection signal — both checks gate the path push so WSDL
   # and other XML files aren't mistakenly registered.
   class Burp < Detector
+    # Registers Burp sitemap paths in `CodeLocator` for the analyzer pass.
+    # Must keep firing past the first match so multi-file sitemaps land in
+    # the locator.
+    detector_for "burp", extensions: %w[.xml], idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       return false unless file_contents.includes?("<items") && file_contents.includes?("burpVersion=")
@@ -14,21 +19,6 @@ module Detector::Specification
       locator = CodeLocator.instance
       locator.push("burp-sitemap", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".xml")
-    end
-
-    def set_name
-      @name = "burp"
-    end
-
-    # Registers Burp sitemap paths in `CodeLocator` for the analyzer pass.
-    # Must keep firing past the first match so multi-file sitemaps land in
-    # the locator.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/caddy.cr
+++ b/src/detector/detectors/specification/caddy.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Caddy < Detector
+    # Registers each Caddy config path in `CodeLocator`.
+    detector_for "caddy", idempotent: false
+
     CADDYFILE_NAMES = {"Caddyfile", "caddyfile"}
 
     # Every `.json` in the tree reaches these guards. Both must match, so
@@ -33,15 +36,6 @@ module Detector::Specification
     def applicable?(filename : String) : Bool
       base = File.basename(filename)
       CADDYFILE_NAMES.includes?(base) || filename.ends_with?(".json")
-    end
-
-    def set_name
-      @name = "caddy"
-    end
-
-    # Registers each Caddy config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def caddy_json?(content : String) : Bool

--- a/src/detector/detectors/specification/caido.cr
+++ b/src/detector/detectors/specification/caido.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Caido < Detector
+    # Registers Caido export paths in `CodeLocator`.
+    detector_for "caido", extensions: %w[.json], idempotent: false
+
     # Every `.json` in the tree reaches these guards. The first four must
     # all match, so they stay separate probes; only the last pair is an
     # alternation.
@@ -44,19 +47,6 @@ module Detector::Specification
       rescue
         false
       end
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".json")
-    end
-
-    def set_name
-      @name = "caido"
-    end
-
-    # Registers Caido export paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def caido_json_candidate?(content : String) : Bool

--- a/src/detector/detectors/specification/cloudflare_wrangler.cr
+++ b/src/detector/detectors/specification/cloudflare_wrangler.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class CloudflareWrangler < Detector
+    # Registers each wrangler config path in `CodeLocator`.
+    detector_for "cloudflare_wrangler", idempotent: false
+
     WRANGLER_FILES = {"wrangler.toml", "wrangler.jsonc", "wrangler.json"}
 
     def detect(filename : String, file_contents : String) : Bool
@@ -27,15 +30,6 @@ module Detector::Specification
 
     def applicable?(filename : String) : Bool
       WRANGLER_FILES.includes?(File.basename(filename))
-    end
-
-    def set_name
-      @name = "cloudflare_wrangler"
-    end
-
-    # Registers each wrangler config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/directus.cr
+++ b/src/detector/detectors/specification/directus.cr
@@ -13,6 +13,9 @@ module Detector::Specification
   # exports, MongoDB configs, CI matrices), so it is required rather than
   # merely preferred.
   class Directus < Detector
+    # Registers each snapshot path in `CodeLocator`.
+    detector_for "directus", idempotent: false
+
     SNAPSHOT_EXTENSIONS = {".yaml", ".yml", ".json"}
 
     # Cheap gate before libyaml: one precompiled alternation beats
@@ -51,15 +54,6 @@ module Detector::Specification
       File.basename(path).downcase.starts_with?("snapshot") ||
         path.includes?("/directus/") ||
         path.includes?("/snapshots/")
-    end
-
-    def set_name
-      @name = "directus"
-    end
-
-    # Registers each snapshot path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def collections_present?(root : Hash(YAML::Any, YAML::Any)) : Bool

--- a/src/detector/detectors/specification/envoy.cr
+++ b/src/detector/detectors/specification/envoy.cr
@@ -5,6 +5,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Envoy < Detector
+    # Registers every matching config path in CodeLocator.
+    detector_for "envoy", extensions: %w[.yaml .yml .json], idempotent: false
+
     # Every `.yaml`/`.yml`/`.json` in the tree reaches these gates.
     VIRTUAL_HOSTS_MARKER = /virtual_hosts/
     DOMAINS_MARKER       = /domains/
@@ -27,19 +30,6 @@ module Detector::Specification
         end
       end
 
-      false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml") || filename.ends_with?(".json")
-    end
-
-    def set_name
-      @name = "envoy"
-    end
-
-    # Registers every matching config path in CodeLocator.
-    def idempotent? : Bool
       false
     end
 

--- a/src/detector/detectors/specification/graphql_sdl.cr
+++ b/src/detector/detectors/specification/graphql_sdl.cr
@@ -3,6 +3,10 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class GraphqlSdl < Detector
+    # Registers every SDL path in `CodeLocator` for the analyzer pass.
+    # Must keep running after the first match so all schema files get picked up.
+    detector_for "graphql_sdl", extensions: %w[.graphql .gql .graphqls], idempotent: false
+
     # SDL declaration signals — distinguished at top-level only by
     # `sdl_document?`. A broad keyword-only check is too loose: generated
     # operation documents often select fields named `type`, `schema`, or
@@ -123,22 +127,6 @@ module Detector::Specification
         end
       end
       depth
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".graphql") ||
-        filename.ends_with?(".gql") ||
-        filename.ends_with?(".graphqls")
-    end
-
-    def set_name
-      @name = "graphql_sdl"
-    end
-
-    # Registers every SDL path in `CodeLocator` for the analyzer pass.
-    # Must keep running after the first match so all schema files get picked up.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/grpc.cr
+++ b/src/detector/detectors/specification/grpc.cr
@@ -3,6 +3,11 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Grpc < Detector
+    # Records every matching `.proto` path in `CodeLocator` for the
+    # analyzer pass. Must keep running after the first match so all
+    # service files get registered.
+    detector_for "grpc", extensions: %w[.proto], idempotent: false
+
     # A gRPC service is defined by a `service Name { ... }` block. Matching that
     # structural marker — rather than the bare substrings "service"/"rpc", which
     # also occur in ordinary field names like `service_url` or `rpc_timeout` —
@@ -15,21 +20,6 @@ module Detector::Specification
         return true
       end
 
-      false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".proto")
-    end
-
-    def set_name
-      @name = "grpc"
-    end
-
-    # Records every matching `.proto` path in `CodeLocator` for the
-    # analyzer pass. Must keep running after the first match so all
-    # service files get registered.
-    def idempotent? : Bool
       false
     end
   end

--- a/src/detector/detectors/specification/har.cr
+++ b/src/detector/detectors/specification/har.cr
@@ -6,6 +6,9 @@ require "har"
 
 module Detector::Specification
   class Har < Detector
+    # Registers HAR file paths in `CodeLocator`.
+    detector_for "har", extensions: %w[.har .json], idempotent: false
+
     # Every `.json` in the tree reaches these guards. Both must match, so
     # they stay separate probes rather than a union.
     LOG_MARKER     = /"log"/
@@ -27,19 +30,6 @@ module Detector::Specification
         end
       end
 
-      false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".har") || filename.ends_with?(".json")
-    end
-
-    def set_name
-      @name = "har"
-    end
-
-    # Registers HAR file paths in `CodeLocator`.
-    def idempotent? : Bool
       false
     end
 

--- a/src/detector/detectors/specification/hasura.cr
+++ b/src/detector/detectors/specification/hasura.cr
@@ -19,6 +19,9 @@ module Detector::Specification
   # required and the document must also carry a key from Hasura's own
   # permission/relationship vocabulary.
   class Hasura < Detector
+    # Registers every metadata path in `CodeLocator`.
+    detector_for "hasura", idempotent: false
+
     METADATA_SEGMENT = "/metadata/"
 
     TABLE_MARKER = /^\s*(?:-\s+)?table\s*:/m
@@ -53,15 +56,6 @@ module Detector::Specification
 
       basename = File.basename(path)
       basename == "tables.yaml" || basename == "rest_endpoints.yaml"
-    end
-
-    def set_name
-      @name = "hasura"
-    end
-
-    # Registers every metadata path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def detect_rest_endpoints(filename : String, file_contents : String) : Bool

--- a/src/detector/detectors/specification/http_file.cr
+++ b/src/detector/detectors/specification/http_file.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class HttpFile < Detector
+    # Registers `.http` / `.rest` request-file paths in `CodeLocator`.
+    detector_for "http_file", extensions: %w[.http .rest], idempotent: false
+
     # A request line: an HTTP method followed by a target whose first token
     # carries a URL-ish char (`.` `/` `:` `{`). This is the unambiguous
     # signal shared by the VS Code REST Client and JetBrains HTTP Client
@@ -17,19 +20,6 @@ module Detector::Specification
       locator = CodeLocator.instance
       locator.push("http-file", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".http") || filename.ends_with?(".rest")
-    end
-
-    def set_name
-      @name = "http_file"
-    end
-
-    # Registers `.http` / `.rest` request-file paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/insomnia.cr
+++ b/src/detector/detectors/specification/insomnia.cr
@@ -5,6 +5,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Insomnia < Detector
+    # Registers Insomnia export paths in `CodeLocator`.
+    detector_for "insomnia", extensions: %w[.json .yaml .yml], idempotent: false
+
     # Every `.json`/`.yaml`/`.yml` in the tree reaches these gates.
     EXPORT_FORMAT_MARKER = /"__export_format"/
     TYPE_FIELD_MARKER    = /"_type"/
@@ -50,19 +53,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".json") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "insomnia"
-    end
-
-    # Registers Insomnia export paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/istio_virtualservice.cr
+++ b/src/detector/detectors/specification/istio_virtualservice.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class IstioVirtualservice < Detector
+    # Registers each VirtualService manifest path in `CodeLocator`.
+    detector_for "istio_virtualservice", extensions: %w[.yaml .yml], idempotent: false
+
     ISTIO_API_PREFIX = "networking.istio.io/"
 
     # Every `.yaml`/`.yml` in the tree reaches these guards. Both must
@@ -22,19 +25,6 @@ module Detector::Specification
 
       CodeLocator.instance.push("istio-virtualservice-spec", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "istio_virtualservice"
-    end
-
-    # Registers each VirtualService manifest path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def valid_yaml_documents?(content : String) : Bool

--- a/src/detector/detectors/specification/k8s_gateway_api.cr
+++ b/src/detector/detectors/specification/k8s_gateway_api.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class K8sGatewayApi < Detector
+    # Registers each Gateway API manifest path in `CodeLocator`.
+    detector_for "k8s_gateway_api", extensions: %w[.yaml .yml], idempotent: false
+
     GATEWAY_API_PREFIX = "gateway.networking.k8s.io/"
 
     # Every `.yaml`/`.yml` in the tree reaches these guards. Both must
@@ -22,19 +25,6 @@ module Detector::Specification
 
       CodeLocator.instance.push("k8s-gateway-api-spec", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "k8s_gateway_api"
-    end
-
-    # Registers each Gateway API manifest path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def valid_yaml_documents?(content : String) : Bool

--- a/src/detector/detectors/specification/k8s_ingress.cr
+++ b/src/detector/detectors/specification/k8s_ingress.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class K8sIngress < Detector
+    # Registers each ingress manifest path in `CodeLocator`.
+    detector_for "k8s_ingress", extensions: %w[.yaml .yml], idempotent: false
+
     INGRESS_API_VERSION_PREFIXES = ["networking.k8s.io/", "extensions/v1beta1"]
 
     # Every `.yml`/`.yaml` in the tree reaches this gate.
@@ -16,19 +19,6 @@ module Detector::Specification
 
       CodeLocator.instance.push("k8s-ingress-spec", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "k8s_ingress"
-    end
-
-    # Registers each ingress manifest path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def ingress_document_present?(content : String) : Bool

--- a/src/detector/detectors/specification/kamal.cr
+++ b/src/detector/detectors/specification/kamal.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Kamal < Detector
+    # Registers each Kamal config path in `CodeLocator`.
+    detector_for "kamal", idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       return false unless kamal_markers?(file_contents)
@@ -29,15 +32,6 @@ module Detector::Specification
       return true if base.includes?("deploy") || base.includes?("kamal")
       path = filename.includes?('\\') ? filename.gsub('\\', '/') : filename
       path.includes?("/.kamal/") || path.includes?("/config/deploy")
-    end
-
-    def set_name
-      @name = "kamal"
-    end
-
-    # Registers each Kamal config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     # Cheap substring pre-check ahead of the (relatively costly) YAML

--- a/src/detector/detectors/specification/kong.cr
+++ b/src/detector/detectors/specification/kong.cr
@@ -4,6 +4,8 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Kong < Detector
+    detector_for "kong", extensions: %w[.yaml .yml], idempotent: false
+
     # Necessary-condition guard: both accepted shapes require one of these
     # literals somewhere in the document (`deck_shape?` needs a
     # `_format_version` key, `kic_shape?` an apiVersion containing
@@ -26,18 +28,6 @@ module Detector::Specification
         logger.debug "Kong detection failed for #{filename}: #{e}"
       end
 
-      false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "kong"
-    end
-
-    def idempotent? : Bool
       false
     end
 

--- a/src/detector/detectors/specification/mitmproxy.cr
+++ b/src/detector/detectors/specification/mitmproxy.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Mitmproxy < Detector
+    # Registers mitmproxy flow paths in `CodeLocator`.
+    detector_for "mitmproxy", extensions: %w[.mitm .flow .flows], idempotent: false
+
     # Tnetstring length prefix: one or more ASCII digits then a colon.
     LENGTH_PREFIX = /\A\d+:/
 
@@ -21,21 +24,6 @@ module Detector::Specification
       locator = CodeLocator.instance
       locator.push("mitmproxy-path", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".mitm") ||
-        filename.ends_with?(".flow") ||
-        filename.ends_with?(".flows")
-    end
-
-    def set_name
-      @name = "mitmproxy"
-    end
-
-    # Registers mitmproxy flow paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/netlify.cr
+++ b/src/detector/detectors/specification/netlify.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Netlify < Detector
+    # Registers file paths for analyzer pass.
+    detector_for "netlify", idempotent: false
+
     REDIRECTS_FILE = "_redirects"
     TOML_FILE      = "netlify.toml"
 
@@ -25,15 +28,6 @@ module Detector::Specification
     def applicable?(filename : String) : Bool
       base = File.basename(filename)
       base == REDIRECTS_FILE || base == TOML_FILE
-    end
-
-    def set_name
-      @name = "netlify"
-    end
-
-    # Registers file paths for analyzer pass.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/nginx.cr
+++ b/src/detector/detectors/specification/nginx.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Nginx < Detector
+    # Registers each Nginx config path in `CodeLocator`.
+    detector_for "nginx", idempotent: false
+
     # `.conf` is by far the most common extension for Nginx fragments;
     # `.tmpl`/`.template` files are common in docker-gen and deployment
     # repositories that render Nginx configs from templates.
@@ -28,15 +31,6 @@ module Detector::Specification
     def applicable?(filename : String) : Bool
       return true if File.basename(filename) == "nginx.conf"
       EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
-    end
-
-    def set_name
-      @name = "nginx"
-    end
-
-    # Registers each Nginx config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def nginx_shape?(content : String) : Bool

--- a/src/detector/detectors/specification/oas2.cr
+++ b/src/detector/detectors/specification/oas2.cr
@@ -5,6 +5,10 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Oas2 < Detector
+    # Registers every OAS2 spec path in `CodeLocator` for the
+    # analyzer pass. Must keep running after first match.
+    detector_for "oas2", extensions: %w[.json .yaml .yml], idempotent: false
+
     # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate.
     SWAGGER_MARKER = /swagger/
 
@@ -37,20 +41,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".json") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "oas2"
-    end
-
-    # Registers every OAS2 spec path in `CodeLocator` for the
-    # analyzer pass. Must keep running after first match.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/oas3.cr
+++ b/src/detector/detectors/specification/oas3.cr
@@ -5,6 +5,10 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Oas3 < Detector
+    # Registers every OAS3 spec path in `CodeLocator` for the
+    # analyzer pass. Must keep running after first match.
+    detector_for "oas3", extensions: %w[.json .yaml .yml], idempotent: false
+
     # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate.
     OPENAPI_MARKER = /openapi/
 
@@ -37,20 +41,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".json") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "oas3"
-    end
-
-    # Registers every OAS3 spec path in `CodeLocator` for the
-    # analyzer pass. Must keep running after first match.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/odata.cr
+++ b/src/detector/detectors/specification/odata.cr
@@ -7,6 +7,11 @@ module Detector::Specification
   # gate — root marker plus namespace — keeps generic WSDL/XML files
   # from being claimed by this detector.
   class OData < Detector
+    # Registers OData spec paths for the analyzer pass. Must keep
+    # firing past the first match so multi-service repos land every
+    # `$metadata` document in the locator.
+    detector_for "odata", idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       return false unless file_contents.includes?("edmx:Edmx") || file_contents.includes?("<Edmx")
@@ -22,17 +27,6 @@ module Detector::Specification
       base = File.basename(filename)
       return true if base == "$metadata" || base == "$metadata.xml" || base == "metadata.xml"
       filename.ends_with?(".xml") || filename.ends_with?(".edmx") || filename.ends_with?(".csdl")
-    end
-
-    def set_name
-      @name = "odata"
-    end
-
-    # Registers OData spec paths for the analyzer pass. Must keep
-    # firing past the first match so multi-service repos land every
-    # `$metadata` document in the locator.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/openrpc.cr
+++ b/src/detector/detectors/specification/openrpc.cr
@@ -4,6 +4,10 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class OpenRpc < Detector
+    # Registers every OpenRPC spec path in `CodeLocator` for the
+    # analyzer pass. Must keep running after first match.
+    detector_for "openrpc", extensions: %w[.json], idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
       return false unless file_contents.includes?("openrpc")
@@ -22,20 +26,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".json")
-    end
-
-    def set_name
-      @name = "openrpc"
-    end
-
-    # Registers every OpenRPC spec path in `CodeLocator` for the
-    # analyzer pass. Must keep running after first match.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/payload_cms.cr
+++ b/src/detector/detectors/specification/payload_cms.cr
@@ -16,6 +16,9 @@ module Detector::Specification
   # Matching bare `slug:` + `fields:` would trip on all three of the
   # above, so that gap is accepted.
   class PayloadCms < Detector
+    # Registers every collection, global and config path in `CodeLocator`.
+    detector_for "payload_cms", idempotent: false
+
     CONFIG_EXTENSIONS = {".ts", ".tsx", ".js", ".mjs", ".cjs", ".mts", ".cts"}
 
     # Single combined gate, checked before anything else. This detector is
@@ -68,15 +71,6 @@ module Detector::Specification
       return false if path.includes?(".test.") || path.includes?(".spec.")
 
       CONFIG_EXTENSIONS.includes?(File.extname(path).downcase)
-    end
-
-    def set_name
-      @name = "payload_cms"
-    end
-
-    # Registers every collection, global and config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/postman.cr
+++ b/src/detector/detectors/specification/postman.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Postman < Detector
+    # Registers Postman collection paths in `CodeLocator`.
+    detector_for "postman", extensions: %w[.json], idempotent: false
+
     # Every `.json` in the tree reaches this guard.
     CANDIDATE_MARKER = Regex.union(
       "schema.getpostman.com", "schema.postman.com", "\"_postman_id\"",
@@ -34,19 +37,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".json")
-    end
-
-    def set_name
-      @name = "postman"
-    end
-
-    # Registers Postman collection paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def postman_json_candidate?(content : String) : Bool

--- a/src/detector/detectors/specification/raml.cr
+++ b/src/detector/detectors/specification/raml.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class RAML < Detector
+    # Registers RAML spec paths in `CodeLocator`.
+    detector_for "raml", extensions: %w[.raml .yaml .yml], idempotent: false
+
     # Every `.raml`/`.yaml`/`.yml` in the tree reaches this guard.
     RAML_MARKER = /\#%RAML/
 
@@ -23,19 +26,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".raml") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "raml"
-    end
-
-    # Registers RAML spec paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/serverless_framework.cr
+++ b/src/detector/detectors/specification/serverless_framework.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class ServerlessFramework < Detector
+    # Registers each Serverless Framework config path in `CodeLocator`.
+    detector_for "serverless_framework", idempotent: false
+
     CONFIG_FILES = {"serverless.yml", "serverless.yaml", "serverless.json"}
 
     def detect(filename : String, file_contents : String) : Bool
@@ -24,15 +27,6 @@ module Detector::Specification
 
     def applicable?(filename : String) : Bool
       CONFIG_FILES.includes?(File.basename(filename))
-    end
-
-    def set_name
-      @name = "serverless_framework"
-    end
-
-    # Registers each Serverless Framework config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def serverless_doc?(data : JSON::Any) : Bool

--- a/src/detector/detectors/specification/smithy.cr
+++ b/src/detector/detectors/specification/smithy.cr
@@ -3,6 +3,10 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Smithy < Detector
+    # Registers every `.smithy` path in `CodeLocator` for the analyzer
+    # pass; must keep running after the first match.
+    detector_for "smithy", extensions: %w[.smithy], idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".smithy")
       return false unless file_contents.includes?("$version")
@@ -10,20 +14,6 @@ module Detector::Specification
       locator = CodeLocator.instance
       locator.push("smithy-spec", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".smithy")
-    end
-
-    def set_name
-      @name = "smithy"
-    end
-
-    # Registers every `.smithy` path in `CodeLocator` for the analyzer
-    # pass; must keep running after the first match.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/strapi.cr
+++ b/src/detector/detectors/specification/strapi.cr
@@ -11,6 +11,9 @@ module Detector::Specification
   # Scoped to v4+. Strapi v3's `config/routes.json` is EOL since 2023 and
   # its shape is indistinguishable from an APISIX route export.
   class Strapi < Detector
+    # Registers every schema and route path in `CodeLocator`.
+    detector_for "strapi", idempotent: false
+
     SCHEMA_FILENAME  = "schema.json"
     ROUTE_EXTENSIONS = {".ts", ".js", ".mts", ".cts", ".mjs", ".cjs"}
 
@@ -47,15 +50,6 @@ module Detector::Specification
       return false unless ROUTE_EXTENSIONS.includes?(File.extname(path).downcase)
 
       routes_module?(path)
-    end
-
-    def set_name
-      @name = "strapi"
-    end
-
-    # Registers every schema and route path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def detect_schema(filename : String, file_contents : String) : Bool

--- a/src/detector/detectors/specification/supabase.cr
+++ b/src/detector/detectors/specification/supabase.cr
@@ -21,6 +21,9 @@ module Detector::Specification
   # adds no syntax of its own, so nothing in the file distinguishes a
   # schema served by PostgREST from any other schema.
   class Supabase < Detector
+    # Registers every migration path in `CodeLocator`.
+    detector_for "supabase", idempotent: false
+
     # `alter table` counts too: a migration that only adds a column is
     # still part of the schema, and dropping those would leave the
     # emitted params stuck at whatever the first migration declared.
@@ -62,15 +65,6 @@ module Detector::Specification
       return false unless path.ends_with?(".sql")
 
       supabase_directory?(path) || path.includes?("/migrations/") || path.starts_with?("migrations/")
-    end
-
-    def set_name
-      @name = "supabase"
-    end
-
-    # Registers every migration path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def supabase_directory?(path : String) : Bool

--- a/src/detector/detectors/specification/terraform.cr
+++ b/src/detector/detectors/specification/terraform.cr
@@ -6,6 +6,9 @@ module Detector::Specification
   # declares AWS API Gateway routes, and registers the path so the analyzer can
   # reconstruct endpoints module-wide.
   class Terraform < Detector
+    # Registers each Terraform config path in `CodeLocator`.
+    detector_for "terraform", extensions: %w[.tf .tf.json], idempotent: false
+
     # Resource types that produce endpoints. Markers are quoted so they match a
     # `resource "aws_apigatewayv2_route"` block (HCL) or an `"aws_apigatewayv2_route"`
     # key (JSON) but NOT sibling types that merely share a prefix
@@ -22,19 +25,6 @@ module Detector::Specification
 
       CodeLocator.instance.push("terraform-spec", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".tf") || filename.ends_with?(".tf.json")
-    end
-
-    def set_name
-      @name = "terraform"
-    end
-
-    # Registers each Terraform config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/traefik.cr
+++ b/src/detector/detectors/specification/traefik.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Traefik < Detector
+    # Registers every Traefik config path in `CodeLocator`.
+    detector_for "traefik", extensions: %w[.yaml .yml .toml], idempotent: false
+
     # Necessary-condition guard for the YAML branch: every accepted shape
     # requires one of these literals in the raw document — a `routers` key
     # (`traefik_dynamic_config?`, and the `traefik.http.routers.` label
@@ -36,19 +39,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml") || filename.ends_with?(".toml")
-    end
-
-    def set_name
-      @name = "traefik"
-    end
-
-    # Registers every Traefik config path in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def traefik_dynamic_config?(data : YAML::Any) : Bool

--- a/src/detector/detectors/specification/typespec.cr
+++ b/src/detector/detectors/specification/typespec.cr
@@ -3,6 +3,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class TypeSpec < Detector
+    # Registers TypeSpec spec paths in `CodeLocator`.
+    detector_for "typespec", extensions: %w[.tsp], idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".tsp")
       # `.tsp` is unambiguous on its own, but the issue spec also calls out a
@@ -19,19 +22,6 @@ module Detector::Specification
 
       CodeLocator.instance.push("typespec-spec", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".tsp")
-    end
-
-    def set_name
-      @name = "typespec"
-    end
-
-    # Registers TypeSpec spec paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/vercel.cr
+++ b/src/detector/detectors/specification/vercel.cr
@@ -4,6 +4,9 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Vercel < Detector
+    # Registers Vercel config paths in `CodeLocator`.
+    detector_for "vercel", idempotent: false
+
     CONFIG_FILES = {"vercel.json", "now.json"}
     @expanded_base_paths : Array(String)?
 
@@ -32,15 +35,6 @@ module Detector::Specification
       expanded_base_paths.any? do |base_path|
         File.join(base_path, base) == absolute
       end
-    end
-
-    def set_name
-      @name = "vercel"
-    end
-
-    # Registers Vercel config paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
 
     private def expanded_base_paths : Array(String)

--- a/src/detector/detectors/specification/wsdl.cr
+++ b/src/detector/detectors/specification/wsdl.cr
@@ -3,6 +3,11 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class WSDL < Detector
+    # Registers WSDL paths in `CodeLocator` for the analyzer pass to
+    # consume. Must keep running after the first match so every spec
+    # in a multi-WSDL repo is captured.
+    detector_for "wsdl", extensions: %w[.wsdl .xml], idempotent: false
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       return false unless file_contents.includes?("wsdl:definitions") ||
@@ -13,21 +18,6 @@ module Detector::Specification
       locator = CodeLocator.instance
       locator.push("wsdl-spec", filename)
       true
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".wsdl") || filename.ends_with?(".xml")
-    end
-
-    def set_name
-      @name = "wsdl"
-    end
-
-    # Registers WSDL paths in `CodeLocator` for the analyzer pass to
-    # consume. Must keep running after the first match so every spec
-    # in a multi-WSDL repo is captured.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -5,6 +5,16 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class ZapSitesTree < Detector
+    # Extension only. A `*sites*` basename gate looks tempting, but ZAP
+    # export filenames are chosen by the user at export time — an export
+    # saved as `zap_export.yaml` or `target.yaml` would be dropped with
+    # no diagnostic. The expensive work (`yaml_any?`) is already gated
+    # in `detect` by the `SITES_MARKER` content guard, so the name
+    # gate only saved a substring scan and bought that at the price of a
+    # silent false negative.
+    # Registers ZAP sites-tree paths in `CodeLocator`.
+    detector_for "zap_sites_tree", extensions: %w[.yaml .yml], idempotent: false
+
     # Every `.yaml`/`.yml` in the tree reaches this guard.
     SITES_MARKER = /Sites/
 
@@ -27,26 +37,6 @@ module Detector::Specification
       end
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      # Extension only. A `*sites*` basename gate looks tempting, but ZAP
-      # export filenames are chosen by the user at export time — an export
-      # saved as `zap_export.yaml` or `target.yaml` would be dropped with
-      # no diagnostic. The expensive work (`yaml_any?`) is already gated
-      # in `detect` by the `SITES_MARKER` content guard, so the name
-      # gate only saved a substring scan and bought that at the price of a
-      # silent false negative.
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-    end
-
-    def set_name
-      @name = "zap_sites_tree"
-    end
-
-    # Registers ZAP sites-tree paths in `CodeLocator`.
-    def idempotent? : Bool
-      false
     end
   end
 end

--- a/src/detector/detectors/swift/cli.cr
+++ b/src/detector/detectors/swift/cli.cr
@@ -6,6 +6,8 @@ module Detector::Swift
   # ParsableCommand conformance, ArgumentParser property wrappers, SwiftCLI /
   # Commander, or builtin CommandLine.arguments.
   class Cli < Detector
+    detector_for "swift_cli", extensions: %w[.swift]
+
     PARSABLE  = /\b(?:struct|enum|class)\s+\w+\s*:\s*[^\{]*\b(?:Async)?ParsableCommand\b/
     WRAPPERS  = /@(?:Option|Argument|Flag|OptionGroup)\b/
     SWIFTCLI  = /\bimport\s+SwiftCLI\b/
@@ -17,14 +19,6 @@ module Detector::Swift
       file_contents.includes?("import ArgumentParser") || content_matches?(file_contents, PARSABLE) ||
         content_matches?(file_contents, WRAPPERS) || content_matches?(file_contents, SWIFTCLI) ||
         content_matches?(file_contents, COMMANDER) || content_matches?(file_contents, CMDLINE)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".swift")
-    end
-
-    def set_name
-      @name = "swift_cli"
     end
   end
 end

--- a/src/detector/detectors/swift/hummingbird.cr
+++ b/src/detector/detectors/swift/hummingbird.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Swift
   class Hummingbird < Detector
+    detector_for "swift_hummingbird", basenames: %w[Package.swift]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check if this is a Package.swift file
       return false unless filename.includes?("Package.swift")
@@ -14,14 +16,6 @@ module Detector::Swift
                          file_contents.includes?(".package(")))
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      File.basename(filename) == "Package.swift"
-    end
-
-    def set_name
-      @name = "swift_hummingbird"
     end
   end
 end

--- a/src/detector/detectors/swift/kitura.cr
+++ b/src/detector/detectors/swift/kitura.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Swift
   class Kitura < Detector
+    detector_for "swift_kitura", basenames: %w[Package.swift]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check if this is a Package.swift file
       return false unless filename.includes?("Package.swift")
@@ -14,14 +16,6 @@ module Detector::Swift
                          file_contents.includes?(".package(")))
 
       check
-    end
-
-    def applicable?(filename : String) : Bool
-      File.basename(filename) == "Package.swift"
-    end
-
-    def set_name
-      @name = "swift_kitura"
     end
   end
 end

--- a/src/detector/detectors/swift/vapor.cr
+++ b/src/detector/detectors/swift/vapor.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Swift
   class Vapor < Detector
+    detector_for "swift_vapor", basenames: %w[Package.swift]
+
     def detect(filename : String, file_contents : String) : Bool
       # Check if this is a Package.swift file
       return false unless filename.includes?("Package.swift")
@@ -16,14 +18,6 @@ module Detector::Swift
       file_contents.includes?("vapor/vapor") ||
         file_contents.includes?(%(package: "vapor")) ||
         file_contents.includes?(%(name: "Vapor"))
-    end
-
-    def applicable?(filename : String) : Bool
-      File.basename(filename) == "Package.swift"
-    end
-
-    def set_name
-      @name = "swift_vapor"
     end
   end
 end

--- a/src/detector/detectors/typescript/nestjs.cr
+++ b/src/detector/detectors/typescript/nestjs.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Typescript
   class Nestjs < Detector
+    detector_for "ts_nestjs",
+      extensions: %w[.ts .tsx .cts .mts .js .jsx .cjs .mjs],
+      basenames: %w[package.json tsconfig.json]
+
     # Single precompiled alternation — one PCRE2 scan instead of seven.
     SIGNAL = Regex.union(
       /require\(['"]@nestjs\/core['"]\)/,
@@ -16,14 +20,6 @@ module Detector::Typescript
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx")
       content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ts") || filename.ends_with?(".tsx") || filename.ends_with?(".cts") || filename.ends_with?(".mts") || filename.ends_with?(".js") || filename.ends_with?(".jsx") || filename.ends_with?(".cjs") || filename.ends_with?(".mjs") || File.basename(filename) == "package.json" || File.basename(filename) == "tsconfig.json"
-    end
-
-    def set_name
-      @name = "ts_nestjs"
     end
   end
 end

--- a/src/detector/detectors/typescript/tanstack_router.cr
+++ b/src/detector/detectors/typescript/tanstack_router.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Typescript
   class TanstackRouter < Detector
+    detector_for "ts_tanstack_router",
+      extensions: %w[.ts .tsx .cts .mts .js .jsx .cjs .mjs],
+      basenames: %w[package.json tsconfig.json]
+
     # Single precompiled alternation — one PCRE2 scan instead of eight.
     SIGNAL = Regex.union(
       /import.*from ['"]@tanstack\/react-router['"]/,
@@ -17,14 +21,6 @@ module Detector::Typescript
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx")
       content_matches?(file_contents, SIGNAL)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ts") || filename.ends_with?(".tsx") || filename.ends_with?(".cts") || filename.ends_with?(".mts") || filename.ends_with?(".js") || filename.ends_with?(".jsx") || filename.ends_with?(".cjs") || filename.ends_with?(".mjs") || File.basename(filename) == "package.json" || File.basename(filename) == "tsconfig.json"
-    end
-
-    def set_name
-      @name = "ts_tanstack_router"
     end
   end
 end

--- a/src/detector/detectors/typescript/trpc.cr
+++ b/src/detector/detectors/typescript/trpc.cr
@@ -2,6 +2,10 @@ require "../../../models/detector"
 
 module Detector::Typescript
   class TRPC < Detector
+    detector_for "ts_trpc",
+      extensions: %w[.ts .tsx .cts .mts .js .jsx .cjs .mjs],
+      basenames: %w[package.json]
+
     # Single precompiled alternation — one PCRE2 scan instead of eight.
     SIGNAL = Regex.union(
       /import[^'"`]+from\s+['"`]@trpc\/server(?:\/[^'"`]*)?['"`]/,
@@ -30,18 +34,6 @@ module Detector::Typescript
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
-        filename.ends_with?(".cts") || filename.ends_with?(".mts") ||
-        filename.ends_with?(".js") || filename.ends_with?(".jsx") ||
-        filename.ends_with?(".cjs") || filename.ends_with?(".mjs") ||
-        File.basename(filename) == "package.json"
-    end
-
-    def set_name
-      @name = "ts_trpc"
     end
   end
 end

--- a/src/detector/detectors/zig/cli.cr
+++ b/src/detector/detectors/zig/cli.cr
@@ -5,19 +5,13 @@ module Detector::Zig
   # std.process argv parsing. Never gates on bare getEnvMap (zap/jetzig/httpz
   # config).
   class Cli < Detector
+    detector_for "zig_cli", extensions: %w[.zig]
+
     MARKERS = /@import\s*\(\s*"cli"\s*\)|@import\s*\(\s*"clap"\s*\)|@import\s*\(\s*"args"\s*\)|@import\s*\(\s*"yazap"\s*\)|\b(?:std\.)?process\.argsAlloc\s*\(|\bclap\.(?:parseParamsComptime|parse)\b|\bcli\.(?:Command|App|Runner)\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".zig")
       content_matches?(file_contents, MARKERS)
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".zig")
-    end
-
-    def set_name
-      @name = "zig_cli"
     end
   end
 end

--- a/src/detector/detectors/zig/http.cr
+++ b/src/detector/detectors/zig/http.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Zig
   class Http < Detector
+    detector_for "zig_http", extensions: %w[.zig], basenames: %w[build.zig.zon]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".zig")
 
@@ -12,14 +14,6 @@ module Detector::Zig
       has_response = file_contents.includes?(".respond(")
 
       has_std && has_server_flow && has_response
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
-    end
-
-    def set_name
-      @name = "zig_http"
     end
   end
 end

--- a/src/detector/detectors/zig/httpz.cr
+++ b/src/detector/detectors/zig/httpz.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Zig
   class Httpz < Detector
+    detector_for "zig_httpz", extensions: %w[.zig], basenames: %w[build.zig.zon]
+
     def detect(filename : String, file_contents : String) : Bool
       return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"httpz\")")
 
@@ -11,14 +13,6 @@ module Detector::Zig
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
-    end
-
-    def set_name
-      @name = "zig_httpz"
     end
   end
 end

--- a/src/detector/detectors/zig/jetzig.cr
+++ b/src/detector/detectors/zig/jetzig.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Zig
   class Jetzig < Detector
+    detector_for "zig_jetzig", extensions: %w[.zig], basenames: %w[build.zig.zon]
+
     def detect(filename : String, file_contents : String) : Bool
       # Source files import the framework directly.
       return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"jetzig\")")
@@ -14,14 +16,6 @@ module Detector::Zig
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
-    end
-
-    def set_name
-      @name = "zig_jetzig"
     end
   end
 end

--- a/src/detector/detectors/zig/tokamak.cr
+++ b/src/detector/detectors/zig/tokamak.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Zig
   class Tokamak < Detector
+    detector_for "zig_tokamak", extensions: %w[.zig], basenames: %w[build.zig.zon]
+
     def detect(filename : String, file_contents : String) : Bool
       return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"tokamak\")")
 
@@ -11,14 +13,6 @@ module Detector::Zig
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
-    end
-
-    def set_name
-      @name = "zig_tokamak"
     end
   end
 end

--- a/src/detector/detectors/zig/zap.cr
+++ b/src/detector/detectors/zig/zap.cr
@@ -2,6 +2,8 @@ require "../../../models/detector"
 
 module Detector::Zig
   class Zap < Detector
+    detector_for "zig_zap", extensions: %w[.zig], basenames: %w[build.zig.zon]
+
     def detect(filename : String, file_contents : String) : Bool
       return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"zap\")")
 
@@ -11,14 +13,6 @@ module Detector::Zig
       end
 
       false
-    end
-
-    def applicable?(filename : String) : Bool
-      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
-    end
-
-    def set_name
-      @name = "zig_zap"
     end
   end
 end

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -39,6 +39,85 @@ class Detector
     false
   end
 
+  # Declares the detector's tech name and the cheap filename gate that lets
+  # the detect loop skip `detect` on files this detector cannot match.
+  #
+  #     class Gin < Detector
+  #       detector_for "go_gin", extensions: %w[.go], basenames: %w[go.mod]
+  #     end
+  #
+  # Expands to the same short-circuiting chain the detectors used to write by
+  # hand — one `ends_with?` / `==` per declared term, *not* a runtime loop
+  # over an array — so the hot path is unchanged. Terms are emitted
+  # extension, then path segment, then basename: extensions reject the most
+  # files for the least work, and only a surviving candidate pays for
+  # `File.basename`.
+  #
+  # A `path_segments` term that names a directory (`"/metadata/"`) implies
+  # `path_sensitive?`, and that link is the whole point. `applicable?` is
+  # memoized by basename, so a detector that consults directory segments
+  # without declaring itself path-sensitive has its gate silently deleted —
+  # that is how the Hasura `metadata/**` gate was lost. Declaring the
+  # segment *is* declaring the sensitivity, so the two can no longer drift
+  # apart.
+  #
+  # A separator-free term (`"go.mod"`) is a plain substring test on the whole
+  # path and deliberately does *not* imply sensitivity, because
+  # `detector_path_sensitive?` does not flag those today: the probe compares
+  # `applicable?("a/b/c/go.mod")` with `applicable?("go.mod")`, which agree.
+  # Declaring them sensitive would drop those detectors out of the basename
+  # memo and slow the hot loop for no correctness gain here.
+  #
+  # Pass `idempotent: false` for a detector whose `detect` has side effects
+  # (registering spec paths in `CodeLocator`), so the pass keeps calling it
+  # after its first match.
+  #
+  # A gate that is more than a term list — one that normalises separators,
+  # checks a parent directory, or excludes `.d.ts` — keeps its hand-written
+  # `applicable?`. Pass just the tech name and define the method below; with
+  # no terms the macro emits no gate to collide with.
+  macro detector_for(tech, extensions = nil, basenames = nil, path_segments = nil, idempotent = nil)
+    def set_name
+      @name = {{ tech }}
+    end
+
+    # The tech name without needing an instance, so the registry can be
+    # read off the classes themselves rather than from a parallel list.
+    def self.tech_name : String
+      {{ tech }}
+    end
+
+    {% if extensions || basenames || path_segments %}
+      def applicable?(filename : String) : Bool
+        {% for ext in (extensions || [] of String) %}
+          return true if filename.ends_with?({{ ext }})
+        {% end %}
+        {% for segment in (path_segments || [] of String) %}
+          return true if filename.includes?({{ segment }})
+        {% end %}
+        {% if basenames %}
+          base = File.basename(filename)
+          {% for name in basenames %}
+            return true if base == {{ name }}
+          {% end %}
+        {% end %}
+        false
+      end
+    {% end %}
+
+    {% if path_segments && path_segments.any?(&.includes?("/")) %}
+      def path_sensitive? : Bool
+        true
+      end
+    {% end %}
+
+    {% if idempotent == false %}
+      def idempotent? : Bool
+        false
+      end
+    {% end %}
+  end
+
   # Cheap filename-only filter the detector pass uses to skip
   # `detect` on files the detector cannot possibly match. The
   # default `true` preserves prior behavior (every detector runs on


### PR DESCRIPTION
Every one of the 241 detectors hand-wrote the same trio: `set_name` (three lines of `@name = "..."`), `applicable?` (an OR-chain of literal `ends_with?` / basename / `includes?` terms — 50 of them a single bare `ends_with?`), and `idempotent?` (`false` and nothing else). Together that was **1,713 of the detector layer's 9,248 lines** — mechanical restatement, one file at a time, of three facts.

`detector_for` states those facts once:

```crystal
class Gin < Detector
  detector_for "go_gin", extensions: %w[.go], path_segments: %w[go.mod]
end
```

It expands to **the same short-circuiting chain** the detectors wrote by hand — one `ends_with?` / `==` per term, *not* a runtime loop over an array — so the hot loop is unchanged. Terms are emitted extension → path segment → basename, so only a surviving candidate pays for `File.basename`.

**213** detectors move their whole gate onto it. The remaining **28** have gates that are more than a term list (separator normalisation, parent-directory checks, `.d.ts` exclusion, a shared constant used elsewhere in the file) and keep their hand-written `applicable?` — with no terms declared the macro emits no gate to collide with. All **241** declare their name through it, so `set_name` no longer appears anywhere under `detectors/`.

## Two things the macro makes structural rather than remembered

**`path_sensitive?` can no longer drift from the gate it describes.** A `path_segments` term naming a directory (`"/metadata/"`) derives it. `applicable?` is memoized by basename, so a directory gate that does not declare itself path-sensitive is silently deleted — that is how the Hasura `metadata/**` gate was lost. Declaring the segment is now the same act as declaring the sensitivity.

A separator-free term (`"go.mod"`) deliberately does **not** derive it: `detector_path_sensitive?` does not flag those today (its probe compares `applicable?("a/b/c/go.mod")` with `applicable?("go.mod")`, which agree), and declaring them sensitive would drop those detectors out of the basename memo for no correctness gain. Checked across all 241 — the derived value matches every existing hand-written declaration, so nothing changes hands here.

**`self.tech_name`** exposes the name without an instance, so a follow-up can read the registry off the classes instead of the parallel list in `detect_techs`. That is the thread back to #2384: the integrity spec added there proves the parallel lists agree; this makes it possible to stop having parallel lists.

## Spec-suite interaction worth knowing about

`applicable_lookup_fidelity_spec.cr` now scopes its `all_subclasses` sweep to the `Detector::` namespace. `crystal spec` compiles the whole suite into one binary, so that sweep also saw the throwaway subclasses `detector_for_spec.cr` defines to exercise the macro — and being file-private, naming them there did not even compile. Scoping to the production namespace is the honest filter.

## Verification

Behaviour-identical, measured twice over:

- A harness dumped every detector's `name`, `path_sensitive?`, `idempotent?`, `detector_path_sensitive?` verdict, and `applicable?` answer over **all 2,477 real fixture paths** plus synthetic root/nested probes — 241 × 2,477. The dumps before and after are **byte-identical**.
- base (`origin/main`) and this branch, both `--release`, scanned **all 661 functional-test fixture directories** with `--include-path`; normalised endpoint output is identical in every one.

```
crystal spec spec/unit_test         4,170 examples, 0 failures
crystal spec spec/functional_test  22,432 examples, 0 failures
crystal tool format --check         clean
ameba                               1,806 files, 0 failures
```

Detector layer **9,248 → 7,500 lines**; diff is −1,298 net (854 insertions, 2,152 deletions).