### PR TITLE
fix(analyzer/php): stop claiming another framework's route file

### DIFF
--- a/spec/unit_test/analyzer/php_framework_relevance_spec.cr
+++ b/spec/unit_test/analyzer/php_framework_relevance_spec.cr
@@ -1,0 +1,113 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/php/slim"
+require "../../../src/analyzer/analyzers/php/laminas"
+
+# Every PHP analyzer is fed every `.php` file in the scan, so each one's
+# relevance gate is the only thing keeping it off the other frameworks' route
+# files. These harnesses expose the gates so the cross-framework rules can be
+# pinned without running a full multi-framework scan.
+class SlimRelevanceHarness < Analyzer::Php::Slim
+  def relevant?(content : String) : Bool
+    slim_relevant?(content)
+  end
+end
+
+class LaminasRelevanceHarness < Analyzer::Php::Laminas
+  def relevant?(path : String, content : String) : Bool
+    laminas_relevant?(path, content)
+  end
+end
+
+private CODEIGNITER_ROUTES = <<-PHP
+  <?php
+  $routes->get('users/(:num)', 'UserController::show/$1');
+  $routes->put('users/(:num)', 'UserController::update/$1');
+  $routes->group('tenant/(:num)', function ($routes) {
+      $routes->get('billing', 'Billing::index');
+  });
+  PHP
+
+private CAKEPHP_ROUTES = <<-PHP
+  <?php
+  $routes->scope('/', function (RouteBuilder $builder) {
+      $builder->get('/status', ['controller' => 'Api', 'action' => 'status']);
+      $builder->get('/users', ['controller' => 'Users', 'action' => 'index']);
+  });
+  PHP
+
+private LUMEN_ROUTES = <<-PHP
+  <?php
+  $router->get('/health', 'HealthController@index');
+  $router->put('/users/{id}', 'UserController@update');
+  PHP
+
+describe "PHP cross-framework relevance gates" do
+  describe Analyzer::Php::Slim do
+    harness = SlimRelevanceHarness.new(create_test_options)
+
+    it "claims a file that names Slim" do
+      harness.relevant?(<<-PHP).should be_true
+        <?php
+        use Slim\\Factory\\AppFactory;
+        $app = AppFactory::create();
+        $app->get('/status', function ($req, $res) { return $res; });
+        PHP
+    end
+
+    it "still claims a marker-less file registering on a Slim-shaped handle" do
+      # Slim 3-era `routes.php` files carry no `Slim\` reference at all; the
+      # fallback exists for them and must keep working.
+      harness.relevant?(<<-PHP).should be_true
+        <?php
+        $app->get('/status', function ($req, $res) { return $res; });
+        PHP
+    end
+
+    it "does not claim another framework's route file" do
+      # `$routes` is CodeIgniter/CakePHP, `$builder` is CakePHP's RouteBuilder,
+      # `$router` is Lumen. Pre-fix each of these produced phantom Slim routes
+      # in any repo holding more than one PHP framework — CodeIgniter's
+      # `users/(:num)` was reported verbatim as a Slim route.
+      harness.relevant?(CODEIGNITER_ROUTES).should be_false
+      harness.relevant?(CAKEPHP_ROUTES).should be_false
+      harness.relevant?(LUMEN_ROUTES).should be_false
+    end
+  end
+
+  describe Analyzer::Php::Laminas do
+    harness = LaminasRelevanceHarness.new(create_test_options)
+
+    it "claims a file that names Laminas/Zend/Mezzio" do
+      harness.relevant?("/app/config/routes.php", <<-PHP).should be_true
+        <?php
+        use Mezzio\\Application;
+        return function (Application $app) {
+            $app->get('/api/ping', PingHandler::class, 'api.ping');
+        };
+        PHP
+    end
+
+    it "claims a config file carrying a router array" do
+      harness.relevant?("/app/config/autoload/routes.global.php", <<-PHP).should be_true
+        <?php
+        return ['router' => ['routes' => []]];
+        PHP
+    end
+
+    it "no longer claims any file that merely calls ->get with a string" do
+      # The old catch-all branch treated `->get('…')` as a Laminas signal. It
+      # is a "some PHP code calls a getter with a string" signal, and it
+      # claimed other frameworks' route files (16 phantom endpoints across the
+      # fixture tree) plus ordinary config reads.
+      harness.relevant?("/app/config/Routes.php", CODEIGNITER_ROUTES).should be_false
+      harness.relevant?("/app/config/routes.php", CAKEPHP_ROUTES).should be_false
+      harness.relevant?("/app/routes/web.php", LUMEN_ROUTES).should be_false
+      harness.relevant?("/app/src/Service.php", <<-PHP).should be_false
+        <?php
+        class Service {
+            public function boot() { return $this->config->get('db.host'); }
+        }
+        PHP
+    end
+  end
+end

