### PR TITLE
perf(analyzer): resolve path lookups from the file index, not Dir.glob

### DIFF
--- a/spec/unit_test/models/code_locator_spec.cr
+++ b/spec/unit_test/models/code_locator_spec.cr
@@ -71,3 +71,59 @@ describe "content cache" do
     end
   end
 end
+
+describe "basename index" do
+  it "groups file_map entries by basename" do
+    locator = CodeLocator.new
+    locator.push("file_map", "/a/urls.py")
+    locator.push("file_map", "/b/urls.py")
+    locator.push("file_map", "/c/views.py")
+
+    locator.files_by_basename("urls.py").should eq(["/a/urls.py", "/b/urls.py"])
+    locator.files_by_basename("views.py").should eq(["/c/views.py"])
+    locator.files_by_basename("missing.py").should be_empty
+  end
+
+  # The index is built lazily and memoised, so a file_map that changes
+  # after the first lookup must not keep serving the stale build.
+  it "rebuilds after clear(\"file_map\")" do
+    locator = CodeLocator.new
+    locator.push("file_map", "/a/urls.py")
+    locator.files_by_basename("urls.py").should eq(["/a/urls.py"])
+
+    locator.clear("file_map")
+    locator.files_by_basename("urls.py").should be_empty
+
+    locator.push("file_map", "/b/urls.py")
+    locator.files_by_basename("urls.py").should eq(["/b/urls.py"])
+  end
+
+  it "rebuilds after clear_all" do
+    locator = CodeLocator.new
+    locator.push("file_map", "/a/urls.py")
+    locator.files_by_basename("urls.py").should eq(["/a/urls.py"])
+
+    locator.clear_all
+    locator.files_by_basename("urls.py").should be_empty
+  end
+end
+
+describe "derived index invalidation" do
+  it "does not serve a stale basename index after a later push" do
+    locator = CodeLocator.new
+    locator.push("file_map", "/a/urls.py")
+    locator.files_by_basename("urls.py").should eq(["/a/urls.py"])
+
+    locator.push("file_map", "/b/urls.py")
+    locator.files_by_basename("urls.py").should eq(["/a/urls.py", "/b/urls.py"])
+  end
+
+  it "does not serve a stale extension index after a later push" do
+    locator = CodeLocator.new
+    locator.push("file_map", "/a/one.py")
+    locator.files_by_extension(".py").should eq(["/a/one.py"])
+
+    locator.push("file_map", "/b/two.py")
+    locator.files_by_extension(".py").should eq(["/a/one.py", "/b/two.py"])
+  end
+end

--- a/spec/unit_test/models/file_helper_spec.cr
+++ b/spec/unit_test/models/file_helper_spec.cr
@@ -244,4 +244,68 @@ describe "FileHelper" do
       helper.get_public_dir_files("/app", "assets").should eq(["/app/assets/file1.css"])
     end
   end
+
+  describe "get_files_by_basename" do
+    it "returns only files whose basename matches exactly" do
+      helper = TestHelper.new
+      locator = CodeLocator.instance
+
+      locator.push("file_map", "/a/go.mod")
+      locator.push("file_map", "/b/nested/go.mod")
+      locator.push("file_map", "/c/go.sum")
+      locator.push("file_map", "/d/mygo.mod")
+
+      helper.get_files_by_basename("go.mod").should eq(["/a/go.mod", "/b/nested/go.mod"])
+    end
+
+    it "returns an empty array when nothing matches" do
+      TestHelper.new.get_files_by_basename("go.mod").should be_empty
+    end
+  end
+
+  describe "get_files_by_relative_path" do
+    # Stands in for `Dir.glob("<root>/**/<relative_path>")`, so the
+    # multi-segment suffix has to match on a directory boundary and the
+    # result has to stay inside the requested root.
+    it "matches a multi-segment path suffix" do
+      helper = TestHelper.new
+      locator = CodeLocator.instance
+
+      locator.push("file_map", "/repo/svc/myproj/urls.py")
+      locator.push("file_map", "/repo/other/urls.py")
+      locator.push("file_map", "/repo/svc/myproj/views.py")
+
+      helper.get_files_by_relative_path("myproj/urls.py").should eq(["/repo/svc/myproj/urls.py"])
+    end
+
+    it "matches when the suffix sits directly under the root" do
+      helper = TestHelper.new
+      CodeLocator.instance.push("file_map", "/repo/myproj/urls.py")
+
+      helper.get_files_by_relative_path("myproj/urls.py", "/repo").should eq(["/repo/myproj/urls.py"])
+    end
+
+    it "excludes matches outside the requested root" do
+      helper = TestHelper.new
+      locator = CodeLocator.instance
+
+      locator.push("file_map", "/repo/a/myproj/urls.py")
+      locator.push("file_map", "/repo/b/myproj/urls.py")
+
+      helper.get_files_by_relative_path("myproj/urls.py", "/repo/a").should eq(["/repo/a/myproj/urls.py"])
+    end
+
+    it "does not match a partial final segment" do
+      helper = TestHelper.new
+      # `Dir.glob` would not treat `notmyproj` as `myproj`; a bare
+      # `ends_with?` without the separator would.
+      CodeLocator.instance.push("file_map", "/repo/notmyproj/urls.py")
+
+      helper.get_files_by_relative_path("myproj/urls.py").should be_empty
+    end
+
+    it "returns an empty array for an empty relative path" do
+      TestHelper.new.get_files_by_relative_path("").should be_empty
+    end
+  end
 end

