### PR TITLE
docs: show contributors SVG in Built in the open section

### DIFF
--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -185,7 +185,7 @@ template = "landing"
 <section class="section wrap">
   <div class="community-inner">
     <div class="poster-frame" data-reveal>
-      <img src="../images/hak-poster.webp" alt="빗속에 트렌치코트와 고글 차림으로 서 있는 OWASP Noir 마스코트 학의 영화 포스터." width="2000" height="1116" loading="lazy" decoding="async">
+      <img src="https://owasp-noir.github.io/noir/CONTRIBUTORS.svg" alt="OWASP Noir에 기여한 사람들의 프로필 이미지." width="720" height="240" loading="lazy" decoding="async">
     </div>
     <div class="community-copy" data-reveal style="--reveal-delay: 90ms">
       <h2 class="section-title">공개적으로 만듭니다</h2>
@@ -195,9 +195,5 @@ template = "landing"
         <svg class="ic" aria-hidden="true"><use href="#i-arrow-up-right"/></svg>
       </a>
     </div>
-  </div>
-  <div class="contributors" data-reveal>
-    <p>기여해 주신 모든 분께 감사드립니다.</p>
-    <img src="../CONTRIBUTORS.svg" alt="OWASP Noir에 기여한 사람들의 프로필 이미지." width="720" height="240" loading="lazy" decoding="async">
   </div>
 </section>

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -183,7 +183,7 @@ template = "landing"
 <section class="section wrap">
   <div class="community-inner">
     <div class="poster-frame" data-reveal>
-      <img src="./images/hak-poster.webp" alt="A film poster of Hak, the OWASP Noir mascot: a crane in a trench coat and goggles, standing in the rain." width="2000" height="1116" loading="lazy" decoding="async">
+      <img src="https://owasp-noir.github.io/noir/CONTRIBUTORS.svg" alt="Avatars of the people who have contributed to OWASP Noir." width="720" height="240" loading="lazy" decoding="async">
     </div>
     <div class="community-copy" data-reveal style="--reveal-delay: 90ms">
       <h2 class="section-title">Built in the open</h2>
@@ -193,9 +193,5 @@ template = "landing"
         <svg class="ic" aria-hidden="true"><use href="#i-arrow-up-right"/></svg>
       </a>
     </div>
-  </div>
-  <div class="contributors" data-reveal>
-    <p>Thanks to everyone who has contributed.</p>
-    <img src="./CONTRIBUTORS.svg" alt="Avatars of the people who have contributed to OWASP Noir." width="720" height="240" loading="lazy" decoding="async">
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Replace the Hak poster in the landing "Built in the open" section with the hosted CONTRIBUTORS.svg.
- Remove the duplicate "Thanks to everyone who has contributed." block that reused the same image.
- Applied to both English and Korean landing pages.

## Test plan
- [ ] Open the docs landing page and confirm the left image in "Built in the open" is CONTRIBUTORS.svg.
- [ ] Confirm the bottom contributors/thanks section is gone.
- [ ] Check the Korean landing page (`/ko/`) for the same layout.