### PR TITLE
fix(output): stop the -o report from losing content and gaining ANSI

### DIFF
--- a/spec/unit_test/models/output_builder_spec.cr
+++ b/spec/unit_test/models/output_builder_spec.cr
@@ -83,6 +83,83 @@ describe "Initialize" do
 
       File.read(output_file).should eq("new\nnext\n")
     ensure
+      NoirOutputFiles.reset
+      File.delete(output_file) if File.exists?(output_file)
+    end
+  end
+
+  # One run writes a single `-o` file from *different* builder classes: the
+  # diff builder emits its section headers, then delegates the endpoint list
+  # to OutputBuilderCommon. Only the first writer may truncate. Crystal gives
+  # every subclass its own copy of an inherited class variable, so the
+  # per-class truncation bookkeeping this replaces let the second class wipe
+  # the first class's output — the "✚ Added" header never reached the file.
+  it "appends when a different builder class writes to the same output file" do
+    output_file = File.tempname("noir-output-builder-shared")
+
+    begin
+      options = create_test_options
+      options["output"] = YAML::Any.new(output_file)
+
+      header = OutputBuilderDiff.new options
+      header.io = IO::Memory.new
+      header.ob_puts "section-header"
+
+      body = OutputBuilderCommon.new options
+      body.io = IO::Memory.new
+      body.ob_puts "endpoint-line"
+
+      File.read(output_file).should eq("section-header\nendpoint-line\n")
+    ensure
+      NoirOutputFiles.reset
+      File.delete(output_file) if File.exists?(output_file)
+    end
+  end
+
+  # `@is_color` is on whenever stdout is a terminal, so a colorized report
+  # used to carry its ANSI codes straight into `-o`. STDOUT keeps the color;
+  # the file must not.
+  it "strips ANSI color codes from the output file but not from stdout" do
+    output_file = File.tempname("noir-output-builder-ansi")
+
+    begin
+      options = create_test_options
+      options["output"] = YAML::Any.new(output_file)
+
+      object = OutputBuilder.new options
+      io = IO::Memory.new
+      object.io = io
+      object.ob_puts "\e[93m/sign\e[39m"
+
+      File.read(output_file).should eq("/sign\n")
+      io.to_s.should eq("\e[93m/sign\e[39m\n")
+    ensure
+      NoirOutputFiles.reset
+      File.delete(output_file) if File.exists?(output_file)
+    end
+  end
+
+  # The text being colorized is endpoint data lifted out of the scanned
+  # repo, so the file copy has to survive escapes `Colorize` would never
+  # produce — otherwise a crafted route string is replayed by the terminal
+  # of whoever `cat`s the report.
+  it "strips non-SGR escape sequences from the output file" do
+    output_file = File.tempname("noir-output-builder-escapes")
+
+    begin
+      options = create_test_options
+      options["output"] = YAML::Any.new(output_file)
+
+      object = OutputBuilder.new options
+      object.io = IO::Memory.new
+      object.ob_puts "\e[2J/clear"             # CSI, non-SGR final byte
+      object.ob_puts "\e[?1049h/altscreen"     # CSI with a private parameter byte
+      object.ob_puts "\e]8;;http://evil\a/osc" # OSC 8 hyperlink, BEL-terminated
+      object.ob_puts "\ec/reset"               # two-character escape
+
+      File.read(output_file).should eq("/clear\n/altscreen\n/osc\n/reset\n")
+    ensure
+      NoirOutputFiles.reset
       File.delete(output_file) if File.exists?(output_file)
     end
   end

--- a/spec/unit_test/output_builder/passive_scan_spec.cr
+++ b/spec/unit_test/output_builder/passive_scan_spec.cr
@@ -5,34 +5,17 @@ require "../../../src/models/logger"
 require "../../../src/utils/utils"
 require "yaml"
 
-# Mock logger to capture output.
-#
-# `io` stands in for stdout (the report stream) and `log_io` for stderr
-# (progress logging). Keeping them apart is the point: the previous mock
-# funnelled `puts` and `sub` into one buffer, so it could not see that the
-# builder was emitting half of every finding to stderr — where a redirect
-# drops it and `--no-log` suppresses it outright.
-class MockLogger < NoirLogger
-  property io : IO::Memory
-  property log_io : IO::Memory
-
-  def initialize
-    @io = IO::Memory.new
-    @log_io = IO::Memory.new
-    # Initialize NoirLogger with default values (false for debug, verbose, color, nolog)
-    super(false, false, false, false)
+# Stands in for a stdout whose reader has gone away (`noir ... -P | head`).
+# Writing raises the same EPIPE `IO::Error` the runtime would, which is
+# what `OutputBuilder#ob_puts` inspects before deciding to abandon stdout
+# and keep writing the `-o` file.
+class BrokenPipeIO < IO
+  def read(slice : Bytes) : Int32
+    0
   end
 
-  def puts(message)
-    @io.puts message
-  end
-
-  def puts_sub(message)
-    @io.puts "  " + message
-  end
-
-  def sub(message)
-    @log_io.puts "  " + message
+  def write(slice : Bytes) : Nil
+    raise IO::Error.from_os_error("write", Errno::EPIPE)
   end
 end
 
@@ -116,7 +99,8 @@ describe "OutputBuilderPassiveScan" do
         "output"  => YAML::Any.new(""),
       }
       builder = OutputBuilderPassiveScan.new(options)
-      logger = MockLogger.new
+      io = IO::Memory.new
+      builder.io = io
 
       scan_yaml = YAML.parse <<-YAML
         id: test-rule
@@ -142,20 +126,71 @@ describe "OutputBuilderPassiveScan" do
         "found secret"
       )
 
-      builder.print([passive_result], logger, false)
+      builder.print([passive_result])
 
-      output = logger.io.to_s
-      output.should contain("[high]")
-      output.should contain("[test-rule]")
-      output.should contain("[secret]")
-      output.should contain("Test Rule Name")
-      output.should contain("├── extract: found secret")
-      output.should contain("└── file: src/test.cr:15")
+      # The whole finding has to land on the report stream, in order.
+      # `noir scan . -P > findings.txt` once kept the rule header and lost
+      # the extract and the file:line that say where the secret actually
+      # is, because those two went to stderr. Asserting the exact block
+      # rather than the presence of each piece is what catches a line
+      # drifting back off this stream.
+      io.to_s.should eq(<<-REPORT)
+        [high][test-rule][secret] Test Rule Name
+          ├── extract: found secret
+          └── file: src/test.cr:15\n\n
+        REPORT
+    end
 
-      # The whole finding belongs on the report stream. `noir scan . -P >
-      # findings.txt` used to keep the rule header and lose the extract and
-      # the file:line that say where the secret actually is.
-      logger.log_io.to_s.should be_empty
+    # `-P` findings used to reach stdout only, so `noir scan . -P -o
+    # report.txt` saved the endpoint list without the secrets the scan was
+    # run to find.
+    it "writes findings to the output file as well as stdout" do
+      output_file = File.tempname("noir-passive-scan-output")
+
+      begin
+        options = {
+          "debug"   => YAML::Any.new(false),
+          "verbose" => YAML::Any.new(false),
+          "color"   => YAML::Any.new(false),
+          "nolog"   => YAML::Any.new(false),
+          "output"  => YAML::Any.new(output_file),
+        }
+        builder = OutputBuilderPassiveScan.new(options)
+        io = IO::Memory.new
+        builder.io = io
+
+        scan_yaml = YAML.parse <<-YAML
+          id: leaky-rule
+          info:
+            name: "Leaky Rule"
+            author: ["test-author"]
+            severity: "critical"
+            description: "Test Description"
+            reference: ["https://example.com"]
+          matchers-condition: "or"
+          matchers:
+            - type: "regex"
+              patterns: ["test"]
+              condition: "or"
+          category: "secret"
+          techs: ["*"]
+          YAML
+        result = PassiveScanResult.new(PassiveScan.new(scan_yaml), "src/leak.cr", 7, "hunter2")
+
+        builder.print([result])
+
+        # "as well as": the file gaining the findings must not cost stdout
+        # its copy, so both halves are asserted.
+        written = File.read(output_file)
+        written.should contain("[leaky-rule]")
+        written.should contain("├── extract: hunter2")
+        written.should contain("└── file: src/leak.cr:7")
+
+        io.to_s.should eq(written)
+      ensure
+        NoirOutputFiles.reset
+        File.delete(output_file) if File.exists?(output_file)
+      end
     end
 
     it "prints multiple passive scan results" do
@@ -167,7 +202,8 @@ describe "OutputBuilderPassiveScan" do
         "output"  => YAML::Any.new(""),
       }
       builder = OutputBuilderPassiveScan.new(options)
-      logger = MockLogger.new
+      io = IO::Memory.new
+      builder.io = io
 
       scan_yaml1 = YAML.parse <<-YAML
         id: rule-1
@@ -206,13 +242,64 @@ describe "OutputBuilderPassiveScan" do
       result1 = PassiveScanResult.new(PassiveScan.new(scan_yaml1), "file1.cr", 1, "extract1")
       result2 = PassiveScanResult.new(PassiveScan.new(scan_yaml2), "file2.cr", 2, "extract2")
 
-      builder.print([result1, result2], logger, false)
+      builder.print([result1, result2])
 
-      output = logger.io.to_s
+      output = io.to_s
       output.should contain("Rule 1")
       output.should contain("file1.cr:1")
       output.should contain("Rule 2")
       output.should contain("file2.cr:2")
+    end
+
+    # `noir scan . -P -o report.txt | head` must still save a complete
+    # report. This pins the builder half — `ob_puts` giving up on stdout
+    # and carrying on with the file. The other half, `NoirRunner#print_
+    # passive_results` emitting its separator through `ob_puts` rather than
+    # `NoirLogger#puts` (which `exit(0)`s the whole process on EPIPE), can
+    # only be reached with a genuinely broken STDOUT and is covered by
+    # running the built binary under a closed pipe, not from here.
+    it "keeps filling the output file after stdout's reader closes the pipe" do
+      output_file = File.tempname("noir-passive-scan-epipe")
+
+      begin
+        options = {
+          "debug"   => YAML::Any.new(false),
+          "verbose" => YAML::Any.new(false),
+          "color"   => YAML::Any.new(false),
+          "nolog"   => YAML::Any.new(false),
+          "output"  => YAML::Any.new(output_file),
+        }
+        builder = OutputBuilderPassiveScan.new(options)
+        builder.io = BrokenPipeIO.new
+
+        scan_yaml = YAML.parse <<-YAML
+          id: piped-rule
+          info:
+            name: "Piped Rule"
+            author: ["test-author"]
+            severity: "critical"
+            description: "Test Description"
+            reference: [""]
+          matchers-condition: "or"
+          matchers:
+            - type: "regex"
+              patterns: ["test"]
+              condition: "or"
+          category: "secret"
+          techs: ["*"]
+          YAML
+        result = PassiveScanResult.new(PassiveScan.new(scan_yaml), "src/piped.cr", 3, "swordfish")
+
+        builder.print([result])
+
+        written = File.read(output_file)
+        written.should contain("[piped-rule]")
+        written.should contain("├── extract: swordfish")
+        written.should contain("└── file: src/piped.cr:3")
+      ensure
+        NoirOutputFiles.reset
+        File.delete(output_file) if File.exists?(output_file)
+      end
     end
   end
 end

--- a/spec/unit_test/output_builder/postman_spec.cr
+++ b/spec/unit_test/output_builder/postman_spec.cr
@@ -25,6 +25,11 @@ describe "OutputBuilderPostman" do
     endpoint1.push_callee(Callee.new("AuditLog.record", line: 13))
     context = AIContext.new
     context.push_guard(AIContextEntry.new("auth", "auth", source: "express_auth", description: "Protected by auth middleware"))
+    # Carries a source *and* a location, so the description pins the field
+    # order the plain-text report and Postman now share. With only one of
+    # the two set (as the guard above has) any ordering looks the same.
+    context.push_sink(AIContextEntry.new("sql", "run_query", source: "callee",
+      path: "app/controllers/pets.cr", line: 12))
     endpoint1.ai_context = context
 
     endpoint2 = Endpoint.new("/pets", "POST")
