### PR TITLE
fix(optimizer): one field, one value

### DIFF
--- a/spec/functional_test/testers/specification/apisix_spec.cr
+++ b/spec/functional_test/testers/specification/apisix_spec.cr
@@ -6,10 +6,7 @@ expected_endpoints = [
   Endpoint.new("/admin", "GET", [Param.new("Host", "admin.example.com", "header")]),
   Endpoint.new("/admin/*", "GET", [Param.new("Host", "admin.example.com", "header")]),
   Endpoint.new("/api/*", "ANY"),
-  Endpoint.new("/internal", "DELETE", [
-    Param.new("Host", "api.example.com", "header"),
-    Param.new("Host", "internal.example.com", "header"),
-  ]),
+  Endpoint.new("/internal", "DELETE", [Param.new("Host", "api.example.com", "header")]),
   Endpoint.new("/json/users", "GET"),
   Endpoint.new("/json/admin", "ANY"),
   Endpoint.new("/json/admin/*", "ANY"),

--- a/spec/unit_test/analyzer/specification/apisix_spec.cr
+++ b/spec/unit_test/analyzer/specification/apisix_spec.cr
@@ -51,7 +51,7 @@ describe "Apisix Analyzer" do
     ])
   end
 
-  it "captures all hosts from hosts[] and host as Host header params" do
+  it "emits one Host param and keeps the alternates as a tag" do
     yaml = <<-YAML
       routes:
         - uri: /internal
@@ -68,13 +68,18 @@ describe "Apisix Analyzer" do
     endpoints = analyze_apisix(yaml_content: yaml)
     internal = endpoints.find { |ep| ep.url == "/internal" && ep.method == "DELETE" }
     raise "expected /internal DELETE endpoint" unless internal
-    internal_hosts = internal.params.select { |p| p.name == "Host" && p.param_type == "header" }.map(&.value).sort!
-    internal_hosts.should eq(["api.example.com", "internal.example.com"])
+    # One Host param — a request carries exactly one Host header, and two of
+    # them rendered as `curl -H 'Host: a' -H 'Host: b'`.
+    internal_hosts = internal.params.select { |p| p.name == "Host" && p.param_type == "header" }.map(&.value)
+    internal_hosts.should eq(["api.example.com"])
+    # The alternate host is still surface, so it survives as a tag.
+    internal.tags.map { |t| {t.name, t.description} }.should eq([{"apisix-host", "internal.example.com"}])
 
     admin = endpoints.find { |ep| ep.url == "/admin" && ep.method == "GET" }
     raise "expected /admin GET endpoint" unless admin
     admin_hosts = admin.params.select { |p| p.name == "Host" && p.param_type == "header" }.map(&.value)
     admin_hosts.should eq(["admin.example.com"])
+    admin.tags.should be_empty
   end
 
   it "handles APISIX JSON route documents" do

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -44,6 +44,29 @@ describe "EndpointOptimizer" do
       result[0].params.map(&.name).should eq(["session_id"])
     end
 
+    # `push_param` / `merge_params` / the graphql merges all dedup on
+    # (name, param_type), and `params_to_hash` collapses on it regardless —
+    # but an analyzer that appends straight to `params` bypasses all of them,
+    # and the duplicate reached the report as two conflicting values for one
+    # field (`-H 'Host: a' -H 'Host: b'`).
+    it "collapses repeated (name, param_type) params, first value wins" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/test", "GET", [
+          Param.new("Host", "api.example.com", "header"),
+          Param.new("Host", "internal.example.com", "header"),
+          # Same name in a different bucket is a different param and stays.
+          Param.new("Host", "query-value", "query"),
+        ]),
+      ]
+
+      result = optimizer.optimize_endpoints(endpoints)
+      result[0].params.map { |p| {p.name, p.value, p.param_type} }.should eq([
+        {"Host", "api.example.com", "header"},
+        {"Host", "query-value", "query"},
+      ])
+    end
+
     it "normalizes HTTP methods" do
       optimizer = EndpointOptimizer.new(logger, options)
       endpoints = [

--- a/src/analyzer/analyzers/specification/apisix.cr
+++ b/src/analyzer/analyzers/specification/apisix.cr
@@ -52,12 +52,11 @@ module Analyzer::Specification
       paths = route_paths_json(route)
       return if paths.empty?
       methods = route_methods_json(route)
-      host_params = host_params_json(route)
+      hosts = route_hosts_json(route)
 
       paths.each do |path|
         methods.each do |method|
-          endpoint_params = host_params.dup
-          @result << Endpoint.new(path, method, endpoint_params, details)
+          @result << build_endpoint(path, method, hosts, details)
         end
       end
     end
@@ -68,12 +67,11 @@ module Analyzer::Specification
       paths = route_paths_yaml(route)
       return if paths.empty?
       methods = route_methods_yaml(route)
-      host_params = host_params_yaml(route)
+      hosts = route_hosts_yaml(route)
 
       paths.each do |path|
         methods.each do |method|
-          endpoint_params = host_params.dup
-          @result << Endpoint.new(path, method, endpoint_params, details)
+          @result << build_endpoint(path, method, hosts, details)
         end
       end
     end
@@ -138,21 +136,28 @@ module Analyzer::Specification
       normalize_methods(methods)
     end
 
-    private def host_params_json(route : JSON::Any) : Array(Param)
-      hosts = [] of String
-      if host = route["host"]?.try(&.as_s?)
-        hosts << host unless host.empty?
+    # A request carries exactly one `Host` header, so a route configured with
+    # several (`hosts: [a, b]`) gets one `Host` param — the first, mirroring
+    # the single-representative-server rule the OAS analyzers already apply to
+    # a multi-entry `servers` block. Emitting one param per host produced
+    # `curl -i -X DELETE /internal -H 'Host: a' -H 'Host: b'`, a request no
+    # server can answer, and left a duplicate (name, param_type) entry in the
+    # inventory that every consumer collapses anyway.
+    #
+    # The alternates are real attack surface, so they are kept as an
+    # `apisix-host` tag instead of being dropped — same shape as iris's
+    # `subdomain` and wrangler's `wrangler-zone` tags.
+    private def build_endpoint(path : String, method : String, hosts : Array(String), details : Details) : Endpoint
+      endpoint = Endpoint.new(path, method, details)
+      if primary = hosts.first?
+        endpoint.params << Param.new("Host", primary, "header")
+        alternates = hosts[1..]
+        endpoint.add_tag(Tag.new("apisix-host", alternates.join(", "), "apisix_analyzer")) unless alternates.empty?
       end
-      if host_list = route["hosts"]?.try(&.as_a?)
-        host_list.each do |host_node|
-          next unless host_text = host_node.as_s?
-          hosts << host_text unless host_text.empty?
-        end
-      end
-      hosts.uniq.map { |host_value| Param.new("Host", host_value, "header") }
+      endpoint
     end
 
-    private def host_params_yaml(route : YAML::Any) : Array(Param)
+    private def route_hosts_json(route : JSON::Any) : Array(String)
       hosts = [] of String
       if host = route["host"]?.try(&.as_s?)
         hosts << host unless host.empty?
@@ -163,7 +168,21 @@ module Analyzer::Specification
           hosts << host_text unless host_text.empty?
         end
       end
-      hosts.uniq.map { |host_value| Param.new("Host", host_value, "header") }
+      hosts.uniq
+    end
+
+    private def route_hosts_yaml(route : YAML::Any) : Array(String)
+      hosts = [] of String
+      if host = route["host"]?.try(&.as_s?)
+        hosts << host unless host.empty?
+      end
+      if host_list = route["hosts"]?.try(&.as_a?)
+        host_list.each do |host_node|
+          next unless host_text = host_node.as_s?
+          hosts << host_text unless host_text.empty?
+        end
+      end
+      hosts.uniq
     end
 
     private def normalize_methods(methods : Array(String)) : Array(String)

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -273,13 +273,24 @@ class EndpointOptimizer
       # `{"name": ""}` entry that makes the OAS document invalid, so an
       # analyzer that knows a param exists but not what it is called must
       # not leak that hole into the report.
+      #
+      # Repeats of the same (name, param_type) are collapsed here too,
+      # first-wins. `Endpoint#push_param`, `merge_params` and the graphql
+      # merges all dedup on that key, and `params_to_hash` / `Endpoint#==`
+      # collapse on it unconditionally — but an analyzer that appends
+      # straight to `params` bypasses every one of those, and the duplicate
+      # then reaches the report. It renders as two conflicting values for one
+      # field (`-H 'Host: a' -H 'Host: b'`), which is not a request any
+      # server can answer. Deduping here makes the emitted list agree with
+      # what every consumer already computes from it.
       if endpoint.params.present?
         tiny_tmp.params = [] of Param
+        seen_params = Set(Tuple(String, String)).new
         endpoint.params.each do |param|
-          if !param.name.includes?(" ") && !param.name.blank?
-            param.value = apply_pvalue(param.param_type, param.name, param.value).to_s
-            tiny_tmp.params << param
-          end
+          next if param.name.includes?(" ") || param.name.blank?
+          next unless seen_params.add?({param.name, param.param_type})
+          param.value = apply_pvalue(param.param_type, param.name, param.value).to_s
+          tiny_tmp.params << param
         end
       end
 


### PR DESCRIPTION
An endpoint's `params` could hold two entries with the same `(name, param_type)`.

`Endpoint#push_param`, `merge_params` and the GraphQL merges all dedup on that key, and `params_to_hash` / `Endpoint#==` collapse on it unconditionally — but an analyzer that appends straight to `params` bypasses every one of them, and the duplicate reaches the report as two conflicting values for one field.

### The concrete case: APISIX multi-host routes

A route declared with `hosts: [a, b]` got one `Host` header param per host:

```console
$ noir -b <apisix-config> -f curl
curl -i -X 'DELETE' '/internal' -H 'Host: api.example.com' -H 'Host: internal.example.com'
```

That is not a request any server can answer. A request carries exactly one `Host` header, so the route now gets one `Host` param — the first, mirroring the single-representative-server rule the OAS analyzers already apply to a multi-entry `servers` block.

The alternate hosts are real attack surface, so they are kept rather than dropped, as an `apisix-host` tag — same shape as iris's `subdomain` and wrangler's `wrangler-zone` tags:

```json
{
  "url": "/internal",
  "params": [{ "name": "Host", "value": "api.example.com", "param_type": "header" }],
  "tags":   [{ "name": "apisix-host", "description": "internal.example.com", "tagger": "apisix_analyzer" }]
}
```

### The safety net

The optimizer now collapses repeats on `(name, param_type)` too, first value wins, so the same class of bug can't reach a report from any other analyzer. That makes the emitted list agree with what every consumer already computes from it — `params_to_hash` was collapsing these anyway, so only the raw list disagreed.

### Tests

Regression specs for both layers: the optimizer collapse (including that the same name in a different bucket is a different param and survives), and the APISIX one-param-plus-tag shape. The functional APISIX expectation is updated to the single `Host` param.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean