### PR TITLE
fix(analyzer/rust): scope each analyzer to a crate that depends on it

### DIFF
--- a/spec/unit_test/analyzer/rust_crate_scope_spec.cr
+++ b/spec/unit_test/analyzer/rust_crate_scope_spec.cr
@@ -1,0 +1,113 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+require "file_utils"
+
+# Every Rust analyzer is handed every `.rs` file in the scan, and the route
+# DSLs are close enough to collide: axum's `.route("/foo", get(handler))` and
+# actix's glob-imported `.route("/foo", get().to(handler))` are the same tree.
+# The Cargo manifest is what tells them apart.
+private def scan_tree(root : String, techs : String? = nil) : Array(Endpoint)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  options["techs"] = YAML::Any.new(techs) if techs
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints
+ensure
+  CodeLocator.instance.clear("file_map")
+end
+
+private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)
+  endpoints.compact_map do |endpoint|
+    next unless endpoint.details.technology == technology
+    endpoint.details.code_paths.first?.try(&.path)
+  end.uniq!
+end
+
+private def write_axum_crate(dir : String)
+  FileUtils.mkdir_p(File.join(dir, "src"))
+  File.write(File.join(dir, "Cargo.toml"), <<-TOML)
+    [package]
+    name = "gateway"
+
+    [dependencies]
+    axum = "0.7"
+    tokio = { version = "1", features = ["full"] }
+    TOML
+  File.write(File.join(dir, "src", "main.rs"), <<-RUST)
+    use axum::{routing::{get, post}, Router};
+
+    #[tokio::main]
+    async fn main() {
+        let app = Router::new()
+            .route("/gateway/health", get(handler))
+            .route("/gateway/submit", post(handler));
+        axum::serve(listener, app).await.unwrap();
+    }
+    RUST
+end
+
+private def write_actix_crate(dir : String)
+  FileUtils.mkdir_p(File.join(dir, "src"))
+  File.write(File.join(dir, "Cargo.toml"), <<-TOML)
+    [package]
+    name = "billing"
+
+    [dependencies]
+    actix-web = "4.9"
+    TOML
+  File.write(File.join(dir, "src", "main.rs"), <<-RUST)
+    use actix_web::{get, web, App, HttpServer, Responder};
+
+    #[get("/billing/invoices")]
+    async fn invoices() -> impl Responder { "ok" }
+
+    #[actix_web::main]
+    async fn main() -> std::io::Result<()> {
+        HttpServer::new(|| App::new().service(invoices)).bind(("127.0.0.1", 8080))?.run().await
+    }
+    RUST
+end
+
+describe "Rust crate scoping" do
+  it "keeps actix-web off an axum crate and the other way round" do
+    root = File.tempname("noir-rust-crate-scope")
+
+    begin
+      write_axum_crate(File.join(root, "gateway"))
+      write_actix_crate(File.join(root, "billing"))
+
+      endpoints = scan_tree(root)
+
+      axum_sources = tech_sources(endpoints, "rust_axum")
+      axum_sources.any?(&.includes?("/gateway/src/main.rs")).should be_true
+      axum_sources.any?(&.includes?("/billing/")).should be_false
+
+      actix_sources = tech_sources(endpoints, "rust_actix_web")
+      actix_sources.any?(&.includes?("/billing/src/main.rs")).should be_true
+      # Pre-fix actix claimed every axum `.route(path, get(handler))` in the
+      # scan, because a bare `get(...)` argument is also actix's glob-imported
+      # route constructor.
+      actix_sources.any?(&.includes?("/gateway/")).should be_false
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+
+  it "falls back to scanning everything when no manifest declares the crate" do
+    # A source tree checked out without its Cargo.toml (or a `-t` forced tech)
+    # must behave exactly as it did before the gate existed.
+    root = File.tempname("noir-rust-no-manifest")
+
+    begin
+      write_axum_crate(root)
+      File.delete(File.join(root, "Cargo.toml"))
+
+      endpoints = scan_tree(root, techs: "rust_axum")
+      endpoints.map(&.url).should contain("/gateway/health")
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+end

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -13,6 +13,13 @@ module Analyzer::Rust
   class ActixWeb < RustEngine
     analyzer_for "rust_actix_web"
 
+    # Only files inside a crate that depends on `actix-web`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["actix-web"]
+    end
+
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
     alias GlobalFunctionEntry = NamedTuple(name: String, path: String, hints: Array(String), params_text: String?, callees: Array(Noir::RustCalleeExtractor::Entry))
 

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -13,6 +13,13 @@ module Analyzer::Rust
   class Axum < RustEngine
     analyzer_for "rust_axum"
 
+    # Only files inside a crate that depends on `axum`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["axum"]
+    end
+
     alias UtoipaScopedKey = Tuple(String, String, String)
     alias UtoipaNestEdge = Tuple(UtoipaScopedKey, String)
     alias NestScopedKey = Tuple(String, String, String)

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -18,6 +18,13 @@ module Analyzer::Rust
   class Gotham < RustEngine
     analyzer_for "rust_gotham"
 
+    # Only files inside a crate that depends on `gotham`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["gotham"]
+    end
+
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
     def analyze_file(path : String) : Array(Endpoint)

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -12,6 +12,13 @@ module Analyzer::Rust
   class Loco < RustEngine
     analyzer_for "rust_loco"
 
+    # Only files inside a crate that depends on `loco-rs`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["loco-rs"]
+    end
+
     REST_ACTIONS = Set{"index", "show", "new", "create", "edit", "update", "destroy", "delete"}
     HTTP_VERBS   = Set{"get", "post", "put", "delete", "patch", "head", "options", "trace"}
 

--- a/src/analyzer/analyzers/rust/poem.cr
+++ b/src/analyzer/analyzers/rust/poem.cr
@@ -15,6 +15,13 @@ module Analyzer::Rust
   class Poem < RustEngine
     analyzer_for "rust_poem"
 
+    # Only files inside a crate that depends on `poem`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["poem"]
+    end
+
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
     def analyze_file(path : String) : Array(Endpoint)

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -13,6 +13,13 @@ module Analyzer::Rust
   class Rocket < RustEngine
     analyzer_for "rust_rocket"
 
+    # Only files inside a crate that depends on `rocket`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["rocket"]
+    end
+
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
     alias ScopedRouteKey = Tuple(String, String, String)
     alias AliasKey = Tuple(String, String)

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -24,6 +24,13 @@ module Analyzer::Rust
   class Rwf < RustEngine
     analyzer_for "rust_rwf"
 
+    # Only files inside a crate that depends on `rwf`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["rwf"]
+    end
+
     HTTP_METHODS = %w[GET POST PUT DELETE PATCH HEAD OPTIONS]
 
     # Precompiled union for collect_route_macro_fragments' per-macro

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -28,6 +28,13 @@ module Analyzer::Rust
   class Salvo < RustEngine
     analyzer_for "rust_salvo"
 
+    # Only files inside a crate that depends on `salvo`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["salvo"]
+    end
+
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
     alias ScopedNameKey = Tuple(String, String)
     alias PrefixEdge = Tuple(ScopedNameKey, String)

--- a/src/analyzer/analyzers/rust/tide.cr
+++ b/src/analyzer/analyzers/rust/tide.cr
@@ -18,6 +18,13 @@ module Analyzer::Rust
   class Tide < RustEngine
     analyzer_for "rust_tide"
 
+    # Only files inside a crate that depends on `tide`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["tide"]
+    end
+
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
     def analyze_file(path : String) : Array(Endpoint)

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -19,6 +19,13 @@ module Analyzer::Rust
   class Warp < RustEngine
     analyzer_for "rust_warp"
 
+    # Only files inside a crate that depends on `warp`. See
+    # `RustEngine#crate_dependencies` — without this every Rust analyzer
+    # sees every `.rs` file in the scan.
+    protected def crate_dependencies : Array(String)
+      ["warp"]
+    end
+
     @external_handler_callee_cache = {} of String => Array(Noir::RustCalleeExtractor::Entry)
     @external_handler_miss_cache = Set(String).new
     @external_handler_callee_cache_mutex = Mutex.new

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -37,8 +37,10 @@ module Analyzer::Rust
     # regular files — no per-path `File.exists?` / `File.directory?`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
+        roots = crate_roots
         parallel_analyze(get_files_by_extension(".rs")) do |path|
           next if RustEngine.test_path?(path)
+          next unless path_under_crate_roots?(path, roots)
 
           begin
             block.call(path)
@@ -49,6 +51,57 @@ module Analyzer::Rust
       rescue e
         logger.debug e
       end
