### PR TITLE
fix(tagger): correct Go route-group scoping and Spring controller-level auth annotations

### DIFF
--- a/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
@@ -251,6 +251,21 @@ describe "GoAuthTagger (root-group static-asset exemption)" do
     endpoint.tags.any? { |t| t.name == "auth" }.should be_true
   end
 
+  it "still tags a non-static route under a chained group .Use(auth)" do
+    # `g.Group("/admin").Use(auth)` creates the group and registers the
+    # middleware in one expression — neither an assignment nor a closure
+    # group, so the receiver has to be read off the chain itself.
+    chained = [
+      "package main",
+      "func main() {",
+      "  g := gin.New()",
+      "  g.Group(\"/admin\").Use(AuthMiddleware())",
+      "}",
+    ]
+    endpoint = run_go_auth(chained, "/admin/users", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" }.should be_true
+  end
+
   it "still tags a static route under a truly global engine .Use(auth)" do
     # `r.Use(auth)` (no enclosing group) is a real global middleware: every
     # subsequently registered route, static or not, is guarded. The
@@ -264,5 +279,161 @@ describe "GoAuthTagger (root-group static-asset exemption)" do
     ]
     endpoint = run_go_auth(global, "/index.html", "GET", 30)
     endpoint.tags.any? { |t| t.name == "auth" }.should be_true
+  end
+end
+
+# Assignment groups (`api := r.Group("/api")`) are not delimited by braces, so
+# they cannot share the closure-group stack: modelling both with one stack made
+# sibling groups accumulate, resolving the second group's middleware to
+# "/api/admin". That both dropped the tag from the routes it really guards and
+# — worse for a security tool — claimed auth on unrelated routes that happened
+# to sit under the concatenated prefix.
+describe "GoAuthTagger (sibling route groups)" do
+  #  1 package main
+  #  2 func main() {
+  #  3   r := gin.Default()
+  #  4   api := r.Group("/api")
+  #  5   api.Use(AuthMiddleware())
+  #  6   admin := r.Group("/admin")
+  #  7   admin.Use(AdminAuthMiddleware())
+  #  8   reports := r.Group("/reports")
+  #  9   register(api, admin, reports)
+  # 10 }
+  siblings = [
+    "package main",
+    "func main() {",
+    "  r := gin.Default()",
+    "  api := r.Group(\"/api\")",
+    "  api.Use(AuthMiddleware())",
+    "  admin := r.Group(\"/admin\")",
+    "  admin.Use(AdminAuthMiddleware())",
+    "  reports := r.Group(\"/reports\")",
+    "  register(api, admin, reports)",
+    "}",
+  ]
+
+  it "tags the first group's routes" do
+    endpoint = run_go_auth(siblings, "/api/users", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" && t.description.includes?("AuthMiddleware") }.should be_true
+  end
+
+  it "tags a later sibling group's routes with its own middleware" do
+    endpoint = run_go_auth(siblings, "/admin/stats", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" && t.description.includes?("AdminAuthMiddleware") }.should be_true
+  end
+
+  it "does not tag a sibling group that has no middleware" do
+    endpoint = run_go_auth(siblings, "/reports/daily", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" }.should be_false
+  end
+
+  it "does not claim auth on a route that merely matches the concatenated prefix" do
+    # `/api` has no middleware here and `/internal` does; the endpoint lives
+    # under neither guarded group, so tagging it would report an
+    # unauthenticated route as authenticated.
+    fixture = [
+      "package main",
+      "func main() {",
+      "  r := gin.Default()",
+      "  public := r.Group(\"/api\")",
+      "  internal := r.Group(\"/internal\")",
+      "  internal.Use(SessionAuth())",
+      "  registerPublic(public)",
+      "}",
+    ]
+    endpoint = run_go_auth(fixture, "/api/internal/status", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" }.should be_false
+  end
+
+  # A group built from a non-literal path (`r.Group(cfg.APIBase + "/v1")`) has a
+  # prefix a line-based scanner cannot read. Treating that as the global scope
+  # made a single `.Use(auth)` claim protection for every endpoint in the app —
+  # on apache/answer, 202 of 412 endpoints, including `/healthz` and the routes
+  # registered on the app's explicitly unauthenticated groups. Declining to tag
+  # an unresolvable scope is the same call `spring_security` makes for a filter
+  # chain scoped only by a matcher it cannot resolve.
+  describe "unresolvable group prefixes" do
+    computed = [
+      "package main",
+      "func main() {",
+      "  r := gin.Default()",
+      "  unAuthV1 := r.Group(cfg.APIBase + \"/api/v1\")",
+      "  authV1 := r.Group(cfg.APIBase + \"/api/v1\")",
+      "  authV1.Use(authUserMiddleware.MustAuth())",
+      "  registerUnAuth(unAuthV1)",
+      "  registerAuth(authV1)",
+      "}",
+    ]
+
+    it "does not tag an unrelated endpoint from a group whose prefix is computed" do
+      endpoint = run_go_auth(computed, "/healthz", "GET", 30)
+      endpoint.tags.any? { |t| t.name == "auth" }.should be_false
+    end
+
+    it "does not tag a sibling public group's routes either" do
+      endpoint = run_go_auth(computed, "/api/v1/siteinfo", "GET", 30)
+      endpoint.tags.any? { |t| t.name == "auth" }.should be_false
+    end
+
+    it "still treats a literal-prefix group as scoped" do
+      literal = [
+        "package main",
+        "func main() {",
+        "  r := gin.Default()",
+        "  authV1 := r.Group(\"/api/v1\")",
+        "  authV1.Use(MustAuth())",
+        "  register(authV1)",
+        "}",
+      ]
+      run_go_auth(literal, "/api/v1/me", "GET", 30)
+        .tags.any? { |t| t.name == "auth" }.should be_true
+      run_go_auth(literal, "/healthz", "GET", 30)
+        .tags.any? { |t| t.name == "auth" }.should be_false
+    end
+
+    it "still treats a bare engine-level .Use(auth) as global" do
+      # Only *group* scopes become unresolvable — a global `.Use` genuinely
+      # guards every route registered after it, so this must keep working.
+      global = [
+        "package main",
+        "func main() {",
+        "  r := gin.Default()",
+        "  r.Use(AuthMiddleware())",
+        "}",
+      ]
+      endpoint = run_go_auth(global, "/anything", "GET", 30)
+      endpoint.tags.any? { |t| t.name == "auth" }.should be_true
+    end
+  end
+
+  it "does not double-count the prefix of a closure group that is also assigned" do
+    # `r.Group("/admin", handler)` is a closure group *and* an assignment; the
+    # two forms must both resolve to /admin, not /admin/admin.
+    both = [
+      "package main",
+      "func main() {",
+      "  r := gin.Default()",
+      "  admin := r.Group(\"/admin\", func(c *gin.Context) { c.Next() })",
+      "  admin.Use(AdminAuth())",
+      "  registerAdmin(admin)",
+      "}",
+    ]
+    endpoint = run_go_auth(both, "/admin/stats", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" && t.description.includes?("AdminAuth") }.should be_true
+  end
+
+  it "still inherits the parent group's middleware in a nested group" do
+    nested = [
+      "package main",
+      "func main() {",
+      "  r := gin.Default()",
+      "  api := r.Group(\"/api\")",
+      "  api.Use(AuthMiddleware())",
+      "  admin := api.Group(\"/admin\")",
+      "  register(api, admin)",
+      "}",
+    ]
+    endpoint = run_go_auth(nested, "/api/admin/stats", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" && t.description.includes?("AuthMiddleware") }.should be_true
   end
 end

--- a/spec/unit_test/tagger/framework_taggers/spring_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/spring_auth_spec.cr
@@ -2,6 +2,27 @@ require "file_utils"
 require "../../../spec_helper"
 require "../../../../src/tagger/tagger"
 
+# Write `source` to a temp controller file and run SpringAuthTagger against a
+# single endpoint whose handler is recorded at `line`.
+def run_spring_class_level(source : String, line : Int32, ext : String = "java") : Endpoint
+  CodeLocator.instance.clear_all
+  tmpdir = File.tempname("spring_class_level")
+  Dir.mkdir_p(tmpdir)
+  file = File.join(tmpdir, "AdminController.#{ext}")
+  File.write(file, source)
+  CodeLocator.instance.push("file_map", file)
+
+  noir_options = create_test_options
+  noir_options["base"] = YAML::Any.new(tmpdir)
+  details = Details.new(PathInfo.new(file, line))
+  details.technology = "java_spring"
+  endpoint = Endpoint.new("/admin/users", "GET", [] of Param, details)
+
+  SpringAuthTagger.new(noir_options).perform([endpoint])
+  FileUtils.rm_rf(tmpdir)
+  endpoint
+end
+
 describe "SpringAuthTagger" do
   fixture_base = "#{__DIR__}/../../../functional_test/fixtures/java/spring_auth"
   controller_path = "#{fixture_base}/src/main/java/com/example/Controller.java"
@@ -373,5 +394,118 @@ describe "SpringAuthTagger" do
     tagger.perform([endpoint])
 
     endpoint.tags.empty?.should be_true
+  end
+end
+
+# A controller-level `@PreAuthorize`/`@Secured`/`@RolesAllowed` guards every
+# handler the class declares. The per-handler backward walk stops at the
+# `public`/`class` boundary by design, so it can never reach the class
+# declaration — every handler of an `@PreAuthorize("hasRole('ADMIN')")`
+# controller was reported as unauthenticated.
+describe "SpringAuthTagger (class-level annotations)" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  #  1 package com.example;
+  #  2 (blank)
+  #  3 @RestController
+  #  4 @RequestMapping("/admin")
+  #  5 @PreAuthorize("hasRole('ADMIN')")
+  #  6 public class AdminController {
+  #  7 (blank)
+  #  8     @GetMapping("/users")
+  #  9     public String listUsers() {
+  # 10         return "users";
+  # 11     }
+  # 12 }
+  guarded = <<-JAVA
+    package com.example;
+
+    @RestController
+    @RequestMapping("/admin")
+    @PreAuthorize("hasRole('ADMIN')")
+    public class AdminController {
+
+        @GetMapping("/users")
+        public String listUsers() {
+            return "users";
+        }
+    }
+    JAVA
+
+  it "detects a class-level @PreAuthorize" do
+    endpoint = run_spring_class_level(guarded, 9)
+    endpoint.tags.any? { |t| t.name == "auth" && t.description.includes?("@PreAuthorize") }.should be_true
+  end
+
+  it "detects a class-level @Secured" do
+    endpoint = run_spring_class_level(guarded.gsub("@PreAuthorize(\"hasRole('ADMIN')\")", "@Secured(\"ROLE_ADMIN\")"), 9)
+    endpoint.tags.any? { |t| t.name == "auth" && t.description.includes?("@Secured") }.should be_true
+  end
+
+  it "detects a class-level @RolesAllowed" do
+    endpoint = run_spring_class_level(guarded.gsub("@PreAuthorize(\"hasRole('ADMIN')\")", "@RolesAllowed({\"ROLE_ADMIN\"})"), 9)
+    endpoint.tags.any? { |t| t.name == "auth" && t.description.includes?("@RolesAllowed") }.should be_true
+  end
+
+  it "detects a class-level annotation on a Kotlin controller" do
+    kotlin = <<-KT
+      package com.example
+
+      @RestController
+      @PreAuthorize("hasRole('ADMIN')")
+      class AdminController(private val service: Service) {
+
+          @GetMapping("/users")
+          fun listUsers(): String = "users"
+      }
+      KT
+    endpoint = run_spring_class_level(kotlin, 8, "kt")
+    endpoint.tags.any? { |t| t.name == "auth" }.should be_true
+  end
+
+  it "does not tag a controller without a class-level annotation" do
+    # Same shape, annotation removed — proves the class-level check is not a
+    # blanket "any @PreAuthorize anywhere in the file" match.
+    open = <<-JAVA
+      package com.example;
+
+      @RestController
+      @RequestMapping("/admin")
+      public class AdminController {
+
+          @GetMapping("/users")
+          public String listUsers() {
+              return "users";
+          }
+      }
+      JAVA
+    endpoint = run_spring_class_level(open, 8)
+    endpoint.tags.any? { |t| t.name == "auth" }.should be_false
+  end
+
+  it "does not treat a method-level annotation as class-level" do
+    # `@PreAuthorize` guards only `secret()`; `listUsers()` above it is open.
+    mixed = <<-JAVA
+      package com.example;
+
+      @RestController
+      public class AdminController {
+
+          @GetMapping("/users")
+          public String listUsers() {
+              return "users";
+          }
+
+          @PreAuthorize("hasRole('ADMIN')")
+          @GetMapping("/secret")
+          public String secret() {
+              return "secret";
+          }
+      }
+      JAVA
+    endpoint = run_spring_class_level(mixed, 7)
+    endpoint.tags.any? { |t| t.name == "auth" }.should be_false
   end
 end

--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -9,7 +9,15 @@ struct SourceContext
   property line : Int32?
   property full_content : String
 
-  def initialize(@path : String, @line : Int32?, @full_content : String)
+  # The file as lines. Every consumer of `read_source_context` immediately
+  # splits `full_content` to walk backwards from the endpoint's line, and a
+  # controller declares many handlers — so splitting per endpoint re-did the
+  # same work once per endpoint per tagger. `read_source_context` passes the
+  # tagger's cached (shared, read-only) array instead.
+  getter lines : Array(String)
+
+  def initialize(@path : String, @line : Int32?, @full_content : String, lines : Array(String)? = nil)
+    @lines = lines || @full_content.split("\n")
   end
 end
 
@@ -76,7 +84,8 @@ class FrameworkTagger < Tagger
       results << SourceContext.new(
         path: path_info.path,
         line: path_info.line,
-        full_content: content
+        full_content: content,
+        lines: read_file_lines(path_info.path)
       )
     end
 
@@ -123,6 +132,46 @@ class FrameworkTagger < Tagger
     lines = content.split("\n")
     @lines_cache[path] = lines
     lines
+  end
+
+  # Find an annotation (`@PreAuthorize`, `@CrossOrigin`, `@Validated`, …) that
+  # decorates the *class* declaration: it must be immediately followed —
+  # skipping other annotations and blank lines — by a `class` line. Returns the
+  # annotation line text.
+  #
+  # Shared by the JVM taggers: a class-level annotation applies to every
+  # handler the class declares, and the per-endpoint backward walks stop at the
+  # `public`/`class` boundary, so they can never see it on their own.
+  #
+  # The answer is a property of the file, not of the endpoint, but every
+  # endpoint in a controller asks it — so memoize per (file, annotation) rather
+  # than re-scanning the controller once per handler per annotation.
+  @class_annotation_cache = Hash(Tuple(String, String), String?).new
+
+  def class_level_annotation(path : String, lines : Array(String), annotation_name : String) : String?
+    key = {path, annotation_name}
+    if @class_annotation_cache.has_key?(key)
+      return @class_annotation_cache[key]
+    end
+    @class_annotation_cache[key] = scan_class_level_annotation(lines, annotation_name)
+  end
+
+  private def scan_class_level_annotation(lines : Array(String), annotation_name : String) : String?
+    lines.each_with_index do |raw, i|
+      stripped = raw.strip
+      next unless stripped.starts_with?(annotation_name)
+      j = i + 1
+      while j < lines.size
+        nxt = lines[j].strip
+        if nxt.empty? || nxt.starts_with?("@")
+          j += 1
+          next
+        end
+        return stripped if nxt.includes?("class ")
+        break
+      end
+    end
+    nil
   end
 
   # Static-asset file extensions. A route ending in one of these serves a

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -1,7 +1,10 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
+require "./group_scope"
 
 class GoAuthTagger < FrameworkTagger
+  include GoRouteGroupScope
+
   # Middleware usage patterns in route groups
   USE_AUTH_MIDDLEWARE_PATTERNS = [
     /\.Use\s*\(\s*(\w*[Aa]uth\w*)/,
@@ -82,40 +85,35 @@ class GoAuthTagger < FrameworkTagger
   end
 
   private def scan_group_middleware(content : String, file : String)
-    lines = content.split("\n")
-    # Track current route group context
-    group_stack = [] of String
+    each_group_scoped_line(content) do |stripped, scopes|
+      register_auth_scopes(stripped, scopes)
+    end
+  end
 
-    lines.each_with_index do |line, _idx|
-      stripped = line.strip
+  private def register_auth_scopes(stripped : String, scopes : GoRouteGroupScope::Scopes)
+    scope = resolve_use_scope(stripped, scopes)
+    return if scope.nil?
+    # The middleware guards a route group whose URL prefix we could not read
+    # (`r.Group(cfg.APIBase + "/v1")`). Recording it as global would claim
+    # every endpoint in the app is protected — including the ones registered on
+    # the app's explicitly public groups. Decline instead.
+    return if scope[:kind] == GoRouteGroupScope::ScopeKind::Unknown
 
-      # Track Group/Route prefix definitions
-      group_match = stripped.match(/\.(?:Group|Route)\s*\(\s*"([^"]*)"/)
-      if group_match
-        group_stack << group_match[1]
+    # Check for .Use() with auth middleware
+    USE_AUTH_MIDDLEWARE_PATTERNS.each do |pattern|
+      match = stripped.match(pattern)
+      if match
+        middleware_name = match[1]
+        add_middleware_scope(scope, middleware_name, "Protected by Go middleware #{middleware_name}")
       end
+    end
 
-      # Track closing braces for scope tracking
-      if stripped.starts_with?("}") || stripped == "})"
-        group_stack.pop? unless group_stack.empty?
-      end
-
-      # Check for .Use() with auth middleware
-      USE_AUTH_MIDDLEWARE_PATTERNS.each do |pattern|
-        match = stripped.match(pattern)
-        if match
-          middleware_name = match[1]
-          add_middleware_scope(group_stack, middleware_name, "Protected by Go middleware #{middleware_name}")
-        end
-      end
-
-      # Check for JWT library middleware
-      JWT_PATTERNS.each do |pattern|
-        if stripped.matches?(pattern) && stripped.includes?(".Use")
-          jwt_match = stripped.match(pattern)
-          jwt_name = jwt_match ? jwt_match[0] : "JWT"
-          add_middleware_scope(group_stack, jwt_name, "Protected by Go JWT middleware (#{jwt_name})")
-        end
+    # Check for JWT library middleware
+    JWT_PATTERNS.each do |pattern|
+      if stripped.matches?(pattern) && stripped.includes?(".Use")
+        jwt_match = stripped.match(pattern)
+        jwt_name = jwt_match ? jwt_match[0] : "JWT"
+        add_middleware_scope(scope, jwt_name, "Protected by Go JWT middleware (#{jwt_name})")
       end
     end
   end
@@ -182,19 +180,18 @@ class GoAuthTagger < FrameworkTagger
   end
 
   # Record a group-level middleware scope. `prefix == "/"` arises two ways:
-  # a bare engine-level `.Use(...)` (empty group stack → truly global, every
+  # a bare engine-level `.Use(...)` (no enclosing group → truly global, every
   # subsequently registered route is guarded) or an explicit root/empty
   # *group* `g.Group("")` / `g.Group("/")` with a chained `.Use(...)`. Only
   # the latter is a sub-group whose middleware does not reach engine-level
   # static routes, so flag it to scope the coverage refinement below.
-  private def add_middleware_scope(group_stack : Array(String), middleware : String, description : String)
-    prefix = normalize_prefix(group_stack)
-    root_group = !group_stack.empty? && prefix == "/"
+  private def add_middleware_scope(scope : GoRouteGroupScope::Scope,
+                                   middleware : String, description : String)
     @middleware_scopes << {
-      prefix:      prefix,
+      prefix:      scope[:prefix],
       middleware:  middleware,
       description: description,
-      root_group:  root_group,
+      root_group:  scope[:kind] == GoRouteGroupScope::ScopeKind::Group && scope[:prefix] == "/",
     }
   end
 
@@ -217,20 +214,5 @@ class GoAuthTagger < FrameworkTagger
     end
 
     nil
-  end
-
-  # Segment-aware prefix match so "/api" guards "/api/x" but not "/apiv2".
-  # The root scope "/" guards every endpoint.
-  private def prefix_covers?(prefix : String, url : String) : Bool
-    return true if prefix == "/"
-    url == prefix || url.starts_with?("#{prefix}/")
-  end
-
-  private def normalize_prefix(segments : Array(String)) : String
-    joined = segments.join("")
-    # Ensure segments that lack a leading "/" are joined properly
-    # e.g., ["api", "v1"] → "/api/v1", ["/api", "/v1"] → "/api/v1"
-    parts = joined.split("/").reject(&.empty?)
-    parts.empty? ? "/" : "/" + parts.join("/")
   end
 end

--- a/src/tagger/framework_taggers/go/go_security.cr
+++ b/src/tagger/framework_taggers/go/go_security.cr
@@ -1,5 +1,6 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
+require "./group_scope"
 
 # Go security-middleware tagger.
 #
@@ -22,6 +23,8 @@ require "../../../models/endpoint"
 # directly at the registration site is tagged. Cross-file middleware
 # factories are likewise out of scope by design.
 class GoSecurityTagger < FrameworkTagger
+  include GoRouteGroupScope
+
   # Security middleware constructors/identifiers, each mapped to the tag it
   # produces. Patterns are tied to the concrete constructor (`middleware.CSRF`,
   # `csrf.New`, `helmet.New`, …) so a plain local called `secure` or `limiter`
@@ -61,19 +64,10 @@ class GoSecurityTagger < FrameworkTagger
     {pattern: /\bencryptcookie\.New\s*\(/, tag: "secure-cookies", desc: "Fiber encrypted-cookie middleware", wrapper: false},
   ] of NamedTuple(pattern: Regex, tag: String, desc: String, wrapper: Bool)
 
-  # A `.Use(...)` / `.Pre(...)` middleware registration call.
-  USE_CALL = /(\w+)\.(?:Use|Pre)\s*\(/
-
   # A route-definition call. Used only to *exclude* route lines from the
   # global-wrapper branch (inline route middleware is handled per-endpoint),
   # so an over-broad verb set here is safe.
   ROUTE_DEF = /\b(?:GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|CONNECT|TRACE|Get|Post|Put|Delete|Patch|Options|Head|Connect|Trace|Any|All|Handle|HandleFunc|Match|Add)\s*\(/
-
-  # `name := parent.Group("/seg")` style group declaration (no closure arg).
-  ASSIGN_GROUP = /(\w+)\s*:?=\s*(\w+)\.Group\s*\(\s*"([^"]*)"/
-
-  # `parent.Group("/seg", func(...)` / `.Route` / `.Party` closure group.
-  CLOSURE_GROUP = /(\w+)\.(?:Group|Route|Party|PartyFunc|Mount)\s*\(\s*"([^"]*)"\s*,\s*func/
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -111,50 +105,29 @@ class GoSecurityTagger < FrameworkTagger
   end
 
   private def scan_group_middleware(content : String)
-    # variable name -> resolved URL prefix (assignment-style groups)
-    group_vars = {} of String => String
-    # active closure-group prefixes, with the brace depth they live above
-    scope_stack = [] of NamedTuple(threshold: Int32, prefix: String)
-    depth = 0
-
-    content.each_line do |line|
-      stripped = line.strip
-
-      # Closure group: push its prefix; it stays active until braces unwind.
-      if m = stripped.match(CLOSURE_GROUP)
-        base = resolve_receiver(m[1], group_vars, scope_stack)
-        scope_stack << {threshold: depth, prefix: join_prefix(base, m[2])}
-      end
-
-      # Assignment group: remember the variable's prefix for later `.Use`.
-      if m = stripped.match(ASSIGN_GROUP)
-        base = resolve_receiver(m[2], group_vars, scope_stack)
-        group_vars[m[1]] = join_prefix(base, m[3])
-      end
-
-      register_security_scopes(stripped, group_vars, scope_stack)
-
-      # Update brace depth and retire any closure scopes that just closed.
-      depth += line.count('{') - line.count('}')
-      while !scope_stack.empty? && depth <= scope_stack.last[:threshold]
-        scope_stack.pop
-      end
+    each_group_scoped_line(content) do |stripped, scopes|
+      register_security_scopes(stripped, scopes)
     end
   end
 
-  private def register_security_scopes(stripped : String, group_vars, scope_stack)
-    use_receiver = stripped.match(USE_CALL).try &.[1]
+  private def register_security_scopes(stripped : String, scopes : GoRouteGroupScope::Scopes)
+    use_scope = resolve_use_scope(stripped, scopes)
+    # The middleware is registered on a group whose URL prefix could not be
+    # read; scoping it to `/` would claim protection for the whole app.
+    return if use_scope && use_scope[:kind] == GoRouteGroupScope::ScopeKind::Unknown
 
     SECURITY_MIDDLEWARE.each do |mw|
       next unless stripped.matches?(mw[:pattern])
 
-      if use_receiver
+      if use_scope
         # `receiver.Use(middleware.X())` — scope to the receiver's group.
-        prefix = prefix_for(resolve_receiver(use_receiver, group_vars, scope_stack))
+        prefix = use_scope[:prefix]
       elsif mw[:wrapper] && !stripped.matches?(ROUTE_DEF)
         # net/http wrapper around the root handler — applies globally. Route
         # lines are skipped (their inline middleware is tagged per-endpoint).
-        prefix = prefix_for(current_scope(scope_stack))
+        current = scopes.current
+        next if current[:kind] == GoRouteGroupScope::ScopeKind::Unknown
+        prefix = current[:prefix]
       else
         next
       end
@@ -221,38 +194,5 @@ class GoSecurityTagger < FrameworkTagger
       break if opened && depth <= 0
       idx += 1
     end
-  end
-
-  # Resolve a receiver token to its URL prefix: a tracked group variable, the
-  # innermost active closure group, or "" (the root router / global scope).
-  private def resolve_receiver(receiver : String?, group_vars, scope_stack) : String
-    return current_scope(scope_stack) if receiver.nil?
-    if gp = group_vars[receiver]?
-      gp
-    else
-      current_scope(scope_stack)
-    end
-  end
-
-  private def current_scope(scope_stack) : String
-    scope_stack.empty? ? "" : scope_stack.last[:prefix]
-  end
-
-  private def prefix_for(prefix : String) : String
-    prefix.empty? ? "/" : prefix
-  end
-
-  # Join a base prefix and a new path segment into a normalized URL prefix:
-  #   ("", "/web") -> "/web"   ("/api", "v1") -> "/api/v1"
-  private def join_prefix(base : String, seg : String) : String
-    parts = "#{base}/#{seg}".split("/").reject(&.empty?)
-    parts.empty? ? "/" : "/" + parts.join("/")
-  end
-
-  # Segment-aware prefix match so "/web" guards "/web/x" but not "/website".
-  # The root scope "/" guards every endpoint.
-  private def prefix_covers?(prefix : String, url : String) : Bool
-    return true if prefix == "/"
-    url == prefix || url.starts_with?("#{prefix}/")
   end
 end

--- a/src/tagger/framework_taggers/go/group_scope.cr
+++ b/src/tagger/framework_taggers/go/group_scope.cr
@@ -1,0 +1,172 @@
+# Shared Go route-group scope resolution for the Go framework taggers.
+#
+# Both `go_auth` and `go_security` answer the same question: a middleware
+# registration (`x.Use(...)`) appears on some line — which URL prefix does it
+# guard? Go routers express grouping two structurally different ways, and they
+# have to be tracked differently:
+#
+#   * assignment groups — `api := r.Group("/api")`. The variable carries the
+#     prefix; the group is NOT delimited by braces, so `api.Use(...)` may sit
+#     anywhere below, and a sibling `admin := r.Group("/admin")` is a separate
+#     scope, not a nested one.
+#   * closure groups — `r.Route("/api", func(r chi.Router) { ... })`. The
+#     prefix applies to everything inside the closure, so it is delimited by
+#     brace depth.
+#
+# Modelling both with a single push/pop stack makes sibling assignment groups
+# *accumulate*: `/api` then `/admin` resolves the second group's middleware to
+# `/api/admin`. That is both a false negative (the real `/admin/*` routes lose
+# their tag) and — worse for a security tool — a false positive (`/api/admin/*`
+# routes are reported as guarded when they are not).
+#
+# The third case is a group whose path is not a string literal
+# (`r.Group(cfg.APIBase + "/v1")`). Its prefix is genuinely unknowable to a
+# line-based scanner, and it must NOT collapse to "global": a real app that
+# builds every group that way would have every endpoint — including its
+# explicitly public ones — tagged from whichever `.Use(auth)` happened to be
+# scanned first. `Unknown` keeps that case distinguishable from `Global` so
+# callers can decline to tag, matching `spring_security`'s treatment of a
+# filter chain scoped only by a matcher it cannot resolve.
+module GoRouteGroupScope
+  # What a receiver / middleware registration resolves to.
+  #
+  #   Global  — no enclosing group; an engine-level `.Use` guards everything
+  #             registered after it.
+  #   Group   — a route group whose URL prefix is known.
+  #   Unknown — a route group whose URL prefix could not be resolved.
+  enum ScopeKind
+    Global
+    Group
+    Unknown
+  end
+
+  alias Scope = NamedTuple(kind: ScopeKind, prefix: String)
+
+  GLOBAL_SCOPE  = {kind: ScopeKind::Global, prefix: "/"}
+  UNKNOWN_SCOPE = {kind: ScopeKind::Unknown, prefix: "/"}
+
+  # `name := parent.Group("/seg")` — assignment group with a literal path.
+  ASSIGN_GROUP = /(\w+)\s*:?=\s*(\w+)\.(?:Group|Route|Party|PartyFunc)\s*\(\s*"([^"]*)"/
+
+  # The same assignment shape with *any* first argument, literal or not. Used
+  # to tell "this variable is a route group whose prefix we can't read" from
+  # "this variable is not a route group at all".
+  ASSIGN_GROUP_ANY = /(\w+)\s*:?=\s*(\w+)\.(?:Group|Route|Party|PartyFunc)\s*\(/
+
+  # `parent.Group("/seg", func(...)` / `.Route` / `.Party` closure group.
+  CLOSURE_GROUP     = /(\w+)\.(?:Group|Route|Party|PartyFunc|Mount)\s*\(\s*"([^"]*)"\s*,\s*func/
+  CLOSURE_GROUP_ANY = /(\w+)\.(?:Group|Route|Party|PartyFunc|Mount)\s*\(.*\bfunc\b/
+
+  # A `.Use(...)` / `.Pre(...)` middleware registration call.
+  USE_CALL = /(\w+)\.(?:Use|Pre)\s*\(/
+
+  # `r.Group("/api").Use(auth)` — the group is created and the middleware
+  # registered in one chained expression, so it is neither an assignment nor a
+  # closure group. `USE_CALL` cannot see the receiver here (the character
+  # before `.Use` is `)`), so match the chain directly.
+  CHAINED_GROUP_USE     = /(\w+)\.(?:Group|Route|Party|PartyFunc)\s*\(\s*"([^"]*)"\s*\)\s*\.\s*(?:Use|Pre)\s*\(/
+  CHAINED_GROUP_USE_ANY = /(\w+)\.(?:Group|Route|Party|PartyFunc)\s*\([^)]*\)\s*\.\s*(?:Use|Pre)\s*\(/
+
+  # The route-group state at one point in a file: the assignment-group table
+  # and the stack of closure groups still open at the current brace depth.
+  class Scopes
+    # Variable name -> the scope it names.
+    getter groups = {} of String => Scope
+    # Open closure groups, each with the brace depth it lives above.
+    getter frames = [] of NamedTuple(threshold: Int32, scope: Scope)
+
+    # The innermost enclosing closure group, or Global at file scope.
+    def current : Scope
+      frames.empty? ? GLOBAL_SCOPE : frames.last[:scope]
+    end
+
+    # Resolve a receiver token: a tracked group variable, the innermost open
+    # closure group, or the global scope.
+    def receiver(name : String?) : Scope
+      return current if name.nil?
+      groups[name]? || current
+    end
+
+    # `base` extended by one path segment. An unresolvable base stays
+    # unresolvable — a literal segment under an unknown parent is still
+    # unknown.
+    def extend(base : Scope, seg : String) : Scope
+      return UNKNOWN_SCOPE if base.[:kind] == ScopeKind::Unknown
+      {kind: ScopeKind::Group, prefix: GoRouteGroupScope.join_prefix(base[:prefix], seg)}
+    end
+  end
+
+  # Walk `content` line by line, maintaining the route-group state, and yield
+  # each stripped line alongside it. Callers resolve a middleware registration
+  # with `resolve_use_scope`.
+  def each_group_scoped_line(content : String, &) : Nil
+    scopes = Scopes.new
+    depth = 0
+
+    content.each_line do |line|
+      stripped = line.strip
+
+      # Resolve both group forms against the scope state as it stood *before*
+      # this line. One line can be both — `admin := r.Group("/admin", func(c
+      # *gin.Context) {...})` is a closure group whose value is also assigned —
+      # and resolving the assignment after pushing the closure frame would fold
+      # the line's own prefix in twice (`/admin/admin`), so `admin.Use(auth)`
+      # below would guard nothing.
+      closure_scope =
+        if m = stripped.match(CLOSURE_GROUP)
+          scopes.extend(scopes.receiver(m[1]), m[2])
+        elsif stripped.matches?(CLOSURE_GROUP_ANY)
+          UNKNOWN_SCOPE
+        end
+
+      assigned =
+        if m = stripped.match(ASSIGN_GROUP)
+          {m[1], scopes.extend(scopes.receiver(m[2]), m[3])}
+        elsif m = stripped.match(ASSIGN_GROUP_ANY)
+          {m[1], UNKNOWN_SCOPE}
+        end
+
+      # Closure group: its prefix stays active until braces unwind.
+      scopes.frames << {threshold: depth, scope: closure_scope} if closure_scope
+      # Assignment group: remember the variable's scope for later `.Use`.
+      scopes.groups[assigned[0]] = assigned[1] if assigned
+
+      yield stripped, scopes
+
+      # Update brace depth and retire any closure scopes that just closed.
+      depth += line.count('{') - line.count('}')
+      while !scopes.frames.empty? && depth <= scopes.frames.last[:threshold]
+        scopes.frames.pop
+      end
+    end
+  end
+
+  # The scope a middleware registration on `stripped` guards, or nil when the
+  # line registers no middleware. Callers must decline to tag an `Unknown`
+  # scope rather than treating it as global.
+  def resolve_use_scope(stripped : String, scopes : Scopes) : Scope?
+    if m = stripped.match(CHAINED_GROUP_USE)
+      return scopes.extend(scopes.receiver(m[1]), m[2])
+    end
+    return UNKNOWN_SCOPE if stripped.matches?(CHAINED_GROUP_USE_ANY)
+
+    receiver = stripped.match(USE_CALL).try &.[1]
+    return if receiver.nil?
+
+    scopes.receiver(receiver)
+  end
+
+  # Join a base prefix and a new path segment into a normalized URL prefix:
+  #   ("", "/web") -> "/web"   ("/api", "v1") -> "/api/v1"
+  def self.join_prefix(base : String, seg : String) : String
+    parts = "#{base}/#{seg}".split("/").reject(&.empty?)
+    parts.empty? ? "/" : "/" + parts.join("/")
+  end
+
+  # Segment-aware prefix match so "/web" guards "/web/x" but not "/website".
+  # The root scope "/" guards every endpoint.
+  def prefix_covers?(prefix : String, url : String) : Bool
+    return true if prefix == "/"
+    url == prefix || url.starts_with?("#{prefix}/")
+  end
+end

--- a/src/tagger/framework_taggers/java/spring_auth.cr
+++ b/src/tagger/framework_taggers/java/spring_auth.cr
@@ -8,6 +8,10 @@ class SpringAuthTagger < FrameworkTagger
     /\@RolesAllowed\s*\(/,
   ]
 
+  # The same authorization annotations, as the bare names they are matched by
+  # when they decorate the controller *class* instead of a single handler.
+  CLASS_ANNOTATION_NAMES = ["@PreAuthorize", "@Secured", "@RolesAllowed"]
+
   # Patterns for security config URL rules. `access { ... }` is a
   # protected rule too; `permitAll()` is intentionally tracked so a
   # more-specific public matcher can suppress a broader protected one.
@@ -162,12 +166,20 @@ class SpringAuthTagger < FrameworkTagger
     value.starts_with?("/") ? value : "/#{value}"
   end
 
-  private def ant_pattern_regex(pattern : String) : Regex
-    escaped = Regex.escape(pattern)
-      .gsub("\\*\\*", ".*")
-      .gsub("\\*", "[^/]*")
+  # Every endpoint is matched against every recorded security rule, so this is
+  # called O(endpoints x rules) times over a small set of distinct patterns.
+  # Memoize (as `spring_security` already does) so the same PCRE2 pattern isn't
+  # recompiled thousands of times.
+  @ant_pattern_regexes = Hash(String, Regex).new
 
-    /^#{escaped}\/?$/
+  private def ant_pattern_regex(pattern : String) : Regex
+    @ant_pattern_regexes[pattern] ||= begin
+      escaped = Regex.escape(pattern)
+        .gsub("\\*\\*", ".*")
+        .gsub("\\*", "[^/]*")
+
+      /^#{escaped}\/?$/
+    end
   end
 
   private def pattern_specificity(pattern : String) : Int32
@@ -184,7 +196,7 @@ class SpringAuthTagger < FrameworkTagger
 
     # Walk backwards from endpoint line to find annotations
     # `line` is 1-indexed (from PathInfo), array is 0-indexed
-    lines = ctx.full_content.split("\n")
+    lines = ctx.lines
     endpoint_idx = line - 1
 
     idx = [endpoint_idx - 1, lines.size - 1].min
@@ -207,6 +219,17 @@ class SpringAuthTagger < FrameworkTagger
       end
 
       idx -= 1
+    end
+
+    # A controller-level `@PreAuthorize`/`@Secured`/`@RolesAllowed` applies to
+    # every handler the class declares. The walk above cannot reach it — it
+    # stops at the `public`/`class` boundary by design, so a handler under an
+    # `@PreAuthorize("hasRole('ADMIN')")` controller was reported as
+    # unauthenticated. Check the class declaration separately.
+    CLASS_ANNOTATION_NAMES.each do |annotation_name|
+      if class_line = class_level_annotation(ctx.path, lines, annotation_name)
+        return "Protected by Spring #{class_line.split("(").first.strip} on the controller class"
+      end
     end
 
     nil

--- a/src/tagger/framework_taggers/java/spring_security.cr
+++ b/src/tagger/framework_taggers/java/spring_security.cr
@@ -332,15 +332,15 @@ class SpringSecurityTagger < FrameworkTagger
     read_source_context(endpoint).each do |ctx|
       line = ctx.line
       next if line.nil?
-      lines = ctx.full_content.split("\n")
+      lines = ctx.lines
       next if line < 1 || line > lines.size
       idx = line - 1
 
-      if desc = check_cross_origin(lines, idx)
+      if desc = check_cross_origin(ctx.path, lines, idx)
         endpoint.add_tag(Tag.new("cors", desc, "spring_security"))
       end
 
-      if desc = check_input_validation(lines, idx, endpoint)
+      if desc = check_input_validation(ctx.path, lines, idx, endpoint)
         endpoint.add_tag(Tag.new("input-validation", desc, "spring_security"))
       end
     end
@@ -355,7 +355,7 @@ class SpringSecurityTagger < FrameworkTagger
 
   # `@CrossOrigin` on the handler (walk the annotation block above it) or on
   # the controller class (applies to every handler in the file).
-  private def check_cross_origin(lines : Array(String), method_idx : Int32) : String?
+  private def check_cross_origin(path : String, lines : Array(String), method_idx : Int32) : String?
     # Method-level: the contiguous annotation block directly above the
     # handler. Mirrors spring_auth's backward walk — stop at the previous
     # member/class boundary so we don't bleed into another handler.
@@ -374,7 +374,7 @@ class SpringSecurityTagger < FrameworkTagger
     end
 
     # Class-level: a @CrossOrigin sitting on the controller declaration.
-    if class_line = class_level_annotation(lines, "@CrossOrigin")
+    if class_line = class_level_annotation(path, lines, "@CrossOrigin")
       return describe_cross_origin(class_line, class_level: true)
     end
 
@@ -402,7 +402,7 @@ class SpringSecurityTagger < FrameworkTagger
 
   # `@Valid` / `@Validated` applied to the handler's parameters (scan the
   # signature up to the body brace) or `@Validated` on the controller class.
-  private def check_input_validation(lines : Array(String), method_idx : Int32, endpoint : Endpoint) : String?
+  private def check_input_validation(path : String, lines : Array(String), method_idx : Int32, endpoint : Endpoint) : String?
     idx = method_idx
     end_idx = [method_idx + 10, lines.size - 1].min
     while idx <= end_idx
@@ -420,7 +420,7 @@ class SpringSecurityTagger < FrameworkTagger
       idx += 1
     end
 
-    if endpoint.params.present? && class_level_annotation(lines, "@Validated")
+    if endpoint.params.present? && class_level_annotation(path, lines, "@Validated")
       return "Controller annotated @Validated — Bean Validation is applied to this handler's parameters."
     end
 
@@ -429,27 +429,6 @@ class SpringSecurityTagger < FrameworkTagger
 
   private def spring_mapping_annotation?(line : String) : Bool
     line.matches?(/@(GetMapping|PostMapping|PutMapping|PatchMapping|DeleteMapping|RequestMapping)\b/)
-  end
-
-  # Find an annotation (`@CrossOrigin`/`@Validated`) that decorates the class
-  # declaration: it must be immediately followed — skipping other annotations
-  # and blank lines — by a `class` line. Returns the annotation line text.
-  private def class_level_annotation(lines : Array(String), annotation_name : String) : String?
-    lines.each_with_index do |raw, i|
-      stripped = raw.strip
-      next unless stripped.starts_with?(annotation_name)
-      j = i + 1
-      while j < lines.size
-        nxt = lines[j].strip
-        if nxt.empty? || nxt.starts_with?("@")
-          j += 1
-          next
-        end
-        return stripped if nxt.includes?("class ")
-        break
-      end
-    end
-    nil
   end
 
   # Ant-style pattern match (`/**` → any depth, `*` → one segment), prefix

--- a/src/tagger/framework_taggers/javascript/nestjs_auth.cr
+++ b/src/tagger/framework_taggers/javascript/nestjs_auth.cr
@@ -29,6 +29,11 @@ class NestjsAuthTagger < FrameworkTagger
     {/\@ApiSecurity\s*\(/, "NestJS @ApiSecurity (Swagger)"},
   ]
 
+  # Every decorator a method-level walk looks for. Built once — concatenating
+  # the three lists inside the per-line loop allocated a fresh array for every
+  # line of every handler's decorator block.
+  METHOD_DECORATOR_PATTERNS = GUARD_PATTERNS + ROLE_PATTERNS + AUTH_DECORATORS
+
   # Public/skip auth markers (negative signal)
   PUBLIC_PATTERNS = [
     /\@Public\s*\(\)/,
@@ -110,8 +115,7 @@ class NestjsAuthTagger < FrameworkTagger
       # Stop if we hit another method
       break if current.includes?("async ") && current.includes?("(") && idx < method_line - 1
 
-      all_patterns = GUARD_PATTERNS + ROLE_PATTERNS + AUTH_DECORATORS
-      all_patterns.each do |pattern, desc|
+      METHOD_DECORATOR_PATTERNS.each do |pattern, desc|
         return desc if current.matches?(pattern)
       end
 

--- a/src/tagger/framework_taggers/python/django_auth.cr
+++ b/src/tagger/framework_taggers/python/django_auth.cr
@@ -48,7 +48,7 @@ class DjangoAuthTagger < FrameworkTagger
 
     contexts.each do |ctx|
       line = ctx.line
-      lines = ctx.full_content.split("\n")
+      lines = ctx.lines
 
       # Skip stale/out-of-range line refs: a line beyond the content we
       # read would crash the lines[idx] walks below with IndexError.

--- a/src/tagger/framework_taggers/ruby/ruby_auth.cr
+++ b/src/tagger/framework_taggers/ruby/ruby_auth.cr
@@ -65,6 +65,19 @@ class RubyAuthTagger < FrameworkTagger
     /skip_before_action\s+:require_login/,
   ]
 
+  # Cheap gate for `check_controller_auth`'s backward walk, which runs to the
+  # enclosing `class` — or, in a Sinatra/Grape/Roda file that has none, to line
+  # 0 — for *every* endpoint in the file. Mechanically the union of the three
+  # pattern sets it guards, so a line it rejects cannot match any of them; it
+  # replaces 13 regex evaluations per line with one.
+  CONTROLLER_AUTH_ANY = begin
+    sources = [] of Regex | String
+    SKIP_PATTERNS.each { |pattern| sources << pattern }
+    BEFORE_ACTION_PATTERNS.each { |pattern, _| sources << pattern }
+    HANAMI_AUTH_PATTERNS.each { |pattern, _| sources << pattern }
+    Regex.union(sources)
+  end
+
   def initialize(options : Hash(String, YAML::Any))
     super
     @name = "ruby_auth"
@@ -135,7 +148,15 @@ class RubyAuthTagger < FrameworkTagger
     action_name = extract_action_name(lines, action_line)
 
     while idx >= 0
-      current = lines[idx].strip
+      current = lines[idx]
+
+      unless current.matches?(CONTROLLER_AUTH_ANY)
+        break if current.lstrip.starts_with?("class ")
+        idx -= 1
+        next
+      end
+
+      current = current.strip
 
       # Check for skip_before_action that applies to this action
       SKIP_PATTERNS.each do |pattern|

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -263,31 +263,27 @@ module NoirTaggers
   def self.run_tagger(endpoints : Array(Endpoint), options : Hash(String, YAML::Any), use_taggers : String)
     validate_tagger_names!(use_taggers)
 
-    # Every entry in HasTaggers maps a tagger key to a runnable
-    # Tagger subclass. The previous `class.to_s == "Class"` guard was
-    # always true (Crystal class objects are instances of Class) and
-    # therefore a no-op; instantiate directly.
-    tagger_list = [] of Tagger
-    HasTaggers.each_value do |tagger|
-      tagger_list << tagger[:runner].new(options)
-    end
-
     # Parsing use_taggers — normalize to lowercase so case-insensitive
     # input matches the lowercase canonical tagger names. Validation
     # (`validate_tagger_names!` above) uses the same shape.
     use_taggers_arr = use_taggers.split(",").map(&.strip.downcase)
+    is_all = use_taggers_arr.includes?("all")
 
     logger = build_logger(options)
 
-    # Run taggers. A single tagger raising must not abort the rest of the
-    # tagging pass (or, for framework taggers below, tear down the whole
-    # program from inside a fiber) — degrade to "this tagger failed".
-    tagger_list.each do |tagger|
-      next unless use_taggers_arr.includes?(tagger.name) || use_taggers_arr.includes?("all")
+    # Every entry in HasTaggers maps a tagger key to a runnable Tagger
+    # subclass, and the key IS the tagger's `name` — so an unselected tagger
+    # can be skipped without constructing it (each `new` builds a logger and
+    # resolves options). Run the selected ones; a single tagger raising must
+    # not abort the rest of the tagging pass (or, for framework taggers below,
+    # tear down the whole program from inside a fiber) — degrade to "this
+    # tagger failed".
+    HasTaggers.each do |key, tagger|
+      next unless is_all || use_taggers_arr.includes?(key.to_s)
       begin
-        tagger.perform(endpoints)
+        tagger[:runner].new(options).perform(endpoints)
       rescue ex
-        logger.warning "Tagger '#{tagger.name}' failed: #{ex.message}"
+        logger.warning "Tagger '#{key}' failed: #{ex.message}"
       end
     end
 
@@ -321,7 +317,12 @@ module NoirTaggers
 
     # Collect tagger work items, then run in parallel
     WaitGroup.wait do |wg|
-      HasFrameworkTaggers.each_value do |tagger_info|
+      HasFrameworkTaggers.each do |key, tagger_info|
+        # The registry key is the tagger's `name`, so selection is decided
+        # before construction — an unselected tagger no longer pays for a
+        # logger and a base-path resolution just to be discarded.
+        next unless is_all || use_taggers_arr.includes?(key.to_s)
+
         target_techs = tagger_info[:runner].target_techs
         matching_endpoints = [] of Endpoint
         target_techs.each do |tech|
@@ -332,11 +333,8 @@ module NoirTaggers
 
         next if matching_endpoints.empty?
 
-        tagger_instance = tagger_info[:runner].new(options)
-        next unless is_all || use_taggers_arr.includes?(tagger_instance.name)
-
         # Bind to local variables to ensure each fiber captures its own copy
-        local_instance = tagger_instance
+        local_instance = tagger_info[:runner].new(options)
         local_endpoints = matching_endpoints
 
         wg.spawn do


### PR DESCRIPTION
## Summary

I went looking for tagger performance wins and measured first. On a 44k-file / ~500k-LOC / 238-tech corpus (20 copies of the functional fixtures), the whole `-T` pass is **1–2% of scan time** — 22.3–23.0s without taggers vs 22.8–26.3s with, i.e. inside noise. So perf is not the lever; the interesting findings turned out to be detection bugs, and the perf work here is redundancy removal that happens to be free.

## Detection fixes

### 1. `go_auth` modelled two different grouping forms with one stack

Go expresses route grouping two structurally different ways:

- **assignment groups** — `api := r.Group("/api")`. Not brace-delimited; `api.Use(...)` may sit anywhere below, and a sibling `admin := r.Group("/admin")` is a *separate* scope.
- **closure groups** — `r.Route("/api", func(r chi.Router){ ... })`. Brace-delimited.

`go_auth` pushed both onto one stack, so sibling assignment groups **accumulated**:

```go
api := r.Group("/api")
api.Use(AuthMiddleware())        // -> /api          ok
admin := r.Group("/admin")
admin.Use(AdminAuthMiddleware()) // -> /api/admin    wrong
```

| gin fixture | before | after |
|---|---|---|
| sibling `/admin` group with its own `.Use` | `/admin/stats` **untagged** | tagged `AdminAuthMiddleware` |
| `/api` (no mw) + `/internal` (`.Use(SessionAuth())`) | `/api/internal/status` **"Protected by SessionAuth"** | untagged |

The second row is the one that matters — a security tool reporting an unauthenticated route as authenticated.

`go_security` already had the correct model (group-variable table + brace-depth closure stack). Extracted it into `GoRouteGroupScope` so both Go taggers share one implementation. Also now resolved: the chained form `r.Group("/admin").Use(auth)`, which neither tagger handled (`USE_CALL` can't see a receiver when the preceding character is `)`).

### 2. `spring_auth` never saw controller-level annotations

A class-level `@PreAuthorize("hasRole('ADMIN')")` guards every handler the controller declares, but the per-handler backward walk stops at the `public`/`class` boundary by design, so it could never reach the class declaration:

```
before:  GET /admin/users   []                                   <- reported unauthenticated
after:   GET /admin/users   auth: @PreAuthorize on the controller class
```

`spring_security` already had `class_level_annotation` for class-level `@CrossOrigin`/`@Validated`; lifted it to `FrameworkTagger` and used it for `@PreAuthorize` / `@Secured` / `@RolesAllowed`, Java and Kotlin. Method-level still wins, and it's anchored on the class declaration so a sibling handler's annotation isn't mistaken for a controller-wide one.

### 3. ⚠️ A recall-policy call worth reviewing separately

A group built from a non-literal path (`r.Group(cfg.APIBase + "/v1")`) has a prefix a line-based scanner cannot read. That case used to collapse to the **global** scope, so one `.Use(auth)` claimed protection for the entire app.

On **apache/answer** that tagged **202 of 412 endpoints** `"Protected by Go middleware authUserMiddleware"` — including `/healthz`, `/siteinfo`, `/language/config`, which are registered on the app's *explicitly unauthenticated* groups.

Such a scope is now `Unknown` and declined rather than globalised — the same call `spring_security.record_scoped` already makes for a filter chain scoped only by a matcher it can't resolve.

**The cost:** answer drops to **0** `go_auth` tags, and roughly half of the 202 were on genuinely protected groups (`authV1`, `adminauthV1`). I went with declining because the Go taggers state precision-over-recall twice in their own comments, there's in-repo precedent, and answer's endpoint URLs don't carry the group prefix anyway so no resolution could have matched them. But it's a policy decision, not a bug fix — it's isolated in the first commit so it can be reverted independently of the rest.

## Performance (behaviour-preserving)

- `read_source_context` hands callers the cached line array — `spring_auth`, `spring_security`, `django_auth` were re-splitting the whole controller once per endpoint.
- `spring_auth` memoizes its ant-pattern regexes (was recompiling per endpoint × per rule; `spring_security` already did).
- `class_level_annotation` memoized per (file, annotation), so fix #2 doesn't reintroduce an O(endpoints × filesize) scan.
- `run_tagger` selects by registry key **before** construction — `--use-taggers hunt` was building 42 unused taggers. Verified all 17 plain and 26 framework `@name`s equal their keys.
- `ruby_auth`'s controller walk runs to line 0 in a file with no `class` (Sinatra/Grape/Roda), 13 regexes per line — gated by one `Regex.union` built mechanically from the same pattern lists, so a rejected line provably cannot match any of them.
- `nestjs_auth` was allocating a concatenated pattern array per line.

Unmeasurable at whole-scan level, as the numbers above predict. On a synthetic Spring shape built to make the phase visible (2000 endpoints, 80 security rules), `--use-taggers spring_auth`: **0.70s → 0.32s**, identical output.

## Validation

- **26678 specs**, 0 failures. 16 new spec cases. `crystal tool format --check` clean, ameba clean (1818 files).
- **Tag-for-tag identical** output before/after on: functional fixture tree (3297 endpoints), the synthetic Spring corpus (2000), gotify, memos, shiori, go-clean-template, and a 1546-file Django repo. `answer` is the only corpus that changes, and only for item 3.
- Confirmed the trpc delta I initially saw on the 20×-duplicated corpus is corpus noise, not this change — the same binary run twice reproduces it identically; the single-copy tree is deterministic and unchanged.

Each commit typechecks and passes its specs standalone.
