### PR TITLE
refactor: drop unreachable code, and share the duplicated path join

### DIFF
--- a/spec/unit_test/utils/url_path_spec.cr
+++ b/spec/unit_test/utils/url_path_spec.cr
@@ -34,3 +34,40 @@ describe "Noir::URLPath.join" do
     Noir::URLPath.join("/api//v1", "users").should eq("/api//v1/users")
   end
 end
+
+# `join_trimmed` replaced seven byte-identical `join_paths` copies (http4k,
+# JAX-RS, Micronaut, the shared JVM lambda-DSL extractor, AdonisJS, Elysia,
+# and the Scala Play analyzer). It sits next to `join` and is easy to reach
+# for by mistake, so these pin the cases where the two disagree.
+describe "Noir::URLPath.join_trimmed" do
+  it "collapses every slash at the seam, not just one" do
+    Noir::URLPath.join_trimmed("/api//", "/users").should eq "/api/users"
+    Noir::URLPath.join_trimmed("/api", "//users").should eq "/api/users"
+    Noir::URLPath.join_trimmed("/api///", "///users").should eq "/api/users"
+  end
+
+  it "drops a trailing slash when the suffix is empty" do
+    Noir::URLPath.join_trimmed("/api/", "").should eq "/api"
+    Noir::URLPath.join_trimmed("/api", "").should eq "/api"
+  end
+
+  it "returns the suffix untouched when the prefix is empty" do
+    Noir::URLPath.join_trimmed("", "/users").should eq "/users"
+    Noir::URLPath.join_trimmed("", "users").should eq "users"
+  end
+
+  it "agrees with join on already-normalised segments" do
+    [{"/api", "users"}, {"/api/", "/users"}, {"/api", "/users"}].each do |prefix, suffix|
+      Noir::URLPath.join_trimmed(prefix, suffix).should eq Noir::URLPath.join(prefix, suffix)
+    end
+  end
+
+  # The reason it is a separate method rather than a call to `join`.
+  it "differs from join where the seam has repeated or trailing slashes" do
+    Noir::URLPath.join("/api//", "/users").should eq "/api//users"
+    Noir::URLPath.join_trimmed("/api//", "/users").should eq "/api/users"
+
+    Noir::URLPath.join("/api/", "").should eq "/api/"
+    Noir::URLPath.join_trimmed("/api/", "").should eq "/api"
+  end
+end

