### PR TITLE
fix(docs): stop Geist Mono ligatures from eating the space before `--`

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -187,7 +187,18 @@ a:hover { text-decoration: underline; text-underline-offset: 0.2em; }
    fixed, so content images (e.g. running.png) render stretched. */
 img, svg, picture, video { display: block; max-width: 100%; height: auto; }
 
-code, kbd, pre, samp { font-family: var(--font-mono); }
+/* Geist Mono's code ligatures are drawn backwards out of a single one-cell
+   advance: hyphen_hyphen.liga is 600 units wide with a -476 left side bearing.
+   Two hyphens therefore advance one cell instead of two, and everything after
+   them slides left over the preceding space, so `noir scan . --ai-provider`
+   renders as `noir scan .--ai-provider`. `----`, `||||`, `!=` and `...` fuse
+   the same way. These pages quote literal CLI flags, where `--` has to read as
+   two hyphens, so the ligatures would be wrong even with a correct advance.
+   Any new element that switches to --font-mono needs this line as well. */
+code, kbd, pre, samp {
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+}
 
 button { font: inherit; color: inherit; background: none; border: 0; cursor: pointer; }
 


### PR DESCRIPTION
## Problem

[The AI-power usage docs](https://owasp-noir.github.io/noir/get_started/ai_power/#usage) show

```
noir scan . --ai-provider acp:codex
```

but the page renders it as `noir scan .--ai-provider acp:codex`. A reader copying by eye gets a command that does not parse.

The markdown source and the built HTML both carry a plain ASCII space — verified with `od -c` against the live page. The font is what loses it.

## Root cause

Geist Mono's code ligatures are drawn backwards out of a single one-cell advance:

| glyph | advance | ink bounds |
|---|---|---|
| `hyphen` | 600 | 120 … 480 |
| `hyphen_hyphen.liga` | 600 | **-476** … 476 |
| `hyphen_hyphen_hyphen.liga` | 600 | **-1065** … 465 |

`--` collapses into one glyph that advances a single cell instead of two, so every glyph after it slides one cell left, right over the preceding space.

This was never specific to one page. It hits every code block and inline `<code>` on the site — `----`, `||||`, `!=`, `..` and `...` fuse the same way, and `!=` renders as `≠`.

Before / after, same page, headless Chrome:

```
before:  noir scan .--ai-provider openai--ai-model gpt-5.5--ai-key $OPENAI_API_KEY
after:   noir scan . --ai-provider openai --ai-model gpt-5.5 --ai-key $OPENAI_API_KEY
```

Inline code in prose was affected too: `), --ai-model` rendered as `),--ai-model`.

## Fix

`font-variant-ligatures: none` on the mono base rule. These pages quote literal CLI flags, where `--` has to read as two hyphens, so the ligatures would be wrong here even with a correct advance.

Scoped to the mono face rather than set globally: the sans face has no `--` ligature, so prose keeps its `fi`/`fl`. The landing page's `.flow-cmd` is a `<code>` element, so it is covered by the same rule.

The `@font-face` `font-feature-settings` descriptor also works in Chrome, but browser support for that descriptor is uneven, so this uses the element property that is supported everywhere.

## Verification

- Rendered the page in headless Chrome at 3x before and after; space restored, checked at 430px
- `docs/scripts/check_doc_parity.sh` — OK, every page has both EN and KO
- `hwaro build` — 132 pages, clean
- `docs/scripts/check_edit_links.sh` — all 122 links point at existing files
- `hwaro doctor` — 0 errors, 0 warnings
- `hwaro tool validate` — no issues

No content files changed; the markdown was already correct.