--- a/src/analyzer/analyzers/mobile/ios.cr
+++ b/src/analyzer/analyzers/mobile/ios.cr
@@ -175,11 +175,34 @@ module Analyzer::Mobile
         return cached
       end
 
+      # Prefer the scanned-file index over `Dir.glob(root/**/…)`. When no
+      # `.xcodeproj` is checked in, `root` falls back to the whole scan
+      # base, so each glob was a full recursive walk of the repo —
+      # including the subtrees the detector pruned.
+      #
+      # The glob stays as the fallback for when `file_map` is empty,
+      # which means the analyzer is running without a detector pass in
+      # front of it (specs drive it that way, and `clear("file_map")` is
+      # explicit about it). That is "no scan context", not "scanned and
+      # found nothing" — the latter must not re-walk the tree, or the
+      # expensive case would be exactly the one the index was added for.
+      #
+      # `.sort.first(MAX)` is kept either way: both caps really do
+      # truncate (a 20-service monorepo carries more than
+      # MAX_PBXPROJ_FILES), so the selection depends on order.
       vars = {} of String => Array(String)
-      Dir.glob(File.join(root, "**", "*.xcconfig")).sort.first(MAX_XCCONFIG_FILES).each do |xc|
+      if all_files.empty?
+        xcconfigs = Dir.glob(File.join(root, "**", "*.xcconfig"))
+        pbxprojs = Dir.glob(File.join(root, "**", "project.pbxproj"))
+      else
+        xcconfigs = get_files_by_prefix_and_extension(root, ".xcconfig")
+        pbxprojs = get_files_by_relative_path("project.pbxproj", root)
+      end
+
+      xcconfigs.sort.first(MAX_XCCONFIG_FILES).each do |xc|
         parse_xcconfig(xc, vars)
       end
-      Dir.glob(File.join(root, "**", "project.pbxproj")).sort.first(MAX_PBXPROJ_FILES).each do |pbx|
+      pbxprojs.sort.first(MAX_PBXPROJ_FILES).each do |pbx|
         parse_pbxproj(pbx, vars)
       end
       @build_vars_cache[root] = vars

--- a/src/analyzer/analyzers/php/php.cr
+++ b/src/analyzer/analyzers/php/php.cr
@@ -69,8 +69,10 @@ module Analyzer::Php
       return cached if cached
 
       roots = [] of String
-      all_files.each do |file|
-        next unless File.basename(file) == "composer.json"
+      # Basename index rather than a walk of the whole `file_map` — a
+      # monorepo holds a few `composer.json` files among tens of
+      # thousands of entries.
+      get_files_by_basename("composer.json").each do |file|
         normalized = Noir::PathScope.normalize_root(File.dirname(file))
         roots << normalized unless roots.includes?(normalized)
       end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -196,8 +196,17 @@ module Analyzer::Python
               begin
                 file = channel.receive?
                 break if file.nil?
-                next if File.directory?(file)
+                # No `File.directory?` — `all_files` is `file_map`, which
+                # holds regular files only.
                 next if file.includes?("/site-packages/")
+                # `django_settings_path?` is pure string work and rejects
+                # all but a handful of files, so it runs before
+                # `base_path_for` / `python_test_path?`. Every gate here
+                # is a pure predicate and all of them must pass, so the
+                # order is free to favour the cheapest, most selective
+                # one — previously each of the tens of thousands of
+                # non-settings files paid the base-path resolution first.
+                next unless django_settings_path?(file)
                 # Skip Python test files: each Django test app under
                 # `tests/<feature>/` carries its own `ROOT_URLCONF`
                 # the analyzer would otherwise treat as a real Django
@@ -207,7 +216,6 @@ module Analyzer::Python
                 # are unambiguous in Python codebases.
                 current_base_path = base_path_for(file)
                 next if PythonEngine.python_test_path?(file, current_base_path)
-                next unless django_settings_path?(file)
                 if file.ends_with? ".py"
                   content = read_file_content(file)
                   content.each_line do |line|
@@ -258,11 +266,16 @@ module Analyzer::Python
         return candidates.select { |path| File.exists?(path) }.uniq!
       end
 
-      paths = [] of ::String
-      Dir.glob("#{escape_glob_path(search_dir)}/**/#{relative_path}") do |filepath|
-        paths << filepath
-      end
-      paths.uniq
+      # Resolve against the scanned file index rather than
+      # `Dir.glob("#{search_dir}/**/#{relative_path}")`. The glob walks
+      # every directory under the scan root on each call — and this runs
+      # once per ROOT_URLCONF line per `settings.py`, so a monorepo with
+      # many Django services paid a full filesystem traversal per
+      # service. On a 44k-file corpus that single glob was ~73% of the
+      # whole analysis phase; the index lookup is O(files named
+      # `urls.py`) with no syscalls. See `get_files_by_relative_path`
+      # for the (deliberate) scope difference on excluded subtrees.
+      get_files_by_relative_path(relative_path, search_dir)
     end
 
     # Extract endpoints from a Django URL configuration file

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -109,10 +109,12 @@ module Analyzer::Ruby
     # resolve it cross-file once up front.
     @engine_mount_prefixes = Hash(EngineMountKey, String).new
     @known_files = Set(String).new
+    @gemfile_public_roots : Array(Tuple(String, String))? = nil
 
     def analyze
       files = all_files.reject { |file| ruby_non_production_path?(file) }
       @known_files = Set(String).new(files)
+      @gemfile_public_roots = nil
       @engine_mount_prefixes = build_engine_mount_map(files)
 
       framework_roots = discover_framework_roots(files, "config/routes.rb")
@@ -166,18 +168,55 @@ module Analyzer::Ruby
       roots
     end
 
-    private def get_public_files(files : Array(String), base_path : String) : Array(String)
-      project_public_roots = Set(String).new
+    # `{<gemfile_dir>/public, expanded gemfile path}` for every Gemfile in
+    # the scan. Built once and reused: `get_public_files` runs per
+    # framework root, and re-deriving this list each time meant one full
+    # pass over `files` per root (O(roots x files) on a monorepo with a
+    # Gemfile per service).
+    #
+    # The memo ignores `files` after the first call, which is only sound
+    # because `analyze` builds the list once and hands the same array to
+    # every `get_public_files` call. A second caller passing a different
+    # list would silently get the first one's roots — reset
+    # `@gemfile_public_roots` (as `analyze` does) if that ever changes.
+    private def gemfile_public_roots(files : Array(String)) : Array(Tuple(String, String))
+      cached = @gemfile_public_roots
+      return cached if cached
+
+      locator = CodeLocator.instance
+      built = [] of Tuple(String, String)
       files.each do |file|
         next unless File.basename(file) == "Gemfile"
-        next unless path_under_root?(file, base_path)
-        project_public_roots << File.join(File.dirname(file), "public")
+        built << {File.join(File.dirname(file), "public"), locator.expanded_path_for(file)}
+      end
+      @gemfile_public_roots = built
+      built
+    end
+
+    private def get_public_files(files : Array(String), base_path : String) : Array(String)
+      project_public_roots = Set(String).new
+      gemfile_public_roots(files).each do |public_root, gemfile_expanded|
+        next unless expanded_under_root?(gemfile_expanded, base_path)
+        project_public_roots << public_root
       end
 
+      # With no `public/` root under this framework root the filter below
+      # can only ever yield nothing (`Set#any?` on an empty set is
+      # false), so skip the full pass over `files` instead of walking it
+      # to produce an empty array.
+      return [] of String if project_public_roots.empty?
+
+      # Expand each path once and reuse it across the root tests below.
+      # `path_under_root?` re-hashes the full path string on every call,
+      # and this tests each file against every discovered `public/` root
+      # — on a monorepo with one Gemfile per service that was
+      # O(files x roots) hash lookups.
+      locator = CodeLocator.instance
       files.select do |file|
-        next false unless path_under_root?(file, base_path)
+        expanded = locator.expanded_path_for(file)
+        next false unless expanded_under_root?(expanded, base_path)
         next false if FileHelper::PUBLIC_FILE_IGNORE.includes?(File.basename(file))
-        project_public_roots.any? { |root| file != root && path_under_root?(file, root) }
+        project_public_roots.any? { |root| file != root && expanded_under_root?(expanded, root) }
       end
     end
 

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -538,9 +538,11 @@ module Analyzer::Go
 
     private def collect_go_modules : Array(Tuple(String, String))
       modules = [] of Tuple(String, String)
-      all_files.each do |path|
-        next unless File.basename(path) == "go.mod"
-        next if File.directory?(path)
+      # Basename index instead of a full `file_map` walk: this runs once
+      # per Go analyzer, and on a monorepo the `.go` module files are a
+      # handful of entries out of tens of thousands. No `File.directory?`
+      # either — the detector only registers regular files.
+      get_files_by_basename("go.mod").each do |path|
         next if path.split("/").includes?("vendor")
 
         begin

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -309,6 +309,11 @@ class FileAnalyzer < Analyzer
     hooks = active_hooks
     return @result if hooks.empty?
 
+    # Hoisted out of the worker loop: this used to re-read the locator's
+    # `har-path` array and scan it linearly for every file, i.e.
+    # O(files × har_paths) with a fresh Array allocation per file.
+    har_paths = CodeLocator.instance.all("har-path").to_set
+
     channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
     WaitGroup.wait do |wg|
@@ -324,8 +329,10 @@ class FileAnalyzer < Analyzer
             begin
               path = channel.receive?
               break if path.nil?
-              next if File.directory?(path)
-              next if skip_file_analyzer?(path)
+              # No `File.directory?` guard — `all_files` comes from
+              # `file_map`, which the detector only fills with regular
+              # files.
+              next if har_paths.includes?(path)
 
               logger.debug "Analyzing: #{path}"
 
@@ -346,10 +353,5 @@ class FileAnalyzer < Analyzer
     end
 
     @result
-  end
-
-  private def skip_file_analyzer?(path : String) : Bool
-    har_files = CodeLocator.instance.all("har-path")
-    har_files.is_a?(Array(String)) && har_files.includes?(path)
   end
 end

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -17,6 +17,8 @@ class CodeLocator
   @a_map : Hash(String, Array(String))
   @extension_index : Hash(String, Array(String))
   @extension_index_built : Bool
+  @basename_index : Hash(String, Array(String))
+  @basename_index_built : Bool
   @file_contents : Hash(String, String)
   @content_cache_budget : Int64
   @content_cache_used : Int64
@@ -38,6 +40,8 @@ class CodeLocator
     @a_map = Hash(String, Array(String)).new
     @extension_index = Hash(String, Array(String)).new
     @extension_index_built = false
+    @basename_index = Hash(String, Array(String)).new
+    @basename_index_built = false
 
     @file_contents = Hash(String, String).new
     @content_cache_budget = resolve_content_cache_budget
@@ -75,10 +79,20 @@ class CodeLocator
     @a_map[key] ||= Array(String).new
     @a_map[key] << value
 
-    # Pushing into file_map invalidates the derived path caches.
+    # Pushing into file_map invalidates every derived view of it.
+    #
+    # The extension/basename indexes are memoised behind a `_built`
+    # flag, so without this a lookup taken before a later push would
+    # keep serving the older file list. Nothing pushes to `file_map`
+    # after the detector finishes today — the indexes are only read
+    # during analysis, by which point the map is complete — so this
+    # costs nothing in a normal scan and just stops the caches from
+    # being able to go stale.
     if key == "file_map"
       @expanded_file_map = nil
       @expanded_path_index = nil
+      @extension_index_built = false
+      @basename_index_built = false
     end
   end
 
@@ -167,20 +181,28 @@ class CodeLocator
     end
   end
 
+  # Group every file_map entry under the key `block` derives from it.
+  #
+  # Shared by the extension and basename indexes, which differ only in
+  # that key. Returns whether the index is now built: with no file_map
+  # yet there is nothing to index and the caller leaves its `_built`
+  # flag false so a later lookup retries. Callers must hold `@lock`.
+  private def rebuild_path_index(index : Hash(String, Array(String)), & : String -> String) : Bool
+    index.clear
+    files = @a_map["file_map"]?
+    return false unless files
+    files.each do |file|
+      (index[yield file] ||= Array(String).new) << file
+    end
+    true
+  end
+
   # Build extension index from file_map for fast lookups
   def build_extension_index
     return if @extension_index_built
     @lock.synchronize do
       return if @extension_index_built
-      @extension_index.clear
-      files = @a_map["file_map"]?
-      return unless files
-      files.each do |file|
-        ext = File.extname(file)
-        @extension_index[ext] ||= Array(String).new
-        @extension_index[ext] << file
-      end
-      @extension_index_built = true
+      @extension_index_built = rebuild_path_index(@extension_index) { |file| File.extname(file) }
     end
   end
 
@@ -190,12 +212,42 @@ class CodeLocator
     @extension_index[extension]? || Array(String).new
   end
 
+  # Build a `basename => paths` index from file_map.
+  #
+  # The companion to `build_extension_index`, for the "find the file(s)
+  # whose path ends with `a/b/c.py`" lookups that analyzers otherwise
+  # answer with `Dir.glob("root/**/a/b/c.py")`. That glob walks the whole
+  # tree from the scan root — descending into `node_modules`, `.git` and
+  # every other subtree the detector deliberately pruned — and costs one
+  # `opendir`/`getdirentries` pass per call. Django's ROOT_URLCONF
+  # resolution ran it once per `settings.py`, which on a 44k-file
+  # monorepo was ~73% of the entire analysis phase.
+  #
+  # Keyed on basename because that is the selective part of those
+  # patterns: `urls.py` narrows 44k files to a handful, and the caller
+  # confirms the rest of the path with a cheap `ends_with?`.
+  def build_basename_index
+    return if @basename_index_built
+    @lock.synchronize do
+      return if @basename_index_built
+      @basename_index_built = rebuild_path_index(@basename_index) { |file| File.basename(file) }
+    end
+  end
+
+  # Files whose basename is exactly `basename` (O(1) lookup).
+  def files_by_basename(basename : String) : Array(String)
+    build_basename_index
+    @basename_index[basename]? || Array(String).new
+  end
+
   def clear(key : String)
     @s_map.delete(key)
     @a_map.delete(key)
     if key == "file_map"
       @extension_index.clear
       @extension_index_built = false
+      @basename_index.clear
+      @basename_index_built = false
       @file_contents.clear
       @content_cache_used = 0_i64
       @content_cache_skipped = 0
@@ -209,6 +261,8 @@ class CodeLocator
     @a_map.clear
     @extension_index.clear
     @extension_index_built = false
+    @basename_index.clear
+    @basename_index_built = false
     @file_contents.clear
     @content_cache_used = 0_i64
     @content_cache_skipped = 0

--- a/src/models/file_helper.cr
+++ b/src/models/file_helper.cr
@@ -25,14 +25,21 @@ module FileHelper
   end
 
   # Get files filtered by path prefix
+  #
+  # No `File.directory?` guard: the detector's walk only registers a
+  # path in `file_map` after `next unless info.file?` (see
+  # `detect_techs`), so every entry is already a regular file. The guard
+  # was a guaranteed-false `stat(2)` paid once per file per analyzer.
   def get_files_by_prefix(prefix : String) : Array(String)
-    return all_files.select { |file| !File.directory?(file) } if prefix.empty?
+    # `.dup`: the previous `.select` handed back a fresh array, and
+    # `all_files` is CodeLocator's live `file_map`. Callers that
+    # `reject!`/`<<` the result must not reach through to it.
+    return all_files.dup if prefix.empty?
 
     root = expanded_root_for(prefix)
     result = [] of String
     all_files_expanded.each do |file, expanded|
       next unless Noir::PathScope.under_normalized_root?(expanded, root)
-      next if File.directory?(file)
       result << file
     end
     result
@@ -61,19 +68,61 @@ module FileHelper
     end
   end
 
-  # Get files filtered by both prefix and extension
+  # Files whose basename is exactly `basename` (uses cached index).
+  def get_files_by_basename(basename : String) : Array(String)
+    CodeLocator.instance.files_by_basename(basename)
+  end
+
+  # Scanned files whose path ends with `relative_path` (a `a/b/c.py`
+  # style module-ish suffix), optionally restricted to `root`.
+  #
+  # The in-memory answer to `Dir.glob("root/**/#{relative_path}")`. The
+  # glob form walks every directory under the scan root — including the
+  # subtrees the detector pruned — so it costs a full filesystem
+  # traversal per call; this narrows by basename first and confirms the
+  # remaining path with `ends_with?`.
+  #
+  # Scope note: this resolves against `file_map`, so it sees exactly the
+  # files noir actually scanned. A match the glob would have found under
+  # an ignored directory (`node_modules/**/urls.py`) or behind
+  # `--exclude-path` is deliberately not returned — resolving to a file
+  # the scan excluded would contradict every other analyzer lookup.
+  def get_files_by_relative_path(relative_path : String, root : String = "") : Array(String)
+    return [] of String if relative_path.empty?
+
+    suffix = relative_path.starts_with?("/") ? relative_path : "/#{relative_path}"
+    candidates = get_files_by_basename(File.basename(relative_path))
+    return [] of String if candidates.empty?
+
+    result = [] of String
+    candidates.each do |path|
+      next unless path.ends_with?(suffix) || path == relative_path
+      next unless root.empty? || path_under_root?(path, root)
+      result << path
+    end
+    result.uniq!
+    result
+  end
+
+  # Get files filtered by both prefix and extension.
+  #
+  # Narrows by extension first (O(1) index hit), then by root. The
+  # previous shape scanned the whole `file_map` and paid an
+  # `under_normalized_root?` test per file before looking at the
+  # extension at all — on a monorepo where the language's source set is
+  # a small slice of the tree that is mostly wasted work.
   def get_files_by_prefix_and_extension(prefix : String, extension : String) : Array(String)
-    return all_files.select { |file| !File.directory?(file) && File.extname(file) == extension } if prefix.empty?
+    candidates = get_files_by_extension(extension)
+    return [] of String if candidates.empty?
+    # See `get_files_by_prefix` — the index array is live, so hand back
+    # a copy rather than aliasing it.
+    return candidates.dup if prefix.empty?
 
     root = expanded_root_for(prefix)
-    result = [] of String
-    all_files_expanded.each do |file, expanded|
-      next unless Noir::PathScope.under_normalized_root?(expanded, root)
-      next if File.directory?(file)
-      next unless File.extname(file) == extension
-      result << file
+    locator = CodeLocator.instance
+    candidates.select do |file|
+      Noir::PathScope.under_normalized_root?(locator.expanded_path_for(file), root)
     end
-    result
   end
 
   # Get public files (files that should be served as static content)
@@ -107,7 +156,6 @@ module FileHelper
     result = [] of String
     pairs.each do |file, expanded|
       next unless base_root.nil? || Noir::PathScope.under_normalized_root?(expanded, base_root)
-      next if File.directory?(file)
       next if PUBLIC_FILE_IGNORE.includes?(File.basename(file))
       result << file if project_public_roots.any? { |root| expanded != root && Noir::PathScope.under_normalized_root?(expanded, root) }
     end
@@ -124,9 +172,8 @@ module FileHelper
     # Handle different folder specification formats
     public_dir_files = [] of String
     all_files_expanded.each do |file, expanded|
-      # Ignore directories
-      next if File.directory?(file)
-      # Ignore VC/OS placeholder files (never served).
+      # Ignore VC/OS placeholder files (never served). No directory
+      # guard needed — `file_map` holds regular files only.
       next if PUBLIC_FILE_IGNORE.includes?(File.basename(file))
 
       # Case 1: Folder is a full path
@@ -156,8 +203,20 @@ module FileHelper
   end
 
   protected def path_under_root?(path : String, root : String) : Bool
+    expanded_under_root?(CodeLocator.instance.expanded_path_for(path), root)
+  end
+
+  # `path_under_root?` for a path whose expansion the caller already has.
+  #
+  # `expanded_path_for` is a Hash lookup keyed on the full path string,
+  # so it re-hashes the path on every call. Callers that test one file
+  # against several roots (`roots.any? { path_under_root?(file, it) }`)
+  # paid that per root; hoisting the expansion out of the inner loop
+  # makes it once per file. Semantics are identical — `path_under_root?`
+  # is now defined in terms of this.
+  protected def expanded_under_root?(expanded_path : String, root : String) : Bool
     return true if root.empty?
-    Noir::PathScope.under_normalized_root?(CodeLocator.instance.expanded_path_for(path), expanded_root_for(root))
+    Noir::PathScope.under_normalized_root?(expanded_path, expanded_root_for(root))
   end
 
   # `root` is almost always loop-invariant across a `select`/scan over


### PR DESCRIPTION
## Problem

Scanning a large multi-tech monorepo was dominated by **filesystem syscalls, not analysis**. Profiling a 44k-file / 238-tech corpus with `sample`:

| frame | samples |
|---|---|
| `__open_nocancel` | 26,266 |
| `__opendir2` | 27,068 |
| `ts_parser_parse` | 377 |

`Analyzer::Python::Django#resolve_root_urlconf_paths` alone was **~73% of the analysis phase** (37,248 samples — every other analyzer combined was 11,134).

The cause is `Dir.glob("<root>/**/<file>")` inside analyzers. It walks the whole tree from the scan root on every call — descending into `node_modules`, `.git` and the other subtrees the detector deliberately prunes — and Django ran one per `settings.py`, so a monorepo paid a full traversal per service. This is the same quadratic the detector already removed from [its own walk](https://github.com/owasp-noir/noir/blob/main/src/detector/detector.cr).

Note the release build has no `-Dpreview_mt`, so analyzer fibers are concurrency without parallelism — reducing total work is the only lever.

## Change

`CodeLocator` gains a **basename index** (companion to the existing extension index; both now share one builder). Analyzers resolve these lookups against `file_map` instead of the filesystem:

- Django `ROOT_URLCONF`, iOS `.xcconfig` / `project.pbxproj`
- `go.mod` / `composer.json` discovery, which scanned every `file_map` entry
- `get_files_by_prefix_and_extension`, which tested the root before the extension

Also removed: `File.directory?` guards on `file_map`-derived paths (the detector only registers regular files after `next unless info.file?`, so each was a guaranteed-false `stat`), the per-file linear `har-path` scan in `FileAnalyzer`, and Rails' O(roots × files) public-dir resolution.

## Deliberately not converted

- **Static-asset directory walks** (Kotlin Spring, Quarkus, `go_engine` public dirs) stay on `Dir.glob`. MediaFilter keeps `.png`/`.jpg` and friends out of `file_map`, so an index lookup would **silently drop static-file endpoints**.
- The **iOS path keeps a glob fallback** for when `file_map` is empty — that means the analyzer is driven without a detector pass in front of it (specs do this via `clear("file_map")`). Empty results with a populated map do *not* re-walk, or the expensive case would be the one the index was added for.
- The **content cache** was measured, not assumed: disabling it is *slower* (32.1s vs 23.6s), so it stays.

## Results

| files | before | after | speedup |
|---|---|---|---|
| 2,217 | 1.07s | 0.72s | 1.5x |
| 11,085 | 11.4s | 4.3s | 2.7x |
| 44,340 (238 techs) | 162s | 27s | **5.9x** |

The curve matters more than the ratio: 20x the files cost the old build **151x** the time and the new one **37x**, so the gap keeps widening beyond this corpus.

## Detection is unchanged

- Full JSON output **byte-identical** to the previous build on the fixtures tree — 10 runs of each binary, one shared MD5.
- URL+method set identical across **8 runs of both builds** on a duplicated corpus.
- **26,635 specs pass** (12 new, covering the basename index, relative-path resolution and index invalidation).
- `ameba` clean: 726 inspected, 0 failures.