--- a/src/analyzer/analyzers/cfml/wheels.cr
+++ b/src/analyzer/analyzers/cfml/wheels.cr
@@ -29,7 +29,6 @@ module Analyzer::Cfml
 
     MAPPER_RE   = /(?<![\w.])mapper\s*\(/i
     DSL_CALL_RE = /\.\s*([A-Za-z_]\w*)\s*\(/
-    UNESCAPE_RE = /##/
     # Wheels writes path variables in brackets, not colons.
     PLACEHOLDER_RE = /\[([A-Za-z_]\w*)\]/
 

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -848,18 +848,6 @@ module Analyzer::Elixir
       {base, "#{endpoint.method}::#{endpoint.url}"}
     end
 
-    def should_extract_params_for_endpoint?(endpoint : Endpoint, controller_name : String, action_name : String) : Bool
-      # Check if the endpoint's route_map entry matches this controller/action
-      route_key = endpoint_route_map_key(endpoint)
-      if mapping = @route_map[route_key]?
-        return controller_refs_match?(controller_name, mapping.controller) && mapping.action == action_name
-      end
-
-      # Fallback: try to match by conventional naming
-      # For example, resources routes: GET /posts -> PostController.index
-      false
-    end
-
     private def controller_refs_match?(controller_name : String, mapped_controller : String) : Bool
       normalized_controller = normalize_controller_ref(controller_name)
       normalized_mapping = normalize_controller_ref(mapped_controller)

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -141,15 +141,6 @@ module Analyzer::Go
       result
     end
 
-    def get_method_from_line(line : String) : String
-      # Extract method from .Methods("GET", "POST") or default to GET
-      if match = line.match(/\.Methods\(\s*[\"']([^\"']+)[\"']/)
-        match[1].upcase
-      else
-        "GET"
-      end
-    end
-
     def get_param(line : String, pattern : String, endpoint : Endpoint? = nil) : Param
       param_name = ""
       param_type = ""

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -462,12 +462,6 @@ module Analyzer::Java
         (content.includes?("HttpServlet") && !!content.match(/\bextends\s+HttpServlet\b/))
     end
 
-    private def java_class_name(content : String) : String?
-      if match = content.match(/\bclass\s+([A-Za-z_][A-Za-z0-9_]*)/)
-        match[1]
-      end
-    end
-
     private def java_package_name(content : String) : String?
       if match = content.match(/\bpackage\s+([A-Za-z_][A-Za-z0-9_.]*)\s*;/)
         match[1]

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -1294,15 +1294,5 @@ module Analyzer::Java
       return "" if trimmed.empty? || trimmed == "/"
       trimmed.starts_with?("/") ? trimmed : "/#{trimmed}"
     end
-
-    def find_base_path(current_path : String, base_paths : Hash(String, String))
-      base_paths.keys.sort_by!(&.size).reverse!.each do |path|
-        if current_path.starts_with?(path)
-          return base_paths[path]
-        end
-      end
-
-      ""
-    end
   end
 end

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -477,12 +477,6 @@ module Analyzer::Javascript
       match ? match[1] : ""
     end
 
-    def extract_path(line : String) : String
-      # Extract path from route definition, handling different quote styles
-      match = line.match(/\(\s*['"]([^'"]+)['"]/)
-      match ? match[1] : ""
-    end
-
     def line_to_param(line : String) : Param
       # Extract request body parameters
       if line.includes?("req.body.")

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -136,13 +136,6 @@ module Analyzer::Ruby
       Endpoint.new(join_paths(current_path_prefix(stack), m[1]), "GET", details)
     end
 
-    def extract_action_path(content : String, framework_root : String = @base_path) : String
-      target = extract_action_target(content)
-      return "" unless target
-
-      find_action_path(target, framework_root, nil)
-    end
-
     def scan_action_file(endpoint : Endpoint, action_path : String, include_callee : Bool = false)
       return unless File.exists?(action_path)
 

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -1,3 +1,4 @@
+require "../../../utils/url_path"
 require "../../../models/analyzer"
 require "../../../miniparsers/scala_callee_extractor"
 
@@ -439,11 +440,11 @@ module Analyzer::Scala
           include_prefix = include_match[1]
           include_target = include_match[2]
           if included_path = resolve_included_routes_file(include_target, routes_by_key, path)
-            process_routes_file(included_path, controller_methods, routes_by_key, join_paths(prefix, include_prefix), seen)
+            process_routes_file(included_path, controller_methods, routes_by_key, Noir::URLPath.join_trimmed(prefix, include_prefix), seen)
           elsif router = resolve_sird_router(include_target, path)
             # The include target is a programmatic SIRD router class
             # (`-> /v1/posts v1.post.PostRouter`), not a routes file.
-            process_sird_router(router, join_paths(prefix, include_prefix))
+            process_sird_router(router, Noir::URLPath.join_trimmed(prefix, include_prefix))
           end
           next
         end
@@ -544,12 +545,6 @@ module Analyzer::Scala
       nil
     end
 
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
-    end
-
     # Join a mount prefix onto a route defined in an included routes file, but
     # don't double the prefix when the included file already carries it.
     # Standard Play sub-routes are relative (`-> /appeal appeal.Routes` over
@@ -558,7 +553,7 @@ module Analyzer::Scala
     # would yield `/appeal/appeal/landing`. The boundary check (exact match or
     # `prefix/…`) keeps a coincidental relative path like `/appeals` prefixed.
     private def join_included_route(prefix : String, suffix : String) : String
-      return join_paths(prefix, suffix) if prefix.empty?
+      return Noir::URLPath.join_trimmed(prefix, suffix) if prefix.empty?
 
       normalized_prefix = prefix.rstrip('/')
       normalized_suffix = suffix.starts_with?('/') ? suffix : "/#{suffix}"
@@ -566,7 +561,7 @@ module Analyzer::Scala
         return normalized_suffix
       end
 
-      join_paths(prefix, suffix)
+      Noir::URLPath.join_trimmed(prefix, suffix)
     end
 
     # Extract path parameters from route pattern
@@ -847,7 +842,7 @@ module Analyzer::Scala
       body.scan(/case\s+(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*p"([^"]*)"/) do |match|
         method = match[1]
         url_path, params = normalize_sird_path(match[2])
-        full_path = join_paths(prefix, url_path)
+        full_path = Noir::URLPath.join_trimmed(prefix, url_path)
         full_path = "/" if full_path.empty?
 
         line = line_at(source, body_start + (match.begin(0) || 0))

--- a/src/analyzer/analyzers/specification/smithy.cr
+++ b/src/analyzer/analyzers/specification/smithy.cr
@@ -37,10 +37,6 @@ module Analyzer::Specification
         @http_query = nil
         @http_header = nil
       end
-
-      def any_member_binding? : Bool
-        http_label? || http_payload? || !@http_query.nil? || !@http_header.nil?
-      end
     end
 
     # A field on an `@input` structure with its derived param type.

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -169,14 +169,6 @@ module Analyzer::Crystal
       end
     end
 
-    protected def each_public_dir_file(folder : String, &block : String -> Nil) : Nil
-      base_paths.each do |base|
-        get_public_dir_files(base, folder).each do |file|
-          block.call(file)
-        end
-      end
-    end
-
     protected def attach_crystal_callees(endpoint : Endpoint, callees : Array(Noir::CrystalCalleeExtractor::Entry))
       Noir::CrystalCalleeExtractor.attach_to(endpoint, callees)
     end
@@ -397,14 +389,6 @@ module Analyzer::Crystal
     private def crystal_closes_block?(line : String) : Bool
       line.starts_with?("end") && line.matches?(CLOSES_BLOCK_RE)
     end
-
-    # Shared `verb "/path"` matchers for Kemal/Lucky/Grip-style DSLs.
-    # One combined PCRE2 scan replaces the previous 7–8 sequential
-    # per-verb `.scan` calls that ran on every source line. Leftmost
-    # match wins, which matches real one-verb-per-line route DSLs and
-    # the prior first-matching-verb behaviour for those lines. Optional
-    # `extra` covers framework-only verbs (Lucky's `trace`).
-    HTTP_ROUTE_VERBS = %w[get post put delete patch head options]
 
     # Group 1 = verb (or `ws`), group 2 = path. `ws` is folded in so a
     # single scan covers WebSocket routes too; the caller maps `ws` →

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -671,10 +671,6 @@ module Analyzer::Python
       def params : Array(FunctionParameter)
         @params
       end
-
-      def add_parameter(param : FunctionParameter)
-        @params << param
-      end
     end
 
     # Net `(` − `)` count on a single Python source line, ignoring

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -51,15 +51,6 @@ module Analyzer::Scala
       extract_scala_brace_block_with_end_at(lines, start_index, opening_brace)
     end
 
-    protected def extract_scala_brace_block_at(lines : Array(String),
-                                               start_index : Int32,
-                                               opening_brace : Int32) : Tuple(String, Int32)?
-      block = extract_scala_brace_block_with_end_at(lines, start_index, opening_brace)
-      return unless block
-
-      {block[0], block[1]}
-    end
-
     protected def extract_scala_brace_block_with_end_at(lines : Array(String),
                                                         start_index : Int32,
                                                         opening_brace : Int32) : Tuple(String, Int32, Int32)?
@@ -90,10 +81,6 @@ module Analyzer::Scala
     #   * structural view: all strings/comments blanked, for brace matching.
     protected def scala_code_lines(content : String) : Array(String)
       Noir::ScalaLexer.new(content).code_lines
-    end
-
-    protected def scala_structural_lines(content : String) : Array(String)
-      Noir::ScalaLexer.new(content).masked_lines
     end
 
     # One lexer per file when an analyzer needs BOTH the code and structural

--- a/src/detector/detectors/specification/istio_virtualservice.cr
+++ b/src/detector/detectors/specification/istio_virtualservice.cr
@@ -7,8 +7,6 @@ module Detector::Specification
     # Registers each VirtualService manifest path in `CodeLocator`.
     detector_for "istio_virtualservice", extensions: %w[.yaml .yml], idempotent: false
 
-    ISTIO_API_PREFIX = "networking.istio.io/"
-
     # Every `.yaml`/`.yml` in the tree reaches these guards. Both must
     # match, so they stay separate probes rather than a union.
     ISTIO_API_PREFIX_MARKER     = /networking\.istio\.io\//

--- a/src/detector/detectors/specification/k8s_gateway_api.cr
+++ b/src/detector/detectors/specification/k8s_gateway_api.cr
@@ -7,8 +7,6 @@ module Detector::Specification
     # Registers each Gateway API manifest path in `CodeLocator`.
     detector_for "k8s_gateway_api", extensions: %w[.yaml .yml], idempotent: false
 
-    GATEWAY_API_PREFIX = "gateway.networking.k8s.io/"
-
     # Every `.yaml`/`.yml` in the tree reaches these guards. Both must
     # match, so they stay separate probes rather than a union.
     GATEWAY_API_PREFIX_MARKER = /gateway\.networking\.k8s\.io\//

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -131,6 +131,24 @@ end
 # Thin high-level facade. Keeps tree lifetime tied to an object so callers
 # don't have to think about `ts_tree_delete`.
 module Noir::TreeSitter
+  # Names the `error_type` that `ts_query_new` writes back on failure.
+  # `LibTreeSitter`'s `TS_QUERY_ERROR_*` constants existed for exactly this
+  # and were never used, so a broken query reported a bare `code=2` and the
+  # reader had to go find `TSQueryError` in tree-sitter's `api.h` to learn
+  # that meant an unknown node type.
+  def self.query_error_name(error_type : Int32) : String
+    case error_type
+    when LibTreeSitter::TS_QUERY_ERROR_NONE      then "no error"
+    when LibTreeSitter::TS_QUERY_ERROR_SYNTAX    then "syntax error"
+    when LibTreeSitter::TS_QUERY_ERROR_NODE_TYPE then "unknown node type"
+    when LibTreeSitter::TS_QUERY_ERROR_FIELD     then "unknown field name"
+    when LibTreeSitter::TS_QUERY_ERROR_CAPTURE   then "unknown capture name"
+    when LibTreeSitter::TS_QUERY_ERROR_STRUCTURE then "invalid pattern structure"
+    when LibTreeSitter::TS_QUERY_ERROR_LANGUAGE  then "language mismatch"
+    else                                              "unrecognised code=#{error_type}"
+    end
+  end
+
   # Recursion guard for AST walkers. Crystal's default fiber stack
   # is generous (~8 MB) but a malicious source file with deeply
   # nested syntax — `(((((((...)))))))` chains, deeply nested
@@ -243,19 +261,6 @@ module Noir::TreeSitter
   # (axum, actix-web, rocket, …) and the Rust callee extractor.
   def self.parse_rust(source : String, &)
     parse(source, LibTreeSitter.tree_sitter_rust) { |root| yield root }
-  end
-
-  # Convenience: returns the root-node s-expression for `source`.
-  def self.python_sexp(source : String) : String
-    parse_python(source) do |root|
-      ptr = LibTreeSitter.ts_node_string(root)
-      begin
-        String.new(ptr)
-      ensure
-        # ts_node_string allocates with malloc; free it.
-        LibC.free(ptr.as(Void*))
-      end
-    end
   end
 
   # --- Small helpers used by extractors. Kept here so callers don't
@@ -401,7 +406,8 @@ module Noir::TreeSitter
       )
       if handle.null?
         raise CompileError.new(
-          "tree-sitter query failed to compile (code=#{error_type}, byte_offset=#{error_offset})"
+          "tree-sitter query failed to compile " \
+          "(#{Noir::TreeSitter.query_error_name(error_type)}, byte_offset=#{error_offset})"
         )
       end
       @handle = handle

--- a/src/llm/acp/client.cr
+++ b/src/llm/acp/client.cr
@@ -40,12 +40,6 @@ module LLM
       ENV["NOIR_ACP_ALLOW_CUSTOM_COMMAND"]? == "1"
     end
 
-    # True when the provider resolves to a built-in target, or the operator
-    # opted into custom commands. Used for a friendly CLI-time pre-flight.
-    def self.allowed_target?(provider : String) : Bool
-      KNOWN_TARGETS.includes?(extract_target(provider).downcase) || custom_command_allowed?
-    end
-
     def initialize(@provider : String, @model : String, @event_sink : Proc(String, Nil)? = nil)
       @command, @args = self.class.resolve_command(provider)
       @session_lock = Mutex.new

--- a/src/miniparsers/adonisjs_extractor_ts.cr
+++ b/src/miniparsers/adonisjs_extractor_ts.cr
@@ -1,3 +1,4 @@
+require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./js_callee_extractor"
@@ -172,7 +173,7 @@ module Noir
       receiver = chain_receiver(call)
       return unless receiver
 
-      new_prefix = arg ? join_paths(prefix, arg) : prefix
+      new_prefix = arg ? Noir::URLPath.join_trimmed(prefix, arg) : prefix
       walk(receiver, source, new_prefix, routes, depth + 1, include_callees)
     end
 
@@ -219,7 +220,7 @@ module Noir
     private def emit_verb(call : LibTreeSitter::TSNode, source : String, verb : String, prefix : String, routes : Array(Route), include_callees : Bool)
       path = first_string_argument(call, source)
       return unless path
-      full = join_paths(prefix, path)
+      full = Noir::URLPath.join_trimmed(prefix, path)
       line = Noir::TreeSitter.node_start_row(call)
       callees = include_callees ? route_callees(call, source, line) : [] of JSCalleeExtractor::Entry
       routes << Route.new(verb, full, line, callees)
@@ -228,7 +229,7 @@ module Noir
     private def emit_resource(call : LibTreeSitter::TSNode, source : String, prefix : String, actions : Array(String), routes : Array(Route), include_callees : Bool)
       name = first_string_argument(call, source)
       return unless name
-      base = join_paths(prefix, name.starts_with?("/") ? name : "/#{name}")
+      base = Noir::URLPath.join_trimmed(prefix, name.starts_with?("/") ? name : "/#{name}")
       line = Noir::TreeSitter.node_start_row(call)
 
       actions.each do |action|
@@ -330,7 +331,7 @@ module Noir
     private def emit_on(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
       path = first_string_argument(call, source)
       return unless path
-      full = join_paths(prefix, path)
+      full = Noir::URLPath.join_trimmed(prefix, path)
       line = Noir::TreeSitter.node_start_row(call)
       routes << Route.new("GET", full, line)
     end
@@ -417,12 +418,6 @@ module Noir
       else
         raw
       end
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
   end
 end

--- a/src/miniparsers/elysia_extractor_ts.cr
+++ b/src/miniparsers/elysia_extractor_ts.cr
@@ -1,3 +1,4 @@
+require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./js_callee_extractor"
@@ -166,7 +167,7 @@ module Noir
       end
       return unless group_path && group_body
 
-      new_prefix = join_paths(prefix, group_path)
+      new_prefix = Noir::URLPath.join_trimmed(prefix, group_path)
       walk(group_body, source, new_prefix, routes, depth + 1, include_callees)
     end
 
@@ -197,7 +198,7 @@ module Noir
       end
       return unless path
 
-      full_path = join_paths(prefix, path)
+      full_path = Noir::URLPath.join_trimmed(prefix, path)
       line = Noir::TreeSitter.node_start_row(call)
 
       query_params = [] of String
@@ -408,12 +409,6 @@ module Noir
       else
         raw
       end
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
   end
 end

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -1,3 +1,4 @@
+require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./kotlin_callee_extractor"
@@ -225,7 +226,7 @@ module Noir
 
           path_text = route_path_from(inner_lhs, source, string_constants, local_string_constants)
           return false unless path_text
-          emit_route(verb, join_paths(prefix, path_text), node, rhs, source, routes, include_callees)
+          emit_route(verb, Noir::URLPath.join_trimmed(prefix, path_text), node, rhs, source, routes, include_callees)
           true
         else
           # Bare `VERB to handler` directly inside a `routes(...)` call
@@ -246,7 +247,7 @@ module Noir
 
         path_text = resolve_string_value(lhs, source, string_constants, local_string_constants)
         return false unless path_text
-        new_prefix = join_paths(prefix, path_text)
+        new_prefix = Noir::URLPath.join_trimmed(prefix, path_text)
         walk_routes_args(rhs, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true, contract_routes)
         true
       else
@@ -261,14 +262,14 @@ module Noir
                                      contract_routes : Hash(String, Array(Route)))
       line = Noir::TreeSitter.node_start_row(node)
       contract_description_paths(node, source).each do |path|
-        routes << Route.new("GET", join_paths(prefix, path), line, false, [] of String, [] of String, [] of String, [] of Tuple(String, Int32))
+        routes << Route.new("GET", Noir::URLPath.join_trimmed(prefix, path), line, false, [] of String, [] of String, [] of String, [] of Tuple(String, Int32))
       end
 
       contract_route_references(node, source).each do |name|
         next unless helper_routes = contract_routes[name]?
 
         helper_routes.each do |route|
-          routes << route.with_path(join_paths(prefix, route.path))
+          routes << route.with_path(Noir::URLPath.join_trimmed(prefix, route.path))
         end
       end
     end
@@ -590,12 +591,6 @@ module Noir
         end
         parts.join
       end
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
   end
 end

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -1,3 +1,4 @@
+require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./java_callee_extractor"
@@ -294,7 +295,7 @@ module Noir
         method_name = method_name_of(member, source) || ""
         method_path = annotation_string_value(member, "Path", source, local_constants, class_name) || ""
 
-        full_path = join_paths(class_path, method_path)
+        full_path = Noir::URLPath.join_trimmed(class_path, method_path)
         method_consumes = consumes_format(member, source) || class_consumes
 
         unless verb && verb_node
@@ -357,7 +358,7 @@ module Noir
         if interface_decl = class_index[interface_name]?
           interface_path = annotation_string_value(interface_decl, "Path", source, constants, interface_name) || ""
           collect_class_routes(interface_decl, source, dto_index, bean_index, routes, include_callees,
-            base_path: join_paths(class_path, interface_path), inherited_consumes: class_consumes,
+            base_path: Noir::URLPath.join_trimmed(class_path, interface_path), inherited_consumes: class_consumes,
             class_index: class_index, constants: constants, subresource_sources: subresource_sources,
             current_file: current_file, visited: visited, method_excludes: method_excludes)
         elsif source_entry = subresource_sources[interface_name]?
@@ -450,7 +451,7 @@ module Noir
         constants = TreeSitterJavaRouteExtractor.extract_string_constants_from(root, interface_source)
         own_path = annotation_string_value(interface_decl, "Path", interface_source, constants, interface_name) || ""
         collect_class_routes(interface_decl, interface_source, dto_index, bean_index, routes, include_callees,
-          base_path: join_paths(class_path, own_path), inherited_consumes: class_consumes,
+          base_path: Noir::URLPath.join_trimmed(class_path, own_path), inherited_consumes: class_consumes,
           class_index: classes, constants: constants, subresource_sources: subresource_sources,
           current_file: interface_path, visited: visited, method_excludes: method_excludes)
       end
@@ -779,12 +780,6 @@ module Noir
     # cosmetic — Jakarta REST normalises it. We emit `/users` rather
     # than `/users/` for the index handler, matching how callers
     # actually request the route.
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
-    end
-
     # ---- formal-parameter walk --------------------------------------
 
     private def collect_method_params(method : LibTreeSitter::TSNode,

--- a/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
+++ b/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
@@ -1,3 +1,4 @@
+require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 require "./java_callee_extractor"
 require "./java_route_extractor_ts"
@@ -152,7 +153,7 @@ module Noir
           return
         when config.nest_methods.includes?(name)
           path_arg = first_string_argument(node, source, constants)
-          new_prefix = path_arg ? join_paths(prefix, path_arg) : prefix
+          new_prefix = path_arg ? Noir::URLPath.join_trimmed(prefix, path_arg) : prefix
           if body = lambda_body_in_args(node)
             walk(body, source, new_prefix, config, routes, constants, method_bodies, handler_vars, depth + 1, include_callees)
           end
@@ -189,7 +190,7 @@ module Noir
         path_arg = ""
       end
 
-      full_path = join_paths(prefix, path_arg)
+      full_path = Noir::URLPath.join_trimmed(prefix, path_arg)
       line = Noir::TreeSitter.node_start_row(call)
 
       query_params = [] of String
@@ -256,7 +257,7 @@ module Noir
       item_path_arg = first_string_argument(call, source, constants)
       return if item_path_arg.nil? && prefix.empty?
 
-      item_path = item_path_arg ? join_paths(prefix, item_path_arg) : prefix
+      item_path = item_path_arg ? Noir::URLPath.join_trimmed(prefix, item_path_arg) : prefix
       collection_path = crud_collection_path(item_path)
       line = Noir::TreeSitter.node_start_row(call)
 
@@ -775,12 +776,6 @@ module Noir
     # Single-`/` join: `prefix + suffix` with one separator,
     # collapsing trailing/leading slashes. Empty prefix or suffix is
     # passed through unchanged.
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
-    end
-
     private def crud_collection_path(item_path : String) : String
       trimmed = item_path.rstrip('/')
       return trimmed if trimmed.empty?

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -1,3 +1,4 @@
+require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./java_callee_extractor"
@@ -287,7 +288,7 @@ module Noir
 
         controller_paths.each do |class_path|
           method_paths.each do |method_path|
-            full_path = join_paths(class_path, method_path)
+            full_path = Noir::URLPath.join_trimmed(class_path, method_path)
             normalized_path = strip_uri_template_query(full_path)
             query_vars = uri_template_query_vars(full_path)
             path_vars = uri_template_path_vars(normalized_path)
@@ -343,7 +344,7 @@ module Noir
 
         interface_paths.each do |interface_path|
           method_paths.each do |method_path|
-            full_path = join_paths(interface_path, method_path)
+            full_path = Noir::URLPath.join_trimmed(interface_path, method_path)
             normalized_path = strip_uri_template_query(full_path)
             query_vars = uri_template_query_vars(full_path)
             path_vars = uri_template_path_vars(normalized_path)
@@ -645,12 +646,6 @@ module Noir
 
     # Micronaut joins class + method paths with a single `/`. Empty
     # method path → just the class prefix (no trailing slash).
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
-    end
-
     private def strip_uri_template_query(path : String) : String
       normalized = path.gsub(/\{\?[^}]*\}/, "")
       normalized.empty? ? "/" : normalized

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -15,7 +15,6 @@ class CodeLocator
   @is_log : Bool
   @s_map : Hash(String, String)
   @a_map : Hash(String, Array(String))
-  @file_usage_stats : Hash(String, Int32) # Track number of file reads
   @extension_index : Hash(String, Array(String))
   @extension_index_built : Bool
   @file_contents : Hash(String, String)
@@ -37,7 +36,6 @@ class CodeLocator
 
     @s_map = Hash(String, String).new
     @a_map = Hash(String, Array(String)).new
-    @file_usage_stats = Hash(String, Int32).new
     @extension_index = Hash(String, Array(String)).new
     @extension_index_built = false
 
@@ -77,9 +75,8 @@ class CodeLocator
     @a_map[key] ||= Array(String).new
     @a_map[key] << value
 
-    # Track file usage if this is the file_map
+    # Pushing into file_map invalidates the derived path caches.
     if key == "file_map"
-      increment_file_usage(value)
       @expanded_file_map = nil
       @expanded_path_index = nil
     end
@@ -210,7 +207,6 @@ class CodeLocator
   def clear_all
     @s_map.clear
     @a_map.clear
-    @file_usage_stats.clear
     @extension_index.clear
     @extension_index_built = false
     @file_contents.clear
@@ -228,32 +224,6 @@ class CodeLocator
     @logger.sub("Array Map:")
     @a_map.each do |key, value|
       @logger.sub("  #{key} => #{value.size} items")
-    end
-  end
-
-  # Get file usage statistics
-  def file_usage_stats : Hash(String, Int32)
-    @file_usage_stats
-  end
-
-  # Increment file usage count
-  private def increment_file_usage(file_path : String)
-    @file_usage_stats[file_path] ||= 0
-    @file_usage_stats[file_path] += 1
-  end
-
-  # Show file usage statistics
-  def show_file_stats
-    @logger.sub("File Usage Statistics:")
-    @logger.sub("  Total unique files: #{@file_usage_stats.size}")
-    total_usages = @file_usage_stats.values.sum
-    @logger.sub("  Total file reads: #{total_usages}")
-
-    if @is_verbose && !@file_usage_stats.empty?
-      @logger.sub("  Top 10 most accessed files:")
-      @file_usage_stats.to_a.sort_by { |_, count| -count }[0..9].each do |file, count|
-        @logger.sub("    #{count} times: #{file}")
-      end
     end
   end
 end

--- a/src/models/minilexer/minilexer.cr
+++ b/src/models/minilexer/minilexer.cr
@@ -81,16 +81,4 @@ class MiniLexer
       puts token.to_s
     end
   end
-
-  def start_repl
-    loop do
-      print ">> "
-      input = gets
-      break if input.nil?
-      input = input.chomp
-      break if input == "exit"
-      tokenize(input)
-      trace
-    end
-  end
 end

--- a/src/utils/url_path.cr
+++ b/src/utils/url_path.cr
@@ -33,5 +33,31 @@ module Noir
         "#{parent}#{child}"
       end
     end
+
+    # Join two URL path segments, collapsing *every* slash at the seam to
+    # exactly one.
+    #
+    # Seven route extractors had this open-coded, byte for byte: the JVM DSL
+    # ones (http4k, JAX-RS, Micronaut, the shared lambda-DSL extractor),
+    # AdonisJS, Elysia, and the Scala Play analyzer.
+    #
+    # It is deliberately NOT `join`, and the two are not interchangeable —
+    # `join` removes at most one slash and keeps a trailing one:
+    #
+    #   join("/api//", "/users")  # => "/api//users"
+    #   join_trimmed(...)         # => "/api/users"
+    #
+    #   join("/api/", "")         # => "/api/"
+    #   join_trimmed("/api/", "") # => "/api"
+    #
+    # Use this where a framework's prefix stack can contribute repeated or
+    # trailing slashes that must not survive into the emitted URL; use `join`
+    # where the segments are already normalised and a trailing slash is
+    # meaningful.
+    def self.join_trimmed(prefix : String, suffix : String) : String
+      return suffix if prefix.empty?
+      return prefix.rstrip('/') if suffix.empty?
+      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
+    end
   end
 end


### PR DESCRIPTION
Re-opens the content of #2390, which was closed rather than merged when its base branch was deleted. Stacked on #2391.

## Dead code

Removed **13 methods and 4 constants** that nothing referenced, plus the `file_usage_stats` feature in `CodeLocator` — not merely unused but **running**:

```crystal
def push(key : String, value : String)
  ...
  if key == "file_map"
    increment_file_usage(value)   # once per file in the scanned tree
```

Nothing ever read the hash back. On a large monorepo that is a String key and an Int32 held for the whole scan, per file, for a report nobody asks for.

### Two flagged items kept, because deleting them was the wrong reading

**`LibTreeSitter::TS_QUERY_ERROR_*`** were unused, but they exist to name the `error_type` `ts_query_new` writes back — which the failure path printed raw:

```
tree-sitter query failed to compile (code=2, byte_offset=41)
```

Now used by `Noir::TreeSitter.query_error_name`, so it reads `(unknown node type, byte_offset=41)`.

**`ZAP`** (`models/delivers/zap.cr`) is unreachable from production — only its own spec constructs it. Left alone: a spec-covered deliver class looks deliberate, and removing it is a maintainer's call. Flagged, not acted on.

## join_paths

Seven byte-identical private copies (http4k, JAX-RS, Micronaut, the shared JVM lambda-DSL extractor, AdonisJS, Elysia, Scala Play) collapse into `Noir::URLPath.join_trimmed`.

**Deliberately a new method rather than a call to the existing `URLPath.join`** — measured, not assumed:

| input | `join` | `join_trimmed` |
|---|---|---|
| `("/api//", "/users")` | `/api//users` | `/api/users` |
| `("/api", "//users")` | `/api//users` | `/api/users` |
| `("/api/", "")` | `/api/` | `/api` |
| `("/api/", "/users")` | `/api/users` | `/api/users` |
| `("/api", "users")` | `/api/users` | `/api/users` |

`join` removes at most one slash at the seam and keeps a trailing one; `join_trimmed` collapses the whole run. **Three of five probe cases differ**, so reusing `join` would have been a silent behaviour change in seven route extractors. The spec pins both side by side.

The other three `join_paths(prefix, suffix)` definitions (kotlin_ktor, struts2, hanami) have genuinely different bodies and are left alone.

```
crystal spec spec/unit_test         4,183 examples, 0 failures
crystal spec spec/functional_test  22,432 examples, 0 failures
crystal tool format --check         clean
```