### PR TITLE
fix(output): don't open a second query string on a route that has one

### DIFF
--- a/spec/unit_test/models/output_builder_spec.cr
+++ b/spec/unit_test/models/output_builder_spec.cr
@@ -214,3 +214,45 @@ describe OutputBuilderDiff do
     result[:removed].should eq [Endpoint.new("GET", "/old", [Param.new("a", "b", "query"), Param.new("c", "d", "json")])]
   end
 end
+
+describe "OutputBuilder#bake_endpoint" do
+  options = create_test_options
+  builder = OutputBuilder.new options
+
+  it "opens the query string with ? and separates the rest with &" do
+    baked = builder.bake_endpoint("/search", [Param.new("q", "1", "query"), Param.new("page", "2", "query")])
+    baked[:url].should eq("/search?q=1&page=2")
+  end
+
+  it "appends to a query string the route already carries" do
+    # WordPress addresses an AJAX handler as `admin-ajax.php?action=…`; a
+    # second `?` would swallow everything after it into the first value.
+    baked = builder.bake_endpoint("/admin-ajax.php?action=x", [Param.new("id", "1", "query")])
+    baked[:url].should eq("/admin-ajax.php?action=x&id=1")
+  end
+
+  it "skips a query pair the route already spells out verbatim" do
+    baked = builder.bake_endpoint("/admin-ajax.php?action=x", [Param.new("action", "x", "query")])
+    baked[:url].should eq("/admin-ajax.php?action=x")
+  end
+
+  it "still appends an overridden value for a name already in the query" do
+    baked = builder.bake_endpoint("/admin-ajax.php?action=x", [Param.new("action", "FUZZ", "query")])
+    baked[:url].should eq("/admin-ajax.php?action=x&action=FUZZ")
+  end
+
+  it "treats route-syntax ? as part of the path, not as a query string" do
+    # Express optional segments (`/geo/:ip?`) and regex routes (`(?:a|b)`)
+    # both spell a `?` that opens no query string.
+    builder.bake_endpoint("/geo/:ip?", [Param.new("q", "1", "query")])[:url]
+      .should eq("/geo/:ip??q=1")
+    builder.bake_endpoint("/grp/(?:a|b)", [Param.new("q", "1", "query")])[:url]
+      .should eq("/grp/(?:a|b)?q=1")
+  end
+
+  it "keeps tags from a query param that was skipped as redundant" do
+    param = Param.new("action", "x", "query")
+    param.add_tag(Tag.new("pii", "personal data", "metadata_tagger"))
+    builder.bake_endpoint("/a.php?action=x", [param])[:tags].should eq(["pii"])
+  end
+end

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -176,7 +176,6 @@ class OutputBuilder
     final_cookies = [] of String
     final_tags = [] of String
     is_json = false
-    first_query = true
     first_form = true
 
     if final_url.starts_with?("//")
@@ -185,14 +184,38 @@ class OutputBuilder
       end
     end
 
+    # A route can arrive carrying its own query string —
+    # `/wp-admin/admin-ajax.php?action=get_user_data` is how WordPress
+    # addresses an AJAX handler, and the analyzer records `action` as a query
+    # param on top of it. Opening the baked params with another `?` produced
+    # `...?action=get_user_data?action=get_user_data`, where the second `?`
+    # and everything after it is swallowed into the first value: a URL that no
+    # longer addresses the endpoint, in every format that bakes one (plain,
+    # only-url, curl, httpie, powershell, html, adb, simctl).
+    #
+    # `?` here does not always open a query string — it is also route syntax
+    # (Express `/geo/:ip?`, regex routes `/grp/(?:a|b)`). Only a `?` that
+    # introduces a `key=value` pair before the next path separator does.
+    existing_query = final_url.match(/\?([^?\/#]*=[^?#]*)/).try(&.[1])
+    existing_pairs = existing_query.try(&.split('&')) || [] of String
+    first_query = existing_query.nil?
+
     unless params.nil?
       params.each do |param|
         if param.param_type == "query"
-          if first_query
-            final_url += "?#{param.name}=#{param.value}"
-            first_query = false
-          else
-            final_url += "&#{param.name}=#{param.value}"
+          pair = "#{param.name}=#{param.value}"
+          # A pair the route already spells out verbatim adds nothing. A
+          # *different* value for the same name is an override (`--pvalue
+          # query=…`) and is still appended — the later pair is the one
+          # servers read, so the override survives. Skipping with `next` would
+          # also skip this param's tag collection at the bottom of the block.
+          unless existing_pairs.includes?(pair)
+            if first_query
+              final_url += "?#{pair}"
+              first_query = false
+            else
+              final_url += "&#{pair}"
+            end
           end
         end
 


### PR DESCRIPTION
A route can arrive carrying its own query string — `admin-ajax.php?action=x` is how WordPress addresses an AJAX handler, and the analyzer records `action` as a query param on top of it. `bake_endpoint` always opened the baked params with `?`:

```
- /wp-admin/admin-ajax.php?action=get_user_data?action=get_user_data
+ /wp-admin/admin-ajax.php?action=get_user_data
```

The second `?` and everything after it is swallowed into the first value, so the URL no longer addresses the endpoint. Every format that bakes a URL was affected — `plain`, `only-url`, `curl`, `httpie`, `powershell`, `html` (both the row and copy-as-curl), `adb`, `simctl`.

### Fix

- Use `&` when the route already carries a query string.
- Skip a pair the route already spells out verbatim, so the common case stays clean rather than becoming `?action=x&action=x`.
- A **different** value for the same name is still appended — that is a `--pvalue query=…` override, and the later pair is the one servers read, so appending is exactly what makes the override take effect.

`?` is not always a query separator here: it is also route syntax (Express `/geo/:ip?`, regex routes `/grp/(?:a|b)`). Only a `?` that introduces a `key=value` pair before the next path separator counts, so those routes are left byte-identical.

One implementation note: the skip is an `unless`, not a `next` — `next` would also skip the param's tag collection at the bottom of the same block. Covered by a spec.

### Verification

Every URL-baking format diffed against `main`, **per fixture directory** (scanning the whole fixture tree as one project is nondeterministic):

| format | changed lines | where |
| --- | --- | --- |
| only-url | 8 | php |
| curl / httpie / powershell | 16 each | php |
| plain | 20 | php |
| html | 32 | php |
| adb / simctl / markdown-table / mermaid / json | 0 | — |

All of them are the four WordPress URLs above; nothing else moved.

`crystal spec` green (4293 unit incl. 6 new `bake_endpoint` examples + 22428 functional), `crystal tool format --check` and `ameba` clean.