### PR TITLE
fix(output): keep the whole passive-scan finding on the report stream

### DIFF
--- a/spec/unit_test/output_builder/passive_scan_spec.cr
+++ b/spec/unit_test/output_builder/passive_scan_spec.cr
@@ -5,12 +5,20 @@ require "../../../src/models/logger"
 require "../../../src/utils/utils"
 require "yaml"
 
-# Mock logger to capture output
+# Mock logger to capture output.
+#
+# `io` stands in for stdout (the report stream) and `log_io` for stderr
+# (progress logging). Keeping them apart is the point: the previous mock
+# funnelled `puts` and `sub` into one buffer, so it could not see that the
+# builder was emitting half of every finding to stderr — where a redirect
+# drops it and `--no-log` suppresses it outright.
 class MockLogger < NoirLogger
   property io : IO::Memory
+  property log_io : IO::Memory
 
   def initialize
     @io = IO::Memory.new
+    @log_io = IO::Memory.new
     # Initialize NoirLogger with default values (false for debug, verbose, color, nolog)
     super(false, false, false, false)
   end
@@ -19,8 +27,12 @@ class MockLogger < NoirLogger
     @io.puts message
   end
 
-  def sub(message)
+  def puts_sub(message)
     @io.puts "  " + message
+  end
+
+  def sub(message)
+    @log_io.puts "  " + message
   end
 end
 
@@ -139,6 +151,11 @@ describe "OutputBuilderPassiveScan" do
       output.should contain("Test Rule Name")
       output.should contain("├── extract: found secret")
       output.should contain("└── file: src/test.cr:15")
+
+      # The whole finding belongs on the report stream. `noir scan . -P >
+      # findings.txt` used to keep the rule header and lose the extract and
+      # the file:line that say where the secret actually is.
+      logger.log_io.to_s.should be_empty
     end
 
     it "prints multiple passive scan results" do

--- a/src/output_builder/passive_scan.cr
+++ b/src/output_builder/passive_scan.cr
@@ -8,8 +8,13 @@ class OutputBuilderPassiveScan < OutputBuilder
   def print(passive_results : Array(PassiveScanResult), logger : NoirLogger, is_color : Bool)
     passive_results.each do |result|
       logger.puts "[#{severity_color(result.info.severity, is_color)}][#{result.id.colorize(:light_blue).toggle(is_color)}][#{result.category.colorize(:light_yellow).toggle(is_color)}] #{result.info.name.colorize(:light_green).toggle(is_color)}"
-      logger.sub "├── extract: #{result.extract}"
-      logger.sub "└── file: #{result.file_path}:#{result.line_number}"
+      # `puts_sub`, not `sub`: these two lines are the finding, not progress
+      # logging. `sub` writes to stderr and returns early under `--no-log`,
+      # which split one finding across two streams — `noir scan . -P >
+      # findings.txt` kept the rule header and dropped the extract and the
+      # file:line that say where the secret is.
+      logger.puts_sub "├── extract: #{result.extract}"
+      logger.puts_sub "└── file: #{result.file_path}:#{result.line_number}"
       logger.puts ""
     end
   end


### PR DESCRIPTION
## Problem

`OutputBuilderPassiveScan` printed the rule header with `logger.puts` (stdout) but the two lines under it with `logger.sub` — which writes to **stderr** and returns early under `--no-log`. One finding, split across two streams:

```console
$ noir scan spec/functional_test/fixtures/etc/passive_scan -P --no-color 2>/dev/null | grep -c "file:"
0
$ noir scan spec/functional_test/fixtures/etc/passive_scan -P --no-color 2>&1 >/dev/null | grep -c "file:"
2
```

So the common shape loses the actionable half of every finding:

```console
$ noir scan . -P > findings.txt        # keeps the rule header, drops extract + file:line
$ noir scan . -P --no-log              # "Show only results" — suppresses them outright
[critical][private-key][secret] Detect PRIVATE_KEY

[high][webhook-slack][secret] Detect SLACK_WEBHOOK
```

For a secret finding, `file:line` *is* the result.

## Fix

Use `logger.puts_sub` — stdout, no `--no-log` gate. It exists for exactly this and had **no callers**; the comment on `NoirLogger#puts` already names "OutputBuilderPassiveScan's plain-text findings" as its intended user. Every other output builder writes its report through `logger.puts`; this one was the outlier.

### Why the spec didn't catch it

`MockLogger` overrode both `puts` and `sub` into one `IO::Memory`, so the assertions passed no matter which stream the builder used. It now keeps stdout and stderr apart and asserts nothing from a finding lands on the log stream.

## After

```console
$ noir scan spec/functional_test/fixtures/etc/passive_scan -P --no-log --no-color 2>/dev/null

[critical][private-key][secret] Detect PRIVATE_KEY
  ├── extract: -----BEGIN PRIVATE KEY-----
  └── file: spec/functional_test/fixtures/etc/passive_scan/private_key.pem:1

[high][webhook-slack][secret] Detect SLACK_WEBHOOK
  ├── extract: https://hooks.slack.com/services/T12345678/B12345678/AbCdEfGhIjKlMnOpQrStUvWx
  └── file: spec/functional_test/fixtures/etc/passive_scan/slack.fake.txt:2
```

No duplication with logs enabled (each line is emitted once), and structured formats are untouched — they already carried `file_path`/`line_number` in the payload.

## Verification

- `just check` — 1817 inspected, 0 failures
- `crystal spec spec/unit_test` — 4203 examples, 0 failures
- `crystal spec spec/functional_test` — 22432 examples, 0 failures

Found while exploring a local build for unexpected behaviour.