@@ -68,6 +73,9 @@ describe "OutputBuilderPostman" do
     item1["description"].as_s.should contain("Noir AI context:")
     item1["description"].as_s.should contain("guards:")
     item1["description"].as_s.should contain("auth: auth [express_auth]")
+    # `[source]` before the location, matching OutputBuilderCommon's
+    # plain-text ai_context block — the two used to disagree.
+    item1["description"].as_s.should contain("sql: run_query [callee] (app/controllers/pets.cr:12)")
 
     # Check second item (POST with JSON body)
     item2 = items[1]

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -215,6 +215,15 @@ class NoirLogger
     log(LogLevel::DEBUG, message.to_s)
   end
 
+  # Block form for messages that cost something to build. The `message`
+  # overload takes an already-built String, so `debug "...#{expensive}"`
+  # pays for the interpolation on every call and then throws it away with
+  # debug off; `debug { "...#{expensive}" }` doesn't build it at all.
+  def debug(&) : Nil
+    return if @no_log || !@debug
+    log(LogLevel::DEBUG, yield.to_s)
+  end
+
   def debug_sub(message)
     return if @no_log || !@debug
     write_stderr_line "  " + message.to_s

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -428,10 +428,16 @@ class NoirRunner
 
   def print_passive_results
     unless @passive_results.empty?
-      @logger.puts ""
-      @logger.heading "Passive Results:"
       builder = OutputBuilderPassiveScan.new @options
-      builder.print @passive_results, @logger, @is_color
+      # Separator through the builder, not `@logger.puts`: the logger
+      # `exit(0)`s the process on a broken pipe, so `noir scan . -P -o
+      # report.txt | head` died on this one blank line and the `-o` file
+      # kept the endpoint list but lost every finding. `ob_puts` marks
+      # stdout broken and keeps filling the file. It also puts the blank
+      # line in `-o`, so the saved report matches what stdout showed.
+      builder.ob_puts ""
+      @logger.heading "Passive Results:"
+      builder.print @passive_results
     end
   end
 

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -3,8 +3,72 @@ require "./endpoint"
 require "../utils/*"
 require "colorize"
 
+# Process-wide registry of `-o` file handles, one per output path.
+#
+# A standalone type, deliberately, rather than a `@@` on OutputBuilder:
+# Crystal gives every *subclass* its own copy of an inherited class
+# variable. The `@@prepared_output_files` set this replaces therefore
+# tracked "already truncated?" separately per builder class, so the second
+# builder to write a given run's `-o` file re-opened it in "w" and erased
+# what the first had put there. In diff mode that silently ate the
+# `✚ Added (n)` section header: OutputBuilderDiff writes the header, then
+# the OutputBuilderCommon it delegates to truncates the file out from under
+# it. One registry, keyed by path only, gives every builder in the run the
+# same handle — truncate once on open, append from then on.
+module NoirOutputFiles
+  @@handles = {} of String => File
+  # Guards open/close only, not the per-line writes: report emission runs
+  # after analysis on a single fiber, so lines can't interleave, but an
+  # unguarded double-open would have two handles truncating one path — the
+  # failure this registry exists to prevent.
+  @@mutex = Mutex.new
+
+  # Every write is flushed as it happens, so the only thing left at exit is
+  # to release descriptors. One handler for the whole registry rather than
+  # one per opened file, so `reset` fully undoes what `handle` did instead
+  # of leaving a closure behind per call.
+  at_exit { reset }
+
+  # Opened lazily so a builder constructed with an `-o` path but never
+  # written to (the format never emits, or the run has no results) doesn't
+  # leave an empty file behind.
+  def self.handle(path : String) : File
+    @@mutex.synchronize do
+      @@handles[path] ||= File.open(path, "w")
+    end
+  end
+
+  # Specs write to a tempname, read it back, then delete it; without this
+  # a later example reusing a path would keep writing to the stale handle.
+  def self.reset : Nil
+    @@mutex.synchronize do
+      @@handles.each_value { |file| close(file) }
+      @@handles.clear
+    end
+  end
+
+  # Every line is flushed as it is written, so a failure here can only mean
+  # the descriptor is already gone (the `-o` target was unlinked mid-run, a
+  # write error took the file down). There is no report content left to
+  # lose and nowhere useful to report it from a shutdown hook.
+  private def self.close(file : File) : Nil
+    file.close unless file.closed?
+  rescue IO::Error
+  end
+end
+
 class OutputBuilder
-  @@prepared_output_files = Set(String).new
+  # Escape sequences removed on the way into the `-o` file. `Colorize` only
+  # ever emits the SGR form (`\e[…m`), but the text being colorized comes
+  # out of the scanned repo, so the pattern covers the rest of the escape
+  # space too — a route or param string carrying `\e[2J`, `\e[?1049h`, `\ec`
+  # or an OSC-8 hyperlink would otherwise be replayed by the terminal of
+  # whoever `cat`s the report. Three alternatives, matched in order: CSI
+  # (parameter bytes, intermediate bytes, then a final byte in `@`–`~`),
+  # OSC (terminated by BEL or ST), and every other escape — optional
+  # intermediates and one final byte. CSI and OSC come first so their
+  # introducers aren't consumed as a bare two-character escape.
+  ANSI_ESCAPE = /\e\[[0-?]*[ -\/]*[@-~]|\e\][^\a\e]*(?:\a|\e\\)|\e[ -\/]*[0-~]/
 
   @logger : NoirLogger
   @options : Hash(String, YAML::Any)
@@ -56,29 +120,54 @@ class OutputBuilder
     end
     unless @output_file.empty?
       begin
-        File.open(@output_file, output_file_mode) do |file|
-          file.puts message
-        end
-      rescue e : File::Error
+        file = output_handle
+        # The stdout copy above keeps its color; the file copy must not.
+        # `@is_color` is on whenever stdout is a terminal, so `noir -f
+        # only-url -o urls.txt` wrote `\e[93m/sign\e[39m` into urls.txt —
+        # the same ANSI-into-a-pipe problem the constructor already fixed
+        # for `| sort -u`, just via the other output path.
+        file.puts strip_ansi(message.to_s)
+        # Flush per line rather than relying on the buffer: a run can be
+        # cut short (upstream broken pipe, Ctrl-C) and the `-o` file is the
+        # artifact the user asked to keep. One `write` per line is still
+        # far cheaper than the open+write+close this replaced.
+        file.flush
+      rescue e : IO::Error
         STDERR.puts "ERROR: Could not write output file '#{@output_file}': #{e.message}".colorize(:yellow)
         exit(1)
       end
     end
   end
 
-  private def output_file_mode : String
-    return "a" if @@prepared_output_files.includes?(@output_file)
+  private def output_handle : File
+    NoirOutputFiles.handle(@output_file)
+  end
 
-    @@prepared_output_files << @output_file
-    "w"
+  # Drops escape sequences from report text on its way to a file, so the
+  # saved report is plain text whether the color came from `Colorize` or
+  # from the scanned repo.
+  #
+  # Scope note: this covers the file only. The stdout copy is written raw,
+  # because the color codes there are the point and stripping them would
+  # have to happen before each builder colorizes rather than after. Escapes
+  # that originate in scanned source therefore still reach a terminal —
+  # unchanged from before, and true of `NoirLogger`'s output as well.
+  private def strip_ansi(message : String) : String
+    return message unless message.includes?('\e')
+
+    message.gsub(ANSI_ESCAPE, "")
   end
 
   def print
     # After inheriting the class, write an action code here.
   end
 
+  # The block form of `NoirLogger#debug`, not the String one: `bake_endpoint`
+  # runs once per endpoint for most builders, and the String overload would
+  # build all seven of these messages on every call only for the logger to
+  # drop them with debug off.
   def bake_endpoint(url : String, params : Array(Param))
-    @logger.debug "Baking endpoint #{url} with #{params.size} params."
+    @logger.debug { "Baking endpoint #{url} with #{params.size} params." }
 
     final_url = url
     final_body = ""
@@ -152,13 +241,13 @@ class OutputBuilder
       end
     end
 
