### PR TITLE
fix(ai-context): accept the `sources` bucket, from one vocabulary

### DIFF
--- a/spec/unit_test/ai_context/features_spec.cr
+++ b/spec/unit_test/ai_context/features_spec.cr
@@ -1,0 +1,60 @@
+require "../../spec_helper"
+require "../../../src/ai_context/features"
+require "../../../src/options"
+
+# `sources` is a fully implemented AI-context bucket: `apply_feature_filter`
+# gates on it and every output builder emits it. But the CLI validator's
+# vocabulary was a separate hand-written list that omitted it, so
+# `--ai-context=sources` was rejected and `--ai-context=guards,sources` was
+# unreachable — the bucket could only be obtained by asking for all of them.
+# The help text disagreed too, listing a `callees` category that is spelled
+# `callee` everywhere it is accepted.
+#
+# There is now one vocabulary. These specs pin the agreement.
+
+describe "NoirAIContext::FEATURES" do
+  it "is the vocabulary the CLI validates against" do
+    # Not `should eq` on a literal list: the point is that the CLI derives
+    # from the constant, so a bucket added in one place cannot be missing
+    # from the other.
+    AI_CONTEXT_VALID_FEATURES.should eq NoirAIContext::ACCEPTED_FEATURES.to_set
+    AI_CONTEXT_FEATURES.should eq NoirAIContext::ACCEPTED_FEATURES
+  end
+
+  it "accepts every bucket plus the all alias, and nothing else" do
+    NoirAIContext::ACCEPTED_FEATURES.sort.should eq(
+      (NoirAIContext::FEATURES + ["all"]).sort
+    )
+    NoirAIContext::FEATURES.should_not contain "all"
+  end
+
+  it "includes sources" do
+    NoirAIContext::FEATURES.should contain "sources"
+    AI_CONTEXT_VALID_FEATURES.should contain "sources"
+  end
+
+  it "names callee in the singular, as the validator accepts it" do
+    NoirAIContext::FEATURES.should contain "callee"
+    NoirAIContext::FEATURES.should_not contain "callees"
+  end
+end
+
+describe "NoirAIContext.parse_feature_set" do
+  it "treats an empty value as every bucket" do
+    NoirAIContext.parse_feature_set("").should eq NoirAIContext.all_features
+  end
+
+  it "treats all as every bucket, wherever it appears in the list" do
+    NoirAIContext.parse_feature_set("all").should eq NoirAIContext.all_features
+    NoirAIContext.parse_feature_set("guards,all").should eq NoirAIContext.all_features
+  end
+
+  it "narrows to the named buckets" do
+    NoirAIContext.parse_feature_set("sources").should eq Set{"sources"}
+    NoirAIContext.parse_feature_set("guards,sources").should eq Set{"guards", "sources"}
+  end
+
+  it "tolerates surrounding whitespace and empty entries" do
+    NoirAIContext.parse_feature_set(" guards , ,sources ").should eq Set{"guards", "sources"}
+  end
+end

--- a/src/ai_context/augmentor.cr
+++ b/src/ai_context/augmentor.cr
@@ -1,3 +1,4 @@
+require "./features.cr"
 require "../models/endpoint"
 require "./pattern_definition"
 require "./patterns"
@@ -29,16 +30,10 @@ module NoirAIContext
   # plain-text builder's feature filter so JSON/YAML/SARIF/Postman/
   # OAS — which serialize the struct directly — show the same
   # subset the user asked for via `--ai-context=guards,sinks`.
-  # `features` follows the canonical bucket names: "guards",
-  # "callee", "sources", "sinks", "validators", "signals". An empty set or
-  # one containing every name is a no-op.
+  # `features` holds bucket names from `NoirAIContext::FEATURES`. An empty
+  # set, or one naming every bucket, is a no-op.
   def apply_feature_filter(endpoints : Array(Endpoint), features : Set(String))
-    return endpoints if features.includes?("guards") &&
-                        features.includes?("callee") &&
-                        features.includes?("sources") &&
-                        features.includes?("sinks") &&
-                        features.includes?("validators") &&
-                        features.includes?("signals")
+    return endpoints if FEATURES.all? { |feature| features.includes?(feature) }
 
     # Endpoint is a struct (value type). `endpoints.each` iterates
     # copies, so `endpoint.ai_context = …` would only mutate the
