### PR TITLE
fix(ai-context): drop blank lines from snippets instead of emitting placeholders

### DIFF
--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -21,6 +21,42 @@ describe "NoirAIContext" do
     end
   end
 
+  # Blank lines used to be emitted as bare `N: ` entries. Handlers are
+  # almost always preceded by a blank line or two, so nearly every
+  # snippet opened with a run of placeholders that carried no evidence
+  # and spent part of the 240-char budget the surrounding code needs.
+  it "omits blank lines instead of emitting bare line-number placeholders" do
+    source = "import os\n\n\n\n@app.route('/run')\ndef run():\n    os.system(q)"
+
+    with_temp_ai_context_source(source) do |path|
+      reader = NoirAIContext::SourceReader.new
+
+      # The radius is unchanged — blank lines are dropped from the
+      # window, not backfilled with lines from outside it.
+      window = reader.snippet_for(path, 5, 2).should_not be_nil
+      window.should_not match(/(?:^|\| )\d+: (?=\||\z)/)
+      window.should start_with("5: @app.route('/run')")
+      window.should contain("7: os.system(q)")
+
+      scope = reader.route_scope_snippet_for(path, 5).should_not be_nil
+      scope.should_not match(/(?:^|\| )\d+: (?=\||\z)/)
+      scope.should start_with("5: @app.route('/run')")
+    end
+  end
+
+  it "still captures decorators separated from the handler by a blank line" do
+    source = "@login_required\n\n@app.route('/admin')\ndef admin():\n    pass"
+
+    with_temp_ai_context_source(source) do |path|
+      reader = NoirAIContext::SourceReader.new
+
+      scope = reader.route_scope_snippet_for(path, 3).should_not be_nil
+      scope.should contain("1: @login_required")
+      scope.should contain("3: @app.route('/admin')")
+      scope.should_not match(/(?:^|\| )\d+: (?=\||\z)/)
+    end
+  end
+
   it "builds aggregated AI context from callees and tags" do
     source = <<-CODE
       app.post("/users/:id/avatar", requireAuth, async (req, res) => {

--- a/src/ai_context/source_reader.cr
+++ b/src/ai_context/source_reader.cr
@@ -44,8 +44,18 @@ module NoirAIContext
       end_idx = Math.min(line + radius - 1, lines.size - 1)
       selected = [] of String
 
+      # Blank lines carry no evidence, and every entry is already
+      # prefixed with its own line number, so dropping them loses
+      # nothing an LLM or a reviewer can use. Emitting them produced
+      # bare `N: ` placeholders — the run of blank lines that precedes
+      # most handlers turned into `5: | 6: | 7: | …` at the front of
+      # the snippet — and spent part of the character budget that the
+      # surrounding code needs.
       (start_idx..end_idx).each do |idx|
-        selected << "#{idx + 1}: #{lines[idx].strip}"
+        stripped = lines[idx].strip
+        next if stripped.empty?
+
+        selected << "#{idx + 1}: #{stripped}"
       end
 
       snippet = selected.join(" | ").gsub(/\s+/, " ").strip
@@ -71,18 +81,22 @@ module NoirAIContext
       # annotation lines and blank lines between them. Stops at the
       # first line that's not a decorator / annotation / blank —
       # that's the end of the preceding declaration boundary.
+      #
+      # A blank line only lets the scan *continue* (decorators are
+      # often separated by one); it is not itself evidence, so it is
+      # never appended. Appending them emitted bare `N: ` placeholders
+      # for the run of blank lines that precedes almost every handler,
+      # which read as a bug and — worse — spent part of the snippet's
+      # character budget, truncating real code off the end.
       lead_lines = [] of String
       back_idx = line - 2
       MAX_LEAD_DECORATOR_LINES.times do
         break if back_idx < 0
-        raw = lines[back_idx]
-        stripped = raw.strip
-        if stripped.empty? || stripped.starts_with?("@")
-          lead_lines.unshift("#{back_idx + 1}: #{stripped}")
-          back_idx -= 1
-        else
-          break
-        end
+        stripped = lines[back_idx].strip
+        break unless stripped.empty? || stripped.starts_with?("@")
+
+        lead_lines.unshift("#{back_idx + 1}: #{stripped}") unless stripped.empty?
+        back_idx -= 1
       end
 
       start_idx = line - 1
@@ -123,7 +137,13 @@ module NoirAIContext
           end
         end
 
-        selected << "#{idx + 1}: #{raw_line.strip}"
+        # Blank lines inside the body are skipped for the same reason as
+        # the lead-in ones: they add a bare `N: ` placeholder and nothing
+        # else. Only the append is skipped — the block-boundary tracking
+        # below still sees every line, so brace depth and indent
+        # detection are unaffected.
+        body_line = raw_line.strip
+        selected << "#{idx + 1}: #{body_line}" unless body_line.empty?
 
         sanitized = raw_line.gsub(/(['"]).*?\1/, "\"\"")
         opens = sanitized.count('{')


### PR DESCRIPTION
## Summary

Every snippet line is rendered as `<line-number>: <content>` — including lines with no content. Handlers are almost always preceded by a blank line or two, so most snippets opened with a run of bare placeholders:

```
4: | 5: | 6: | 7: | 8: @app.route("/run", ...) | 9: def run(): | 10: logger.info(...) | 11: os.system(request.form.get
```

Those carry no evidence — the line number of an empty line tells a reader nothing — and they are not free. Snippets are capped at 240 characters, so the placeholders pushed real code off the end; note the example truncates mid-call at `os.system(request.form.get`. After:

```
8: @app.route("/run", methods=["POST"]) | 9: def run(): | 10: logger.info("user %s", request.form.get("q")) | 11: os.system(request.form.get("q")) | 12:
```

## Changes

Blank lines are skipped in all three places that build a snippet: the fixed-radius window, the route-scope lead-in, and the route-scope body.

- **Radius and line budgets are unchanged** — blanks are dropped from the window, not backfilled with lines from outside it.
- In the lead-in a blank still lets the scan *continue*, so a decorator separated from its handler by a blank line is still captured.
- The route-scope block-boundary tracking still sees every line; only the append is skipped, so brace-depth and indent detection are untouched.

## Verification

Fixture corpus (3297 endpoints / 19670 snippets) + 8 OSS repos — juice-shop, redash, superset, dispatch, full-stack-fastapi-template, flask, microblog, node-express-realworld:

| | before | after |
|---|---|---|
| snippets opening with placeholders | 3937 | **0** |
| snippets containing any placeholder | 11772 | 14 ¹ |
| snippets hitting the 240-char cap | 1348 | 1237 |

¹ the remainder are the 240-char cap cutting mid-entry, e.g. `… | 37: // Server-streaming method | 38:` — a truncation artifact, not a blank line.

**No detection was lost.** The freed budget changed 6 entries, all for the better. Five are evidence labels that had been truncated mid-token:

```
auth_guard       authenticatedU              -> authenticatedUsers
template_render  render(                     -> render(user)
template_render  render_template(template_file, **base_par -> …**base_parameters.templa
redirect         redirect(url_for("Sq        -> redirect(url_for("SqllabVie
template_render  render_template('           -> render_template('user_popup.h
```

The sixth is a **false positive that disappeared**. Flask's tutorial registers

```python
@bp.route("/register", methods=("GET", "POST"))
def register():
    """Register a new user.
    ...
    """
    if request.method == "POST":
        ...
        db.commit()
```

`GET /auth/register` was flagged `unsafe_method` (`GET → db.commit`), plus a `priority_review` scored off it, because the truncated scope never reached the `request.method` line that `METHOD_DISPATCH_PATTERN` exists to suppress on. It reaches it now.

Also run:
- `crystal spec spec/unit_test` — 4227 examples, 0 failures
- `crystal spec spec/functional_test` — 22428 examples, 0 failures
- `just check` — format + ameba clean

New specs pin that no bare placeholder is emitted by either snippet builder, and that a decorator separated from its handler by a blank line is still captured.

## Note

Touches `source_reader.cr`, as does #2406 (different hunks — no conflict expected). Whichever lands second may want a rebase.