### PR TITLE
fix(ai-context): validate config feature list, let --ai-context=all override it

### DIFF
--- a/spec/unit_test/ai_context/features_spec.cr
+++ b/spec/unit_test/ai_context/features_spec.cr
@@ -17,7 +17,6 @@ describe "NoirAIContext::FEATURES" do
     # Not `should eq` on a literal list: the point is that the CLI derives
     # from the constant, so a bucket added in one place cannot be missing
     # from the other.
-    AI_CONTEXT_VALID_FEATURES.should eq NoirAIContext::ACCEPTED_FEATURES.to_set
     AI_CONTEXT_FEATURES.should eq NoirAIContext::ACCEPTED_FEATURES
   end
 
@@ -30,7 +29,7 @@ describe "NoirAIContext::FEATURES" do
 
   it "includes sources" do
     NoirAIContext::FEATURES.should contain "sources"
-    AI_CONTEXT_VALID_FEATURES.should contain "sources"
+    AI_CONTEXT_FEATURES.should contain "sources"
   end
 
   it "names callee in the singular, as the validator accepts it" do
@@ -56,5 +55,26 @@ describe "NoirAIContext.parse_feature_set" do
 
   it "tolerates surrounding whitespace and empty entries" do
     NoirAIContext.parse_feature_set(" guards , ,sources ").should eq Set{"guards", "sources"}
+  end
+
+  # The CLI lowercases before storing, but a config-file `ai_context_features`
+  # reaches the filter verbatim. Without folding here, `Guards` matched no
+  # bucket and silently emptied every endpoint's AI context.
+  it "matches bucket names case-insensitively" do
+    NoirAIContext.parse_feature_set("Guards,SOURCES").should eq Set{"guards", "sources"}
+    NoirAIContext.parse_feature_set("ALL").should eq NoirAIContext.all_features
+  end
+end
+
+describe "NoirAIContext.unknown_features" do
+  it "returns nothing for accepted names, in any case" do
+    NoirAIContext.unknown_features("").should be_empty
+    NoirAIContext.unknown_features("guards, sinks ,all").should be_empty
+    NoirAIContext.unknown_features("Guards,SOURCES").should be_empty
+  end
+
+  it "echoes an unknown name in the spelling the user wrote" do
+    NoirAIContext.unknown_features("Sinkz").should eq ["Sinkz"]
+    NoirAIContext.unknown_features("guards,bogus,sinks").should eq ["bogus"]
   end
 end

--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -295,6 +295,49 @@ describe "run_options_parser" do
     end
   end
 
+  # The config file is read before OptionParser runs, so `--ai-context=all`
+  # and the bare flag used to `return` before writing `ai_context_features` —
+  # leaving a config-file narrowing in place. Asking for every bucket on the
+  # command line then produced *fewer* buckets than asking for one.
+  ["all", ""].each do |spec|
+    flag = spec.empty? ? "--ai-context" : "--ai-context=all"
+
+    it "#{flag} resets a config-file ai_context_features to every bucket" do
+      original_argv = ARGV.dup
+      config_path = File.tempname("noir-ai-context", ".yaml")
+      File.write(config_path, "ai_context_features: \"guards\"\n")
+      ARGV.clear
+      ARGV.concat(["-b", "./app", "--config-file", config_path, flag])
+
+      begin
+        noir_options = run_options_parser()
+        noir_options["ai_context"].should be_true
+        noir_options["ai_context_features"].to_s.should eq("")
+      ensure
+        File.delete?(config_path)
+        ARGV.clear
+        ARGV.concat(original_argv)
+      end
+    end
+  end
+
+  it "--ai-context=signals overrides a config-file ai_context_features" do
+    original_argv = ARGV.dup
+    config_path = File.tempname("noir-ai-context", ".yaml")
+    File.write(config_path, "ai_context_features: \"guards\"\n")
+    ARGV.clear
+    ARGV.concat(["-b", "./app", "--config-file", config_path, "--ai-context=signals"])
+
+    begin
+      noir_options = run_options_parser()
+      noir_options["ai_context_features"].to_s.should eq("signals")
+    ensure
+      File.delete?(config_path)
+      ARGV.clear
+      ARGV.concat(original_argv)
+    end
+  end
+
   it "--ai-context=callee accepts the explicit-equals form" do
     original_argv = ARGV.dup
     ARGV.clear

--- a/src/ai_context/features.cr
+++ b/src/ai_context/features.cr
@@ -26,16 +26,34 @@ module NoirAIContext
 
   # Parses a `--ai-context=…` value into the set of buckets that survive the
   # filter. An empty value, or one naming `all`, means every bucket.
+  #
+  # Names are case-folded to match the CLI, which lowercases before storing:
+  # a config-file `ai_context_features: "Guards"` reaches here unmodified and
+  # would otherwise match no bucket at all.
   def self.parse_feature_set(raw : String) : Set(String)
     return all_features if raw.empty?
 
     filtered = Set(String).new
     raw.split(',').each do |feature|
-      f = feature.strip
+      f = feature.strip.downcase
       next if f.empty?
       return all_features if f == FEATURE_ALL
       filtered << f
     end
     filtered
+  end
+
+  # Names in `raw` that are outside the accepted vocabulary, in the user's
+  # original spelling so an error message can echo the typo as written.
+  #
+  # `--ai-context=` validates through this; so does the effective option
+  # value after config + CLI are merged. Without the second check a typo in
+  # a config file's `ai_context_features` reached `parse_feature_set`,
+  # matched no bucket, and silently emptied every endpoint's AI context —
+  # the same value on the command line was a hard error.
+  def self.unknown_features(raw : String) : Array(String)
+    raw.split(',').map(&.strip).reject(&.empty?).reject do |feature|
+      ACCEPTED_FEATURES.includes?(feature.downcase)
+    end
   end
 end

--- a/src/options.cr
+++ b/src/options.cr
@@ -171,8 +171,8 @@ end
 # <the typo>". A single bare word still has to match a known feature
 # exactly, since that shape is genuinely ambiguous with a real one-word
 # directory name (`noir scan --ai-context myapp` must keep scanning `myapp`).
-# Both this and `AI_CONTEXT_VALID_FEATURES` below used to spell the
-# vocabulary out by hand, and both omitted `sources`.
+# Both this and the flag's own validator used to spell the vocabulary out
+# by hand, and both omitted `sources`.
 AI_CONTEXT_FEATURES = NoirAIContext::ACCEPTED_FEATURES
 
 def normalize_ai_context_flag(args : Array(String)) : Array(String)
@@ -584,6 +584,18 @@ def run_options_parser
     append_to_yaml_array(noir_options, "base", positional)
   end
 
+  # Validate the *effective* feature list, not just the one `--ai-context`
+  # supplied. `ai_context_features` is also a config-file key, and that path
+  # never reached the flag's validator: an unknown bucket name there matched
+  # nothing in `parse_feature_set`, so every bucket was filtered out and the
+  # run emitted `ai_context: null` for every endpoint with no diagnostic.
+  # A CLI flag has already normalized its own value by this point, so this
+  # only ever fires on a config-file value that survived unchanged.
+  validate_ai_context_features(
+    noir_options["ai_context_features"]?.try(&.to_s) || "",
+    "config ai_context_features"
+  )
+
   noir_options
 end
 
@@ -645,24 +657,31 @@ end
 # `--ai-context[=LIST]` always enables AI context output. An empty LIST
 # means "every category"; a non-empty LIST narrows the output to the
 # named categories.
-AI_CONTEXT_VALID_FEATURES = NoirAIContext::ACCEPTED_FEATURES.to_set
-
 def apply_ai_context(noir_options : Hash(String, YAML::Any), spec : String)
   noir_options["ai_context"] = YAML::Any.new(true)
+  validate_ai_context_features(spec, "--ai-context")
 
-  raw_list = spec.split(',').map(&.strip).reject(&.empty?)
-  list = raw_list.map(&.downcase)
-  return if list.empty? || list.includes?("all")
-
-  list.each_with_index do |feature, idx|
-    unless AI_CONTEXT_VALID_FEATURES.includes?(feature)
-      # Echo the user's original spelling (not the lowercased form)
-      # in the error so a typo like `Sinkz` reads as the user wrote
-      # it.
-      STDERR.puts "ERROR: --ai-context: unknown feature '#{raw_list[idx]}'. Valid: #{(AI_CONTEXT_VALID_FEATURES.to_a - ["all"]).join(", ")}.".colorize(:yellow)
-      exit(1)
-    end
-  end
+  list = spec.split(',').map(&.strip.downcase).reject(&.empty?)
+  # An empty list, or one naming `all`, means every bucket. Write that out
+  # as the empty value instead of returning early: the config file is read
+  # before OptionParser runs, so an early return left a config-file
+  # `ai_context_features: "guards"` in place and `--ai-context=all` (and the
+  # bare flag) — the two spellings that mean "everything" — were the only
+  # ones that could not override it.
+  list.clear if list.includes?(NoirAIContext::FEATURE_ALL)
 
   noir_options["ai_context_features"] = YAML::Any.new(list.join(","))
+end
+
+# Rejects AI-context bucket names outside the accepted vocabulary. `origin`
+# names the source in the error so a config-file typo doesn't read as a
+# command-line one.
+def validate_ai_context_features(spec : String, origin : String)
+  unknown = NoirAIContext.unknown_features(spec)
+  return if unknown.empty?
+
+  # Echo the user's original spelling (not the lowercased form) so a typo
+  # like `Sinkz` reads as it was written.
+  STDERR.puts "ERROR: #{origin}: unknown feature '#{unknown.first}'. Valid: #{NoirAIContext::FEATURES.join(", ")}.".colorize(:yellow)
+  exit(1)
 end


### PR DESCRIPTION
## Summary

`ai_context_features` is reachable two ways — `--ai-context=LIST` and the config-file key — but only the flag was validated. Two defects fell out of that.

### 1. A config-file typo silently emptied every endpoint's AI context

An unknown bucket name in the config matched nothing in `parse_feature_set`, so `apply_feature_filter` cleared every bucket and the run emitted `ai_context: null` for every endpoint, with no diagnostic. The same value on the command line was a hard error.

```console
$ noir -b ./app --config-file cfg.yaml -f json    # cfg: ai_context_features: "sinkz"
# before: every endpoint -> "ai_context": null, exit 0
# after:  ERROR: config ai_context_features: unknown feature 'sinkz'. Valid: guards, callee, sources, sinks, validators, signals.

$ noir -b ./app --ai-context=sinkz                # unchanged
ERROR: --ai-context: unknown feature 'sinkz'. Valid: guards, callee, sources, sinks, validators, signals.
```

Case was inconsistent for the same reason: the flag lowercased before storing, the config path did not, so `ai_context_features: "Guards"` also matched no bucket and emptied the context.

### 2. `--ai-context=all` could not override a config-file narrowing

`apply_ai_context` returned early for an empty list and for `all`, before writing `ai_context_features`. The config file is read *before* `OptionParser` runs, so the early return left the config value in place — and the two spellings that mean "everything" were the only ones that could not override it.

With `ai_context_features: "guards"` in the config:

| flag | before | after |
|---|---|---|
| `--ai-context=signals` | `signals` only ✅ | unchanged |
| `--ai-context=all` | `guards` only ❌ | every bucket ✅ |
| `--ai-context` (bare) | `guards` only ❌ | every bucket ✅ |

Asking for every bucket produced *fewer* buckets than asking for one.

## Changes

- `parse_feature_set` case-folds bucket names.
- New `NoirAIContext.unknown_features` is now the single vocabulary check. It runs for the flag, and again on the effective value after config + CLI merge, so a config-only typo gets the same rejection.
- `apply_ai_context` writes the empty value instead of returning early.
- Drops the now-unused `AI_CONTEXT_VALID_FEATURES` (the vocabulary already derives from `NoirAIContext::ACCEPTED_FEATURES`).

## Verification

- `crystal spec spec/unit_test` — 4225 examples, 0 failures.
- `just check` — format + ameba clean (1817 files).
- Behavior above reproduced against the built binary before and after.

New specs cover the case-folding, `unknown_features` (including that it echoes the user's original spelling), and the config-override matrix for `=all` / bare / `=signals`.