--- a/src/analyzer/analyzers/php/laminas.cr
+++ b/src/analyzer/analyzers/php/laminas.cr
@@ -63,11 +63,26 @@ module Analyzer::Php
     # `.php` file fed into the analyzer during a project-wide scan.
     NAMESPACE_MARKER_RE = /Laminas\\|Zend\\|Mezzio\\/
 
+    # Every PHP analyzer is fed every `.php` file in the scan, so this gate is
+    # the only thing keeping Laminas off other frameworks' route files.
+    #
+    # There used to be a fourth, catch-all branch: any file containing
+    # `->get('…')` was treated as Laminas. That is not a Laminas signal — it is
+    # a "some PHP code calls a getter with a string" signal, and it matched
+    # `$config->get('db.host')` as readily as a route. In a repo holding more
+    # than one PHP framework it claimed CodeIgniter's `app/Config/Routes.php`,
+    # CakePHP's `config/routes.php` and Lumen's `routes/web.php`, inventing 16
+    # phantom endpoints across the fixture tree alone — several with mangled
+    # paths (`/billing` out of `tenant/(:num)/billing`).
+    #
+    # Nothing is lost by dropping it: a Mezzio/Laminas programmatic route is
+    # registered on a `Mezzio\Application`, and a file that gets hold of one
+    # names `Mezzio\` or `Laminas\` in a `use` statement or a type hint, so the
+    # namespace marker below already covers it.
     private def laminas_relevant?(path : String, content : String) : Bool
       return true if path.includes?("/config/") && (content.includes?("'router'") || content.includes?("\"router\""))
       return true if content.matches?(NAMESPACE_MARKER_RE)
-      return true if content.includes?("RouteStackInterface")
-      !!content.match(/->(?:get|post|put|patch|delete|options|head|any|route)\s*\(\s*['"][^'"]+['"]/i)
+      content.includes?("RouteStackInterface")
     end
 
     private def analyze_config_routes(path : String, content : String) : Array(Endpoint)

--- a/src/analyzer/analyzers/php/slim.cr
+++ b/src/analyzer/analyzers/php/slim.cr
@@ -37,12 +37,34 @@ module Analyzer::Php
     # Cheap pre-filter: avoid heavy regex work on files that clearly aren't
     # Slim. Any file that reaches this analyzer via detection is usually in
     # a Slim project, but project-wide scans still feed unrelated PHP here.
+    # Route-collector handles that belong to a different PHP framework by
+    # convention: `$routes` is CodeIgniter 4 and CakePHP, `$builder` is
+    # CakePHP's `RouteBuilder`, `$router` is Lumen. Slim's own docs and
+    # skeleton use `$app` and `$group` throughout.
+    #
+    # This only gates the marker-less fallback below. Every PHP analyzer is fed
+    # every `.php` file in the scan, so in a repo holding more than one PHP
+    # framework that fallback read `$routes->get('users/(:num)', …)` out of
+    # CodeIgniter's `app/Config/Routes.php` and `$builder->get('/status', …)`
+    # out of CakePHP's `config/routes.php`, and emitted both as Slim routes. A
+    # genuine Slim file naming `Slim\` keeps working regardless of what it
+    # calls its variables.
+    FOREIGN_ROUTE_COLLECTORS = Set{"routes", "router", "route", "builder"}
+
+    VERB_CALL_RECEIVER_RE = /\$(\w+)->(?:get|post|put|patch|delete|options|head|map|group)\s*\(/i
+
     private def slim_relevant?(content : String) : Bool
       return true if content.matches?(RELEVANCE_MARKER_RE)
       # Verb/map/group registrations are always `$var->method(`. Skip the
       # heavier verb regex when no `->` call shape is present.
       return false unless content.includes?("->")
-      !!content.match(/\$\w+->(?:get|post|put|patch|delete|options|head|map|group)\s*\(/i)
+      # Relevant as soon as one registration is made on a handle that isn't
+      # another framework's — a file where every one of them is foreign is
+      # that framework's route file, not a marker-less Slim one.
+      content.scan(VERB_CALL_RECEIVER_RE) do |match|
+        return true unless FOREIGN_ROUTE_COLLECTORS.includes?(match[1].downcase)
+      end
+      false
     end
 
     private def analyze_routes_content(content : String,


### PR DESCRIPTION
Every PHP analyzer is fed every `.php` file in the scan, so each one's relevance gate is the only thing keeping it off the other frameworks' routes. Two gates were loose enough to invent endpoints in any repo that holds more than one PHP framework — and a migration-in-progress repo is exactly the kind of thing noir gets pointed at.

### Laminas

It treated **any** file containing `->get('…')` as its own. That is not a Laminas signal; it is a "some PHP code calls a getter with a string" signal, matching `$config->get('db.host')` as readily as a route. It claimed CodeIgniter's `app/Config/Routes.php`, CakePHP's `config/routes.php` and Lumen's `routes/web.php`, producing **16 phantom endpoints across the fixture tree alone** — several with paths mangled on the way out:

```
php_laminas | GET /billing        <- codeigniter/app/Config/Routes.php   (from `tenant/(:num)/billing`)
php_laminas | GET /dashboard      <- codeigniter/app/Config/Routes.php
php_laminas | GET /ping           <- cakephp/config/routes.php
php_laminas | GET /health         <- lumen_callees/routes/web.php
```

The branch is gone. Nothing is lost: a Mezzio/Laminas programmatic route is registered on a `Mezzio\Application`, and a file that gets hold of one names `Mezzio\` or `Laminas\` in a `use` statement or a type hint — which the namespace marker already catches.

### Slim

Its marker-less fallback accepted a registration on any `$var`. Slim uses `$app` and `$group` throughout its docs and skeleton; `$routes` is CodeIgniter 4 and CakePHP, `$builder` is CakePHP's `RouteBuilder`, `$router` is Lumen. CodeIgniter's `$routes->get('users/(:num)', …)` was reported verbatim as a Slim route.

The fallback now needs one registration on a handle that isn't another framework's — a file where *every* one of them is foreign is that framework's route file, not a marker-less Slim one. Slim 3-era `routes.php` files, which carry no `Slim\` reference and are the whole reason the fallback exists, still resolve.

### Result

Cross-framework false positives across the PHP fixture tree go **20 → 5**, and every framework's own fixture keeps its full endpoint set (slim 12, laminas 30, cakephp 18, lumen 13, codeigniter 38, hyperf 10 — all unchanged).

The 5 that remain are Mezzio and Slim both registering on `$app`, which is genuinely ambiguous without per-project analyzer scoping.

### Tests

New `php_framework_relevance_spec.cr` pins both gates directly: each analyzer still claims its own files (including the marker-less Slim shape) and refuses CodeIgniter/CakePHP/Lumen route files and an ordinary `$this->config->get('db.host')`.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean