### PR TITLE
fix(cache): a huge NOIR_CONTENT_CACHE_MAX_MB shouldn't abort the scan

### DIFF
--- a/spec/unit_test/models/code_locator_spec.cr
+++ b/spec/unit_test/models/code_locator_spec.cr
@@ -59,6 +59,31 @@ describe "content cache" do
     end
   end
 
+  it "saturates instead of overflowing on an absurd NOIR_CONTENT_CACHE_MAX_MB" do
+    # Crystal checks integer arithmetic, so scaling the megabyte figure to
+    # bytes *raised* rather than wrapping — the whole scan aborted with an
+    # unhandled OverflowError stack trace before the first file was read.
+    ENV["NOIR_CONTENT_CACHE_MAX_MB"] = "99999999999999"
+    begin
+      locator = CodeLocator.new
+      locator.content_cache_stats[:budget].should eq(Int64::MAX)
+      # A budget that large means "cache everything", so caching still works.
+      locator.register_file("/tmp/noir-cache-spec-overflow.py", "content")
+      locator.content_for("/tmp/noir-cache-spec-overflow.py").should eq("content")
+    ensure
+      ENV.delete("NOIR_CONTENT_CACHE_MAX_MB")
+    end
+  end
+
+  it "still scales an ordinary NOIR_CONTENT_CACHE_MAX_MB to bytes" do
+    ENV["NOIR_CONTENT_CACHE_MAX_MB"] = "8"
+    begin
+      CodeLocator.new.content_cache_stats[:budget].should eq(8_i64 * 1024 * 1024)
+    ensure
+      ENV.delete("NOIR_CONTENT_CACHE_MAX_MB")
+    end
+  end
+
   it "honours NOIR_CONTENT_CACHE_DISABLE" do
     ENV["NOIR_CONTENT_CACHE_DISABLE"] = "true"
     begin

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -52,11 +52,21 @@ class CodeLocator
     @lock = Mutex.new
   end
 
+  # Megabyte figures at or above this overflow `Int64` once scaled to bytes.
+  # Crystal checks integer arithmetic, so the multiply below *raised* rather
+  # than wrapping: `NOIR_CONTENT_CACHE_MAX_MB=99999999999999` aborted the whole
+  # scan with an unhandled `OverflowError` stack trace before the first file
+  # was read. Saturate instead — a budget that large already means "cache
+  # everything", which is exactly what `Int64::MAX` gives.
+  MAX_CONTENT_CACHE_MB = Int64::MAX // (1024_i64 * 1024)
+
   private def resolve_content_cache_budget : Int64
     return 0_i64 if any_to_bool(ENV["NOIR_CONTENT_CACHE_DISABLE"]?)
     if raw = ENV["NOIR_CONTENT_CACHE_MAX_MB"]?
       parsed = raw.to_i64?
-      return parsed * 1024 * 1024 if parsed && parsed >= 0
+      if parsed && parsed >= 0
+        return parsed >= MAX_CONTENT_CACHE_MB ? Int64::MAX : parsed * 1024 * 1024
+      end
     end
     DEFAULT_CONTENT_CACHE_BUDGET
   end


### PR DESCRIPTION
Crystal checks integer arithmetic, so scaling the megabyte figure to bytes *raised* rather than wrapping. `NOIR_CONTENT_CACHE_MAX_MB=99999999999999` — someone reaching for "just cache everything" — aborted the whole scan before the first file was read:

```console
$ NOIR_CONTENT_CACHE_MAX_MB=99999999999999 noir -b ./app
Unhandled exception: Arithmetic overflow (OverflowError)
  from src/models/code_locator.cr:59:28 in 'resolve_content_cache_budget'
  from src/models/code_locator.cr:47:29 in 'initialize'
  from src/models/code_locator.cr:65:5 in 'instance'
  from src/detector/detector.cr:340:13 in 'detect_techs'
```

The threshold is around 8.8e12 (`Int64::MAX / 1MB`). Anything at or above it now saturates to `Int64::MAX`, which is what such a value means anyway. Ordinary figures still scale normally, and `0` / negative / non-numeric keep their existing fallback behaviour.

### The other knobs are fine

Fuzzed every numeric `NOIR_*` env var with zero, negative, non-numeric and overflow values:

| var | 0 | -1 | non-numeric | overflow |
|---|---|---|---|---|
| `NOIR_CONTENT_CACHE_MAX_MB` | ok | ok | ok | **crash → fixed** |
| `NOIR_MAX_FILE_SIZE` | ok | ok | ok | ok |
| `NOIR_CONCURRENCY` | ok | ok | ok | ok |
| `NOIR_PARSER_MAX_DEPTH` | ok | ok | ok | ok |

`MediaFilter.parse_size` already wraps its multiply in a `rescue`; this was the one unguarded scale.

### Also checked, all clean

While looking for this: every output format stays structurally valid across all 661 fixture projects (json / jsonl / sarif / oas2 / oas3 / postman / toml); scans are byte-identical rerun-to-rerun and between `--concurrency 1` and the default; UTF-8-BOM, Latin-1 and CRLF sources all resolve; and a symlink loop in the scan tree completes in 0.06s.

### Tests

Two `code_locator_spec` cases: the overflow value saturates and still caches, and an ordinary value still scales to bytes. The first errors on `main` with the OverflowError.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean