### PR TITLE
fix(ai-context): make sensitive_response fire on real handler shapes

### DIFF
--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -2256,6 +2256,85 @@ describe "NoirAIContext" do
     end
   end
 
+  # The guard that keeps the check off prose inside a string value —
+  # "the noun must not be preceded by a quote" — also excluded every
+  # *quoted key*, which is how JSON, Python dicts, Go maps and PHP
+  # arrays spell a response field. The check silently stopped firing on
+  # the dominant shape; only JS/Ruby-style bare keys reached it.
+  {
+    {"js", %({ name: u.name, "token": u.access_token })},
+    {"python", %({"user": name, "access_token": tok})},
+    {"single-quoted", %({'refresh_token': tok})},
+  }.each do |(label, payload)|
+    it "emits sensitive_response for a #{label} quoted credential key" do
+      source = <<-CODE
+        app.get('/me', (req, res) => {
+          res.json(#{payload})
+        })
+        CODE
+
+      with_temp_ai_context_source(source) do |path|
+        endpoint = Endpoint.new("/me", "GET")
+        details = endpoint.details
+        details.add_path(PathInfo.new(path, 1))
+        endpoint.details = details
+
+        context = NoirAIContext.apply([endpoint])[0].ai_context.should_not be_nil
+        context.signals.map(&.kind).should contain("sensitive_response")
+      end
+    end
+  end
+
+  # A real handler assembles the payload first and serializes it at the
+  # end, so the emitter and the credential key sit further apart than the
+  # default 12-line / 240-char route scope. Under that window the two
+  # could never co-occur and the check could not fire on the shape it
+  # exists to catch.
+  it "emits sensitive_response when the emitter is far below the credential key" do
+    filler = (1..18).map { |i| "  const step#{i} = compute(#{i})" }.join("\n")
+    source = <<-CODE
+      app.get('/session', (req, res) => {
+        const user = { id: u.id, "apiKey": u.api_key }
+      #{filler}
+        res.json({ user: user })
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/session", "GET")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+
+      context = NoirAIContext.apply([endpoint])[0].ai_context.should_not be_nil
+      context.signals.map(&.kind).should contain("sensitive_response")
+    end
+  end
+
+  # FastAPI and modern Flask handlers serialize a returned literal with
+  # no helper call at all, so an emitter list built purely from helper
+  # names (`jsonify`, `res.json`, …) skipped them entirely.
+  it "emits sensitive_response for a handler that returns a bare dict literal" do
+    source = <<-CODE
+      @bp.route('/tokens', methods=['POST'])
+      def get_token():
+          token = basic_auth.current_user().get_token()
+          return {'token': token}
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/tokens", "POST")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+
+      context = NoirAIContext.apply([endpoint])[0].ai_context.should_not be_nil
+      signal = context.signals.find { |entry| entry.kind == "sensitive_response" }
+      signal = signal.should_not be_nil
+      signal.name.should eq("token")
+    end
+  end
+
   it "emits sensitive_response when a Kotlin handler directly returns a credential value" do
     source = <<-CODE
       @GetMapping
@@ -2322,6 +2401,28 @@ describe "NoirAIContext" do
       # If it does fire here it's a false positive — surface it via
       # the assertion so it's visible if the regex regresses.
       sensitive.should be_false
+    end
+  end
+
+  # Admitting quoted keys must not admit a credential noun that merely
+  # *opens* a string value. The quoted branch only matches when the
+  # string closes right after the noun, so `"password: required"` — the
+  # case the original quote guard was written for — still stays quiet.
+  it "does NOT emit sensitive_response when a credential noun opens a string value" do
+    source = <<-CODE
+      app.get('/help', (req, res) => {
+        res.json({ hint: "password: required", detail: "token: see docs above" })
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/help", "GET")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+
+      context = NoirAIContext.apply([endpoint])[0].ai_context.should_not be_nil
+      context.signals.any? { |s| s.kind == "sensitive_response" }.should be_false
     end
   end
 

--- a/src/ai_context/builder.cr
+++ b/src/ai_context/builder.cr
@@ -357,29 +357,72 @@ module NoirAIContext
     # Sensitive-response detection runs as a two-step check on the
     # route-scope snippet:
     #
-    #   1. RESPONSE_EMITTER_PATTERN — the snippet calls a response-
-    #      serializing helper (`res.json`, `jsonify`, `render json:`,
-    #      `to_json`, `JsonResponse`, …).
+    #   1. RESPONSE_EMITTER_PATTERN — the snippet serializes a response,
+    #      either through a helper (`res.json`, `jsonify`, `render json:`,
+    #      `to_json`, …) or by returning a literal (`return {...}`).
     #   2. CREDENTIAL_KEY_IN_RESPONSE — the snippet also has a
-    #      credential noun *as a key* (followed by `:`, and not
-    #      preceded by a quote or word character — so the noun
-    #      appearing inside a string value like
-    #      `{ message: "Set X-API-KEY header" }` doesn't fire).
+    #      credential noun *as a key*, in either of the two spellings
+    #      a response literal uses:
+    #        bare   — `{ token: … }`   (JS/TS shorthand, Ruby, YAML)
+    #        quoted — `{ "token": … }` (JSON, Python dicts, Go maps,
+    #                                   PHP arrays, any serialized body)
     #
     # Both have to match in the same scope. The earlier single-regex
     # version was too loose and caught english prose mentioning
-    # credentials in response strings.
-    RESPONSE_EMITTER_PATTERN         = /\b(jsonify|res\.json|json_response|JsonResponse|render\s+json:|to_json|respond_with)\b/i
-    CREDENTIAL_KEY_IN_RESPONSE       = /[^"'\w](password|passwd|token|secret|api[_-]?key|session_id|access_token|refresh_token|private_key)\s*:/i
+    # credentials in response strings, so the fix required the noun
+    # not be preceded by a quote. That over-corrected: it also
+    # excluded every *quoted key*, which is the dominant shape in
+    # most languages, and the signal quietly stopped firing on them.
+    #
+    # The two branches below keep the original guard for bare keys
+    # while admitting quoted ones, and stay narrow because the quoted
+    # branch requires the string to *close* immediately after the
+    # noun. `{ message: "Set X-API-KEY header" }` still doesn't fire —
+    # the noun sits mid-string, so no closing quote follows it.
+    CREDENTIAL_NOUNS_IN_RESPONSE = "password|passwd|token|secret|api[_-]?key|session_id|access_token|refresh_token|private_key"
+
+    # The emitter list was built from helper calls (`jsonify`, `res.json`,
+    # …) and so missed the frameworks that serialize a returned literal
+    # with no helper at all: FastAPI and modern Flask handlers just
+    # `return {...}`, which is the single most common response shape in
+    # the Python corpus. Without it the credential-key check could not run
+    # on those handlers no matter what the payload held.
+    RESPONSE_EMITTER_PATTERN = /\b(jsonify|res\.json|res\.send|json_response|JsonResponse|JSONResponse|make_response|render\s+json:|to_json|respond_with)\b|\breturn\s*\{/i
+
+    # Capture 1 is the bare-key noun, capture 3 the quoted-key noun;
+    # exactly one of them is set per match.
+    CREDENTIAL_KEY_IN_RESPONSE = Regex.new(
+      "(?:[^\"'\\w](#{CREDENTIAL_NOUNS_IN_RESPONSE})|([\"'])(#{CREDENTIAL_NOUNS_IN_RESPONSE})\\2)\\s*:",
+      Regex::Options::IGNORE_CASE
+    )
+
     KOTLIN_CREDENTIAL_RETURN_PATTERN = /\bfun\s+\w+[^{|;]*=\s*(?:this\.)?(password|passwd|token|secret|api[_-]?key|session_?id|access_?token|refresh_?token|private_?key)\b/i
+
+    # This check needs the response emitter and the credential key in the
+    # same window, and in real handlers they sit far apart — the body
+    # assembles a dict/struct first and serializes it at the end. Under the
+    # default 12-line / 240-char route scope the two could not co-occur, so
+    # the signal never fired on the shape it exists to catch. Widen the
+    # window for this check only; the scope walk still stops at the end of
+    # the handler, so it cannot pair one route's emitter with another
+    # route's payload.
+    SENSITIVE_RESPONSE_SCOPE_LINES =   40
+    SENSITIVE_RESPONSE_SCOPE_CHARS = 1200
 
     private def add_sensitive_response_signal(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
       return if context.signals.any? { |s| s.kind == "sensitive_response" }
       return if endpoint.details.code_paths.empty?
 
       endpoint.details.code_paths.each do |path_info|
+        # `scope` stays the default-width snippet so the emitted evidence
+        # keeps the same size as every other entry; `body` is the wider
+        # view used only for detection.
         scope = @reader.route_scope_snippet_for(path_info.path, path_info.line)
         next unless scope
+        body = @reader.route_scope_snippet_for(
+          path_info.path, path_info.line,
+          SENSITIVE_RESPONSE_SCOPE_LINES, SENSITIVE_RESPONSE_SCOPE_CHARS
+        ) || scope
 
         if match = scope.match(KOTLIN_CREDENTIAL_RETURN_PATTERN)
           field = match[1]? || "credential"
@@ -397,9 +440,9 @@ module NoirAIContext
           return
         end
 
-        next unless scope.matches?(RESPONSE_EMITTER_PATTERN)
-        if match = scope.match(CREDENTIAL_KEY_IN_RESPONSE)
-          field = match[1]? || "credential"
+        next unless body.matches?(RESPONSE_EMITTER_PATTERN)
+        if match = body.match(CREDENTIAL_KEY_IN_RESPONSE)
+          field = match[1]? || match[3]? || "credential"
           context.push_signal(AIContextEntry.new(
             "sensitive_response",
             field.downcase,

--- a/src/ai_context/source_reader.cr
+++ b/src/ai_context/source_reader.cr
@@ -55,11 +55,21 @@ module NoirAIContext
       snippet
     end
 
-    def route_scope_snippet_for(path : String?, line : Int32?) : String?
+    # `max_lines` / `max_chars` default to the limits every caller used
+    # before they were parameterized. A caller that needs to see further
+    # into the handler — `sensitive_response` has to find a response
+    # emitter and a credential key in the *same* scope, and they are
+    # routinely more than 12 lines apart — raises them. The block-boundary
+    # walk below is unchanged either way, so a wider window still stops at
+    # the end of this handler rather than bleeding into the next one.
+    def route_scope_snippet_for(path : String?,
+                                line : Int32?,
+                                max_lines : Int32 = MAX_ROUTE_SCOPE_LINES,
+                                max_chars : Int32 = MAX_SNIPPET_CHARS) : String?
       return unless path && line
       return if line < 1
 
-      cache_key = "#{path}:#{line}"
+      cache_key = "#{path}:#{line}:#{max_lines}:#{max_chars}"
       if cached = @route_scope_cache[cache_key]?
         return cached
       end
@@ -101,7 +111,7 @@ module NoirAIContext
       # that column (= the next top-level statement / next decorator).
       def_indent : Int32? = nil
 
-      start_idx.upto(Math.min(start_idx + MAX_ROUTE_SCOPE_LINES - 1, lines.size - 1)) do |idx|
+      start_idx.upto(Math.min(start_idx + max_lines - 1, lines.size - 1)) do |idx|
         raw_line = lines[idx]
         line_indent = raw_line.size - raw_line.lstrip.size
 
@@ -172,7 +182,7 @@ module NoirAIContext
 
       snippet = selected.join(" | ").gsub(/\s+/, " ").strip
       return if snippet.empty?
-      snippet = snippet.size > MAX_SNIPPET_CHARS ? snippet[0, MAX_SNIPPET_CHARS] : snippet
+      snippet = snippet.size > max_chars ? snippet[0, max_chars] : snippet
       @route_scope_cache[cache_key] = snippet
       snippet
     end


### PR DESCRIPTION
## Summary

`sensitive_response` flags an endpoint that serializes a credential field into its response body. On real code it almost never fired. Three gates had to line up, and each one excluded a common, idiomatic shape.

### 1. Quoted keys were excluded

The guard that keeps the check off prose inside a string value required the credential noun **not be preceded by a quote**. That also excluded every *quoted key* — the spelling used by JSON, Python dicts, Go maps and PHP arrays. Only JS/Ruby-style bare keys reached the check:

```console
GET /bare/:id    -> [..., sensitive_response, ...]   # res.json({ token: t })
GET /quoted/:id  -> [...]                            # res.json({ "token": t })   <- missed
```

The quoted branch added here requires the string to **close right after the noun**, so the case the original guard was written for still stays quiet:

| snippet | old | new |
|---|---|---|
| `{ token: t }` | fires | fires |
| `{ "token": t }` | — | **fires** |
| `{'access_token': tok}` | — | **fires** |
| `map[string]string{"refresh_token": r}` | — | **fires** |
| `{ message: "Set X-API-KEY header" }` | — | — |
| `{ hint: "password: required" }` | — | — |

### 2. The route scope was too small

The default window is 12 lines / 240 chars, but a handler assembles its payload first and serializes it at the end, so the emitter and the credential key are routinely further apart than that and could never co-occur in one snippet.

`route_scope_snippet_for` now takes optional `max_lines` / `max_chars` — every other caller keeps today's values — and this check asks for 40 / 1200. The block-boundary walk is unchanged, so a wider window still stops at the end of the handler and **cannot pair one route's emitter with another route's payload**. (Verified: redash's `/api/config` sits 5 lines above a different handler holding an `"apiKey"`, and it correctly does not fire.)

### 3. The emitter list was helper-only

It was built from call names (`jsonify`, `res.json`, …) and so skipped the frameworks that serialize a returned literal with no helper at all — FastAPI and modern Flask just `return {...}`, the most common response shape in the Python corpus. Adds `return {`, `res.send`, `JSONResponse`, `make_response`.

## Verification

A/B against 8 OSS repos with before/after binaries — juice-shop, redash, superset, dispatch, full-stack-fastapi-template, flask, microblog, node-express-realworld — **1268 endpoints**:

| | before | after |
|---|---|---|
| `sensitive_response` | 0 | 2 |
| lost | — | 0 |
| false positives | — | 0 |

Both new detections are genuine:

```python
# microblog  POST /tokens
return {'token': token}                        # returns an auth token

# redash     POST /api/dashboards/<id>/share
return {"public_url": public_url, "api_key": api_key.api_key}
#   docstring:  :>json api_key: The API key to use when accessing it.
```

Each needs more than one of the three fixes, which is why the signal was silent on them.

Also run:
- `crystal spec spec/unit_test` — 4225 examples, 0 failures
- `crystal spec spec/functional_test` — 22428 examples, 0 failures
- `just check` — format + ameba clean (1817 files)

New specs cover all three fixes plus a negative case pinning that a credential noun which merely *opens* a string value still does not fire.

## Note

This does not exhaust the gap. Only ~3% of endpoints in the corpus have any recognized response emitter within the route scope, so the emitter vocabulary is still the dominant limiter for this signal. Widening it further is a separate change with its own FP profile.