### PR TITLE
fix(optimizer): a named capture group is a named capture group

### DIFF
--- a/spec/functional_test/testers/perl/dancer2_spec.cr
+++ b/spec/functional_test/testers/perl/dancer2_spec.cr
@@ -37,7 +37,10 @@ expected_endpoints = [
   Endpoint.new("/notify", "HEAD", [Param.new("message", "", "query")]),
   # wildcard + regex routes
   Endpoint.new("/files/*", "GET"),
-  Endpoint.new("/ticket/(?<code>[0-9]+)", "GET", [Param.new("code", "", "path")]),
+  # `get qr{/ticket/(?<code>[0-9]+)}` — the optimizer rewrites the named
+  # capture group to the canonical `{code}` placeholder, so the URL agrees
+  # with the path param the analyzer records.
+  Endpoint.new("/ticket/{code}", "GET", [Param.new("code", "", "path")]),
   # block-scoped prefix (nested)
   Endpoint.new("/api/status", "GET"),
   Endpoint.new("/api/tokens", "POST", [Param.new("scope", "", "form")]),

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -685,6 +685,36 @@ describe "EndpointOptimizer" do
       result[1].url.should eq("/api/0/{event_id}/")
     end
 
+    # `(?P<name>…)` is Python's spelling; `(?<name>…)` is what Perl 5.10+,
+    # PCRE, .NET, Java, Ruby and JavaScript use. Only the first was handled,
+    # so Dancer2's `get qr{/ticket/(?<code>[0-9]+)}` reached reports as the
+    # literal URL `/ticket/(?<code>[0-9]+)` — disagreeing with the `code` path
+    # param the analyzer had already recorded for it.
+    it "normalizes plain (?<name>...) capture groups too" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/ticket/(?<code>[0-9]+)", "GET"),
+        Endpoint.new("/(?<org>[^/]+)/issues/(?<id>\\d+)/", "GET"),
+      ]
+
+      result = optimizer.normalize_url_shapes(endpoints)
+      result[0].url.should eq("/ticket/{code}")
+      result[1].url.should eq("/{org}/issues/{id}/")
+    end
+
+    it "leaves lookbehind assertions alone" do
+      # `(?<=` and `(?<!` open a lookbehind, not a name.
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/files/(?<=v2)report", "GET"),
+        Endpoint.new("/files/(?<!beta)report", "GET"),
+      ]
+
+      result = optimizer.normalize_url_shapes(endpoints)
+      result[0].url.should eq("/files/(?<=v2)report")
+      result[1].url.should eq("/files/(?<!beta)report")
+    end
+
     it "still skips verbatim Express regex-literal routes" do
       optimizer = EndpointOptimizer.new(logger, options)
       endpoints = [

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -108,8 +108,8 @@ class EndpointOptimizer
 
     normalized = url
 
-    # Python `re_path` named groups: `(?P<name>...)` → `{name}`.
-    normalized = strip_python_named_groups(normalized)
+    # Regex named groups: `(?P<name>...)` / `(?<name>...)` → `{name}`.
+    normalized = strip_named_capture_groups(normalized)
 
     # Spring `{name:regex}` path variables — strip the inline regex
     # constraint so downstream consumers see the canonical placeholder.
@@ -152,24 +152,33 @@ class EndpointOptimizer
     normalized
   end
 
-  # Rewrites every `(?P<name>...)` occurrence in `url` to `{name}`,
-  # consuming the matching `)` even when the inner pattern contains
-  # nested parens. Returns `url` unchanged when no named group is
-  # present.
-  private def strip_python_named_groups(url : String) : String
-    return url unless url.includes?("(?P<")
+  # Rewrites every named capture group in `url` to `{name}`, consuming the
+  # matching `)` even when the inner pattern contains nested parens. Returns
+  # `url` unchanged when no named group is present.
+  #
+  # Both spellings are handled. `(?P<name>…)` is Python's; `(?<name>…)` is
+  # what Perl 5.10+, PCRE, .NET, Java, Ruby and JavaScript use, and it reached
+  # reports raw — Dancer2's `get qr{/ticket/(?<code>[0-9]+)}` was emitted as
+  # the literal URL `/ticket/(?<code>[0-9]+)` even though the analyzer had
+  # already recorded `code` as a path param, so the endpoint's URL and its
+  # parameter list disagreed.
+  #
+  # `(?<=` and `(?<!` are lookbehind assertions, not names, and are left alone.
+  private def strip_named_capture_groups(url : String) : String
+    return url unless url.includes?("(?P<") || url.includes?("(?<")
 
     result = String::Builder.new
     i = 0
     size = url.size
     while i < size
-      if i + 3 < size && url[i] == '(' && url[i + 1] == '?' && url[i + 2] == 'P' && url[i + 3] == '<'
-        close_name = url.index('>', i + 4)
+      name_start = named_group_name_start(url, i, size)
+      if name_start
+        close_name = url.index('>', name_start)
         unless close_name
           result << url[i..]
           break
         end
-        name = url[(i + 4)...close_name]
+        name = url[name_start...close_name]
 
         # Walk to the matching `)` from after the name's `>`.
         depth = 1
@@ -201,6 +210,18 @@ class EndpointOptimizer
     end
 
     result.to_s
+  end
+
+  # Index just past the opening delimiter of a named capture group starting at
+  # `i` (i.e. where the name begins), or nil when `i` isn't one.
+  private def named_group_name_start(url : String, i : Int32, size : Int32) : Int32?
+    return unless i + 2 < size && url[i] == '(' && url[i + 1] == '?'
+
+    if url[i + 2] == 'P' && i + 3 < size && url[i + 3] == '<'
+      i + 4
+    elsif url[i + 2] == '<' && i + 3 < size && url[i + 3] != '=' && url[i + 3] != '!'
+      i + 3
+    end
   end
 
   # Stable ordering key: source location first, then technology as a


### PR DESCRIPTION
`normalize_url_shape` rewrote Python's `(?P<name>…)` to the canonical `{name}` placeholder but not the plain `(?<name>…)` form — which is what Perl 5.10+, PCRE, .NET, Java, Ruby and JavaScript all use.

So Dancer2's

```perl
get qr{/ticket/(?<code>[0-9]+)} => sub { … };
```

reached reports as the literal URL, while the analyzer had already recorded `code` as a path param for it:

```console
# before
GET /ticket/(?<code>[0-9]+)  params=["code"]
# after
GET /ticket/{code}           params=["code"]
```

The endpoint's URL and its own parameter list disagreed, and no consumer could reconcile them — the curl builder emitted the raw regex as a path, and the OAS builder had a `code` path parameter with nothing in the template to bind it to.

Both spellings are handled now, sharing the existing paren/bracket walk that finds the matching `)` through nested groups and character classes. `(?<=` and `(?<!` open a lookbehind rather than a name and are left alone.

### How it was found

Swept every fixture project's emitted URLs for framework syntax that should have been normalized away (interpolations, quotes, regex fragments, whitespace). Everything else that turned up is a framework literal noir deliberately keeps verbatim — nginx/istio/kong `.*` prefixes, tornado and drogon regex routes, Express regex-literal routes — and this was the one case where the URL contradicted the endpoint's own params. After the fix no emitted URL in the fixture tree carries a named group.

### Tests

Optimizer specs for both spellings (the new one fails on `main`) and for the two lookbehind forms staying untouched. The Dancer2 functional expectation is updated to `/ticket/{code}`.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean