### PR TITLE
fix(output/postman): keep the host, and keep raw in agreement with query

### DIFF
--- a/spec/unit_test/output_builder/postman_spec.cr
+++ b/spec/unit_test/output_builder/postman_spec.cr
@@ -165,3 +165,60 @@ describe "OutputBuilderPostman" do
     items.map(&.["name"].as_s).should eq(WILDCARD_HTTP_METHODS.map { |method| "#{method} /wildcard" })
   end
 end
+
+describe "OutputBuilderPostman URLs" do
+  options = {
+    "debug"   => YAML::Any.new(false),
+    "verbose" => YAML::Any.new(false),
+    "color"   => YAML::Any.new(false),
+    "nolog"   => YAML::Any.new(false),
+    "output"  => YAML::Any.new(""),
+    "url"     => YAML::Any.new(""),
+  }
+
+  it "keeps the host of an absolute endpoint instead of {{baseUrl}}" do
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    absolute = Endpoint.new("https://demo.example.com.evil/api/users/{id}", "GET")
+    absolute.push_param(Param.new("id", "", "path"))
+
+    builder.print([absolute])
+    url = JSON.parse(builder.io.to_s)["item"][0]["request"]["url"]
+
+    url["raw"].as_s.should eq("https://demo.example.com.evil/api/users/:id")
+    url["host"].as_a.map(&.as_s).should eq(["demo", "example", "com", "evil"])
+    url["protocol"].as_s.should eq("https")
+    # The sidebar shows the name alone, so a host-less name would render this
+    # and `demo.example.com/api/users/{id}` identically.
+    JSON.parse(builder.io.to_s)["item"][0]["name"].as_s
+      .should eq("GET demo.example.com.evil/api/users/{id}")
+  end
+
+  it "still routes a relative endpoint through {{baseUrl}}" do
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/api/users", "GET")])
+    url = JSON.parse(builder.io.to_s)["item"][0]["request"]["url"]
+
+    url["raw"].as_s.should eq("{{baseUrl}}/api/users")
+    url["host"].as_a.map(&.as_s).should eq(["{{baseUrl}}"])
+    url.as_h.has_key?("protocol").should be_false
+  end
+
+  it "keeps raw in agreement with the structured query list" do
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/search", "GET")
+    endpoint.push_param(Param.new("q", "noir", "query"))
+    endpoint.push_param(Param.new("page", "2", "query"))
+
+    builder.print([endpoint])
+    url = JSON.parse(builder.io.to_s)["item"][0]["request"]["url"]
+
+    url["raw"].as_s.should eq("{{baseUrl}}/search?q=noir&page=2")
+    url["query"].as_a.map(&.["key"].as_s).should eq(["q", "page"])
+  end
+end

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -32,12 +32,7 @@ class OutputBuilderPostman < OutputBuilder
         end
       end
 
-      # Build URL object
-      url_obj = {
-        "raw"  => JSON::Any.new("{{baseUrl}}/#{path_with_vars.join("/")}"),
-        "host" => JSON::Any.new([JSON::Any.new("{{baseUrl}}")]),
-        "path" => JSON::Any.new(path_with_vars.map { |p| JSON::Any.new(p) }),
-      } of String => JSON::Any
+      url_obj = build_url_object(uri, path_with_vars)
 
       # Add query parameters
       query_params = [] of JSON::Any
@@ -52,6 +47,12 @@ class OutputBuilderPostman < OutputBuilder
 
       if !query_params.empty?
         url_obj["query"] = JSON::Any.new(query_params)
+        # `raw` is the field a human reads in the URL bar and the one most
+        # non-Postman importers key off, so it has to agree with the
+        # structured `query` list. It was built from the path alone, which
+        # also dropped a query string the route itself carried
+        # (`admin-ajax.php?action=…`).
+        url_obj["raw"] = JSON::Any.new(raw_with_query(url_obj["raw"].as_s, query_params))
       end
 
       # Add path variables
@@ -162,9 +163,12 @@ class OutputBuilderPostman < OutputBuilder
           request["body"] = JSON::Any.new(body)
         end
 
-        # Build item
+        # Build item. The host is part of the name for an absolute URL:
+        # without it `demo.example.com/api/users/{id}` and
+        # `demo.example.com.evil/api/users/{id}` are two entries in the
+        # sidebar reading exactly the same.
         item = {
-          "name"    => JSON::Any.new("#{method} #{uri.path}"),
+          "name"    => JSON::Any.new("#{method} #{item_label(uri)}"),
           "request" => JSON::Any.new(request),
         } of String => JSON::Any
 
@@ -192,5 +196,62 @@ class OutputBuilderPostman < OutputBuilder
     } of String => JSON::Any
 
     ob_puts JSON::Any.new(collection).to_pretty_json
+  end
+
+  # Postman addresses a request either through the collection's `baseUrl`
+  # variable — the common case, an endpoint discovered as a bare path — or
+  # through its own absolute URL. Spec- and capture-derived endpoints carry a
+  # real host (an OpenAPI `servers` entry, a HAR capture spanning domains),
+  # and rewriting those to `{{baseUrl}}` aimed every request at one host,
+  # throwing away the host Noir had actually found: `demo.example.com` and
+  # `demo.example.com.evil` imported as the same request. curl, httpie and
+  # only-url all keep the host on the same scan; this now does too.
+  private def build_url_object(uri : URI, path_with_vars : Array(String)) : Hash(String, JSON::Any)
+    host = uri.host
+    if host.nil? || host.empty?
+      return {
+        "raw"  => JSON::Any.new("{{baseUrl}}/#{path_with_vars.join("/")}"),
+        "host" => JSON::Any.new([JSON::Any.new("{{baseUrl}}")]),
+        "path" => JSON::Any.new(path_with_vars.map { |p| JSON::Any.new(p) }),
+      } of String => JSON::Any
+    end
+
+    authority = String.build do |io|
+      io << uri.scheme << "://" if uri.scheme
+      io << host
+      io << ':' << uri.port if uri.port
+    end
+
+    url_obj = {
+      # Postman splits a real host into its domain labels.
+      "raw"  => JSON::Any.new("#{authority}/#{path_with_vars.join("/")}"),
+      "host" => JSON::Any.new(host.split('.').map { |label| JSON::Any.new(label) }),
+      "path" => JSON::Any.new(path_with_vars.map { |p| JSON::Any.new(p) }),
+    } of String => JSON::Any
+
+    if scheme = uri.scheme
+      url_obj["protocol"] = JSON::Any.new(scheme)
+    end
+    if port = uri.port
+      url_obj["port"] = JSON::Any.new(port.to_s)
+    end
+
+    url_obj
+  end
+
+  private def raw_with_query(raw : String, query_params : Array(JSON::Any)) : String
+    pairs = query_params.map do |param|
+      entry = param.as_h
+      "#{entry["key"].as_s}=#{entry["value"].as_s}"
+    end
+
+    "#{raw}#{raw.includes?('?') ? '&' : '?'}#{pairs.join("&")}"
+  end
+
+  private def item_label(uri : URI) : String
+    host = uri.host
+    return uri.path if host.nil? || host.empty?
+
+    "#{host}#{uri.path}"
   end
 end


### PR DESCRIPTION
Two things the Postman builder threw away.

### The host

Every request was addressed as `{{baseUrl}}/<path>`, built from `uri.path` alone. That is right for the common case — an endpoint discovered as a bare path — but spec- and capture-derived endpoints carry a **real host**: an OpenAPI `servers` entry, a HAR capture spanning domains. Those were rewritten to point at the single collection variable, so the host Noir had actually found was gone:

```diff
- {"raw": "{{baseUrl}}/api/users/:id", "host": ["{{baseUrl}}"]}
+ {"raw": "https://demo.example.com.evil/api/users/:id",
+  "host": ["demo", "example", "com", "evil"], "protocol": "https"}
```

In the `specification` fixture that collapsed 7 requests across `www.hahwul.com`, `demo.example.com` and `demo.example.com.evil` onto one host — and `demo.example.com` vs `demo.example.com.evil` is exactly the distinction that matters in this tool's line of work. They were left distinguishable only by an item name that rendered identically in the sidebar (`GET /api/users/{id}` for both).

`curl`, `httpie` and `only-url` all keep the host on the same scan; Postman was the outlier.

An absolute endpoint now emits its own `raw`, `host` (split into domain labels, as Postman spells it), `protocol` and `port`, and carries the host in the item name. A relative endpoint is byte-identical to before.

### The query string

`raw` was built from the path while the params went into the structured `query` list, so the two disagreed on **62 of 427** items in the specification fixture. `raw` is the field a human reads in the URL bar and the one most non-Postman importers key off. It also meant a query string the *route itself* carried (`admin-ajax.php?action=…`, WordPress AJAX) never appeared in `raw` at all.

```diff
- {"raw": "{{baseUrl}}/search", "query": [{"key":"q",...},{"key":"page",...}]}
+ {"raw": "{{baseUrl}}/search?q=noir&page=2", "query": [...]}
```

### Verification

Every changed item across all 34 fixture directories was classified mechanically — 1234 changed lines, and each one falls into exactly one of the two intended buckets:

| bucket | count |
| --- | --- |
| `raw` gained its query string | 1220 |
| absolute URL keeps host + protocol + name prefix | 14 (7 items) |

No item-count changes, no unexpected field changes, in any fixture. The 8th absolute-URL endpoint in that fixture is `wss://demo.example.com/socket`, which Postman correctly excludes as non-HTTP.

Also re-ran a cross-format hostile-input harness (param names and `--pvalue` values containing quotes, backticks, `$( )`, `|`, `&`, `{{ }}`, `</script>`, `" onload="`, CJK) over every format — Postman output still parses and nothing escapes into markup: 0 problems.

`crystal spec` green (4306 unit incl. 3 new Postman examples + 22428 functional), `crystal tool format --check` and `ameba` clean.