### PR TITLE
fix(deliver): probe the things that can be probed, and only those

### DIFF
--- a/spec/unit_test/deliver/send_elasticsearch_spec.cr
+++ b/spec/unit_test/deliver/send_elasticsearch_spec.cr
@@ -100,6 +100,28 @@ describe SendElasticSearch do
     end
   end
 
+  describe ".normalize_endpoint" do
+    it "defaults a portless http URL to 9200" do
+      SendElasticSearch.normalize_endpoint("http://localhost/noir/_doc").to_s
+        .should eq("http://localhost:9200/noir/_doc")
+    end
+
+    it "leaves a portless https URL on the scheme default" do
+      # Managed clusters (AWS OpenSearch Service, Elastic Cloud) and TLS
+      # reverse proxies listen on 443. Forcing 9200 here turned a working
+      # endpoint into an unreachable one.
+      SendElasticSearch.normalize_endpoint("https://search-x.us-east-1.es.amazonaws.com/noir/_doc").to_s
+        .should eq("https://search-x.us-east-1.es.amazonaws.com/noir/_doc")
+    end
+
+    it "keeps an explicit port on either scheme" do
+      SendElasticSearch.normalize_endpoint("http://localhost:9201/noir/_doc").to_s
+        .should eq("http://localhost:9201/noir/_doc")
+      SendElasticSearch.normalize_endpoint("https://my.cloud.es.io:9243/noir/_doc").to_s
+        .should eq("https://my.cloud.es.io:9243/noir/_doc")
+    end
+  end
+
   it "swallows network errors instead of bubbling out of run" do
     sender = SendElasticSearch.new(base_deliver_options)
     # Unreachable port → Crest raises; the rescue inside `run` must

--- a/spec/unit_test/deliver/send_req_spec.cr
+++ b/spec/unit_test/deliver/send_req_spec.cr
@@ -183,6 +183,45 @@ describe SendReq do
     end
   end
 
+  it "matches an absolute-URL pattern instead of reading its scheme as a method" do
+    server = CapturingServer.new
+    begin
+      ep_keep = Endpoint.new(server.url_for("/public/info"), "GET")
+      ep_drop = Endpoint.new(server.url_for("/admin/users"), "GET")
+
+      options = base_deliver_options
+      # Every delivery target requires -u, so endpoint URLs are absolute and
+      # pasting one into --probe-skip is the natural thing to do. Splitting
+      # on the first ':' used to read this as method `HTTP` + url
+      # `//127.0.0.1:PORT/admin`, matching nothing at all.
+      options["probe_skip"] = YAML::Any.new([YAML::Any.new(server.url_for("/admin"))])
+      sender = SendReq.new(options)
+      sender.run([ep_keep, ep_drop])
+
+      paths = server.requests.map(&.[:path])
+      paths.should eq(["/public/info"])
+    ensure
+      server.close
+    end
+  end
+
+  it "still honours the METHOD:url pattern form" do
+    server = CapturingServer.new
+    begin
+      ep_get = Endpoint.new(server.url_for("/admin/users"), "GET")
+      ep_post = Endpoint.new(server.url_for("/admin/users"), "POST")
+
+      options = base_deliver_options
+      options["probe_match"] = YAML::Any.new([YAML::Any.new("POST:/admin")])
+      sender = SendReq.new(options)
+      sender.run([ep_get, ep_post])
+
+      server.requests.map(&.[:method]).should eq(["POST"])
+    ensure
+      server.close
+    end
+  end
+
   it "swallows network errors so one bad endpoint doesn't abort the batch" do
     server = CapturingServer.new
     begin

--- a/spec/unit_test/models/noir_update_status_codes_spec.cr
+++ b/spec/unit_test/models/noir_update_status_codes_spec.cr
@@ -119,4 +119,28 @@ describe "NoirRunner#update_status_codes" do
 
     runner.last_request_method.should eq(:get)
   end
+
+  it "keeps non-HTTP endpoints without requesting them" do
+    # Mobile deep links, CLI command surfaces and realtime ws:// event
+    # surfaces can't be HTTP-requested at all — Crest raises "Unsupported
+    # scheme" on each. They must pass through untouched, the way SendReq /
+    # SendWithProxy already skip them.
+    runner = TestNoirRunner.new(options)
+
+    deep_link = Endpoint.new("myapp://accounts/profile", "GET")
+    deep_link.protocol = "mobile-scheme"
+    runner.endpoints << deep_link
+
+    cli = Endpoint.new("cli://noir/scan", "CLI")
+    cli.protocol = "cli"
+    runner.endpoints << cli
+
+    runner.endpoints << Endpoint.new("ws://room:lobby/new_msg", "SEND")
+
+    runner.update_status_codes
+
+    runner.endpoints.size.should eq(3)
+    runner.last_request_method.should be_nil
+    runner.endpoints.each(&.details.status_code.should(be_nil))
+  end
 end

--- a/src/deliver/send_elasticsearch.cr
+++ b/src/deliver/send_elasticsearch.cr
@@ -3,11 +3,20 @@ require "../utils/http_symbols"
 require "../models/deliver"
 
 class SendElasticSearch < Deliver
-  def run(endpoints : Array(Endpoint), es_endpoint : String)
+  # `http://` with no port means the local/dev cluster shape, where 9200 is
+  # the useful default. `https://` does not: managed clusters (AWS
+  # OpenSearch Service, Elastic Cloud) and anything behind a TLS reverse
+  # proxy listen on 443, so forcing 9200 there rewrote a working endpoint
+  # into an unreachable one and the export failed with a connection error
+  # the user had no way to explain. An explicit port always wins.
+  def self.normalize_endpoint(es_endpoint : String) : URI
     uri = URI.parse es_endpoint
-    if uri.port.nil?
-      uri.port = 9200
-    end
+    uri.port = 9200 if uri.port.nil? && uri.scheme == "http"
+    uri
+  end
+
+  def run(endpoints : Array(Endpoint), es_endpoint : String)
+    uri = SendElasticSearch.normalize_endpoint(es_endpoint)
 
     applied_endpoints = apply_all(endpoints)
 
@@ -40,8 +49,10 @@ class SendElasticSearch < Deliver
     )
   rescue e
     # Surface the failure at warning level so an indexing outage isn't
-    # mistaken for a successful export.
-    @logger.warning "Elasticsearch delivery to #{uri} failed: #{e.message}"
+    # mistaken for a successful export. Reported against the URL the user
+    # passed: `URI.parse` itself can raise, and the local `uri` is then nil,
+    # which rendered the message as "delivery to  failed".
+    @logger.warning "Elasticsearch delivery to #{es_endpoint} failed: #{e.message}"
     @logger.debug_sub e
   end
 end

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -163,25 +163,34 @@ class Deliver
     end
   end
 
+  # A `METHOD:url` pattern is only method-scoped when the token before the
+  # first colon really is a verb an endpoint can carry. Splitting on *any*
+  # colon read `--probe-skip https://api.example.com/admin` as method
+  # `HTTPS` + url `//api.example.com/admin`, which matches nothing — so the
+  # filter silently did nothing and every endpoint the user meant to skip
+  # was probed anyway. That is the common shape, not an edge case: every
+  # delivery target requires `-u`, which rewrites each endpoint to
+  # `scheme://host/path`, so pasting a full URL into --probe-match /
+  # --probe-skip is the natural thing to do. A `host:8080/x` pattern hit the
+  # same hole.
   private def matches_pattern?(endpoint : Endpoint, pattern : String) : Bool
-    # Check if pattern contains method:url format
-    if pattern.includes? ":"
-      parts = pattern.split(":", 2)
-      method_pattern = parts[0].upcase
-      url_pattern = parts[1]
+    colon_index = pattern.index(':')
+    if colon_index && endpoint_method_token?(pattern[0...colon_index])
+      method_pattern = pattern[0...colon_index].upcase
+      url_pattern = pattern[(colon_index + 1)..]
 
       # Check if method matches and URL contains pattern
-      endpoint.method.upcase == method_pattern && endpoint.url.includes?(url_pattern)
-    else
-      # Check if pattern is just a method name
-      upper_pattern = pattern.upcase
+      return endpoint.method.upcase == method_pattern && endpoint.url.includes?(url_pattern)
+    end
 
-      if ALLOWED_HTTP_METHODS.includes?(upper_pattern)
-        endpoint.method.upcase == upper_pattern
-      else
-        # Backward compatibility: check URL
-        endpoint.url.includes?(pattern)
-      end
+    # Pattern is just a method name. Matched against every verb an endpoint
+    # can carry (not only the real HTTP ones) so `--probe-skip SEND` and
+    # `--probe-skip CLI` filter the same way `SEND:/ws` does.
+    if endpoint_method_token?(pattern)
+      endpoint.method.upcase == pattern.upcase
+    else
+      # Backward compatibility: check URL
+      endpoint.url.includes?(pattern)
     end
   end
 end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -213,6 +213,18 @@ class NoirRunner
     end
 
     @endpoints.each do |endpoint|
+      # Mobile deep links (`myapp://`, `intent://`, `content://`), CLI
+      # command surfaces (`cli://`) and realtime `ws://` event surfaces are
+      # not HTTP requests — the same guard SendReq / SendWithProxy already
+      # apply before probing. Without it every one of them was handed to
+      # Crest, which raised "Unsupported scheme" per endpoint: a mobile scan
+      # with --status-codes printed dozens of `Failed to get status code`
+      # errors for endpoints that can never have one.
+      if endpoint.non_http?
+        final << endpoint
+        next
+      end
+
       request_method = requestable_http_methods(endpoint.method).first?
       unless request_method
         final << endpoint

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -1040,7 +1040,6 @@ class EndpointOptimizer
   # endpoints alone — DAST consumers route on these, and downgrading
   # them to `GET` would collapse publish + subscribe into one row.
   private def get_allowed_methods : Array(String)
-    ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT", "QUERY", "ANY",
-     "PUBLISH", "SUBSCRIBE", "SEND", "RECEIVE"]
+    ALLOWED_HTTP_METHODS + SYNTHETIC_ENDPOINT_METHODS
   end
 end

--- a/src/utils/http_symbols.cr
+++ b/src/utils/http_symbols.cr
@@ -20,8 +20,25 @@ end
 
 ALLOWED_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT", "QUERY"]
 
+# Verbs an endpoint can carry that are not HTTP methods: the wildcard
+# `ANY`, and the AsyncAPI / messaging verbs the optimizer allow-lists so
+# event-driven endpoints aren't downgraded to `GET`.
+SYNTHETIC_ENDPOINT_METHODS = ["ANY", "PUBLISH", "SUBSCRIBE", "SEND", "RECEIVE"]
+
+# The synthetic verb CLI entry points carry (`cli://<binary>/<subcommand>`).
+CLI_ENDPOINT_METHOD = "CLI"
+
+# Every verb that can appear as `Endpoint#method`. Consumers that have to
+# tell "this token names a method" from "this token is part of a URL"
+# (the probe matchers) read this instead of keeping their own list.
+ENDPOINT_METHODS = ALLOWED_HTTP_METHODS + SYNTHETIC_ENDPOINT_METHODS + [CLI_ENDPOINT_METHOD]
+
 def get_allowed_methods
   ALLOWED_HTTP_METHODS
+end
+
+def endpoint_method_token?(token : String) : Bool
+  ENDPOINT_METHODS.includes?(token.upcase)
 end
 
 def synthetic_any_method?(method : String) : Bool


### PR DESCRIPTION
Three delivery-path bugs found while auditing the runner/deliver pipeline. Each one fails silently — no error, no warning, just the wrong result.

### 1. `--status-codes` probes endpoints that are not HTTP

`SendReq` and `SendWithProxy` have skipped `endpoint.non_http?` all along. `update_status_codes` never got the same guard, so mobile deep links (`content://`, `intent://`, `myapp://`), CLI surfaces (`cli://`) and realtime `ws://` endpoints were handed to Crest, which can only raise `Unsupported scheme` on them.

```console
# before — mobile fixture with --status-codes
$ noir -b spec/functional_test/fixtures/mobile -u http://127.0.0.1:9 --status-codes 2>&1 | grep -c "Failed to get"
68
# after
0
```

Endpoint count (69) and the status codes recorded for real HTTP endpoints are unchanged.

### 2. `--probe-match` / `--probe-skip` silently no-op on an absolute-URL pattern

The matcher split on the first `:` in the pattern, so `--probe-skip https://api.example.com/admin` parsed as method `HTTPS` + url `//api.example.com/admin` and matched nothing.

This is the common shape, not an edge case: every delivery target requires `-u`, and `-u` rewrites each endpoint to `scheme://host/path`, so pasting a full URL into the filter is the natural thing to do. A `host:8080/x` pattern hit the same hole.

Verified against a webhook receiver:

```console
$ noir -b <fixture> -u http://127.0.0.1:18899 --export-webhook ... \
       --probe-skip 'http://127.0.0.1:18899/admin'
# before: 25 endpoints delivered, all three /admin/* still there
# after : 22 endpoints delivered, /admin/* dropped

$ ... --probe-match 'POST:/webhook'   # METHOD:url form still works
```

The `METHOD:url` form is now recognized only when the token before the colon really is a verb an endpoint can carry.

### 3. `--export-es` forces port 9200 onto `https://` URLs

Any portless URL had `:9200` written into it. Managed clusters (AWS OpenSearch Service, Elastic Cloud) and TLS reverse proxies listen on 443, so a working endpoint became unreachable and the user saw only a connection error with no explanation.

```
https://search-x.us-east-1.es.amazonaws.com/noir/_doc
  before → https://search-x.us-east-1.es.amazonaws.com:9200/noir/_doc
  after  → unchanged
```

The 9200 default now applies to `http://` only, where it is the local-cluster convenience it was meant to be. Explicit ports always win.

Also fixes the Elasticsearch failure warning interpolating a `uri` that is nil when `URI.parse` itself raised, rendering as `delivery to  failed`.

### Shared verb list

The probe filters need to know every verb an endpoint can carry, not just the real HTTP ones. `ENDPOINT_METHODS` (HTTP + `ANY`/AsyncAPI verbs + `CLI`) joins `ALLOWED_HTTP_METHODS` in `http_symbols.cr`, and the optimizer's hand-copied allow-list is now derived from it instead of repeated. `--probe-skip SEND` works as a method filter as a side effect.

### Tests

Four regression specs: absolute-URL skip, `METHOD:url` preserved, non-HTTP endpoints passed through untouched by the status pass, and ES port normalization across schemes.

- `crystal spec spec/unit_test` — 4312 examples, 0 failures
- `crystal spec spec/functional_test` — 22428 examples, 0 failures
- `crystal tool format --check` and ameba clean