### PR TITLE
fix(cli): run file-based analysis when no technologies are detected

### DIFF
--- a/spec/unit_test/models/analyzer_spec.cr
+++ b/spec/unit_test/models/analyzer_spec.cr
@@ -85,4 +85,14 @@ describe "Initialize FileAnalyzer" do
     analyzer = FileAnalyzer.new(with_url)
     analyzer.active_hooks.size.should be > object.active_hooks.size
   end
+
+  # `noir scan` branches on this to decide whether a code base with zero
+  # detected technologies is still worth an analysis pass. If it ever goes
+  # false the CLI takes its "nothing left to do" exit and every
+  # url-independent hook silently stops contributing to a default scan —
+  # which is exactly the regression that made `.graphql`/`.gql` operation
+  # documents invisible to `noir scan ./app`.
+  it "reports that url-independent hooks exist" do
+    FileAnalyzer.url_independent_hooks?.should be_true
+  end
 end

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -294,6 +294,18 @@ module Noir::CLI::ScanCommand
         app.logger.info "Falling back to file-based analysis because -u was set."
       elsif ai_provider_active?(app.options)
         app.logger.info "Falling back to AI-based analysis because --ai-provider was set."
+      elsif FileAnalyzer.url_independent_hooks?
+        # No tech analyzer will run, but the url-independent file hooks
+        # (GraphQL operation documents) recognise endpoints from file
+        # syntax rather than by matching `-u`, so the analysis pass still
+        # has work to do. Bailing out here made a code base whose only
+        # surface is a `.graphql`/`.gql` operation document report zero
+        # endpoints on a plain `noir scan ./app`, even though the analyzer
+        # layer had already been fixed to run those hooks without `-u`.
+        # FunctionalTester drives `detect`/`analyze` directly, so this
+        # CLI-only gate slipped past the functional spec that asserts the
+        # endpoint is found on a default scan.
+        app.logger.info "Falling back to file-based analysis."
       elsif app.passive_results.size > 0
         app.logger.info "Noir found #{app.passive_results.size} passive results."
         app.report

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -305,6 +305,15 @@ class FileAnalyzer < Analyzer
     active_hooks.size
   end
 
+  # True when at least one hook recognises endpoints from file syntax
+  # alone. `noir scan` consults this before giving up on a code base the
+  # detector found no technologies in: with no techs *and* no
+  # url-independent hook there is genuinely nothing left to analyze, but
+  # with one there still is.
+  def self.url_independent_hooks? : Bool
+    @@hooks.any? { |hook| !hook.requires_url }
+  end
+
   def analyze
     hooks = active_hooks
     return @result if hooks.empty?


### PR DESCRIPTION
## Problem

`noir scan` exits with `exit(0)` as soon as the detector reports zero technologies, **before** `app.analyze` is ever called. A code base whose only surface is a GraphQL operation document reports nothing:

```console
$ noir scan spec/functional_test/fixtures/specification/graphql_operations -f json --no-log
{"endpoints":[],"passive_results":[]}
```

Adding `-u` — or any unrelated `-t` — makes the same endpoint appear, which is what made this read as a url-prefixing quirk rather than a missing analysis pass:

```console
$ noir scan spec/functional_test/fixtures/specification/graphql_operations -f only-url --no-log -t ruby_rails
/graphql
```

The early exit predates `FileAnalyzer#active_hooks`, which exists precisely so url-independent hooks keep running without `-u/--url`. The analyzer layer was fixed then; this CLI gate was not.

### Why the functional spec didn't catch it

`spec/functional_test/testers/specification/graphql_operations_spec.cr` already asserts the endpoint is found on a default scan (no `-u`), and it passes — `FunctionalTester` drives `detect`/`analyze` directly and never routes through the scan command, so a CLI-only gate is invisible to it.

## Fix

Branch on a new `FileAnalyzer.url_independent_hooks?` before taking the fast exit:

- no techs **and** no url-independent hook → nothing left to analyze, fast exit still applies
- no techs **but** a url-independent hook exists → run the analysis pass

The passive-results and `STRUCTURED_OUTPUT_FORMATS` exits stay as the real dead ends. The new unit spec pins the invariant the CLI now depends on — if every hook ever becomes url-requiring, the fast exit would silently swallow them again.

## Verification

```console
$ noir scan spec/functional_test/fixtures/specification/graphql_operations -f json --no-log
{"endpoints":[{...,"url":"/graphql","method":"POST",...,"params":[
  {"name":"graphql_operation_query_GetUser",...},
  {"name":"graphql_operation_mutation_CreateUser",...}]}],"passive_results":[]}

$ noir scan spec/functional_test/fixtures/etc/passive_scan -P --no-log   # passive path unchanged
[critical][private-key][secret] Detect PRIVATE_KEY
[high][webhook-slack][secret] Detect SLACK_WEBHOOK

$ noir scan /tmp/empty-dir -f json --no-log                              # true dead end unchanged
{"endpoints":[],"passive_results":[]}
```

- `just check` — 1817 inspected, 0 failures
- `crystal spec spec/unit_test` — 4204 examples, 0 failures
- `crystal spec spec/functional_test` — 22432 examples, 0 failures

Found while exploring a local build for unexpected behaviour.