### PR TITLE
fix(read): a UTF-16 source file is text, not a binary blob

### DIFF
--- a/spec/unit_test/utils/utf16_source_spec.cr
+++ b/spec/unit_test/utils/utf16_source_spec.cr
@@ -1,0 +1,118 @@
+require "../../spec_helper"
+require "../../../src/utils/text_file"
+require "../../../src/utils/media_filter"
+require "../../../src/models/noir"
+require "file_utils"
+
+# Visual Studio and much of the Windows toolchain still write source as
+# UTF-16, where every ASCII character carries a NUL byte. The detector walk
+# and MediaFilter both read an interior NUL as the signature of a binary blob,
+# so those files were dropped from the scan outright — no detection, no
+# analysis, and nothing on stdout to say so.
+private UTF16_SOURCE = <<-CS
+  using Microsoft.AspNetCore.Mvc;
+
+  namespace App.Controllers
+  {
+      [ApiController]
+      [Route("api/[controller]")]
+      public class UsersController : ControllerBase
+      {
+          [HttpGet("GetAll")]
+          public IActionResult GetAll() => Ok();
+      }
+  }
+  CS
+
+private def write_utf16(path : String, text : String, big_endian : Bool = false)
+  io = IO::Memory.new
+  io.write(big_endian ? Bytes[0xFE_u8, 0xFF_u8] : Bytes[0xFF_u8, 0xFE_u8])
+  text.each_char do |char|
+    code = char.ord
+    hi = ((code >> 8) & 0xFF).to_u8
+    lo = (code & 0xFF).to_u8
+    io.write(big_endian ? Bytes[hi, lo] : Bytes[lo, hi])
+  end
+  File.write(path, io.to_slice)
+end
+
+describe Noir::TextFile do
+  it "decodes a UTF-16 LE source file to UTF-8" do
+    path = File.tempname("noir-utf16", ".cs")
+    begin
+      write_utf16(path, UTF16_SOURCE)
+      content = Noir::TextFile.read(path)
+      content.should contain("public class UsersController")
+      # The BOM is consumed, not left as a leading U+FEFF, and no NUL
+      # survives — the analyzers' regexes would match nothing otherwise.
+      content.starts_with?("using").should be_true
+      content.to_slice.includes?(0_u8).should be_false
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+
+  it "decodes a UTF-16 BE source file to UTF-8" do
+    path = File.tempname("noir-utf16be", ".cs")
+    begin
+      write_utf16(path, UTF16_SOURCE, big_endian: true)
+      Noir::TextFile.read(path).should contain("public class UsersController")
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+
+  it "leaves plain UTF-8 untouched" do
+    path = File.tempname("noir-utf8", ".cs")
+    begin
+      File.write(path, UTF16_SOURCE)
+      Noir::TextFile.read(path).should eq(UTF16_SOURCE)
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+end
+
+describe MediaFilter do
+  it "does not call a UTF-16 source file binary" do
+    path = File.tempname("noir-utf16-sniff", ".cs")
+    begin
+      write_utf16(path, UTF16_SOURCE)
+      MediaFilter.binary_content_signature?(path).should be_false
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+
+  it "still calls a NUL-bearing file with no BOM binary" do
+    path = File.tempname("noir-blob", ".cs")
+    begin
+      File.write(path, Bytes[0x7F_u8, 0x45_u8, 0x4C_u8, 0x46_u8, 0x00_u8, 0x01_u8, 0x00_u8])
+      MediaFilter.binary_content_signature?(path).should be_true
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+end
+
+describe "scanning a UTF-16 project" do
+  it "finds endpoints in a UTF-16 controller" do
+    root = File.tempname("noir-utf16-scan")
+
+    begin
+      FileUtils.mkdir_p(File.join(root, "Controllers"))
+      File.write(File.join(root, "MyApp.csproj"), %(<Project Sdk="Microsoft.NET.Sdk.Web"></Project>))
+      write_utf16(File.join(root, "Controllers", "UsersController.cs"), UTF16_SOURCE)
+
+      options = create_test_options
+      options["base"] = YAML::Any.new([YAML::Any.new(root)])
+      runner = NoirRunner.new(options)
+      runner.detect
+      runner.analyze
+      runner.endpoints.map(&.url).should contain("/api/Users/GetAll")
+      CodeLocator.instance.clear("file_map")
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+end

--- a/src/utils/media_filter.cr
+++ b/src/utils/media_filter.cr
@@ -158,10 +158,25 @@ module MediaFilter
       buffer = Bytes.new(512)
       bytes_read = io.read(buffer)
       return false if bytes_read == 0
-      buffer[0, bytes_read].includes?(0_u8)
+      sample = buffer[0, bytes_read]
+      # A UTF-16 BOM means the interior NULs below are the encoding, not a
+      # binary blob — in UTF-16 every ASCII character carries one. Visual
+      # Studio and much of the Windows toolchain still write source that way,
+      # and without this check those files were dropped from the scan
+      # entirely. `Noir::TextFile.read` transcodes them.
+      return false if utf16_bom?(sample)
+      sample.includes?(0_u8)
     end
   rescue
     false
+  end
+
+  private def self.utf16_bom?(sample : Bytes) : Bool
+    return false if sample.size < 2
+    # UTF-32LE opens `FF FE 00 00` and shares the UTF-16LE prefix; leave it
+    # on the binary path rather than decode it at the wrong width.
+    return false if sample.size >= 4 && sample[0] == 0xFF_u8 && sample[1] == 0xFE_u8 && sample[2] == 0_u8 && sample[3] == 0_u8
+    (sample[0] == 0xFF_u8 && sample[1] == 0xFE_u8) || (sample[0] == 0xFE_u8 && sample[1] == 0xFF_u8)
   end
 
   # Combined check - returns true if file should be skipped. Prefer

--- a/src/utils/text_file.cr
+++ b/src/utils/text_file.cr
@@ -17,9 +17,46 @@ module Noir::TextFile
   # dropped the bad sequences before. The fallback decodes the bytes
   # already in hand rather than re-reading the file, so a file that
   # changes mid-scan cannot yield a half-and-half result.
+  # UTF-16 byte-order marks. Visual Studio and a good deal of Windows
+  # tooling still write source as UTF-16 — `.cs`, `.vb`, `.resx`, `.config`,
+  # PowerShell `.ps1` — and in UTF-16 every ASCII character carries a NUL
+  # byte. Both the detector walk and `MediaFilter` treat an interior NUL as
+  # the signature of a binary blob, so such a file was dropped from the scan
+  # outright: no detection, no analysis, no warning beyond a debug line. A
+  # UTF-16 C# controller contributed exactly zero endpoints.
+  #
+  # The BOM settles it. Nothing else is guessed at: a NUL-bearing file with
+  # no BOM is still treated as binary.
+  UTF16_LE_BOM = Bytes[0xFF_u8, 0xFE_u8]
+  UTF16_BE_BOM = Bytes[0xFE_u8, 0xFF_u8]
+
   def self.read(path : String) : String
     content = File.read(path)
+    return transcode_utf16(content) if utf16_bom?(content)
     return content if content.valid_encoding?
+    decode(content)
+  end
+
+  # True when the bytes open with a UTF-16 BOM. A UTF-32LE file opens
+  # `FF FE 00 00`, which shares the UTF-16LE prefix — it is excluded here so
+  # it keeps falling through to the binary path rather than being decoded as
+  # the wrong width.
+  def self.utf16_bom?(content : String) : Bool
+    bytes = content.to_slice
+    return false if bytes.size < 2
+    prefix = bytes[0, 2]
+    return false if prefix == UTF16_LE_BOM && bytes.size >= 4 && bytes[2] == 0_u8 && bytes[3] == 0_u8
+    prefix == UTF16_LE_BOM || prefix == UTF16_BE_BOM
+  end
+
+  # Decode UTF-16 to UTF-8. The `"UTF-16"` encoding name (rather than an
+  # explicit endianness) is what consumes the BOM instead of leaving it as a
+  # leading U+FEFF in the decoded text.
+  def self.transcode_utf16(content : String) : String
+    io = IO::Memory.new(content.to_slice)
+    io.set_encoding("UTF-16", invalid: :skip)
+    io.gets_to_end
+  rescue
     decode(content)
   end
 


### PR DESCRIPTION
In UTF-16 every ASCII character carries a NUL byte, and both the detector walk and `MediaFilter` read an interior NUL as the signature of a binary blob. So a UTF-16 source file was dropped from the scan outright — no detection, no analysis, and nothing on stdout to say so beyond `Skipped 1 media/large files`, which doesn't even name the right reason.

This is not a hypothetical encoding. Visual Studio and much of the Windows toolchain still write source as UTF-16 — `.cs`, `.vb`, `.resx`, `.config`, PowerShell `.ps1`. A UTF-16 ASP.NET controller contributed exactly zero endpoints:

```console
$ file Controllers/UsersController.cs
Controllers/UsersController.cs: Unicode text, UTF-16, little-endian text

# before
$ noir -b ./app -f only-url
(nothing)

# after
$ noir -b ./app -f only-url
/api/Users/GetAll
```

### The fix

`Noir::TextFile.read` transcodes a BOM-marked UTF-16 file to UTF-8. That one change covers the analyzers and the detector walk alike — the walk's own NUL check runs on the decoded text, so the file stops looking binary there too. `MediaFilter.binary_content_signature?` gets the same BOM exemption for its other callers.

Nothing else is guessed at. The BOM is the whole signal:

- a NUL-bearing file **without** a BOM is still binary (an ELF header still gets skipped);
- **UTF-32LE** opens `FF FE 00 00` and so shares the UTF-16LE prefix — it is explicitly left on the binary path rather than decoded at the wrong width;
- plain UTF-8 goes through the existing fast path untouched.

Crystal's `"UTF-16"` encoding name (rather than an explicit endianness) is what consumes the BOM instead of leaving a stray U+FEFF at the head of the decoded text; both LE and BE resolve.

### How it was found

Swept every fixture project for output-format validity and for scan determinism (rerun-to-rerun and `--concurrency 1` vs default) — both came back completely clean, which is a good sign for the earlier sweeps. Reading the file-skipping path afterwards turned up the comment asserting that "text files in any common encoding (UTF-8, UTF-16-with-BOM, Latin-1, etc.) don't contain interior NULs in practice", which is exactly backwards for UTF-16.

### Tests

`utf16_source_spec.cr`: LE and BE decode (BOM consumed, no surviving NUL), plain UTF-8 unchanged, the MediaFilter sniff in both directions, and an end-to-end scan of a UTF-16 ASP.NET project. Four of the six fail on `main`.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean