### PR TITLE
refactor(ai-context): stop redoing work whose answer is constant

### DIFF
--- a/src/ai_context/builder.cr
+++ b/src/ai_context/builder.cr
@@ -1152,22 +1152,41 @@ module NoirAIContext
       true
     end
 
+    OUTBOUND_URI_PATTERN          = /\.\s*uri\s*\(\s*["']([^"']+)["']/
+    OUTBOUND_TEMPLATE_URI_PATTERN = /\.\s*(?:getForObject|postForObject|exchange)\s*\(\s*["']([^"']+)["']/
+    OUTBOUND_ANY_URI_PATTERN      = /\.\s*(?:uri|getForObject|postForObject|exchange)\s*\(\s*["']([^"']+)["']/
+
     private def outbound_uri_from_snippet(snippet : String?, line : Int32?) : String?
       return unless snippet
 
-      if line && (line_match = snippet.match(/(?:^|\|\s*)#{line}:\s*([^|]+)/))
-        if uri_match = line_match[1].match(/\.\s*uri\s*\(\s*["']([^"']+)["']/)
+      if line && (segment = snippet_segment_for_line(snippet, line))
+        if uri_match = segment.match(OUTBOUND_URI_PATTERN)
           return uri_match[1]
         end
-        if uri_match = line_match[1].match(/\.\s*(?:getForObject|postForObject|exchange)\s*\(\s*["']([^"']+)["']/)
+        if uri_match = segment.match(OUTBOUND_TEMPLATE_URI_PATTERN)
           return uri_match[1]
         end
       end
 
-      match = snippet.match(/\.\s*(?:uri|getForObject|postForObject|exchange)\s*\(\s*["']([^"']+)["']/)
+      match = snippet.match(OUTBOUND_ANY_URI_PATTERN)
       return unless match
 
       match[1]
+    end
+
+    # Pulls the `<line>: …` segment out of a snippet. Snippets are built
+    # by joining `"<n>: <code>"` entries with `" | "`, so splitting on the
+    # separator is exact — and it avoids interpolating the line number
+    # into a regex literal, which made Crystal recompile the pattern on
+    # every outbound_http sink.
+    private def snippet_segment_for_line(snippet : String, line : Int32) : String?
+      prefix = "#{line}:"
+      snippet.split('|').each do |part|
+        stripped = part.strip
+        return stripped[prefix.size..].strip if stripped.starts_with?(prefix)
+      end
+
+      nil
     end
 
     private def add_source_scan_entries(context : AIContext, endpoint : Endpoint)
@@ -1524,9 +1543,7 @@ module NoirAIContext
       # credential_input signals (analyzer missed the param) so
       # destructured login handlers still light up.
       credential_param = endpoint.params.any? do |p|
-        PARAM_PATTERNS.find { |pattern| pattern.kind == "credential_input" }.try do |pattern|
-          PatternMatcher.matches_any?(p.name, pattern.name_patterns)
-        end
+        PatternMatcher.matches_any?(p.name, CREDENTIAL_INPUT_NAME_PATTERNS)
       end
       credential_signal = context.signals.any? { |s| s.kind == "credential_input" }
       if (credential_param || credential_signal) && !has_rate_limit
@@ -1651,8 +1668,14 @@ module NoirAIContext
       tag.name
     end
 
+    # Resolved once from the catalog instead of re-scanning PARAM_PATTERNS
+    # on every call. `identifier_like?` in particular runs several times
+    # per parameter per endpoint, and the answer never changes.
+    IDENTIFIER_INPUT_NAME_PATTERNS = PARAM_PATTERNS.find! { |pattern| pattern.kind == "identifier_input" }.name_patterns
+    CREDENTIAL_INPUT_NAME_PATTERNS = PARAM_PATTERNS.find! { |pattern| pattern.kind == "credential_input" }.name_patterns
+
     private def identifier_like?(name : String) : Bool
-      return true if PatternMatcher.matches_any?(name, PARAM_PATTERNS.find! { |pattern| pattern.kind == "identifier_input" }.name_patterns)
+      return true if PatternMatcher.matches_any?(name, IDENTIFIER_INPUT_NAME_PATTERNS)
       return true if identifier_suffix_like?(name)
 
       false

--- a/src/ai_context/source_reader.cr
+++ b/src/ai_context/source_reader.cr
@@ -177,10 +177,18 @@ module NoirAIContext
       snippet
     end
 
+    # Read-only view of a file's lines. The result is the cached array
+    # itself, not a copy — callers must not mutate it.
+    #
+    # It used to `.dup`, which copied every line of the file on each
+    # call. `add_query_parameter_binding_validator` calls this for every
+    # endpoint × code_path unconditionally, so a 5000-line controller
+    # scanned for 200 endpoints paid 200 full-array copies for data
+    # nobody writes to. No caller mutates the result.
     def lines_for(path : String?) : Array(String)
       return [] of String unless path
 
-      read_lines(path).dup
+      read_lines(path)
     end
 
     private def read_lines(path : String) : Array(String)

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -23,6 +23,8 @@ class OutputBuilderCommon < OutputBuilder
                           "read_permission", "write_permission", "grant_uri_permissions",
                           "path_permissions", "extras"]
 
+  @ai_context_features : Set(String)? = nil
+
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       baked = bake_endpoint(endpoint.url, endpoint.params)
@@ -228,8 +230,12 @@ class OutputBuilderCommon < OutputBuilder
 
   # Returns the set of AI-context category names that should be emitted.
   # An empty/unset `ai_context_features` option means "all categories".
+  #
+  # Memoized: the option cannot change mid-render, but this is read
+  # inside the per-endpoint loop, so it was parsing the option string and
+  # allocating a fresh Set once per endpoint.
   private def ai_context_feature_filter : Set(String)
-    NoirAIContext.parse_feature_set(@options["ai_context_features"]?.try(&.to_s) || "")
+    @ai_context_features ||= NoirAIContext.parse_feature_set(@options["ai_context_features"]?.try(&.to_s) || "")
   end
 
   private def append_ai_context_block(r_buffer : String::Builder, label : String, entries : Array(AIContextEntry))


### PR DESCRIPTION
## Summary

Four spots repeated work that can only ever produce the same result. **Output is byte-identical** — JSON and plain, across the fixture corpus and 6 OSS repos.

| | before | after |
|---|---|---|
| `SourceReader#lines_for` | `read_lines(path).dup` — copies the file's line array on every call, for three callers that only read it | returns the cached array, documented read-only |
| `outbound_uri_from_snippet` | interpolates the line number into a regex literal, so Crystal recompiles the pattern on every call | splits the snippet on its `" | "` separator — no regex; the three fixed patterns it does use are hoisted to constants |
| `identifier_like?` + the rate-limit credential check | re-scan `PARAM_PATTERNS` for a fixed `kind` on every call | resolved once into `IDENTIFIER_INPUT_NAME_PATTERNS` / `CREDENTIAL_INPUT_NAME_PATTERNS` |
| `OutputBuilderCommon#ai_context_feature_filter` | parses the option string and allocates a fresh `Set` once per endpoint, inside the render loop | memoized — the option cannot change mid-render |

## This is hygiene, not a speedup

Measured with `just build-release`, median of 5–7 runs. The difference is **inside run-to-run noise on every corpus tried**, including a synthetic worst case built specifically to stress the `.dup` (one 5203-line file, 400 endpoints):

```
superset    2.944s -> 2.928s   (+0.5%)
dispatch    0.523s -> 0.501s   (+4.1%)
fixtures    1.108s -> 1.112s   (-0.4%)
synthetic   0.477s -> 0.474s   (+0.7%)
```

`Array(String)#dup` is a shallow pointer copy, so even 400 copies of a 5000-element array is only a few ms against a 470ms scan. I had expected this to matter more than it does; it doesn't. The change is worth making because the work is pointless, not because it is hot.

The interpolated-regex removal is the one with a known cost profile (Crystal recompiles `/…#{x}…/` on each evaluation), but it only runs for `outbound_http` sinks, which are rare enough not to show up in a whole-scan measurement either.

## Verification

- Byte-identical `-f json` output on fixtures, juice-shop, redash, superset, dispatch, flask, microblog
- Byte-identical plain output on fixtures (exercises the `common.cr` change)
- `crystal spec spec/unit_test` — 4225 examples, 0 failures
- `crystal spec spec/functional_test` — 22428 examples, 0 failures
- `just check` — format + ameba clean