### PR TITLE
fix(analyzer): record code paths the way the walker spelled them

### DIFF
--- a/src/analyzer/analyzers/haskell/yesod.cr
+++ b/src/analyzer/analyzers/haskell/yesod.cr
@@ -23,10 +23,14 @@ module Analyzer::Haskell
         next if File.directory?(path)
 
         if route_file?(path)
+          # The expanded path canonicalizes the dedup key only. Reporting it
+          # as well recorded an absolute machine path in `code_paths`, while
+          # the walker's own spelling (relative, when the scan base is) is
+          # what every other analyzer records.
           expanded_path = File.expand_path(path)
           next if processed_route_files.includes?(expanded_path)
 
-          process_route_content(expanded_path, read_file_content(path), include_callee, handler_bodies)
+          process_route_content(path, read_file_content(path), include_callee, handler_bodies)
           processed_route_files << expanded_path
           next
         end
@@ -44,7 +48,9 @@ module Analyzer::Haskell
           next if File.directory?(referenced_path)
           next if processed_route_files.includes?(referenced_path)
 
-          process_route_content(referenced_path, read_file_content(referenced_path), include_callee, handler_bodies)
+          # Resolved against the referencing file's directory, so report it
+          # the way the walker saw it rather than as an absolute path.
+          process_route_content(walked_path(referenced_path), read_file_content(referenced_path), include_callee, handler_bodies)
           processed_route_files << referenced_path
         end
       end

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -246,8 +246,13 @@ module Analyzer::Java
       candidates << File.expand_path(include_name, File.dirname(current_path))
       candidates << File.join(configured_base_for(current_path), include_name.lstrip('/'))
 
+      # `walked_path` maps the resolved candidate back to the walker's own
+      # spelling. Without it an `<include>` target resolved against the
+      # including file's directory was recorded — and reported — as an
+      # absolute machine path, while the top-level `struts.xml` next to it
+      # stayed relative.
       if found = candidates.find { |candidate| File.exists?(candidate) }
-        return found
+        return walked_path(found)
       end
 
       normalized = include_name.lstrip('/')

--- a/src/models/file_helper.cr
+++ b/src/models/file_helper.cr
@@ -24,6 +24,25 @@ module FileHelper
     CodeLocator.instance.expanded_file_map
   end
 
+  @walked_path_index : Hash(String, String)? = nil
+
+  # The as-walked spelling of a path an analyzer resolved with
+  # `File.expand_path` — a config `<include>` target, a route file named from
+  # a source file. `code_paths` are reported the way the walker handed them
+  # over, so a resolved path has to be mapped back before it reaches a report:
+  # left absolute it puts the scanning machine's directory layout into
+  # anything shared, and a SARIF `artifactLocation.uri` that isn't
+  # repo-relative can't be matched to a file by GitHub code scanning.
+  #
+  # Falls back to the input for a file outside the scan — there is nothing
+  # better to say about it.
+  def walked_path(expanded : String) : String
+    index = (@walked_path_index ||= all_files_expanded.each_with_object({} of String => String) do |(file, file_expanded), map|
+      map[file_expanded] ||= file
+    end)
+    index[expanded]? || expanded
+  end
+
   # Get files filtered by path prefix
   #
   # No `File.directory?` guard: the detector's walk only registers a


### PR DESCRIPTION
`code_paths` are reported as the file walker handed them over — relative, when the scan base is relative. Two analyzers reported a resolved **absolute** path instead:

```
- /Users/hahwul/.../spec/functional_test/fixtures/java/struts2/src/main/resources/admin-struts.xml
+ spec/functional_test/fixtures/java/struts2/src/main/resources/admin-struts.xml
```

- **`haskell_yesod`** passed `File.expand_path(path)` to the route processor. That expansion exists to canonicalize the dedup key; reporting it too was incidental.
- **`java_struts2`** reported an `<include>` target as resolved against the including file's directory, so `admin-struts.xml` came out absolute while the `struts.xml` that included it stayed relative.

### Why it matters

1. The scanning machine's directory layout — `/Users/<name>/...` — ended up in any shared report (JSON, HTML, SARIF, `--include-path`).
2. A SARIF `artifactLocation.uri` that is not repo-relative can't be matched to a file by GitHub code scanning, so those findings get dropped or mislocated.
3. **It quietly defeated the deterministic endpoint ordering.** `endpoint_order_key` sorts on `code_path.path` precisely so first-wins dedup means *"earliest in the codebase"* rather than *"whichever fiber won"* — the comment there spells out that the winning `technology` must not depend on the machine. An absolute path sorts before every relative one, so the yesod endpoint always won ties against scotty for `/a`, `/b` and `/search` in the haskell fixture — but only because this checkout happens to live under `/Users`. On a checkout whose absolute path sorts after `spec/`, the winner flips. With paths normalized, the tie is broken by the in-repo path and scotty wins the same way everywhere.

That third point is the visible behaviour change in this diff: three haskell fixture endpoints flip `technology` from `haskell_yesod` to `haskell_scotty`. Both are true — they're two separate fixture apps that happen to share a URL — but now the winner is chosen by something that is the same on every machine.

### Fix

`FileHelper#walked_path` maps a resolved path back through the already-cached `{original, expanded}` pairs, so an analyzer that has to resolve a reference can still report it the way the rest of the codebase does. The index is built at most once per analyzer instance, and only when something actually resolves a path.

### Verification

A sweep for absolute `code_paths` over all 34 fixture directories: 4 before (haskell 3, java 1), **0 after**.

Full `(method, url, technology, sorted code_paths)` diff of `-f json --include-callee --ai-context` against `main`, per fixture directory — only `haskell` (12 lines) and `java` (4 lines) differ, and every line is either the absolute→relative rewrite or one of the three tie-break flips explained above.

`crystal spec` green (4300 unit + 22428 functional), `crystal tool format --check` and `ameba` clean.