@@ -58,22 +53,5 @@ module NoirAIContext
       endpoints[idx] = endpoint
     end
     endpoints
-  end
-
-  # Parses the comma-separated `--ai-context=…` value into the set
-  # of bucket names that should survive the filter. Empty value or
-  # `"all"` means every bucket (the no-op set).
-  def parse_feature_set(raw : String) : Set(String)
-    all = Set{"guards", "callee", "sources", "sinks", "validators", "signals"}
-    return all if raw.empty?
-
-    filtered = Set(String).new
-    raw.split(',').each do |feature|
-      f = feature.strip
-      next if f.empty?
-      return all if f == "all"
-      filtered << f
-    end
-    filtered
   end
 end

--- a/src/ai_context/features.cr
+++ b/src/ai_context/features.cr
@@ -1,0 +1,41 @@
+module NoirAIContext
+  # The `--ai-context` bucket vocabulary, in emission order.
+  #
+  # There used to be four copies of this list — two in `options.cr` (the CLI
+  # help text and the validator), one in `NoirAIContext.parse_feature_set`,
+  # one in `OutputBuilderCommon#ai_context_feature_filter` — and they
+  # disagreed. `sources` was in the two that decide what gets *emitted* and
+  # missing from the two that decide what the CLI *accepts*, so
+  # `--ai-context=sources` was rejected for a bucket the augmentor and every
+  # output builder fully implement. The only way to see sources was to ask
+  # for all of them, and `--ai-context=guards,sources` was unreachable.
+  #
+  # Anything that needs the vocabulary reads it here.
+  FEATURES = %w[guards callee sources sinks validators signals]
+
+  # Accepted from the user as "every bucket". Not a bucket itself, so it is
+  # kept out of `FEATURES` and added back only where user input is validated.
+  FEATURE_ALL = "all"
+
+  # Every name `--ai-context=` accepts, including the `all` alias.
+  ACCEPTED_FEATURES = FEATURES + [FEATURE_ALL]
+
+  def self.all_features : Set(String)
+    FEATURES.to_set
+  end
+
+  # Parses a `--ai-context=…` value into the set of buckets that survive the
+  # filter. An empty value, or one naming `all`, means every bucket.
+  def self.parse_feature_set(raw : String) : Set(String)
+    return all_features if raw.empty?
+
+    filtered = Set(String).new
+    raw.split(',').each do |feature|
+      f = feature.strip
+      next if f.empty?
+      return all_features if f == FEATURE_ALL
+      filtered << f
+    end
+    filtered
+  end
+end

--- a/src/options.cr
+++ b/src/options.cr
@@ -1,3 +1,4 @@
+require "./ai_context/features.cr"
 require "./completions.cr"
 require "./config_initializer.cr"
 require "./banner.cr"
@@ -170,7 +171,9 @@ end
 # <the typo>". A single bare word still has to match a known feature
 # exactly, since that shape is genuinely ambiguous with a real one-word
 # directory name (`noir scan --ai-context myapp` must keep scanning `myapp`).
-AI_CONTEXT_FEATURES = ["guards", "sinks", "validators", "signals", "callee", "all"]
+# Both this and `AI_CONTEXT_VALID_FEATURES` below used to spell the
+# vocabulary out by hand, and both omitted `sources`.
+AI_CONTEXT_FEATURES = NoirAIContext::ACCEPTED_FEATURES
 
 def normalize_ai_context_flag(args : Array(String)) : Array(String)
   result = [] of String
@@ -324,9 +327,13 @@ def run_options_parser
     parser.on "--include LIST", "Enrich plain output (comma-separated: path,techs,callee)" do |v|
       apply_include_list(noir_options, v)
     end
+    # Category names come from the one vocabulary so the help can no longer
+    # drift from what the validator accepts. It had: it omitted `sources`
+    # and spelled `callee` as "callees", neither of which is a name you can
+    # actually pass.
     parser.on "--ai-context [LIST]", <<-DESC do |v|
       Include aggregated AI review context. With no argument, emits every
-      category (guards, callees, sinks, validators, signals). Pass a
+      category (#{NoirAIContext::FEATURES.join(", ")}). Pass a
       comma-separated subset to narrow the output:
         --ai-context guards,sinks
         --ai-context=callee
@@ -638,7 +645,7 @@ end
 # `--ai-context[=LIST]` always enables AI context output. An empty LIST
 # means "every category"; a non-empty LIST narrows the output to the
 # named categories.
-AI_CONTEXT_VALID_FEATURES = {"guards", "sinks", "validators", "signals", "callee", "all"}
+AI_CONTEXT_VALID_FEATURES = NoirAIContext::ACCEPTED_FEATURES.to_set
 
 def apply_ai_context(noir_options : Hash(String, YAML::Any), spec : String)
   noir_options["ai_context"] = YAML::Any.new(true)

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -1,3 +1,4 @@
+require "../ai_context/features"
 require "../models/output_builder"
 require "../models/endpoint"
 
@@ -228,18 +229,7 @@ class OutputBuilderCommon < OutputBuilder
   # Returns the set of AI-context category names that should be emitted.
   # An empty/unset `ai_context_features` option means "all categories".
   private def ai_context_feature_filter : Set(String)
-    all = Set{"guards", "callee", "sources", "sinks", "validators", "signals"}
-    raw = @options["ai_context_features"]?.try(&.to_s) || ""
-    return all if raw.empty?
-
-    filtered = Set(String).new
-    raw.split(',').each do |feature|
-      f = feature.strip
-      next if f.empty?
-      return all if f == "all"
-      filtered << f
-    end
-    filtered
+    NoirAIContext.parse_feature_set(@options["ai_context_features"]?.try(&.to_s) || "")
   end
 
   private def append_ai_context_block(r_buffer : String::Builder, label : String, entries : Array(AIContextEntry))


### PR DESCRIPTION
`sources` is a **fully implemented** AI-context bucket. `apply_feature_filter` gates on it, and every output builder emits it — `output_builder/common.cr` has an `append_ai_context_block(..., "sources", context.sources)` call. But the CLI validator checked against a separate hand-written list that omitted it:

```
$ noir --ai-context=sources
ERROR: --ai-context: unknown feature 'sources'. Valid: guards, sinks, validators, signals, callee.
```

So the bucket was reachable only by asking for **every** bucket (bare `--ai-context`, or `=all`), and `--ai-context=guards,sources` was impossible. The help text disagreed a third way, advertising a `callees` category that is spelled `callee` everywhere it is accepted.

## Four copies of one vocabulary

| location | had `sources`? | decides |
|---|---|---|
| `options.cr` `AI_CONTEXT_FEATURES` | ✗ | help/completion |
| `options.cr` `AI_CONTEXT_VALID_FEATURES` | ✗ | what the CLI **accepts** |
| `NoirAIContext.parse_feature_set` | ✓ | what gets **emitted** |
| `OutputBuilderCommon#ai_context_feature_filter` | ✓ | what gets **emitted** |

The two that decide emission had it; the two that decide acceptance did not. Same shape as the tech-registry drift in #2384 — parallel lists with nothing forcing agreement.

## One vocabulary

`src/ai_context/features.cr`:

- `FEATURES` — the buckets, in emission order
- `ACCEPTED_FEATURES` — those plus the `all` alias, for input validation
- `parse_feature_set` — the parser both call sites had duplicated verbatim

`options.cr` derives both constants from it, the help text **interpolates** it so it cannot drift again, and `ai_context_feature_filter` becomes four lines delegating to the shared parser.

## Verification

Against `spec/functional_test/fixtures/javascript/express`, bucket counts per flag:

```
--ai-context                 callees=12 sources=28 sinks=1 signals=136
--ai-context=sources         sources=28
--ai-context=guards          (none — this fixture has no guards)
--ai-context=guards,sources  sources=28
--ai-context=bogus           ERROR (unchanged; the list now includes sources)
```

Selection genuinely narrows now, rather than being rejected.

```
crystal spec spec/unit_test         4,177 examples, 0 failures
crystal spec spec/functional_test  22,432 examples, 0 failures
crystal tool format --check         clean
ameba                               1,809 files, 0 failures
```

New `spec/unit_test/ai_context/features_spec.cr` pins that the CLI vocabulary *is* the canonical one, that `sources` is in it, and that `callee` is singular.