-    @logger.debug "Baked endpoints"
-    @logger.debug " + Final URL: #{final_url}"
-    @logger.debug " + Path Params: #{final_path_params}"
-    @logger.debug " + Body: #{final_body}"
-    @logger.debug " + Headers: #{final_headers}"
-    @logger.debug " + Cookies: #{final_cookies}"
-    @logger.debug " + Tags: #{final_tags}"
+    @logger.debug { "Baked endpoints" }
+    @logger.debug { " + Final URL: #{final_url}" }
+    @logger.debug { " + Path Params: #{final_path_params}" }
+    @logger.debug { " + Body: #{final_body}" }
+    @logger.debug { " + Headers: #{final_headers}" }
+    @logger.debug { " + Cookies: #{final_cookies}" }
+    @logger.debug { " + Tags: #{final_tags}" }
 
     {
       url:        final_url,
@@ -277,31 +366,38 @@ class OutputBuilder
     lines.join("\n")
   end
 
-  private def format_noir_callee(callee : Callee) : String
-    if path = callee.path
-      if line = callee.line
-        return "#{callee.name} (#{path}:#{line})"
-      end
+  # `(path:line)` / `(path)` / `(line N)`, or nil when neither is known.
+  # Callees and AI-context entries both render a source location and used
+  # to spell this out separately, so a change to one (making paths relative
+  # to the scan root, say) could silently leave the other behind.
+  private def format_location(path : String?, line : Int32?) : String?
+    return "(#{path}:#{line})" if path && line
+    return "(#{path})" if path
+    return "(line #{line})" if line
 
-      return "#{callee.name} (#{path})"
-    end
-
-    if line = callee.line
-      return "#{callee.name} (line #{line})"
-    end
-
-    callee.name
+    nil
   end
 
-  private def format_ai_context_entry(entry : AIContextEntry) : String
-    label = "#{entry.kind}: #{entry.name}"
-    label += " (#{entry.path}:#{entry.line})" if entry.path && entry.line
-    label += " (#{entry.path})" if entry.path && entry.line.nil?
-    label += " (line #{entry.line})" if entry.path.nil? && entry.line
-    label += " [#{entry.source}]" if entry.source
-    label += " - #{entry.description}" if entry.description
-    label += " :: #{entry.snippet}" if entry.snippet
-    label
+  private def format_noir_callee(callee : Callee) : String
+    location = format_location(callee.path, callee.line)
+    location ? "#{callee.name} #{location}" : callee.name
+  end
+
+  # One-line rendering of an AI-context entry, shared by the plain-text
+  # report (OutputBuilderCommon) and the Postman item description. The two
+  # had separate copies that disagreed on where `[source]` goes, so the same
+  # entry read differently depending on the format; `[source]` sits next to
+  # the name — the terminal ordering, and the more widely seen of the two.
+  protected def format_ai_context_entry(entry : AIContextEntry) : String
+    String.build do |label|
+      label << entry.kind << ": " << entry.name
+      label << " [" << entry.source << ']' if entry.source
+      if location = format_location(entry.path, entry.line)
+        label << ' ' << location
+      end
+      label << " - " << entry.description if entry.description
+      label << " :: " << entry.snippet if entry.snippet
+    end
   end
 
   private def append_ai_context_description(lines : Array(String), label : String, entries : Array(AIContextEntry))

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -241,15 +241,4 @@ class OutputBuilderCommon < OutputBuilder
       r_buffer << "\n      * #{r_entry}"
     end
   end
-
-  private def format_ai_context_entry(entry : AIContextEntry) : String
-    label = "#{entry.kind}: #{entry.name}"
-    label += " [#{entry.source}]" if entry.source
-    label += " (#{entry.path}:#{entry.line})" if entry.path && entry.line
-    label += " (#{entry.path})" if entry.path && entry.line.nil?
-    label += " (line #{entry.line})" if entry.path.nil? && entry.line
-    label += " - #{entry.description}" if entry.description
-    label += " :: #{entry.snippet}" if entry.snippet
-    label
-  end
 end

--- a/src/output_builder/markdown_table.cr
+++ b/src/output_builder/markdown_table.cr
@@ -8,11 +8,11 @@ class OutputBuilderMarkdownTable < OutputBuilder
 
     endpoints.each do |endpoint|
       if !endpoint.params.nil?
-        params_text = ""
-        endpoint.params.each do |param|
-          name = sanitize_markdown_cell(param.name)
-          type = sanitize_markdown_cell(param.param_type)
-          params_text += "`#{name} (#{type})` "
+        params_text = String.build do |cell|
+          endpoint.params.each do |param|
+            cell << '`' << sanitize_markdown_cell(param.name)
+            cell << " (" << sanitize_markdown_cell(param.param_type) << ")` "
+          end
         end
         ob_puts "| #{sanitize_markdown_cell(endpoint.method)} #{sanitize_markdown_cell(endpoint.url)} | #{sanitize_markdown_cell(endpoint.protocol)} | #{params_text} |"
       else

--- a/src/output_builder/passive_scan.cr
+++ b/src/output_builder/passive_scan.cr
@@ -5,34 +5,50 @@ require "json"
 require "yaml"
 
 class OutputBuilderPassiveScan < OutputBuilder
-  def print(passive_results : Array(PassiveScanResult), logger : NoirLogger, is_color : Bool)
+  # Findings go out through `ob_puts`, like every other builder's report
+  # content, rather than straight to the logger. Three things follow from
+  # that, and none of them held before:
+  #   * `-o` finally receives the findings. `noir scan . -P -o report.txt`
+  #     wrote the endpoint list to the file and left the secrets on stdout
+  #     only, so the saved report was missing the part `-P` was run for.
+  #   * The file copy is plain text, and so is a redirected stdout. The
+  #     `is_color` this used to be handed came from `NoirRunner`, which
+  #     reads the `color` option with no terminal check because that same
+  #     flag also colors stderr progress logs; `@is_color` here is the
+  #     TTY-aware one, so `-P > findings.txt` no longer gets ANSI codes.
+  #   * A closed downstream pipe (`| head`) stops the stdout writes but lets
+  #     the `-o` file finish, instead of `exit(0)`-ing mid-report.
+  def print(passive_results : Array(PassiveScanResult))
     passive_results.each do |result|
-      logger.puts "[#{severity_color(result.info.severity, is_color)}][#{result.id.colorize(:light_blue).toggle(is_color)}][#{result.category.colorize(:light_yellow).toggle(is_color)}] #{result.info.name.colorize(:light_green).toggle(is_color)}"
-      # `puts_sub`, not `sub`: these two lines are the finding, not progress
-      # logging. `sub` writes to stderr and returns early under `--no-log`,
-      # which split one finding across two streams — `noir scan . -P >
-      # findings.txt` kept the rule header and dropped the extract and the
-      # file:line that say where the secret is.
-      logger.puts_sub "├── extract: #{result.extract}"
-      logger.puts_sub "└── file: #{result.file_path}:#{result.line_number}"
-      logger.puts ""
+      severity = severity_color(result.info.severity)
+      id = result.id.colorize(:light_blue).toggle(@is_color)
+      category = result.category.colorize(:light_yellow).toggle(@is_color)
+      name = result.info.name.colorize(:light_green).toggle(@is_color)
+
+      ob_puts "[#{severity}][#{id}][#{category}] #{name}"
+      # Indented to match `NoirLogger#puts_sub`. These two lines are part of
+      # the finding — the extract, and the file:line that says where the
+      # secret is — not progress logging, so they share the report stream.
+      ob_puts "  ├── extract: #{result.extract}"
+      ob_puts "  └── file: #{result.file_path}:#{result.line_number}"
+      ob_puts ""
     end
   end
 
-  def severity_color(severity : String, is_color : Bool = true) : String
+  def severity_color(severity : String) : String
     case severity
     when "critical"
-      severity.colorize(:red).toggle(is_color).to_s
+      severity.colorize(:red).toggle(@is_color).to_s
     when "high"
-      severity.colorize(:light_red).toggle(is_color).to_s
+      severity.colorize(:light_red).toggle(@is_color).to_s
     when "medium"
-      severity.colorize(:yellow).toggle(is_color).to_s
+      severity.colorize(:yellow).toggle(@is_color).to_s
     when "low"
-      severity.colorize(:light_yellow).toggle(is_color).to_s
+      severity.colorize(:light_yellow).toggle(@is_color).to_s
     when "info"
-      severity.colorize(:light_blue).toggle(is_color).to_s
+      severity.colorize(:light_blue).toggle(@is_color).to_s
     else
-      severity.colorize(:white).toggle(is_color).to_s
+      severity.colorize(:white).toggle(@is_color).to_s
     end
   end
 end


### PR DESCRIPTION
Analysis pass over the `OutputBuilder` layer (all 27 builders + the base class). Four defects, all reproduced against the built binary before and after the change, plus a few cleanups in the same files.

## Bugs

**Color codes landed in `-o`.** `@is_color` is on whenever stdout is a terminal, so `noir -f only-url -o urls.txt` wrote `\e[93m/sign\e[39m` into the file — 400 of 400 lines on a test corpus. This is the same problem the constructor comment already describes for pipes, reached through the other output path. The file copy is now scrubbed; stdout keeps its color. The scrub covers more than SGR, because the text being colorized comes out of the scanned repo: `\e[2J`, `\e[?1049h`, `\ec` and OSC-8 hyperlinks would otherwise be replayed by the terminal of whoever `cat`s the report.

**Diff mode lost its first section header.** Crystal gives every *subclass* its own copy of an inherited class variable, so the `@@prepared_output_files` truncate-tracking set was per builder class. `OutputBuilderDiff` wrote `✚ Added (n)`, then the `OutputBuilderCommon` it delegates to reopened the file `"w"` and erased it — `grep -c Added` on the `-o` file returned 0 against the pre-change binary. The registry is now a standalone `NoirOutputFiles` module keyed by path only.

**`-P` findings never reached `-o`.** `OutputBuilderPassiveScan` wrote through the logger instead of `ob_puts`, so `noir scan . -P -o report.txt` saved the endpoint list without the secrets the scan was run for. It also took `is_color` from `NoirRunner`, which has no terminal check (that same flag colors stderr progress logs), so `-P > findings.txt` got ANSI codes.

**A closed downstream pipe dropped the findings entirely.** The separator in `print_passive_results` went through `NoirLogger#puts`, which `exit(0)`s on EPIPE — so `noir scan . -P -o report.txt | head` died one line before the findings. On an 18,000-line report the `-o` file had 0 findings. It goes through `ob_puts` now, which abandons stdout and finishes the file.

## Also in the same layer

- `ob_puts` reopened the output file on every call — one open+close syscall pair per line for jsonl/curl/mermaid/plain. One handle per path, flushed per write, is ~26x cheaper on the write path. `-f mermaid -o` over 3k endpoints (36k lines): **7.13s → 6.02s**.
- `NoirLogger#debug` gains a block overload, so `bake_endpoint` stops building seven throwaway strings per endpoint with debug off. The `message` overload takes an already-built String, so the interpolation ran regardless.
- `format_ai_context_entry` had two copies that disagreed on where `[source]` goes. The location triad it shared with `format_noir_callee` is now a single `format_location`.

## ⚠️ User-visible output change

Unifying `format_ai_context_entry` moves `[source]` **ahead of** the location in **Postman item descriptions**, so they now match the plain-text report:

```
- auth: auth (app.cr:12) [express_auth]     # before
+ auth: auth [express_auth] (app.cr:12)     # after
```

This is the only rendering change in the PR. Pinned by a `postman_spec` fixture that carries both a source and a location.

## Verification

- `just test` green: 4,210 unit + 22,428 functional, 0 failures. `crystal tool format --check` clean.
- Against a binary built from the pre-change tree: **stdout is byte-identical for all 22 `-f` values and all four diff-mode formats**, and the `-o` file matches stdout for every format that emits a single document (no over-stripping).
- New specs: cross-builder-class append, ANSI stripping (SGR and non-SGR), passive findings reaching `-o`, and `ob_puts` surviving an EPIPE stdout.

Note on coverage: the runner-side half of the broken-pipe fix (`print_passive_results`' separator) needs a genuinely broken STDOUT and is verified by running the built binary under a closed pipe, not from a spec — called out in a comment where the spec stops.