### PR TITLE
docs: add closing CTA to the landing page

### DIFF
--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -197,3 +197,19 @@ template = "landing"
     </div>
   </div>
 </section>
+
+<section class="section wrap">
+  <div class="cta" data-reveal>
+    <h2 class="section-title">지금 시작하세요.</h2>
+    <p class="section-lede">Noir를 설치하고 코드베이스를 가리키면 됩니다. 첫 목록은 몇 초면 나옵니다.</p>
+    <div class="cta-actions">
+      <a class="btn btn-primary" href="./get_started/overview/">
+        시작하기
+        <svg class="ic" aria-hidden="true"><use href="#i-arrow-right"/></svg>
+      </a>
+      <a class="btn btn-outline" href="./get_started/installation/">
+        설치하기
+      </a>
+    </div>
+  </div>
+</section>

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -195,3 +195,19 @@ template = "landing"
     </div>
   </div>
 </section>
+
+<section class="section wrap">
+  <div class="cta" data-reveal>
+    <h2 class="section-title">Start hunting.</h2>
+    <p class="section-lede">Install Noir and point it at a codebase. The first inventory takes seconds.</p>
+    <div class="cta-actions">
+      <a class="btn btn-primary" href="./get_started/overview/">
+        Get Started
+        <svg class="ic" aria-hidden="true"><use href="#i-arrow-right"/></svg>
+      </a>
+      <a class="btn btn-outline" href="./get_started/installation/">
+        Install
+      </a>
+    </div>
+  </div>
+</section>

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1134,7 +1134,30 @@ pre.mermaid svg { max-width: 100%; height: auto; margin-inline: auto; }
 .contributors p { color: var(--text-muted); font-size: var(--fs-sm); margin-bottom: 1.25rem; }
 .contributors img { width: 100%; max-width: 780px; margin-inline: auto; height: auto; }
 
-/* ------------------------------------------------ 11.8 Blog and authors */
+/* 11.8 Closing CTA. One last invitation. The accent is spent only on the
+   primary button, never as a decorative stripe or glow. */
+.cta {
+  text-align: center;
+  padding: clamp(2.75rem, 6vw, 4.25rem) clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+}
+.cta .section-title { max-width: 18ch; margin-inline: auto; }
+.cta .section-lede {
+  margin-top: 0.9rem;
+  margin-inline: auto;
+  max-width: 42ch;
+}
+.cta-actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+/* ------------------------------------------------ 11.9 Blog and authors */
 
 .blog { padding-block: clamp(2.5rem, 6vw, 4.5rem) clamp(4rem, 9vw, 7rem); }
 .blog-inner { max-width: 820px; }
@@ -1384,6 +1407,7 @@ a.author-card-inner:hover { border-color: var(--accent-edge); text-decoration: n
   .hero-inner { padding-top: 0; padding-bottom: 3.5rem; margin-top: -2.5rem; }
   .hero h1 { font-size: 1.75rem; }
   .hero-actions .btn { flex: 1 1 auto; justify-content: center; }
+  .cta-actions .btn { flex: 1 1 auto; justify-content: center; }
 
   .cell-a, .cell-b, .cell-c, .cell-d, .cell-e { grid-column: span 12; }
   .stat-row { gap: 1.5rem; }


### PR DESCRIPTION
## Summary
- Add a final call-to-action section at the bottom of the docs landing page (EN + KO).
- Primary button goes to Get Started; secondary goes to Install.
- Style the panel with the existing monochrome surface language (border, `--r-lg`, accent only on the primary button).

## Test plan
- [x] `hwaro build` succeeds
- [x] `docs/scripts/check_doc_parity.sh` passes
- [ ] Spot-check landing in dark and light themes
- [ ] Spot-check at ~390px width (buttons stretch like hero CTAs)