+    end
+
+    # The Cargo dependencies that identify this analyzer's framework. An
+    # analyzer that declares them is only shown files inside a crate that
+    # actually depends on one — without that, every Rust analyzer sees every
+    # `.rs` file in the scan and the route DSLs are close enough to collide.
+    # axum's `.route("/foo", get(handler))` and actix's glob-imported
+    # `.route("/foo", get().to(handler))` are the same tree, so actix read
+    # axum's whole router as its own. Default is empty, meaning no gate.
+    protected def crate_dependencies : Array(String)
+      [] of String
+    end
+
+    # Directories holding a `Cargo.toml` that depends on one of
+    # `crate_dependencies`. Empty when the analyzer declares no dependencies,
+    # and also empty when the scan has no matching manifest at all — in which
+    # case `path_under_crate_roots?` waves everything through, so a source
+    # tree checked out without its manifest keeps working exactly as before.
+    private def crate_roots : Array(String)
+      dependencies = crate_dependencies
+      return [] of String if dependencies.empty?
+
+      patterns = dependencies.map { |name| cargo_dependency_re(name) }
+      roots = [] of String
+      all_files.each do |file|
+        next unless File.basename(file) == "Cargo.toml"
+        begin
+          content = read_file_content(file)
+        rescue
+          next
+        end
+        next unless patterns.any? { |pattern| content.matches?(pattern) }
+        root = Noir::PathScope.normalize_root(File.dirname(file))
+        roots << root unless roots.includes?(root)
+      end
+      roots
+    end
+
+    # `axum = "0.7"`, `axum = { path = "…" }`, `axum.workspace = true` and
+    # `[dependencies.axum]` all declare the dependency. Anchored on the key so
+    # `actix-web` does not match the `actix-web-lab` line above it.
+    private def cargo_dependency_re(name : String) : Regex
+      escaped = Regex.escape(name)
+      Regex.new("^\\s*(?:#{escaped}\\s*[=.]|\\[(?:[\\w.-]+\\.)?dependencies\\.#{escaped}\\])", Regex::Options::MULTILINE)
+    end
+
+    private def path_under_crate_roots?(path : String, roots : Array(String)) : Bool
+      return true if roots.empty?
+
+      expanded = File.expand_path(path)
+      roots.any? { |root| Noir::PathScope.under_normalized_root?(expanded, root) }
     end
 
     # Cargo convention: every `.rs` immediately under a crate's


### PR DESCRIPTION
Continues the project-scoping sweep (#2419, #2420, #2421) into Rust, where nothing scoped anything: `RustEngine#parallel_file_scan` handed every `.rs` file in the scan to all eleven analyzers.

The route DSLs are close enough to collide. axum's

```rust
.route("/foo", get(handler))
```

and actix's glob-imported

```rust
.route("/foo", get().to(handler))
```

are the same tree once the argument is a bare `get(...)` call — actix's own comment even says so ("we only reach here through a `.route(...)` verb-expression argument, so a bare verb name is unambiguously a route constructor"). It isn't, once another framework's file is in the scan.

Cross-claims across the Rust fixture tree, before:

```
  8 rust_actix_web <- axum          5 rust_rocket <- actix_crossfile_scope
  7 rust_actix_web <- rocket        5 rust_actix_web <- actix_auth
  5 rust_salvo     <- gotham        4 rust_rocket <- actix_configure
  5 rust_rwf       <- axum          … 66 total
```

### The fix

Rust has an unambiguous anchor the other languages had to approximate: the crate manifest. An analyzer declares the Cargo dependency that identifies its framework, and the engine only shows it files under a `Cargo.toml` that depends on one.

```crystal
protected def crate_dependencies : Array(String)
  ["actix-web"]
end
```

The key match is anchored so `actix-web` doesn't match the `actix-web-lab` line above it, and it accepts every declaration shape — `axum = "0.7"`, `axum = { path = … }`, `axum.workspace = true`, `[dependencies.axum]`.

With no matching manifest anywhere the root list comes back empty and the gate waves everything through, so a source tree checked out without its `Cargo.toml` — or `-t rust_axum` forcing the tech — behaves exactly as it did before. That fallback is covered by a spec.

### Result

Cross-claims **66 → 5**. All five that remain are an analyzer claiming another fixture of its *own* framework (rocket→rocket_mount, salvo→salvo_crossfn), which is cross-file resolution working, not a bug.

### Measurement method

For each language: scan the whole fixture directory at once, then for every endpoint check whether the standalone scan of the fixture project that owns its `code_paths[0].path` also produces it. Anything only present in the combined scan is a cross-claim. Same harness found the PHP/JS/Ruby/Crystal cases in the earlier PRs.

### Tests

`rust_crate_scope_spec.cr` builds an axum crate beside an actix one and drives the full detect → analyze pipeline, asserting neither claims the other's routes; plus the no-manifest fallback. The first case fails on `main`.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean