### PR TITLE
fix(analyzer): scope Nitro, Hanami and Rails to their own project

### DIFF
--- a/spec/unit_test/analyzer/framework_project_scope_spec.cr
+++ b/spec/unit_test/analyzer/framework_project_scope_spec.cr
@@ -1,0 +1,102 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+require "file_utils"
+
+# Analyzers are handed every file in the scan, so a framework whose only
+# anchor is a common directory or filename can claim a neighbouring project's
+# routes. That never shows up in a single-framework fixture — it needs two
+# projects in one scan, which is what a monorepo actually looks like.
+private def scan_tree(root : String) : Array(Endpoint)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints
+ensure
+  CodeLocator.instance.clear("file_map")
+end
+
+private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)
+  endpoints.compact_map do |endpoint|
+    next unless endpoint.details.technology == technology
+    endpoint.details.code_paths.first?.try(&.path)
+  end.uniq!
+end
+
+describe "analyzer project scoping" do
+  it "keeps Nitro off another JS project's routes/ directory" do
+    # `routes/` is the conventional router directory in Koa, Express and
+    # Fastify too. Nitro used to claim every `*/routes/*.ts` in the scan, and
+    # since a bare file names no method it emitted seven endpoints per file —
+    # 42 phantom endpoints out of the Koa fixture alone.
+    root = File.tempname("noir-nitro-scope")
+
+    begin
+      FileUtils.mkdir_p(File.join(root, "site", "routes"))
+      File.write(File.join(root, "site", "nitro.config.ts"), "export default defineNitroConfig({})\n")
+      File.write(File.join(root, "site", "routes", "hello.ts"), "export default defineEventHandler(() => 'hi')\n")
+
+      FileUtils.mkdir_p(File.join(root, "api", "routes"))
+      File.write(File.join(root, "api", "package.json"), %({"dependencies": {"koa": "^2.0.0", "koa-router": "^12.0.0"}}))
+      File.write(File.join(root, "api", "index.js"), <<-JS)
+        const Koa = require('koa');
+        const Router = require('koa-router');
+        const app = new Koa();
+        const router = new Router();
+        require('./routes/users')(router);
+        app.use(router.routes());
+        JS
+      File.write(File.join(root, "api", "routes", "users.js"), <<-JS)
+        module.exports = (router) => {
+          router.get('/users', (ctx) => { ctx.body = []; });
+        };
+        JS
+
+      endpoints = scan_tree(root)
+      sources = tech_sources(endpoints, "js_nitro")
+      sources.any?(&.includes?("/site/routes/hello.ts")).should be_true
+      sources.any?(&.includes?("/api/routes/")).should be_false
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+
+  it "keeps Hanami and Rails off each other's config/routes.rb" do
+    # Both frameworks anchor on `config/routes.rb`, so each parsed the other's
+    # route table with its own DSL.
+    root = File.tempname("noir-ruby-routes-scope")
+
+    begin
+      FileUtils.mkdir_p(File.join(root, "shop", "config"))
+      File.write(File.join(root, "shop", "Gemfile"), "gem 'rails'\n")
+      File.write(File.join(root, "shop", "config", "routes.rb"), <<-RUBY)
+        Rails.application.routes.draw do
+          get '/orders', to: 'orders#index'
+        end
+        RUBY
+
+      FileUtils.mkdir_p(File.join(root, "admin", "config"))
+      File.write(File.join(root, "admin", "Gemfile"), "gem 'hanami'\n")
+      File.write(File.join(root, "admin", "config", "routes.rb"), <<-RUBY)
+        module Admin
+          class Routes < Hanami::Routes
+            get "/books", to: "books.index"
+          end
+        end
+        RUBY
+
+      endpoints = scan_tree(root)
+
+      hanami_sources = tech_sources(endpoints, "ruby_hanami")
+      hanami_sources.any?(&.includes?("/admin/config/routes.rb")).should be_true
+      hanami_sources.any?(&.includes?("/shop/")).should be_false
+
+      rails_sources = tech_sources(endpoints, "ruby_rails")
+      rails_sources.any?(&.includes?("/shop/config/routes.rb")).should be_true
+      rails_sources.any?(&.includes?("/admin/config/routes.rb")).should be_false
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+end

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -8,10 +8,25 @@ module Analyzer::Javascript
       result = [] of Endpoint
       mutex = Mutex.new
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      # `routes/` on its own is not a Nitro signal — it is the conventional
+      # name for a router directory in Koa, Express, Fastify and most other JS
+      # frameworks. Treating every `*/routes/*.ts` in the scan as a Nitro
+      # file-system route meant that in any repo holding a second JS project,
+      # each of those files became seven phantom endpoints (one per HTTP verb,
+      # since a bare file names no method): 42 out of the Koa fixture alone,
+      # against 10 from the real Nitro one. Scope to the Nitro project root
+      # the same way the SvelteKit analyzer does; with no marker found,
+      # `path_under_project_roots?` waves everything through, so a Nitro
+      # project detected only by a `nitropack` import still resolves.
+      project_roots = discover_js_project_roots(
+        ["nitropack"],
+        ["nitro.config.js", "nitro.config.ts", "nitro.config.mjs", "nitro.config.cjs"]
+      )
 
       parallel_file_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
         # Focus on routes/ directory for Nitro
         next unless path.includes?("/routes/")
+        next unless path_under_project_roots?(path, project_roots)
         analyze_nitro_file(path, result, mutex, include_callee)
       end
 

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -30,11 +30,30 @@ module Analyzer::Ruby
       framework_roots.each do |framework_root|
         path = "#{framework_root}/config/routes.rb"
         next unless File.exists?(path)
+        next if rails_router?(path)
 
         parse_routes_file(path, framework_root, include_callee)
       end
 
       @result
+    end
+
+    # `config/routes.rb` is the anchor for Hanami and for Rails alike, so in a
+    # repo holding both, Hanami parsed Rails' route table as its own DSL — 44
+    # phantom endpoints out of one Rails fixture, several with the Rails
+    # `resources` shorthand half-expanded.
+    #
+    # The exclusion is stated as "not Rails" rather than "looks like Hanami" on
+    # purpose: a Hanami 1 `apps/<app>/config/routes.rb` is a bare route DSL
+    # with no `Hanami::` reference anywhere in it, so requiring a positive
+    # marker would drop real routes. `Rails.application.routes.draw` is never
+    # Hanami.
+    RAILS_ROUTER_RE = /\.routes\.draw\b|ActionDispatch::Routing/
+
+    private def rails_router?(path : String) : Bool
+      read_file_content(path).matches?(RAILS_ROUTER_RE)
+    rescue
+      false
     end
 
     private def parse_routes_file(path : String, framework_root : String, include_callee : Bool)

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -135,11 +135,25 @@ module Analyzer::Ruby
 
         routes_path = "#{framework_root}/config/routes.rb"
         next unless known_file?(routes_path)
+        next if hanami_router?(routes_path)
 
         parse_routes_file(routes_path, framework_root)
       end
 
       @result
+    end
+
+    # `config/routes.rb` is the anchor for Rails and for Hanami alike, so in a
+    # repo holding both, Rails parsed Hanami's route table as its own DSL. A
+    # Hanami 2 routes file always names `Hanami::Routes` (it subclasses it), so
+    # unlike the mirror check in the Hanami analyzer this one can key on the
+    # positive marker.
+    HANAMI_ROUTER_RE = /Hanami::Rout|Hanami\.app\b|Hanami\.routes\b/
+
+    private def hanami_router?(path : String) : Bool
+      read_file_content(path).matches?(HANAMI_ROUTER_RE)
+    rescue
+      false
     end
 
     private def parse_routes_file(routes_path : String, framework_root : String)


### PR DESCRIPTION
Same shape as #2419, in three more frameworks: an analyzer whose only anchor is a common directory or filename claims the neighbouring project's routes. It never shows up in a single-framework fixture — it needs two projects in one scan, which is what a monorepo actually looks like.

### Nitro

It treated every `*/routes/*.{js,ts}` in the scan as a file-system route. `routes/` is the conventional router directory in Koa, Express and Fastify too, and because a bare route file names no HTTP method the analyzer emitted **seven endpoints for each one**.

Nitro-attributed files across the JavaScript fixture tree, before:

```
  42 koa                     21 express_config_array     14 fastify_autoload
  21 sveltekit               20 koa_nested_mount         10 nitro          <- the real one
  21 express_deep_nesting    19 express_prefix_issues      7 remix, nuxtjs, fresh, ...
```

Over 170 phantom endpoints, against 10 from the actual Nitro fixture. After: `10 nitro`, `5 nitro_callees`, nothing else.

It now scopes to the Nitro project root through the same `discover_js_project_roots` helper the SvelteKit analyzer uses. With no marker found the helper waves everything through, so a Nitro project detected only by a `nitropack` import still resolves.

### Hanami and Rails

Both anchor on `config/routes.rb`, so each parsed the other's route table with its own DSL — 51 phantom Hanami endpoints out of the Rails fixtures (some with the Rails `resources` shorthand half-expanded) and 23 the other way:

```
ruby_hanami | GET /posts/:id/edit           <- rails/config/routes.rb
ruby_hanami | POST /{base_c_route}/messages <- rails_advanced/config/routes.rb
```

Rails now skips a routes file naming `Hanami::Routes`. Hanami skips one calling `.routes.draw`.

Hanami's check is stated as "not Rails" rather than "looks like Hanami" on purpose — a Hanami 1 `apps/<app>/config/routes.rb` is a bare route DSL with no `Hanami::` reference anywhere in it, so requiring a positive marker would have dropped real routes.

### Result

Nitro cross-claims 170+ → 0, Hanami 51 → 0, Rails 23 → 3. The three left are a marker-less Hanami 1 app file and a `public/` static asset both frameworks legitimately serve; the endpoints are real, only the technology label is arguable.

### Tests

New `framework_project_scope_spec.cr` builds two-project temp trees (a Nitro site beside a Koa API; a Rails app beside a Hanami one) and drives the full detect → analyze pipeline, asserting each technology only claims its own files. Both cases fail on `main` and pass here.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean