### PR TITLE
fix(analyzer): scope Crystal by shard, and keep Sinatra off Rails/Hanami

### DIFF
--- a/spec/unit_test/analyzer/crystal_ruby_framework_scope_spec.cr
+++ b/spec/unit_test/analyzer/crystal_ruby_framework_scope_spec.cr
@@ -1,0 +1,190 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+require "../../../src/analyzer/analyzers/ruby/sinatra"
+require "file_utils"
+
+# Rails, Hanami and Sinatra all spell a route `get "/books" …`, and every Ruby
+# analyzer is handed every `.rb` file in the scan. These predicates are what
+# let an analyzer step aside from a router that is unmistakably another
+# framework's.
+class RubyRouterHarness < Analyzer::Ruby::Sinatra
+  def rails?(source : String) : Bool
+    rails_router_source?(source)
+  end
+
+  def hanami?(source : String) : Bool
+    hanami_router_source?(source)
+  end
+end
+
+private def scan_tree(root : String) : Array(Endpoint)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints
+ensure
+  CodeLocator.instance.clear("file_map")
+end
+
+private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)
+  endpoints.compact_map do |endpoint|
+    next unless endpoint.details.technology == technology
+    endpoint.details.code_paths.first?.try(&.path)
+  end.uniq!
+end
+
+private def write_shard_project(dir : String, name : String, shard : String, repo : String, source : String)
+  FileUtils.mkdir_p(File.join(dir, "src"))
+  File.write(File.join(dir, "shard.yml"), <<-YAML)
+    name: #{name}
+    version: 0.1.0
+    targets:
+      #{name}:
+        main: src/#{name}.cr
+    dependencies:
+      #{shard}:
+        github: #{repo}
+    YAML
+  File.write(File.join(dir, "src", "#{name}.cr"), source)
+end
+
+describe "analyzer project scoping (crystal, ruby)" do
+  it "tells Kemal, Grip and Lucky apart by their shard manifest" do
+    # `get "/path"` is the same line in all three. Nothing in the source can
+    # separate them; `shard.yml` can.
+    root = File.tempname("noir-crystal-shard-scope")
+
+    begin
+      write_shard_project(File.join(root, "edge"), "edge", "kemal", "kemalcr/kemal", <<-CRYSTAL)
+        require "kemal"
+
+        get "/edge/health" do
+          "ok"
+        end
+        CRYSTAL
+
+      write_shard_project(File.join(root, "api"), "api", "grip", "grip-framework/grip", <<-CRYSTAL)
+        require "grip"
+
+        class Application < Grip::Application
+          def initialize
+            get "/api/status", StatusController
+          end
+        end
+        CRYSTAL
+
+      endpoints = scan_tree(root)
+
+      kemal_sources = tech_sources(endpoints, "crystal_kemal")
+      kemal_sources.any?(&.includes?("/edge/")).should be_true
+      kemal_sources.any?(&.includes?("/api/")).should be_false
+
+      grip_sources = tech_sources(endpoints, "crystal_grip")
+      grip_sources.any?(&.includes?("/api/")).should be_true
+      grip_sources.any?(&.includes?("/edge/")).should be_false
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+
+  it "falls back to scanning everything when no shard.yml declares the framework" do
+    # A source tree checked out without its manifest must behave exactly as it
+    # did before the gate existed.
+    root = File.tempname("noir-crystal-no-shard")
+
+    begin
+      write_shard_project(root, "edge", "kemal", "kemalcr/kemal", <<-CRYSTAL)
+        require "kemal"
+
+        get "/edge/health" do
+          "ok"
+        end
+        CRYSTAL
+      File.delete(File.join(root, "shard.yml"))
+
+      options = create_test_options
+      options["base"] = YAML::Any.new([YAML::Any.new(root)])
+      options["techs"] = YAML::Any.new("crystal_kemal")
+      runner = NoirRunner.new(options)
+      runner.detect
+      runner.analyze
+      runner.endpoints.map(&.url).should contain("/edge/health")
+      CodeLocator.instance.clear("file_map")
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+
+  it "recognizes a Rails or Hanami router so Sinatra can step aside" do
+    # Sinatra has no `config/routes.rb` convention, so a file that is
+    # unmistakably one of theirs is never also a Sinatra app. Pre-fix Sinatra
+    # parsed both route tables with its own DSL, interpolations and all
+    # (`GET /#{ENV.fetch(` out of a Rails routes.rb).
+    harness = RubyRouterHarness.new(create_test_options)
+
+    rails_routes = <<-'RUBY'
+      Rails.application.routes.draw do
+        get "/#{ENV.fetch('URL_COMPONENT', 'bb')}/:area" => "billboards#show"
+        resources :posts
+      end
+      RUBY
+    harness.rails?(rails_routes).should be_true
+    harness.hanami?(rails_routes).should be_false
+
+    hanami_routes = <<-RUBY
+      module Admin
+        class Routes < Hanami::Routes
+          get "/books", to: "books.index"
+        end
+      end
+      RUBY
+    harness.hanami?(hanami_routes).should be_true
+    harness.rails?(hanami_routes).should be_false
+
+    # A plain Sinatra app is neither, so nothing steps aside for it.
+    sinatra_app = <<-RUBY
+      require 'sinatra'
+
+      get '/tools/ping' do
+        'pong'
+      end
+      RUBY
+    harness.rails?(sinatra_app).should be_false
+    harness.hanami?(sinatra_app).should be_false
+  end
+
+  it "keeps Sinatra off a Rails route table end to end" do
+    root = File.tempname("noir-sinatra-scope")
+
+    begin
+      sinatra_dir = File.join(root, "tools")
+      FileUtils.mkdir_p(sinatra_dir)
+      File.write(File.join(sinatra_dir, "Gemfile"), "gem 'sinatra'\n")
+      File.write(File.join(sinatra_dir, "app.rb"), <<-RUBY)
+        require 'sinatra'
+
+        get '/tools/ping' do
+          'pong'
+        end
+        RUBY
+
+      rails_dir = File.join(root, "shop", "config")
+      FileUtils.mkdir_p(rails_dir)
+      File.write(File.join(root, "shop", "Gemfile"), "gem 'rails'\n")
+      File.write(File.join(rails_dir, "routes.rb"), <<-RUBY)
+        Rails.application.routes.draw do
+          get '/orders', to: 'orders#index'
+        end
+        RUBY
+
+      endpoints = scan_tree(root)
+      sinatra_sources = tech_sources(endpoints, "ruby_sinatra")
+      sinatra_sources.any?(&.includes?("/tools/app.rb")).should be_true
+      sinatra_sources.any?(&.includes?("/shop/")).should be_false
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+end

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -4,6 +4,14 @@ module Analyzer::Crystal
   class Amber < CrystalEngine
     analyzer_for "crystal_amber"
 
+    # Only files inside a project whose `shard.yml` depends on `amber`.
+    # See `CrystalEngine#shard_dependencies` — `get "/path"` is the same
+    # line in Kemal, Grip and Amber, so the manifest is what tells the
+    # frameworks apart.
+    protected def shard_dependencies : Array(String)
+      ["amber"]
+    end
+
     # `routes :web, "/admin" do … end` — the optional second argument is a
     # path scope that prefixes every route declared inside the block.
     ROUTES_SCOPE_PATTERN = /^(\s*)routes\s+:\w+(?:\s*,\s*["']([^"']*)["'])?\s+do\b/

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -4,6 +4,14 @@ module Analyzer::Crystal
   class Grip < CrystalEngine
     analyzer_for "crystal_grip"
 
+    # Only files inside a project whose `shard.yml` depends on `grip`.
+    # See `CrystalEngine#shard_dependencies` — `get "/path"` is the same
+    # line in Kemal, Grip and Amber, so the manifest is what tells the
+    # frameworks apart.
+    protected def shard_dependencies : Array(String)
+      ["grip"]
+    end
+
     # One combined PCRE2 scan replaces the previous 7 sequential per-verb
     # matchers. Grip requires whitespace after the verb (`get "/x"`, not
     # `get("/x")`) — the `\s+` keeps that shape, so `input "/x"` still

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -5,6 +5,14 @@ module Analyzer::Crystal
   class Kemal < CrystalEngine
     analyzer_for "crystal_kemal"
 
+    # Only files inside a project whose `shard.yml` depends on `kemal`.
+    # See `CrystalEngine#shard_dependencies` — `get "/path"` is the same
+    # line in Kemal, Grip and Amber, so the manifest is what tells the
+    # frameworks apart.
+    protected def shard_dependencies : Array(String)
+      ["kemal"]
+    end
+
     NAMESPACE_PATTERN = /^(\s*)(?:(\w+)\.)?namespace\s+["'](.+?)["']/
     MOUNT_PATTERN     = /^\s*mount\s+["'](.+?)["']\s*,\s*(\w+)/
     ROUTER_PATTERN    = /^\s*(\w+)\s*=\s*Kemal::Router\.new/

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -4,6 +4,14 @@ module Analyzer::Crystal
   class Lucky < CrystalEngine
     analyzer_for "crystal_lucky"
 
+    # Only files inside a project whose `shard.yml` depends on `lucky`.
+    # See `CrystalEngine#shard_dependencies` — `get "/path"` is the same
+    # line in Kemal, Grip and Amber, so the manifest is what tells the
+    # frameworks apart.
+    protected def shard_dependencies : Array(String)
+      ["lucky"]
+    end
+
     def analyze
       collect_public_dir_endpoints
       super

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -5,6 +5,14 @@ module Analyzer::Crystal
   class Marten < CrystalEngine
     analyzer_for "crystal_marten"
 
+    # Only files inside a project whose `shard.yml` depends on `marten`.
+    # See `CrystalEngine#shard_dependencies` — `get "/path"` is the same
+    # line in Kemal, Grip and Amber, so the manifest is what tells the
+    # frameworks apart.
+    protected def shard_dependencies : Array(String)
+      ["marten"]
+    end
+
     alias HandlerActionKey = Tuple(String, String, String)
     @handler_callees = Hash(HandlerActionKey, Array(Noir::CrystalCalleeExtractor::Entry)).new
 

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -30,7 +30,7 @@ module Analyzer::Ruby
       framework_roots.each do |framework_root|
         path = "#{framework_root}/config/routes.rb"
         next unless File.exists?(path)
-        next if rails_router?(path)
+        next if rails_router_file?(path)
 
         parse_routes_file(path, framework_root, include_callee)
       end
@@ -48,13 +48,6 @@ module Analyzer::Ruby
     # with no `Hanami::` reference anywhere in it, so requiring a positive
     # marker would drop real routes. `Rails.application.routes.draw` is never
     # Hanami.
-    RAILS_ROUTER_RE = /\.routes\.draw\b|ActionDispatch::Routing/
-
-    private def rails_router?(path : String) : Bool
-      read_file_content(path).matches?(RAILS_ROUTER_RE)
-    rescue
-      false
-    end
 
     private def parse_routes_file(path : String, framework_root : String, include_callee : Bool)
       stack = [] of RouteFrame

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -135,7 +135,7 @@ module Analyzer::Ruby
 
         routes_path = "#{framework_root}/config/routes.rb"
         next unless known_file?(routes_path)
-        next if hanami_router?(routes_path)
+        next if hanami_router_file?(routes_path)
 
         parse_routes_file(routes_path, framework_root)
       end
@@ -148,13 +148,6 @@ module Analyzer::Ruby
     # Hanami 2 routes file always names `Hanami::Routes` (it subclasses it), so
     # unlike the mirror check in the Hanami analyzer this one can key on the
     # positive marker.
-    HANAMI_ROUTER_RE = /Hanami::Rout|Hanami\.app\b|Hanami\.routes\b/
-
-    private def hanami_router?(path : String) : Bool
-      read_file_content(path).matches?(HANAMI_ROUTER_RE)
-    rescue
-      false
-    end
 
     private def parse_routes_file(routes_path : String, framework_root : String)
       parsed_route_files = Set(String).new

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -10,7 +10,15 @@ module Analyzer::Ruby
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
         next if ruby_non_production_path?(path)
-        lines = read_file_content(path).each_line.to_a
+        content = read_file_content(path)
+        # `get "/books", to: "books.index"` inside a Rails or Hanami route
+        # table is the same line as a Sinatra route to a line-based matcher.
+        # Sinatra has no `config/routes.rb` convention of its own, so a file
+        # that is unmistakably one of theirs is never also a Sinatra app —
+        # pre-fix this read Rails' and Hanami's route tables as Sinatra
+        # routes, interpolations and all (`GET /#{ENV.fetch(`).
+        next if rails_router_source?(content) || hanami_router_source?(content)
+        lines = content.each_line.to_a
         active_route_endpoints = [] of Endpoint
         active_route_depth = nil.as(Int32?)
         prefix_stack = [] of NamedTuple(depth: Int32, path: String)

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -12,6 +12,56 @@ module Analyzer::Crystal
 
     abstract def analyze_file(path : String) : Array(Endpoint)
 
+    # The shard that identifies this analyzer's framework. An analyzer that
+    # declares one is only shown files inside a project whose `shard.yml`
+    # depends on it. Without that, every Crystal analyzer sees every `.cr`
+    # file in the scan — and `get "/path"` is the same line in Kemal, Grip
+    # and Amber, so in a repo holding two of them each read the other's
+    # routes. Default is empty, meaning no gate.
+    protected def shard_dependencies : Array(String)
+      [] of String
+    end
+
+    # Directories holding a `shard.yml` that depends on one of
+    # `shard_dependencies`. Empty when the analyzer declares none, and also
+    # empty when the scan has no matching manifest at all — in which case
+    # `path_under_shard_roots?` waves everything through, so a source tree
+    # checked out without its manifest keeps working exactly as before.
+    private def shard_roots : Array(String)
+      dependencies = shard_dependencies
+      return [] of String if dependencies.empty?
+
+      patterns = dependencies.map { |name| shard_dependency_re(name) }
+      roots = [] of String
+      all_files.each do |file|
+        next unless File.basename(file) == "shard.yml"
+        begin
+          content = read_file_content(file)
+        rescue
+          next
+        end
+        next unless patterns.any? { |pattern| content.matches?(pattern) }
+        root = Noir::PathScope.normalize_root(File.dirname(file))
+        roots << root unless roots.includes?(root)
+      end
+      roots
+    end
+
+    # A shard entry is a two-space-indented mapping key under `dependencies:`
+    # / `development_dependencies:`. Anchoring on the key keeps `kemal` from
+    # matching a `kemal_json_serializer` line, and keeps the shard's own
+    # `name: kemal` out of it.
+    private def shard_dependency_re(name : String) : Regex
+      Regex.new("^\\s{2}#{Regex.escape(name)}\\s*:\\s*$", Regex::Options::MULTILINE)
+    end
+
+    private def path_under_shard_roots?(path : String, roots : Array(String)) : Bool
+      return true if roots.empty?
+
+      expanded = File.expand_path(path)
+      roots.any? { |root| Noir::PathScope.under_normalized_root?(expanded, root) }
+    end
+
     # `.cr` sources from the extension index, plus `lib/` exclusion
     # (shards puts dependencies under `lib/` and we don't want to
     # analyze them). Subclasses that need a custom scan shape can
@@ -20,8 +70,10 @@ module Analyzer::Crystal
     # files — no per-path `File.exists?` / `File.directory?`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
+        roots = shard_roots
         parallel_analyze(get_files_by_extension(".cr")) do |path|
           next if crystal_dependency_path?(path)
+          next unless path_under_shard_roots?(path, roots)
           # Crystal's standard test directory is `spec/`, and test
           # files always end in `_spec.cr`. Crystal framework repos
           # (lucky, marten, amber, kemal) park hundreds of route

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -130,6 +130,40 @@ module Analyzer::Ruby
       Endpoint.new("", "")
     end
 
+    # Rails, Hanami and Sinatra all spell a route `get "/books" …`, and every
+    # Ruby analyzer is handed every `.rb` file in the scan, so each one could
+    # parse the others' route table with its own DSL. These two predicates
+    # identify a file as unmistakably belonging to Rails or to Hanami; an
+    # analyzer that is neither uses them to step aside.
+    #
+    # `Rails.application.routes.draw` and `Hanami::Routes` are positive
+    # markers — a router that carries one is that framework's and nobody
+    # else's. There is deliberately no Sinatra equivalent: a Sinatra route
+    # file can be a bare `get "/x" do … end` with no framework reference at
+    # all, which is why the checks run in this direction only.
+    RAILS_ROUTER_RE  = /\.routes\.draw\b|ActionDispatch::Routing/
+    HANAMI_ROUTER_RE = /Hanami::Rout|Hanami\.app\b|Hanami\.routes\b/
+
+    protected def rails_router_source?(source : String) : Bool
+      source.matches?(RAILS_ROUTER_RE)
+    end
+
+    protected def hanami_router_source?(source : String) : Bool
+      source.matches?(HANAMI_ROUTER_RE)
+    end
+
+    protected def rails_router_file?(path : String) : Bool
+      rails_router_source?(read_file_content(path))
+    rescue
+      false
+    end
+
+    protected def hanami_router_file?(path : String) : Bool
+      hanami_router_source?(read_file_content(path))
+    rescue
+      false
+    end
+
     # Ruby's `"#{expr}"` interpolation in a route literal — e.g.
     # `get "#{PREFIX}/items"` — used to leak the raw `#{PREFIX}`
     # text into the URL. Rewrite it as a `{expr}` placeholder so


### PR DESCRIPTION
Continues the project-scoping sweep (#2419, #2420, #2421, #2422, #2423).

### Crystal

`CrystalEngine#parallel_file_scan` handed every `.cr` file to every analyzer, and `get "/path"` is the same line in Kemal, Grip and Amber:

```
 6 crystal_grip  <- lucky_callees      3 crystal_grip <- kemal_auth
 3 crystal_kemal <- grip               2 crystal_grip <- kemal_multi_base
 3 crystal_grip  <- lucky              … 23 total
```

Crystal has the same unambiguous anchor Rust does, so this uses the shape from #2422: an analyzer declares the shard that identifies its framework, and the engine only shows it files under a `shard.yml` that depends on one.

```crystal
protected def shard_dependencies : Array(String)
  ["kemal"]
end
```

The key match is anchored to a two-space-indented mapping key, so `kemal` can't match a `kemal_json_serializer` line or the shard's own `name:`. With no matching manifest the root list is empty and the gate waves everything through — a tree checked out without `shard.yml`, or `-t crystal_kemal`, behaves exactly as before (covered by a spec).

**Crystal cross-claims 23 → 0.**

### Sinatra

Also ungated, and `get "/books", to: "books.index"` inside a Rails or Hanami route table is the same line as a Sinatra route to a line-based matcher. It parsed both — one of the phantoms was literally:

```
ruby_sinatra | GET /#{ENV.fetch(          <- rails_advanced/config/routes.rb
ruby_sinatra | GET /{base_c_route}/:message_id
ruby_sinatra | GET /inline                <- hanami_advanced/…
```

Sinatra has no `config/routes.rb` convention of its own, so a file that is unmistakably Rails' or Hanami's router is never also a Sinatra app.

The two router predicates were introduced per-analyzer in #2420; they move to `RubyEngine` now that a third analyzer needs them, so Rails, Hanami and Sinatra share one definition instead of three.

**Ruby cross-claims 10 → 4** — the four left are the `public/` static asset and the marker-less Hanami 1 app file already documented as acceptable in #2420.

### Tests

`crystal_ruby_framework_scope_spec.cr`: a Kemal project beside a Grip one driven through the full detect → analyze pipeline (fails on `main`), the no-manifest fallback, the shared router predicates in both directions, and Sinatra staying off a Rails routes.rb end to end.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean