### PR TITLE
fix(cache): validate argv, handle unreadable dir, sweep stranded temp files

### DIFF
--- a/spec/unit_test/cli/cache_command_spec.cr
+++ b/spec/unit_test/cli/cache_command_spec.cr
@@ -45,16 +45,56 @@ describe Noir::CLI::CacheCommand do
       parsed.rest.should be_empty
     end
 
-    it "collects extra positionals into rest in order" do
-      parsed = Noir::CLI::CacheCommand.parse_argv(["purge", "7", "ignored"])
+    it "collects positionals into rest in order" do
+      parsed = Noir::CLI::CacheCommand.parse_argv(["purge", "7"])
       parsed.action.should eq("purge")
-      parsed.rest.should eq(["7", "ignored"])
+      parsed.rest.should eq(["7"])
+      parsed.error.should be_nil
     end
 
     it "sets help on -h / --help anywhere in argv" do
       Noir::CLI::CacheCommand.parse_argv(["-h"]).help.should be_true
       Noir::CLI::CacheCommand.parse_argv(["--help"]).help.should be_true
       Noir::CLI::CacheCommand.parse_argv(["purge", "--help"]).help.should be_true
+    end
+
+    # An unknown flag used to be filed as a positional and then dropped, so
+    # `noir cache clear --dry-run` performed a real, irreversible wipe while
+    # reading like a rehearsal.
+    it "rejects an unknown option instead of silently dropping it" do
+      parsed = Noir::CLI::CacheCommand.parse_argv(["clear", "--dry-run"])
+      parsed.error.should eq("Unknown option: --dry-run. Run `noir cache --help`.")
+    end
+
+    it "rejects surplus positionals past the action's arity" do
+      Noir::CLI::CacheCommand.parse_argv(["info", "clear"]).error
+        .should eq("Unexpected argument: clear. Usage: noir cache info")
+      Noir::CLI::CacheCommand.parse_argv(["purge", "7", "999"]).error
+        .should eq("Unexpected argument: 999. Usage: noir cache purge <days>")
+      Noir::CLI::CacheCommand.parse_argv(["purge", "7", "999", "junk"]).error
+        .should eq("Unexpected arguments: 999, junk. Usage: noir cache purge <days>")
+    end
+
+    # An unrecognized action must reach the "Unknown cache action" branch in
+    # `run` rather than being pre-empted by an arity complaint about its
+    # trailing arguments.
+    it "leaves an unknown action to the action check, not the arity check" do
+      Noir::CLI::CacheCommand.parse_argv(["bogus", "extra"]).error.should be_nil
+    end
+
+    # `-5` is a value the user meant for <days>, not a flag; it must reach
+    # `parse_days` so the error names the real problem.
+    it "treats a bare negative number as a positional, not an option" do
+      parsed = Noir::CLI::CacheCommand.parse_argv(["purge", "-5"])
+      parsed.rest.should eq(["-5"])
+      parsed.error.should be_nil
+      Noir::CLI::CacheCommand.parse_days("-5").should be_nil
+    end
+
+    it "accepts the router's global flags without treating them as the action" do
+      parsed = Noir::CLI::CacheCommand.parse_argv(["--no-color", "info", "--no-spinner"])
+      parsed.action.should eq("info")
+      parsed.error.should be_nil
     end
   end
 

--- a/spec/unit_test/cli/cache_command_spec.cr
+++ b/spec/unit_test/cli/cache_command_spec.cr
@@ -76,7 +76,7 @@ describe Noir::CLI::CacheCommand do
     end
 
     # An unrecognized action must reach the "Unknown cache action" branch in
-    # `run` rather than being pre-empted by an arity complaint about its
+    # `run` rather than being masked by an arity complaint about its
     # trailing arguments.
     it "leaves an unknown action to the action check, not the arity check" do
       Noir::CLI::CacheCommand.parse_argv(["bogus", "extra"]).error.should be_nil

--- a/spec/unit_test/llm/cache_spec.cr
+++ b/spec/unit_test/llm/cache_spec.cr
@@ -141,4 +141,63 @@ describe LLM::Cache do
       end
     end
   end
+
+  # A crash between `File.write` and `File.rename` strands a temp file.
+  # It doesn't end in `.json`, so it used to be invisible to every bulk
+  # operation: `clear` couldn't delete it and `stats` didn't count its
+  # bytes, leaving unreclaimable files in the cache directory.
+  describe "stranded temp files" do
+    it "recognizes the name shape `store` actually writes" do
+      LLM::Cache.tmp_entry?("abc#{LLM::Cache::CACHE_FILE_SUFFIX}#{LLM::Cache::CACHE_TMP_MARKER}123-dead").should be_true
+      LLM::Cache.tmp_entry?("abc.json").should be_false
+      LLM::Cache.tmp_entry?("user-dropped.txt").should be_false
+    end
+
+    it "counts them in stats apart from usable entries" do
+      with_isolated_cache_dir do |home|
+        cache_dir = File.join(home, "cache", "ai")
+        LLM::Cache.store("live", "12345").should be_true
+        File.write(File.join(cache_dir, "orphan.json.tmp-99999-deadbeef"), "x" * 100)
+
+        stats = LLM::Cache.stats
+        stats.entries.should eq(1)
+        stats.orphans.should eq(1)
+        stats.orphan_bytes.should eq(100)
+      end
+    end
+
+    it "is reclaimed by clear without inflating the entry count" do
+      with_isolated_cache_dir do |home|
+        cache_dir = File.join(home, "cache", "ai")
+        LLM::Cache.store("live", "v").should be_true
+        File.write(File.join(cache_dir, "orphan.json.tmp-99999-deadbeef"), "x")
+
+        outcome = LLM::Cache.clear
+        outcome.deleted.should eq(1)
+        outcome.orphans.should eq(1)
+        outcome.failed.should eq(0)
+        Dir.children(cache_dir).should be_empty
+      end
+    end
+
+    it "is purged on age like any other entry" do
+      with_isolated_cache_dir do |home|
+        cache_dir = File.join(home, "cache", "ai")
+        stale = File.join(cache_dir, "orphan.json.tmp-99999-deadbeef")
+        FileUtils.mkdir_p(cache_dir)
+        File.write(stale, "x")
+        File.touch(stale, Time.utc - 10.days)
+        # An in-flight temp write from a concurrent process is seconds old,
+        # so the age predicate must leave it alone.
+        fresh = File.join(cache_dir, "inflight.json.tmp-88888-cafebabe")
+        File.write(fresh, "y")
+
+        outcome = LLM::Cache.purge_older_than(7)
+        outcome.deleted.should eq(0)
+        outcome.orphans.should eq(1)
+        File.exists?(stale).should be_false
+        File.exists?(fresh).should be_true
+      end
+    end
+  end
 end

--- a/src/cli/commands/cache.cr
+++ b/src/cli/commands/cache.cr
@@ -1,4 +1,5 @@
 require "colorize"
+require "file"
 require "../common"
 require "../../llm/cache"
 
@@ -8,27 +9,70 @@ require "../../llm/cache"
 module Noir::CLI::CacheCommand
   ACTIONS = %w[info clear purge]
 
+  # Positionals each action accepts after the action word. `purge` takes
+  # `<days>`; the rest take none. Used to reject surplus argv rather than
+  # dropping it, which matters most for `clear`: an unrecognized flag
+  # used to sail straight through to a real, irreversible wipe.
+  ACTION_ARITY = {"info" => 0, "clear" => 0, "purge" => 1}
+
   # Parsed argv. Extracted from `run` so the parser itself stays
   # unit-testable — `run` still owns the `exit`/`die` side effects.
-  record Parsed, action : String?, rest : Array(String), help : Bool
+  # `error` is recorded rather than raised so `run` can turn it into a
+  # clean `Noir::CLI.die` line.
+  record Parsed, action : String?, rest : Array(String), help : Bool, error : String?
 
   def self.parse_argv(argv : Array(String)) : Parsed
     action = nil
     rest = [] of String
     help = false
+    error = nil
+
     argv.each do |a|
       case a
       when "-h", "--help"
         help = true
+      when "--no-color", "--no-spinner"
+        # Global flags — the router consumes both before dispatching here.
+        # Accepted (not rejected as unknown) so a direct `run` call and a
+        # future router change both behave.
       else
-        if action.nil?
+        if flag?(a)
+          # Previously an unknown flag was taken as a positional and then
+          # ignored, so `noir cache clear --dry-run` cleared the cache for
+          # real while reading like a no-op rehearsal.
+          error ||= "Unknown option: #{a}. Run `noir cache --help`."
+        elsif action.nil?
           action = a
         else
           rest << a
         end
       end
     end
