### PR TITLE
fix(analyzer): scope Amber, and stop reading a verb as a path

### DIFF
--- a/spec/unit_test/analyzer/framework_project_scope_crystal_python_spec.cr
+++ b/spec/unit_test/analyzer/framework_project_scope_crystal_python_spec.cr
@@ -1,0 +1,92 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+require "../../../src/miniparsers/python_route_extractor_ts"
+require "file_utils"
+
+private def scan_tree(root : String) : Array(Endpoint)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints
+ensure
+  CodeLocator.instance.clear("file_map")
+end
+
+private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)
+  endpoints.compact_map do |endpoint|
+    next unless endpoint.details.technology == technology
+    endpoint.details.code_paths.first?.try(&.path)
+  end.uniq!
+end
+
+describe "analyzer project scoping (crystal, python)" do
+  it "keeps Amber off Kemal's routes" do
+    # `get "/path"` is the same line in Amber, Kemal and Grip, so a per-line
+    # matcher cannot tell them apart — the file has to.
+    root = File.tempname("noir-crystal-scope")
+
+    begin
+      FileUtils.mkdir_p(File.join(root, "shop", "src"))
+      File.write(File.join(root, "shop", "shard.yml"), "name: shop\ndependencies:\n  amber:\n    github: amberframework/amber\n")
+      File.write(File.join(root, "shop", "src", "shop.cr"), <<-CRYSTAL)
+        require "amber"
+
+        Amber::Server.configure do
+          routes :web do
+            get "/orders", OrdersController, :index
+          end
+        end
+        CRYSTAL
+
+      FileUtils.mkdir_p(File.join(root, "edge", "src"))
+      File.write(File.join(root, "edge", "shard.yml"), "name: edge\ndependencies:\n  kemal:\n    github: kemalcr/kemal\n")
+      File.write(File.join(root, "edge", "src", "edge.cr"), <<-CRYSTAL)
+        require "kemal"
+
+        get "/health" do
+          "ok"
+        end
+        CRYSTAL
+
+      endpoints = scan_tree(root)
+      amber_sources = tech_sources(endpoints, "crystal_amber")
+      amber_sources.any?(&.includes?("/shop/src/shop.cr")).should be_true
+      amber_sources.any?(&.includes?("/edge/")).should be_false
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+
+  describe Noir::TreeSitterPythonRouteExtractor do
+    it "reads a leading bare verb as the method, not as the path" do
+      # aiohttp's RouteTableDef spells its generic decorator
+      # `@routes.route('PUT', '/profile')` — method first, path second. Taking
+      # the first positional string blindly produced the route `/PUT`.
+      source = <<-PYTHON
+        @routes.route('PUT', '/profile')
+        async def update_profile(request):
+            return web.Response(text="ok")
+        PYTHON
+
+      decorations = Noir::TreeSitterPythonRouteExtractor.extract_decorations(source)
+      decorations.size.should eq(1)
+      decorations[0].path.should eq("/profile")
+      decorations[0].methods.should eq(["PUT"])
+    end
+
+    it "keeps a single positional string as the path even when it reads like a verb" do
+      # `@app.route("/get")` is a path, not a method.
+      source = <<-PYTHON
+        @app.route("/get")
+        def get_thing():
+            return "x"
+        PYTHON
+
+      decorations = Noir::TreeSitterPythonRouteExtractor.extract_decorations(source)
+      decorations.size.should eq(1)
+      decorations[0].path.should eq("/get")
+    end
+  end
+end

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -41,11 +41,27 @@ module Analyzer::Crystal
       @result
     end
 
+    # `get "/path"` is the same line in Amber, Kemal and Grip — the DSLs are
+    # indistinguishable one line at a time, and this analyzer is handed every
+    # `.cr` file in the scan. Without a file-level gate it read Kemal's, Grip's
+    # and Lucky's routes as Amber ones (22 phantom endpoints across the Crystal
+    # fixture tree), and swallowed their `public_folder` declarations on the
+    # way through.
+    #
+    # A file that declares Amber routes belongs to an Amber app, so it names
+    # the framework: `require "amber"` in the fixtures and in an app's entry
+    # point, `Amber::Server.configure` in a real `config/routes.cr`, or the
+    # `routes :web do` pipeline block, which is Amber's DSL and nobody else's.
+    AMBER_MARKER_RE = /require\s+"amber"|Amber::|^\s*routes\s+:\w+/m
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       file_base = configured_base_for(path)
 
-      lines = mask_crystal_heredocs(read_file_content(path).lines)
+      content = read_file_content(path)
+      return endpoints unless content.matches?(AMBER_MARKER_RE)
+
+      lines = mask_crystal_heredocs(content.lines)
 
       include_callee = callees_needed?
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -396,7 +396,12 @@ module Analyzer::Python
         source.includes?("RouteTableDef") ||
         source.includes?("web.") ||
         HTTP_METHOD_NAMES.any? { |method| source.includes?(".add_#{method}(") } ||
-        source.includes?(".add_route") ||
+        # The trailing `(` matters. Without it this also fired on Django
+        # Ninja's `api.add_router("/events/", …)`, which contains `.add_route`
+        # as a substring — that let the whole aiohttp pass loose on a
+        # django-ninja module and read its `@api.get(…)` decorators as aiohttp
+        # routes.
+        source.includes?(".add_route(") ||
         source.includes?(".add_routes(") ||
         source.includes?(".add_static(") ||
         source.includes?(".add_view(")

--- a/src/miniparsers/python_route_extractor_ts.cr
+++ b/src/miniparsers/python_route_extractor_ts.cr
@@ -309,6 +309,13 @@ module Noir
       end
     end
 
+    # `"PUT"` / `"get"` — a bare verb token, not a route path. `*` is
+    # aiohttp's any-method wildcard.
+    private def bare_http_method?(text : String) : Bool
+      return true if text == "*"
+      HTTP_METHODS.includes?(text.downcase)
+    end
+
     # A `decorator` node wraps either a plain expression (`@foo`) or a
     # call expression (`@foo.route("/x")`). We want the call.
     private def find_call_inside_decorator(decorator : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
@@ -360,11 +367,17 @@ module Noir
 
       path = ""
       methods = [] of String
+      # Positional strings in order. The path is normally the first one, but
+      # aiohttp's `RouteTableDef` spells its generic decorator
+      # `@routes.route('PUT', '/profile')` — method first, path second. Taking
+      # the first string blindly turned that into the route `/PUT`. Collect
+      # them and pick below, so a leading bare verb is read as the method it
+      # is instead of as a path.
+      positional_strings = [] of String
       Noir::TreeSitter.each_named_child(args) do |arg|
         case Noir::TreeSitter.node_type(arg)
         when "string"
-          # First positional string is the path.
-          path = decode_string(arg, source) if path.empty?
+          positional_strings << decode_string(arg, source)
         when "keyword_argument"
           name = Noir::TreeSitter.field(arg, "name")
           value = Noir::TreeSitter.field(arg, "value")
@@ -386,10 +399,22 @@ module Noir
         end
       end
 
+      leading_verb = nil
+      if path.empty?
+        # A leading bare verb is only a verb when something else can be the
+        # path; `@app.route("/get")` must stay a path.
+        if positional_strings.size > 1 && bare_http_method?(positional_strings[0])
+          leading_verb = positional_strings[0].upcase
+          path = positional_strings[1]
+        else
+          path = positional_strings.first? || ""
+        end
+      end
+
       return if path.empty?
 
       if methods.empty?
-        if fallback = method_from_attr
+        if fallback = leading_verb || method_from_attr
           methods = [fallback]
         else
           methods = ["GET"] # Flask default for generic `.route` without methods=


### PR DESCRIPTION
Third pass over the same class of bug (#2419, #2420), in Crystal and Python.

### Amber

`get "/path"` is the same line in Amber, Kemal and Grip — the DSLs are indistinguishable one line at a time, and the Amber analyzer is handed every `.cr` file in the scan. It read Kemal's, Grip's and Lucky's routes as Amber ones (**22 phantom endpoints** across the Crystal fixture tree) and swallowed their `public_folder` declarations on the way through:

```
crystal_amber | GET /chat        <- grip/src/testapp.cr
crystal_amber | GET /token       <- kemal/src/testapp.cr
crystal_amber | GET /api/secret  <- kemal_auth/app.cr
```

A file that declares Amber routes belongs to an Amber app and says so — `require "amber"`, `Amber::Server.configure`, or the `routes :web do` pipeline block, which is Amber's DSL and nobody else's. Cross-claims 22 → 0.

### aiohttp

Its relevance gate tested for `.add_route` as a **substring**, which is also inside Django Ninja's `api.add_router("/events/", …)`. That let the whole aiohttp pass loose on a django-ninja module and read its `@api.get(…)` decorators as aiohttp routes (6 phantom endpoints). The gate now needs the call paren, matching every sibling check in the same list. 6 → 0.

### `@routes.route('PUT', '/profile')` → `/PUT`

The shared tree-sitter Python decorator extractor took the first positional string as the route path. aiohttp's `RouteTableDef` spells its generic decorator method-first, path-second, so that produced an endpoint whose **path was `/PUT`**.

A leading bare verb is now read as the method it is — but only when a second positional string can be the path, so `@app.route("/get")` still resolves to `/get`, not to a GET with no path.

### Tests

New `framework_project_scope_crystal_python_spec.cr`: an Amber app beside a Kemal one driven through the full detect → analyze pipeline, plus two extractor cases pinning the verb-vs-path rule in both directions. The Amber case and the `/PUT` case fail on `main` and pass here.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean