### PR TITLE
fix(models): line 0 is not a line

### DIFF
--- a/spec/unit_test/models/endpoint_spec.cr
+++ b/spec/unit_test/models/endpoint_spec.cr
@@ -220,3 +220,25 @@ describe AIContext do
     ctx.sinks.last.name.should eq "s#{AIContext::MAX_PER_SECTION - 1}"
   end
 end
+
+describe PathInfo do
+  it "keeps a real 1-based line" do
+    PathInfo.new("app.cr", 1).line.should eq(1)
+    PathInfo.new("app.cr", 42).line.should eq(42)
+  end
+
+  it "treats a non-positive line as no line at all" do
+    # Line numbers are 1-based, so 0 means "no line to point at" — the same
+    # thing `nil` already means. Leaving it as 0 printed `(line 0)` in the
+    # plain and HTML reports and emitted `region.startLine: 0` into SARIF,
+    # which the format forbids.
+    PathInfo.new("capture.har", 0).line.should be_nil
+    PathInfo.new("capture.har", -1).line.should be_nil
+    PathInfo.new("capture.har", nil).line.should be_nil
+    PathInfo.new("capture.har").line.should be_nil
+  end
+
+  it "does not serialize an absent line" do
+    JSON.parse(PathInfo.new("capture.har", 0).to_json).as_h.has_key?("line").should be_false
+  end
+end

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -486,7 +486,7 @@ module Analyzer::Scala
 
     # Create an endpoint with the given path and method
     private def create_endpoint(path : String, method : String, source : String)
-      details = Details.new(PathInfo.new(source, 0))
+      details = Details.new(PathInfo.new(source))
       params = [] of Param
 
       Endpoint.new(path, method, params, details)

--- a/src/analyzer/analyzers/specification/har.cr
+++ b/src/analyzer/analyzers/specification/har.cr
@@ -61,7 +61,7 @@ module Analyzer::Specification
 
           add_post_data_params(endpoint, entry.request)
 
-          details = Details.new(PathInfo.new(har_file, 0))
+          details = Details.new(PathInfo.new(har_file))
           details.status_code = entry.response.status
           endpoint.details = details
           endpoint.protocol = "ws" if is_websocket

--- a/src/analyzer/analyzers/specification/mitmproxy.cr
+++ b/src/analyzer/analyzers/specification/mitmproxy.cr
@@ -130,7 +130,7 @@ module Analyzer::Specification
         end
       end
 
-      endpoint.details = Details.new(PathInfo.new(path, 0))
+      endpoint.details = Details.new(PathInfo.new(path))
       endpoint.protocol = "ws" if is_websocket
       @result << endpoint
     end

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -265,7 +265,19 @@ struct PathInfo
     @line = nil
   end
 
-  def initialize(@path : String, @line : Int32?)
+  # Line numbers here are 1-based, so `0` is not a line — it is how a handful
+  # of analyzers spelled "this endpoint came from that file, but there is no
+  # line to point at" (HAR / mitmproxy captures have no source line at all;
+  # akka's nested route DSL had none to hand). `nil` is the representation the
+  # rest of the codebase already uses for that, and every consumer branches on
+  # it: the plain and HTML reports printed a meaningless `(line 0)`, and SARIF
+  # emitted `region.startLine: 0`, which the format forbids — startLine must
+  # be a positive integer, so the report failed validation.
+  #
+  # Normalized here rather than at the three call sites so a future analyzer
+  # can't reintroduce it.
+  def initialize(@path : String, line : Int32?)
+    @line = line && line > 0 ? line : nil
   end
 
   def ==(other : PathInfo) : Bool


### PR DESCRIPTION
Line numbers are 1-based everywhere in Noir, and `nil` is how a `PathInfo` says *"this endpoint came from that file, but there is no line to point at."* Three analyzers spelled that as `0` instead — HAR and mitmproxy captures have no source line at all, and akka's nested route DSL had none to hand — and the `0` flowed straight through to the reports.

### What it broke

**SARIF.** `region.startLine: 0` — the format requires a positive integer, so `-f sarif` produced a document that fails validation. The bundled `sarif` shard's own validator rejects it too (`validator.cr:269`, `sl < 1`).

| fixture | invalid `startLine: 0` regions |
| --- | --- |
| scala | 31 |
| specification | 8 |

**Plain / HTML reports.** `--include-path` printed a meaningless `(line 0)` next to the file:

```
- ○ file: spec/functional_test/fixtures/scala/akka/WebServer.scala (line 0)
+ ○ file: spec/functional_test/fixtures/scala/akka/WebServer.scala
```

**AI context.** The same `0` reached `x-noir-ai-context` and the plain `ai_context` block — 112 entries in scala, 61 in specification — because AI-context entries inherit the code path's line.

### Fix

Normalize a non-positive line to `nil` in `PathInfo`, so no future analyzer can reintroduce it, and use the no-line constructor at the three call sites (`specification/har.cr`, `specification/mitmproxy.cr`, `scala/akka.cr`) so the intent is visible where the endpoint is built.

`line` is a nilable field with no `emit_null`, so it simply stops appearing in JSON/YAML for those endpoints — exactly as it already does for every other line-less code path.

### Verification

A SARIF structural checker (undeclared `ruleId`, missing message, missing location URI, `startLine < 1`) run over `-f sarif -P` for every fixture directory: `startLine: 0` in 2 fixtures before, **0 after**. A sweep for `line == 0` across `code_paths`, `callees` and every `ai_context` bucket in all 34 fixture directories now returns nothing, and `(line 0)` no longer appears in any plain report.

`crystal spec` green (4303 unit incl. 3 new `PathInfo` examples + 22428 functional), `crystal tool format --check` and `ameba` clean.

### Noted, not fixed here

The same sweep found `artifactLocation.uri` carrying **absolute** filesystem paths for `haskell_yesod` (6) and `java_struts2` (2), while every other analyzer records paths relative to the scan base. That leaks the scanning machine's directory layout into shared reports and makes the SARIF unusable for GitHub code scanning, which needs repo-relative URIs. Different root cause (per-analyzer path recording), so it is left for a separate change.