-    Parsed.new(action: action, rest: rest, help: help)
+
+    # Surplus positionals were silently dropped too: `noir cache info
+    # clear` quietly ran only `info`, `noir cache purge 3 999` ignored the
+    # 999. Surface them instead of guessing which one was meant.
+    act = action
+    if error.nil? && act && (arity = ACTION_ARITY[act]?) && rest.size > arity
+      extra = rest[arity..]
+      plural = extra.size > 1 ? "s" : ""
+      error = "Unexpected argument#{plural}: #{extra.join(", ")}. Usage: #{usage_for(act)}"
+    end
+
+    Parsed.new(action: action, rest: rest, help: help, error: error)
+  end
+
+  # A leading `-` marks an option — except on a bare negative number,
+  # which is a plausible (if invalid) `purge <days>` value. Routing `-5`
+  # to the positional slot lets `parse_days` explain the real problem
+  # ("must be a positive integer") instead of "Unknown option: -5".
+  def self.flag?(arg : String) : Bool
+    arg.starts_with?("-") && arg.to_i?.nil?
+  end
+
+  # Single-line usage for one action, used in surplus-argument errors.
+  def self.usage_for(action : String) : String
+    action == "purge" ? "noir cache purge <days>" : "noir cache #{action}"
   end
 
   # Upper bound on `noir cache purge <days>`. 100 years is well past
@@ -53,7 +97,16 @@ module Noir::CLI::CacheCommand
   def self.run(argv : Array(String))
     parsed = parse_argv(argv)
 
-    if parsed.help || parsed.action.nil?
+    if parsed.help
+      print_help
+      exit
+    end
+
+    if err = parsed.error
+      Noir::CLI.die(err)
+    end
+
+    if parsed.action.nil?
       print_help
       exit
     end
@@ -65,6 +118,12 @@ module Noir::CLI::CacheCommand
     else
       Noir::CLI.die("Unknown cache action: #{parsed.action}. Valid: #{ACTIONS.join(", ")}.")
     end
+  rescue ex : File::Error
+    # `Dir.children` raises (rather than returning empty) when the cache
+    # directory or an ancestor can't be read — a permission-denied parent,
+    # a stale mount. Fail like every other subcommand: one clean line, not
+    # a raw Crystal stack trace.
+    Noir::CLI.die("Cannot access the cache directory: #{ex.message}")
   end
 
   def self.print_help(io : IO = STDOUT)
@@ -94,6 +153,10 @@ module Noir::CLI::CacheCommand
     io.puts "Cache directory: #{LLM::Cache.cache_dir}"
     io.puts "Entries:         #{stats.entries}"
     io.puts "Total size:      #{format_bytes(stats.bytes)}"
+    if stats.orphans > 0
+      io.puts "Incomplete:      #{stats.orphans} stranded write#{stats.orphans == 1 ? "" : "s"} " \
+              "(#{format_bytes(stats.orphan_bytes)}) — reclaim with `noir cache clear`"
+    end
     if stats.entries > 0
       if oldest = stats.oldest
         io.puts "Oldest entry:    #{oldest.to_local} (#{format_age(oldest)} ago)"
@@ -114,8 +177,16 @@ module Noir::CLI::CacheCommand
   def self.clear(io : IO = STDOUT)
     outcome = LLM::Cache.clear
     msg = "Removed #{outcome.deleted} cache entr#{outcome.deleted == 1 ? "y" : "ies"} from #{LLM::Cache.cache_dir}."
+    msg += orphan_note(outcome)
     msg += " (#{outcome.failed} failed)" if outcome.failed > 0
     io.puts msg
+  end
+
+  # Reclaimed temp files are reported apart from the entry count so
+  # "Removed N cache entries" keeps meaning N usable cached responses.
+  def self.orphan_note(outcome : LLM::Cache::DeleteOutcome) : String
+    return "" if outcome.orphans < 1
+    " Also reclaimed #{outcome.orphans} incomplete write#{outcome.orphans == 1 ? "" : "s"}."
   end
 
   def self.purge(rest : Array(String), io : IO = STDOUT)
@@ -130,6 +201,7 @@ module Noir::CLI::CacheCommand
 
     outcome = LLM::Cache.purge_older_than(days)
     msg = "Purged #{outcome.deleted} cache entr#{outcome.deleted == 1 ? "y" : "ies"} older than #{days} day#{days == 1 ? "" : "s"} from #{LLM::Cache.cache_dir}."
+    msg += orphan_note(outcome)
     msg += " (#{outcome.failed} failed)" if outcome.failed > 0
     io.puts msg
   end

--- a/src/llm/cache.cr
+++ b/src/llm/cache.cr
@@ -19,9 +19,24 @@ module LLM
   module Cache
     # All cache entries are stored as `<sha256>.json` flat in
     # `cache_dir`. The bulk operations below (`clear`, `purge_older_than`,
-    # `stats`) filter on this suffix so a stray `.tmp`, `.lock`, or
-    # user-dropped file in the directory is left alone.
+    # `stats`) filter on this suffix so a stray `.lock` or user-dropped
+    # file in the directory is left alone.
     CACHE_FILE_SUFFIX = ".json"
+
+    # Infix `store` stamps onto its in-flight temp file (see `store`).
+    # Kept as a constant so the writer and the sweepers below can't drift
+    # apart: a stranded temp file whose name the sweepers don't recognize
+    # is a file nothing can ever delete.
+    CACHE_TMP_MARKER = ".tmp-"
+
+    # True for a temp file stranded by a crash between `File.write` and
+    # `File.rename`. These do *not* end in `.json`, so the bulk operations
+    # used to skip them entirely — `clear` could not remove them and
+    # `stats` did not count their bytes, leaving files that grew the cache
+    # directory with no way to reclaim them from the CLI.
+    def self.tmp_entry?(name : String) : Bool
+      name.includes?("#{CACHE_FILE_SUFFIX}#{CACHE_TMP_MARKER}")
+    end
 
     @@enabled = true
 
@@ -94,7 +109,7 @@ module LLM
       return false unless enabled?
       ensure_dir
       final = path_for(key)
-      tmp = "#{final}.tmp-#{Process.pid}-#{Random::Secure.hex(4)}"
+      tmp = "#{final}#{CACHE_TMP_MARKER}#{Process.pid}-#{Random::Secure.hex(4)}"
       File.write(tmp, content)
       File.rename(tmp, final)
       true
@@ -121,8 +136,10 @@ module LLM
     # Returned by bulk mutations so callers can surface both successful
     # deletes and per-file failures (the prior shape returned just an
     # Int32, hiding partial failures behind a single number that the
-    # caller would print as if everything succeeded).
-    record DeleteOutcome, deleted : Int32, failed : Int32 do
+    # caller would print as if everything succeeded). `orphans` counts
+    # reclaimed temp files separately so "removed N entries" keeps meaning
+    # N real cached responses.
+    record DeleteOutcome, deleted : Int32, failed : Int32, orphans : Int32 = 0 do
       def total
         deleted + failed
       end
@@ -140,44 +157,67 @@ module LLM
       end
     end
 
+    # Sweeps completed entries and stranded temp writes alike. A temp file
+    # still being written by a concurrent process is only seconds old, so
+    # `purge_older_than`'s mtime predicate never selects it; `clear` is
+    # explicitly destructive and may take one, which the writer already
+    # handles (its rename fails, `store` returns false, the next scan
+    # re-requests).
     private def self.delete_matching(& : String -> Bool) : DeleteOutcome
       return DeleteOutcome.new(0, 0) unless File.directory?(cache_dir)
       deleted = 0
       failed = 0
+      orphans = 0
       Dir.children(cache_dir).each do |entry|
-        next unless entry.ends_with?(CACHE_FILE_SUFFIX)
+        tmp = tmp_entry?(entry)
+        next unless tmp || entry.ends_with?(CACHE_FILE_SUFFIX)
         fp = File.join(cache_dir, entry)
         next unless File.file?(fp)
         begin
           next unless yield(fp)
           File.delete(fp)
-          deleted += 1
+          tmp ? (orphans += 1) : (deleted += 1)
         rescue e
           Log.debug { "Cache delete failed for #{fp}: #{e.message}" }
           failed += 1
         end
       end
-      DeleteOutcome.new(deleted, failed)
+      DeleteOutcome.new(deleted, failed, orphans)
     end
 
+    # `orphans`/`orphan_bytes` are tracked apart from `entries`/`bytes` so
+    # `entries` keeps counting usable cached responses while the reported
+    # footprint can still account for every byte the cache occupies.
+    # Stranded temp files also stay out of `oldest`/`newest`, which
+    # describe the age of the *usable* cache.
     record Stats,
       entries : Int32,
       bytes : Int64,
       oldest : Time?,
-      newest : Time?
+      newest : Time?,
+      orphans : Int32 = 0,
+      orphan_bytes : Int64 = 0
 
     def self.stats : Stats
       entries = 0
       bytes = 0_i64
+      orphans = 0
+      orphan_bytes = 0_i64
       oldest : Time? = nil
       newest : Time? = nil
       if File.directory?(cache_dir)
         Dir.children(cache_dir).each do |entry|
-          next unless entry.ends_with?(CACHE_FILE_SUFFIX)
+          tmp = tmp_entry?(entry)
+          next unless tmp || entry.ends_with?(CACHE_FILE_SUFFIX)
           fp = File.join(cache_dir, entry)
           next unless File.file?(fp)
           begin
             info = File.info(fp)
+            if tmp
+              orphans += 1
+              orphan_bytes += info.size.to_i64
+              next
+            end
             entries += 1
             bytes += info.size.to_i64
             mtime = info.modification_time
@@ -188,7 +228,9 @@ module LLM
           end
         end
       end
-      Stats.new(entries: entries, bytes: bytes, oldest: oldest, newest: newest)
+      Stats.new(
+        entries: entries, bytes: bytes, oldest: oldest, newest: newest,
+        orphans: orphans, orphan_bytes: orphan_bytes)
     end
   end
 end


### PR DESCRIPTION
Three bugs found while exercising `noir cache` from the CLI. All reproduced before the fix and re-verified against a `--release` build after.

## 1. `noir cache clear --dry-run` wiped the cache

`parse_argv` filed every non-`-h` token as a positional and nothing validated the surplus, so `clear`/`info` never looked at it.

```console
$ noir cache clear --dry-run
Removed 2 cache entries from ...        # irreversible, exit 0
$ noir cache info clear                 # ran only `info`
$ noir cache purge 3 999 junk           # ignored 999 and junk
```

An invented or misremembered flag reached a destructive action with no warning. `noir rules` already rejects exactly this shape; `cache` was the one holdout.

Now:

```console
$ noir cache clear --dry-run
ERROR: Unknown option: --dry-run. Run `noir cache --help`.
$ noir cache purge 7 999 junk
ERROR: Unexpected arguments: 999, junk. Usage: noir cache purge <days>
```

A bare negative number stays a positional so `purge -5` keeps its specific message ("must be a positive integer between 1 and 36500") instead of degrading to "unknown option". An unrecognized *action* still reaches the `Unknown cache action` branch rather than being pre-empted by an arity complaint.

## 2. Unreadable cache directory dumped a stack trace

`Dir.children` raises instead of returning empty when the directory or an ancestor can't be read.

```console
$ chmod 000 ~/.config/noir/cache/ai && noir cache info
Unhandled exception: Error opening directory: '...': Permission denied (File::AccessDeniedError)
  from ... in 'Dir::children<String>:Array(String)'
```

`info`, `clear`, and `purge` were all affected. Now one clean line, mirroring the `rescue ex : File::Error` that `noir rules` already had:

```console
ERROR: Cannot access the cache directory: Error opening directory: '...': Permission denied
```

The in-scan `--cache-clear` path was already covered by its own `rescue` and is unchanged.

## 3. Stranded temp files could never be reclaimed

`store` writes `<key>.json.tmp-<pid>-<rand>` then renames it into place. A hard crash between the two (SIGKILL, OOM, power loss) leaves a file that does **not** end in `.json` — and every bulk operation filtered on that suffix.

```console
$ noir cache info
Entries:         0
Total size:      0 B          # 4 KB actually on disk
$ noir cache clear
Removed 3 cache entries       # help says "Remove every cached AI response"
$ ls ~/.config/noir/cache/ai
bbb1.json.tmp-99999-deadbeef  # survives, forever
```

The temp marker is a shared constant now so the writer and the sweepers can't drift, and stranded files are swept with real entries. They are counted separately throughout, so `Removed N cache entries` keeps meaning N usable cached responses:

```console
$ noir cache info
Entries:         1
Total size:      8 B
Incomplete:      2 stranded writes (3.9 KB) — reclaim with `noir cache clear`

$ noir cache clear
Removed 1 cache entry from ... Also reclaimed 2 incomplete writes.
```

`purge_older_than` selects them on mtime like anything else, so a temp file being written right now by a concurrent scan (seconds old) is never touched. `clear` may take one, which the writer already handles: the rename fails, `store` returns false, the next scan re-requests.

## Verification

- Full unit suite: 4219 examples, 0 failures.
- `crystal tool format --check` and ameba clean on all four files.
- Every repro above re-run against a `--release` build.
- Regression-checked the paths that already worked: exit codes, `purge` boundaries (0 / -5 / 36500 / 36501 / non-integer / missing), `purge -h` not purging, `NOIR_CACHE_DISABLE`, `--no-color`/`--no-spinner` routing, a missing cache directory, a directory *named* `*.json` inside the cache, user-dropped non-cache files surviving `clear`, and a scan with `--cache-clear`.
- 13 new specs across both layers.