### PR TITLE
fix(output/oas): emit path templates and parameters the spec allows

### DIFF
--- a/spec/unit_test/output_builder/oas2_spec.cr
+++ b/spec/unit_test/output_builder/oas2_spec.cr
@@ -163,4 +163,47 @@ describe "OutputBuilderOas2" do
     paths["/jobs"].as_h.has_key?("subscribe").should be_false
     paths["/jobs"]["x-noir-unsupported-methods"].as_a.should contain(JSON::Any.new("SUBSCRIBE"))
   end
+
+  it "keeps every operation's parameter list valid" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+      "url"     => YAML::Any.new(""),
+    }
+    builder = OutputBuilderOas2.new(options)
+    builder.io = IO::Memory.new
+
+    # A header param already named `Cookie` and a cookie param both claim the
+    # `{in: header, name: Cookie}` slot, which Swagger 2.0 requires to be
+    # unique.
+    cookies = Endpoint.new("/login", "POST")
+    cookies.push_param(Param.new("Cookie", "", "header"))
+    cookies.push_param(Param.new("session", "", "cookie"))
+
+    # `id` is both the path template variable and a query param.
+    shadowed = Endpoint.new("/users/:id", "GET")
+    shadowed.push_param(Param.new("id", "", "query"))
+
+    # A path param the emitted path can't express: `in: path` without a
+    # matching template expression is invalid in both OAS versions.
+    concrete = Endpoint.new("/posts/1", "DELETE")
+    concrete.push_param(Param.new("id", "", "path"))
+
+    builder.print([cookies, shadowed, concrete])
+    paths = JSON.parse(builder.io.to_s)["paths"]
+
+    login_params = paths["/login"]["post"]["parameters"].as_a
+    login_params.count { |p| p["in"].as_s == "header" && p["name"].as_s.downcase == "cookie" }.should eq(1)
+    login_params.find! { |p| p["name"].as_s == "Cookie" }["description"].as_s.should contain("session")
+
+    user_params = paths["/users/{id}"]["get"]["parameters"].as_a
+    user_params.map { |p| {p["in"].as_s, p["name"].as_s} }.should eq([{"path", "id"}])
+
+    delete_op = paths["/posts/1"]["delete"]
+    delete_op["parameters"].as_a.any? { |p| p["in"].as_s == "path" }.should be_false
+    delete_op["x-noir-unmapped-path-params"].as_a.should eq([JSON::Any.new("id")])
+  end
 end

--- a/spec/unit_test/output_builder/oas3_spec.cr
+++ b/spec/unit_test/output_builder/oas3_spec.cr
@@ -179,4 +179,38 @@ describe "OutputBuilderOas3" do
     paths["/jobs"].as_h.has_key?("subscribe").should be_false
     paths["/jobs"]["x-noir-unsupported-methods"].as_a.should contain(JSON::Any.new("SUBSCRIBE"))
   end
+
+  it "moves path parameters with no template expression into an extension" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+      "url"     => YAML::Any.new(""),
+    }
+    builder = OutputBuilderOas3.new(options)
+    builder.io = IO::Memory.new
+
+    # The optimizer substituted a concrete value for the placeholder, so `id`
+    # has nowhere to bind — `in: path` here fails every OAS validator.
+    concrete = Endpoint.new("/posts/1", "GET")
+    concrete.push_param(Param.new("id", "", "path"))
+    concrete.push_param(Param.new("draft", "", "query"))
+
+    # Sanic-style `<name:type>`, resolved by the endpoint's own path param.
+    typed = Endpoint.new("/reports/<report_id:int>", "GET")
+    typed.push_param(Param.new("report_id", "", "path"))
+
+    builder.print([concrete, typed])
+    paths = JSON.parse(builder.io.to_s)["paths"]
+
+    operation = paths["/posts/1"]["get"]
+    operation["parameters"].as_a.map { |p| {p["in"].as_s, p["name"].as_s} }.should eq([{"query", "draft"}])
+    operation["x-noir-unmapped-path-params"].as_a.should eq([JSON::Any.new("id")])
+
+    paths.as_h.has_key?("/reports/{report_id}").should be_true
+    typed_params = paths["/reports/{report_id}"]["get"]["parameters"].as_a
+    typed_params.map { |p| {p["in"].as_s, p["name"].as_s} }.should eq([{"path", "report_id"}])
+  end
 end

--- a/spec/unit_test/output_builder/oas_common_spec.cr
+++ b/spec/unit_test/output_builder/oas_common_spec.cr
@@ -4,8 +4,12 @@ require "../../../src/output_builder/oas_common"
 private struct OasCommonTestHelper
   include OutputBuilderOasCommon
 
-  def test_normalize_oas_path(raw_url : String)
-    normalize_oas_path(raw_url)
+  def test_normalize_oas_path(raw_url : String, declared_path_params : Array(String) = [] of String)
+    normalize_oas_path(raw_url, declared_path_params)
+  end
+
+  def test_extract_unmapped_path_parameters(parameters : Array(Hash(String, JSON::Any)), template_names : Array(String))
+    extract_unmapped_path_parameters(parameters, template_names)
   end
 
   def test_path_template_names(path : String)
@@ -31,6 +35,47 @@ describe OutputBuilderOasCommon do
       helper.test_normalize_oas_path("/users/<int:id>").should eq("/users/{id}")
       helper.test_normalize_oas_path("/users/*id").should eq("/users/{id}")
       helper.test_normalize_oas_path("/files/*").should eq("/files/{wildcard}")
+    end
+
+    it "names each bare wildcard distinctly" do
+      # A path template variable may not repeat, so `/api/*/v1/*` cannot emit
+      # `{wildcard}` twice.
+      helper.test_normalize_oas_path("/api/*/v1/*").should eq("/api/{wildcard}/v1/{wildcard2}")
+    end
+
+    it "resolves name-first typed placeholders" do
+      # Sanic / Bottle / Marten spell the placeholder `<name:type>`, the
+      # reverse of Django / Flask's `<type:name>`.
+      helper.test_normalize_oas_path("/users/<id:int>").should eq("/users/{id}")
+      helper.test_normalize_oas_path("/posts/<post_id:uuid>").should eq("/posts/{post_id}")
+      helper.test_normalize_oas_path("/n/<int(min=1):page>").should eq("/n/{page}")
+    end
+
+    it "prefers the endpoint's declared path params for typed placeholders" do
+      helper.test_normalize_oas_path("/a/<foo:bar>", ["bar"]).should eq("/a/{bar}")
+      helper.test_normalize_oas_path("/a/<foo:bar>", ["foo"]).should eq("/a/{foo}")
+    end
+
+    it "collapses resource patterns and constrained placeholders" do
+      # Google AIP / gRPC transcoding — the pattern is a constraint on `name`,
+      # and left in place the `*` pass nested braces inside the placeholder.
+      helper.test_normalize_oas_path("/v1/{name=projects/*/locations/*}/res")
+        .should eq("/v1/{name}/res")
+      # Play routes spell a constrained param `$path<.+>`.
+      helper.test_normalize_oas_path("/files/$path<.+>").should eq("/files/{path}")
+    end
+  end
+
+  describe "#extract_unmapped_path_parameters" do
+    it "drops path parameters with no matching template expression" do
+      parameters = [
+        {"name" => JSON::Any.new("id"), "in" => JSON::Any.new("path")},
+        {"name" => JSON::Any.new("q"), "in" => JSON::Any.new("query")},
+        {"name" => JSON::Any.new("ghost"), "in" => JSON::Any.new("path")},
+      ]
+
+      helper.test_extract_unmapped_path_parameters(parameters, ["id"]).should eq(["ghost"])
+      parameters.map(&.["name"].as_s).should eq(["id", "q"])
     end
   end
 

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -45,8 +45,15 @@ class OutputBuilderOas2 < OutputBuilder
         end
       end
 
-      oas_path = normalize_oas_path(endpoint.url)
-      path_template_names(oas_path).each do |name|
+      declared_path_params = endpoint.params.compact_map { |p| p.name if p.param_type == "path" }
+      oas_path = normalize_oas_path(endpoint.url, declared_path_params)
+      template_names = path_template_names(oas_path)
+      template_names.each do |name|
+        # A path template variable wins over a same-named query/header
+        # parameter, as it does in the OAS3 builder. `formData` and `body` are
+        # left alone: they are request-payload fields, not another spelling of
+        # the same path segment.
+        parameters.reject! { |p| p["name"].as_s == name && {"query", "header"}.includes?(p["in"].as_s) }
         append_unique_parameter(parameters, swagger_parameter(name, "path", true))
       end
 
@@ -54,6 +61,14 @@ class OutputBuilderOas2 < OutputBuilder
       # Cookies are not directly supported in OAS2, typically sent as Cookie header
       unless cookie_names.empty?
         cookie_desc = "Cookies: " + cookie_names.map { |name| "#{name}=<value>" }.join("; ")
+        # Header names are case-insensitive (RFC 9110), so a header-type param
+        # already named `Cookie`/`cookie` occupies this very slot. Swagger 2.0
+        # keys parameter uniqueness on name+in, so appending unconditionally
+        # put two `{in: header, name: Cookie}` entries in one operation and the
+        # document stopped validating. Replace it — the synthesized entry is
+        # the one that names the cookies. (Mirrors the postman builder's
+        # case-insensitive cookie merge.)
+        parameters.reject! { |p| p["in"].as_s == "header" && p["name"].as_s.downcase == "cookie" }
         parameters << {
           "name"        => JSON::Any.new("Cookie"),
           "in"          => JSON::Any.new("header"),
@@ -91,6 +106,8 @@ class OutputBuilderOas2 < OutputBuilder
         consumes.reject! { |content_type| content_type == "application/json" }
       end
 
+      unmapped_path_params = extract_unmapped_path_parameters(parameters, template_names)
+
       # Build operation object
       operation = {
         "responses" => JSON::Any.new({
@@ -106,6 +123,7 @@ class OutputBuilderOas2 < OutputBuilder
         operation["consumes"] = JSON::Any.new(consumes.map { |c| JSON::Any.new(c) })
       end
 
+      add_unmapped_path_params_extension(operation, unmapped_path_params)
       add_noir_callees_extension(operation, endpoint)
       add_noir_ai_context_extension(operation, endpoint)
 

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -42,8 +42,10 @@ class OutputBuilderOas3 < OutputBuilder
         end
       end
 
-      oas_path = normalize_oas_path(endpoint.url)
-      path_template_names(oas_path).each do |name|
+      declared_path_params = endpoint.params.compact_map { |p| p.name if p.param_type == "path" }
+      oas_path = normalize_oas_path(endpoint.url, declared_path_params)
+      template_names = path_template_names(oas_path)
+      template_names.each do |name|
         # A path template variable must win over a same-named query/header/
         # cookie parameter. Emitting both `in: path` and `in: query` for the
         # same name is redundant and trips strict OAS validators, so drop the
@@ -51,6 +53,7 @@ class OutputBuilderOas3 < OutputBuilder
         parameters.reject! { |p| p["name"].as_s == name && p["in"].as_s != "path" }
         append_unique_parameter(parameters, openapi_parameter(name, "path", true))
       end
+      unmapped_path_params = extract_unmapped_path_parameters(parameters, template_names)
 
       # Build operation object
       operation = {
@@ -98,6 +101,7 @@ class OutputBuilderOas3 < OutputBuilder
         } of String => JSON::Any)
       end
 
+      add_unmapped_path_params_extension(operation, unmapped_path_params)
       add_noir_callees_extension(operation, endpoint)
       add_noir_ai_context_extension(operation, endpoint)
 

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -6,10 +6,25 @@ module OutputBuilderOasCommon
   VALID_OPERATION_METHODS = Set{"get", "put", "post", "delete", "options", "head", "patch", "trace"}
   ANY_OPERATION_METHODS   = WILDCARD_HTTP_METHODS.map(&.downcase)
 
-  private def normalize_oas_path(raw_url : String) : String
+  # Converter names that can appear in a `<…>` path placeholder. Same list the
+  # optimizer's `angle_bracket_param` uses, so the two resolve a placeholder
+  # the same way.
+  PATH_CONVERTER_TYPES = Set{"int", "str", "string", "slug", "uuid", "float", "bool", "path"}
+
+  # `declared_path_params` are the names the endpoint itself records as
+  # `param_type == "path"`. They disambiguate `<a:b>` placeholders, whose two
+  # halves are spelled in either order depending on the framework.
+  private def normalize_oas_path(raw_url : String, declared_path_params : Array(String) = [] of String) : String
     uri = URI.parse(raw_url)
     path = uri.path
     path = "/" if path.empty?
+
+    # Google AIP / gRPC-transcoding resource patterns (`{name=projects/*}`)
+    # embed a path pattern inside the placeholder. Left alone, the `*` pass
+    # below turned it into the nested, unbalanced `{name=projects/{wildcard}}`
+    # — no longer a path template at all. The variable is `name`; the pattern
+    # only says what it matches.
+    path = path.gsub(/\{(\w+)=[^{}]*\}/, "{\\1}")
 
     # Express-style optional segments (`/:id{/:op}`) are not representable as
     # optional in OpenAPI path templates. Drop the route-syntax braces so the
@@ -20,18 +35,54 @@ module OutputBuilderOasCommon
     # Bracket-style path params (`.NET` / Rails-ish `/users/[id]`) → `{id}`.
     path = path.gsub(/\[(\w+)\]/, "{\\1}")
 
+    # Play's routes file spells a constrained param `$path<.+>`. The regex is
+    # a constraint, not a name, and neither `<…>` pass below matches it, so
+    # the placeholder used to survive verbatim into the emitted path.
+    path = path.gsub(/\$(\w+)<[^<>]*>/, "{\\1}")
+
     # Convert typed placeholders before the generic :param pass; otherwise
     # `<int:id>` becomes `<int{id}>` and can no longer be normalized.
-    path = path.gsub(/<[^:>]+:(\w+)>/, "{\\1}")
+    path = path.gsub(/<([^:<>]+):(\w+)>/) do |_, match|
+      "{#{angle_placeholder_name(match[1], match[2], declared_path_params)}}"
+    end
     path = path.gsub(/<(\w+)>/, "{\\1}")
     path = path.gsub(/\*(\w+)/, "{\\1}")
     path = path.gsub(/:(\w+)/, "{\\1}")
 
     # Bare wildcard segments (`/api/*`, `/files/**`) have no name and are not
     # a valid OAS path template char; collapse a run of `*` to a named var.
-    path = path.gsub(/\*+/, "{wildcard}")
+    # Two of them in one path (`/api/*/v1/*`) have to get distinct names —
+    # a repeated template variable is not a valid path template.
+    wildcards = 0
+    path = path.gsub(/\*+/) do
+      wildcards += 1
+      wildcards == 1 ? "{wildcard}" : "{wildcard#{wildcards}}"
+    end
 
     path.starts_with?("/") ? path : "/#{path}"
+  end
+
+  # Resolve the parameter name in a `<head:tail>` placeholder. Both orderings
+  # are in the wild: Django and Flask spell it `<int:id>` (converter first)
+  # while Sanic, Bottle and Marten spell it `<id:int>` (name first). Always
+  # taking the second half named every Sanic route after its converter —
+  # `/users/<id:int>` emitted `{int}`, and two routes sharing a converter
+  # (`/metrics/<metric_id:int>`, `/reports/<report_id:int>`) collapsed onto
+  # the same OAS path.
+  #
+  # The endpoint's own path params are the authoritative signal: the optimizer
+  # resolved the same placeholder when it registered them. The converter list
+  # only decides placeholders they don't cover, and when both halves name a
+  # converter (`<slug:str>`) the Django ordering wins — it is by far the more
+  # common of the two.
+  private def angle_placeholder_name(head : String, tail : String, declared : Array(String)) : String
+    return head if declared.includes?(head)
+    return tail if declared.includes?(tail)
+    # Converter arguments (`<int(min=1):id>`) aren't part of the type name.
+    return tail if PATH_CONVERTER_TYPES.includes?(head.split('(', 2)[0])
+    return head if PATH_CONVERTER_TYPES.includes?(tail)
+
+    tail
   end
 
   private def path_template_names(path : String) : Array(String)
@@ -67,6 +118,36 @@ module OutputBuilderOasCommon
     return if parameters.any? { |existing| parameter_key(existing) == key }
 
     parameters << parameter
+  end
+
+  # Both OAS2 and OAS3 require an `in: path` parameter to correspond to a
+  # template expression in the path, so a declared path param the emitted path
+  # can't express makes the whole document fail validation. Analyzers produce
+  # those routinely: a Rails route whose placeholder the optimizer replaced
+  # with a concrete value (`/posts/1` still reads `id`), a splat literally
+  # named `*`, a param resolved from another file for an otherwise static
+  # route. Drop them from `parameters` and hand the names back so the caller
+  # can keep them in an extension instead of losing them.
+  private def extract_unmapped_path_parameters(parameters : Array(Hash(String, JSON::Any)), template_names : Array(String)) : Array(String)
+    unmapped = [] of String
+
+    parameters.reject! do |parameter|
+      next false unless parameter["in"].as_s == "path"
+
+      name = parameter["name"].as_s
+      next false if template_names.includes?(name)
+
+      unmapped << name
+      true
+    end
+
+    unmapped
+  end
+
+  private def add_unmapped_path_params_extension(operation : Hash(String, JSON::Any), names : Array(String))
+    return if names.empty?
+
+    operation["x-noir-unmapped-path-params"] = JSON::Any.new(names.map { |name| JSON::Any.new(name) })
   end
 
   private def merge_parameters(existing : Array(JSON::Any), incoming : Array(JSON::Any)) : Array(JSON::Any)


### PR DESCRIPTION
Every fixture language currently produces an OpenAPI document that fails validation. Five distinct bugs, all in the two path-shaped steps `oas2` / `oas3` share: turning a route into a path template, and deciding which parameters belong to it.

### Path templates

| Input | Before | After |
| --- | --- | --- |
| `/users/<id:int>` (Sanic) | `/users/{int}` | `/users/{id}` |
| `/api/*/v1/*` | `/api/{wildcard}/v1/{wildcard}` | `/api/{wildcard}/v1/{wildcard2}` |
| `/v1/{name=projects/*}/res` (AIP) | `/v1/{name=projects/{wildcard}}/res` | `/v1/{name}/res` |
| `/files/$path<.+>` (Play) | `/files/$path<.+>` | `/files/{path}` |

- **`<a:b>` ordering.** Django/Flask spell it `<int:id>` (converter first), Sanic/Bottle/Marten spell it `<id:int>` (name first). Taking a fixed half named every Sanic route after its converter, and routes sharing a converter (`/metrics/<metric_id:int>`, `/reports/<report_id:int>`) collapsed onto one `{int}` path. Now resolved against the endpoint's own declared path params — the optimizer resolved the same placeholder when it registered them — falling back to the converter list `Optimizer#angle_bracket_param` uses, so the two can't disagree.
- **Repeated `{wildcard}`** is not a valid path template; later occurrences are numbered.
- **AIP resource patterns** embed a path pattern in the placeholder, so the wildcard pass nested braces inside it.
- **Play's `$name<regex>`** matched neither `<…>` pass and survived verbatim.

### Parameters

- **`in: path` with no template expression.** Both OAS versions require the two to correspond, and analyzers routinely record path params the emitted path can't express — a Rails route whose placeholder the optimizer replaced with a value (`/posts/1` still reads `id`), a splat literally named `*`, a param resolved cross-file for an otherwise static route. These are dropped from `parameters` and kept in a new `x-noir-unmapped-path-params` operation extension, alongside the existing `x-noir-unsupported-methods`, so nothing is silently lost.
- **OAS2 duplicate `Cookie` header.** The synthesized cookie-summary parameter was appended unconditionally, so an endpoint that also had a header param named `Cookie` got two `{in: header, name: Cookie}` entries in one operation — Swagger 2.0 keys parameter uniqueness on name+in. Now replaces rather than appends, matching the postman builder's case-insensitive cookie merge.
- **OAS2 path/query parity.** OAS2 lacked the path-wins-over-same-named-query/header dedup OAS3 already did, so the same scan yielded different parameter sets in the two formats. `formData`/`body` are deliberately left alone — payload fields, not another spelling of the path segment.

### Verification

A structural validator (duplicate/nested/empty templates, duplicate name+in, undeclared and orphan path params) run over `-f oas2` and `-f oas3` for **every** `spec/functional_test/fixtures/*` directory: 13 languages reported violations before, **0 after**.

Emitted paths were diffed against `main` across all fixtures — the only differences are the four rows in the table above. Path-parameter entries were diffed per operation to confirm every dropped name is accounted for by either a corrected template or the new extension.

`crystal spec` green (4294 unit + 22428 functional), `crystal tool format --check` and `ameba` clean.