### PR TITLE
fix(analyzer): keep ASP.NET, Flask and aiohttp inside their own framework

### DIFF
--- a/spec/unit_test/analyzer/csharp_python_framework_scope_spec.cr
+++ b/spec/unit_test/analyzer/csharp_python_framework_scope_spec.cr
@@ -1,0 +1,177 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+require "../../../src/analyzer/analyzers/python/flask"
+require "../../../src/analyzer/analyzers/python/aiohttp"
+require "file_utils"
+
+# The relevance gate is the only thing keeping an analyzer off a competing
+# framework's handler module — every Python analyzer is handed every `.py`
+# file in the scan.
+class FlaskRelevanceHarness < Analyzer::Python::Flask
+  def relevant?(source : String) : Bool
+    flask_relevant_source?(source)
+  end
+end
+
+class AiohttpRelevanceHarness < Analyzer::Python::Aiohttp
+  def relevant?(source : String) : Bool
+    aiohttp_relevant_source?(source)
+  end
+end
+
+private def scan_tree(root : String) : Array(Endpoint)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints
+ensure
+  CodeLocator.instance.clear("file_map")
+end
+
+private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)
+  endpoints.compact_map do |endpoint|
+    next unless endpoint.details.technology == technology
+    endpoint.details.code_paths.first?.try(&.path)
+  end.uniq!
+end
+
+describe "analyzer project scoping (csharp, python)" do
+  it "keeps ASP.NET Core MVC and classic ASP.NET MVC off each other's controllers" do
+    # Both spell a controller almost identically — `public class UserController
+    # : Controller` with `[HttpGet]` actions — and both analyzers see every
+    # `.cs` file. The namespaces are mutually exclusive and are what tell them
+    # apart.
+    root = File.tempname("noir-csharp-scope")
+
+    begin
+      legacy = File.join(root, "Legacy")
+      FileUtils.mkdir_p(File.join(legacy, "Controllers"))
+      File.write(File.join(legacy, "packages.config"), %(<packages><package id="Microsoft.AspNet.Mvc" /></packages>))
+      File.write(File.join(legacy, "Controllers", "ProductController.cs"), <<-CS)
+        using System.Web.Mvc;
+
+        namespace Legacy.Controllers
+        {
+            public class ProductController : Controller
+            {
+                public ActionResult List() { return View(); }
+            }
+        }
+        CS
+
+      modern = File.join(root, "Modern")
+      FileUtils.mkdir_p(File.join(modern, "Controllers"))
+      File.write(File.join(modern, "MyApp.csproj"), %(<Project Sdk="Microsoft.NET.Sdk.Web"></Project>))
+      File.write(File.join(modern, "Controllers", "UsersController.cs"), <<-CS)
+        using Microsoft.AspNetCore.Mvc;
+
+        namespace Modern.Controllers
+        {
+            [ApiController]
+            [Route("api/[controller]")]
+            public class UsersController : ControllerBase
+            {
+                [HttpGet("GetAll")]
+                public IActionResult GetAll() => Ok();
+            }
+        }
+        CS
+
+      endpoints = scan_tree(root)
+
+      core_sources = tech_sources(endpoints, "cs_aspnet_core_mvc")
+      core_sources.any?(&.includes?("/Modern/")).should be_true
+      core_sources.any?(&.includes?("/Legacy/")).should be_false
+
+      legacy_sources = tech_sources(endpoints, "cs_aspnet_mvc")
+      legacy_sources.any?(&.includes?("/Legacy/")).should be_true
+      legacy_sources.any?(&.includes?("/Modern/")).should be_false
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+
+  describe "Python competing-import guards" do
+    flask = FlaskRelevanceHarness.new(create_test_options)
+    aiohttp = AiohttpRelevanceHarness.new(create_test_options)
+
+    it "still claims a real Flask module" do
+      flask.relevant?(<<-PY).should be_true
+        from flask import Flask
+
+        app = Flask(__name__)
+
+        @app.route("/health")
+        def health():
+            return "ok"
+        PY
+    end
+
+    it "keeps Flask off Django Ninja, Bottle and aiohttp modules" do
+      # `@api.get("/x")` and `@app.get("/x")` are the same line in every
+      # decorator-based Python framework. Flask already refused files
+      # importing fastapi/sanic/litestar/… — `ninja`, `bottle` and `aiohttp`
+      # were missing, so their handler modules were relabelled `python_flask`
+      # with Flask-shaped (usually empty) params.
+      flask.relevant?(<<-PY).should be_false
+        from ninja import NinjaAPI
+
+        api = NinjaAPI()
+
+        @api.get("/items")
+        def items(request):
+            return []
+        PY
+
+      flask.relevant?(<<-PY).should be_false
+        from bottle import Bottle
+
+        app = Bottle()
+
+        @app.get("/dashboard")
+        def dashboard():
+            return "ok"
+        PY
+
+      flask.relevant?(<<-PY).should be_false
+        from aiohttp import web
+
+        routes = web.RouteTableDef()
+
+        @routes.get("/stats")
+        async def stats(request):
+            return web.Response(text="ok")
+        PY
+    end
+
+    it "keeps aiohttp off a Sanic module but still claims its own" do
+      # Sanic has an `app.add_route(handler, "/path")` of its own — argument
+      # order reversed from aiohttp's, so aiohttp read the handler name as the
+      # route. The bare `.add_route(` marker cannot tell the two apart; the
+      # import can.
+      aiohttp.relevant?(<<-PY).should be_false
+        from sanic import Sanic
+
+        app = Sanic("test_app")
+
+        app.add_route(create_report, "/create", methods=["POST"])
+
+        @app.get("/status")
+        async def status(request):
+            return response.json({})
+        PY
+
+      aiohttp.relevant?(<<-PY).should be_true
+        from aiohttp import web
+
+        routes = web.RouteTableDef()
+
+        @routes.get("/stats")
+        async def stats(request):
+            return web.Response(text="ok")
+        PY
+    end
+  end
+end

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -168,6 +168,7 @@ module Analyzer::CSharp
 
       content = read_file_content(file)
       return unless content.includes?("Controller")
+      return if Common.aspnet_framework_source?(content)
 
       controller_name = extract_controller_name(content)
       return if controller_name.empty?

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -77,6 +77,7 @@ module Analyzer::CSharp
 
       content = read_file_content(file)
       return unless content.includes?("Controller") && content.includes?("ActionResult")
+      return if Common.aspnet_core_source?(content)
 
       lines = content.lines
       masked_lines = Noir::CSharpLexer.new(content).masked_lines

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -25,6 +25,29 @@ module Analyzer::CSharp::Common
     base.ends_with?("Test.cs")
   end
 
+  # ASP.NET Core and classic ASP.NET MVC 5 spell a controller almost
+  # identically — `public class UserController : Controller` with `[HttpGet]`
+  # action attributes — and both analyzers are handed every `.cs` file in the
+  # scan. In a solution holding both (a migration in progress, the shape noir
+  # gets pointed at) each read the other's controllers: 35 phantom
+  # `cs_aspnet_core_mvc` endpoints out of the classic fixture, 6 the other way,
+  # several with the wrong route template applied on the way out.
+  #
+  # The namespaces are unmistakable and mutually exclusive — a type can only
+  # come from one of them — so each analyzer skips a file that names the
+  # other's. Nothing positive is required, so a helper file that names neither
+  # is still analyzed by both, exactly as before.
+  ASPNET_CORE_NAMESPACE_RE      = /\bMicrosoft\.AspNetCore\b/
+  ASPNET_FRAMEWORK_NAMESPACE_RE = /\bSystem\.Web\.(?:Mvc|Http|Routing)\b/
+
+  def self.aspnet_core_source?(content : String) : Bool
+    content.matches?(ASPNET_CORE_NAMESPACE_RE)
+  end
+
+  def self.aspnet_framework_source?(content : String) : Bool
+    content.matches?(ASPNET_FRAMEWORK_NAMESPACE_RE)
+  end
+
   # `IFormFile`/`IFormFileCollection`/`IFormCollection` are interfaces but
   # bind from the request body (file upload / form), not from DI — keep
   # them as request inputs even though they match the interface rule below.

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -391,7 +391,17 @@ module Analyzer::Python
       result
     end
 
+    # Frameworks whose registration syntax overlaps aiohttp's enough to trip
+    # the loose markers below — sanic's `@app.get("/x")` and its
+    # `app.add_route(handler, "/x")` in particular. A file that imports one of
+    # them and never mentions aiohttp is theirs. Mirrors the same guard in the
+    # Flask analyzer.
+    COMPETING_FRAMEWORK_IMPORT_RE =
+      /^\s*(?:from|import)\s+(?:sanic|fastapi|litestar|starlette|quart|robyn|ninja|bottle|falcon|flask)\b/m
+
     private def aiohttp_relevant_source?(source : ::String) : Bool
+      return false if !source.includes?("aiohttp") && source.matches?(COMPETING_FRAMEWORK_IMPORT_RE)
+
       source.includes?("aiohttp") ||
         source.includes?("RouteTableDef") ||
         source.includes?("web.") ||

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -1024,6 +1024,16 @@ module Analyzer::Python
       python_base_path_for(file_path)
     end
 
+    # Decorator-based Python web frameworks whose route syntax is
+    # indistinguishable from Flask's at the line level — `@app.get("/x")`,
+    # `@api.post("/x")`. A file that imports one of these and never mentions
+    # flask belongs to that framework's analyzer. `ninja` (Django Ninja),
+    # `bottle` and `aiohttp` were missing from the list, so the Flask analyzer
+    # claimed their handler files and relabelled the routes `python_flask`
+    # with Flask-shaped (usually empty) params.
+    COMPETING_FRAMEWORK_IMPORT_RE =
+      /^\s*(?:from|import)\s+(?:fastapi|sanic|litestar|starlette|quart|robyn|ninja|bottle|aiohttp|falcon|pyramid|tornado)\b/m
+
     private def flask_relevant_source?(source : ::String) : Bool
       # Strip # comments (to EOL) before relevance heuristics. This prevents
       # explanatory comments (in fixtures, docs, or real code) that mention
@@ -1045,7 +1055,7 @@ module Analyzer::Python
       # params. The route's real owner still emits it correctly, so this
       # only drops the duplicate mislabel (jupyterhub examples/service-
       # fastapi was reported as python_flask).
-      return false if clean.matches?(/^\s*(?:from|import)\s+(?:fastapi|sanic|litestar|starlette|quart|robyn)\b/m)
+      return false if clean.matches?(COMPETING_FRAMEWORK_IMPORT_RE)
       return true if clean.matches?(ROUTE_DECORATOR_RE)
       return true if clean.matches?(ROUTE_REGISTRAR_RE)
 


### PR DESCRIPTION
Two more languages in the project-scoping sweep (#2419, #2420, #2421, #2422).

### ASP.NET Core vs classic ASP.NET MVC 5

Both spell a controller almost identically —

```csharp
public class UserController : Controller { [HttpGet] public ActionResult List() { … } }
```

— and both analyzers are handed every `.cs` file in the scan. In a solution holding both (a migration in progress: exactly the shape noir gets pointed at) each read the other's controllers:

```
 35 cs_aspnet_core_mvc <- aspnet_mvc          (classic controllers, Core route templates applied)
  8 cs_aspnet_core_mvc <- aspnet_mvc_callees
  6 cs_aspnet_mvc      <- aspnet_core_mvc     e.g. GET /admin/[action]
```

The namespaces are mutually exclusive — a type comes from `Microsoft.AspNetCore` or from `System.Web.Mvc`, never both — so each analyzer skips a file naming the other's. Nothing positive is required, so a helper file naming neither is still analyzed by both, exactly as before.

### Flask

Flask already refused files importing a competing decorator-based framework, but the list was missing `ninja`, `bottle` and `aiohttp`:

```
 7 python_flask <- django_ninja     GET /add, GET /whoami, PUT /items/{item_id}, …
 3 python_flask <- bottle           GET /dashboard, POST /reports/<report_id:int>
 2 python_flask <- aiohttp
```

Their handler modules were relabelled `python_flask` with Flask-shaped (usually empty) params. The list is now a named constant covering the frameworks whose `@app.get("/x")` is indistinguishable from Flask's.

### aiohttp

It had no competing-import guard at all. Sanic has an `app.add_route(handler, "/path")` of its own — arguments in the opposite order — which trips aiohttp's `.add_route(` marker and makes it read the handler name as the route.

### Result

Cross-framework claims: **C# 41 → 0**, **Python 12 → 0**. Everything the measurement harness still flags is an analyzer claiming another fixture of its *own* framework, which is cross-file resolution working, not a bug.

### Tests

`csharp_python_framework_scope_spec.cr`: a classic MVC project beside a Core one driven through the full detect → analyze pipeline, plus relevance-gate cases for Flask (ninja / bottle / aiohttp modules refused, real Flask still claimed) and aiohttp (a Sanic module using `add_route` refused, its own still claimed). All three cases fail on `main`.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean