### PR TITLE
fix(java): stop emitting a nameless cookie param for getCookies()

### DIFF
--- a/spec/functional_test/testers/java/jsp_spec.cr
+++ b/spec/functional_test/testers/java/jsp_spec.cr
@@ -11,7 +11,11 @@ expected_endpoints = [
   Endpoint.new("/reports/summary.jsp", "GET", [Param.new("range", "", "query")]),
   Endpoint.new("/attribute.jsp", "GET", [Param.new("userId", "", "query")]),
   Endpoint.new("/header.jsp", "GET", [Param.new("X-API-Key", "", "header")]),
-  Endpoint.new("/cookie.jsp", "GET", [Param.new("", "", "cookie")]),
+  # `cookie.jsp` only calls `request.getCookies()`, which names no cookie.
+  # The endpoint is still real, it just carries no param — an empty-named
+  # one used to stand in for "reads cookies" and corrupted every builder
+  # downstream (`--cookie '='`, `{"name": "", "in": "cookie"}`).
+  Endpoint.new("/cookie.jsp", "GET"),
   Endpoint.new("/advanced.jsp", "GET", [
     Param.new("q", "", "query"),
     Param.new("tag", "", "query"),
@@ -53,7 +57,6 @@ expected_endpoints = [
   ]),
   Endpoint.new("/audit", "POST", [
     Param.new("note", "", "form"),
-    Param.new("", "", "cookie"),
   ]),
   Endpoint.new("/admin", "GET"),
 ]

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -23,6 +23,27 @@ describe "EndpointOptimizer" do
       result[1].method.should eq("POST")
     end
 
+    # An analyzer that can tell a param exists but not what it is called
+    # (`request.getCookies()` hands back the whole jar) used to stand that
+    # in with an empty name, and every builder rendered the hole:
+    # `curl --cookie '='`, an empty `└──` node in plain output, and a
+    # `{"name": "", "in": "cookie"}` entry that makes the OAS document
+    # invalid. Unsendable names are dropped here alongside spaced ones.
+    it "drops params whose name is blank or contains a space" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/test", "GET", [
+          Param.new("", "", "cookie"),
+          Param.new("   ", "", "query"),
+          Param.new("two words", "", "query"),
+          Param.new("session_id", "", "cookie"),
+        ]),
+      ]
+
+      result = optimizer.optimize_endpoints(endpoints)
+      result[0].params.map(&.name).should eq(["session_id"])
+    end
+
     it "normalizes HTTP methods" do
       optimizer = EndpointOptimizer.new(logger, options)
       endpoints = [

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -26,7 +26,7 @@ module Analyzer::Java
     # The request-access matchers interpolate a discovered receiver name, so
     # they can't be hoisted — memoize them per receiver instead of rebuilding
     # four regexes for every handler body.
-    @servlet_param_regexes = Hash(String, Tuple(Regex, Regex, Regex, Regex)).new
+    @servlet_param_regexes = Hash(String, Tuple(Regex, Regex, Regex)).new
 
     def analyze
       servlet_methods = collect_servlet_methods
@@ -164,7 +164,13 @@ module Analyzer::Java
         add_param(params, match[1], "header")
       end
 
-      add_param(params, "", "cookie") if content.match(/request\s*\.\s*getCookies\s*\(/)
+      # No `getCookies()` param: it hands back the whole cookie jar without
+      # naming anything, so there is no name to report. Emitting a param
+      # with an empty name pushed that hole straight into the output —
+      # `curl --cookie '='`, an empty `└──` node in plain, and a
+      # `{"name": "", "in": "cookie"}` entry that makes the OAS document
+      # invalid (`name` is required and must be non-empty). Named reads
+      # (`${cookie.x}`, `${cookie["x"]}`) are still collected below.
 
       content.scan(/\$\{\s*param(?:Values)?\.([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
         add_param(params, match[1], "query")
@@ -370,12 +376,13 @@ module Analyzer::Java
       request_param_type = method == "GET" ? "query" : "form"
 
       request_receivers.each do |receiver|
-        parameter_re, attribute_re, header_re, cookie_re = @servlet_param_regexes[receiver] ||= begin
+        # No `getCookies()` regex here for the same reason as the JSP path
+        # above: the call names no cookie, so there is nothing to report.
+        parameter_re, attribute_re, header_re = @servlet_param_regexes[receiver] ||= begin
           receiver_pattern = Regex.escape(receiver)
           {/#{receiver_pattern}\s*\.\s*get(?:Parameter|ParameterValues)\s*\(\s*["']([^"']+)["']\s*\)/,
            /#{receiver_pattern}\s*\.\s*getAttribute\s*\(\s*["']([^"']+)["']\s*\)/,
-           /#{receiver_pattern}\s*\.\s*getHeaders?\s*\(\s*["']([^"']+)["']\s*\)/,
-           /#{receiver_pattern}\s*\.\s*getCookies\s*\(/}
+           /#{receiver_pattern}\s*\.\s*getHeaders?\s*\(\s*["']([^"']+)["']\s*\)/}
         end
 
         content.scan(parameter_re) do |match|
@@ -390,8 +397,6 @@ module Analyzer::Java
         content.scan(header_re) do |match|
           add_param(params, match[1], "header")
         end
-
-        add_param(params, "", "cookie") if content.match(cookie_re)
       end
 
       params

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -267,11 +267,16 @@ class EndpointOptimizer
         tiny_tmp.method = "GET"
       end
 
-      # Remove space in param name
+      # Drop param names that cannot be sent as-is: one containing a space,
+      # and one that is blank. A blank name renders as `--cookie '='` in the
+      # curl builder, an empty `└──` node in plain output and a
+      # `{"name": ""}` entry that makes the OAS document invalid, so an
+      # analyzer that knows a param exists but not what it is called must
+      # not leak that hole into the report.
       if endpoint.params.present?
         tiny_tmp.params = [] of Param
         endpoint.params.each do |param|
-          if !param.name.includes? " "
+          if !param.name.includes?(" ") && !param.name.blank?
             param.value = apply_pvalue(param.param_type, param.name, param.value).to_s
             tiny_tmp.params << param
           end


### PR DESCRIPTION
## Problem

`request.getCookies()` returns the whole cookie jar without naming anything, so the JSP/servlet analyzer had no name to report — and stood that in with `add_param(params, "", "cookie")` (`src/analyzer/analyzers/java/jsp.cr`, both the JSP and the servlet path).

An empty param name is not a param, and every builder rendered the hole:

```console
$ noir scan spec/functional_test/fixtures/java/jsp -f curl -u http://t --no-log
curl -i -X 'GET' 'http://t/cookie.jsp' --cookie '='
curl -i -X 'POST' 'http://t/audit' --data-raw 'note=' ... --cookie '='

$ noir scan spec/functional_test/fixtures/java/jsp -f httpie -u http://t --no-log
http 'GET' 'http://t/cookie.jsp' 'Cookie:='

$ noir scan spec/functional_test/fixtures/java/jsp -f oas3 --no-log | jq '.paths["/cookie.jsp"].get.parameters'
[ { "name": "", "in": "cookie", "required": false, "schema": { "type": "string" } } ]
```

`name` is **required and must be non-empty** in OpenAPI, so the emitted oas2/oas3 document failed validation for any code base containing a bulk cookie read. Plain output showed a bare `└──` node with nothing after it.

## Fix

- Drop the nameless param at both JSP analyzer sites. Named reads (`${cookie.x}`, `${cookie["x"]}`, `getHeader("…")`, …) were never affected and still resolve — `/advanced.jsp` still reports its `session_id` cookie.
- Drop blank names in the optimizer too, right next to the existing space-in-name filter and for the same reason: a name that cannot be sent must not reach a builder, whichever analyzer produced it.

The functional spec pinned the old shape (`Param.new("", "", "cookie")` on `/cookie.jsp` and `POST /audit`), so those expectations are updated with a note on why the endpoint now carries no param.

## After

```console
$ noir scan spec/functional_test/fixtures/java/jsp -f curl -u http://t --no-log
curl -i -X 'GET' 'http://t/cookie.jsp'
curl -i -X 'POST' 'http://t/audit' --data-raw 'note=' -H 'Content-Type: application/x-www-form-urlencoded'

$ ... -f oas3 | jq '.paths["/cookie.jsp"].get.parameters'
[]
```

## Verification

Re-scanned every fixture directory under `spec/functional_test/fixtures` (300+ projects, 5106 endpoints) before and after and diffed the `(method, url, params)` set — the only differences are the two intended ones:

```
### DIFF java_jsp
  -  ('GET', '/cookie.jsp', [('cookie', '')])
  -  ('POST', '/audit', [('cookie', ''), ('form', 'note')])
  +  ('GET', '/cookie.jsp', [])
  +  ('POST', '/audit', [('form', 'note')])
files differing: 1
```

- `just check` — 1817 inspected, 0 failures
- `crystal spec spec/unit_test` — 4204 examples, 0 failures
- `crystal spec spec/functional_test` — 22428 examples, 0 failures

Found while exploring a local build for unexpected behaviour.