### PR TITLE
fix(analyzer/js): scope Fresh, and stop reading clients and plugins as routes

### DIFF
--- a/spec/unit_test/analyzer/js_framework_scope_spec.cr
+++ b/spec/unit_test/analyzer/js_framework_scope_spec.cr
@@ -1,0 +1,126 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+require "../../../src/miniparsers/js_route_extractor"
+require "file_utils"
+
+private def scan_tree(root : String) : Array(Endpoint)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints
+ensure
+  CodeLocator.instance.clear("file_map")
+end
+
+private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)
+  endpoints.compact_map do |endpoint|
+    next unless endpoint.details.technology == technology
+    endpoint.details.code_paths.first?.try(&.path)
+  end.uniq!
+end
+
+describe Noir::JSRouteExtractor do
+  describe ".other_shared_extractor_framework?" do
+    it "refuses a client module that stands up no server" do
+      # `client.get('/todo', cb)` is the same call shape as a route
+      # registration, so a restify-clients module read as an Express server:
+      # `GET /todo` and `DELETE /todo/example` out of code that only calls a
+      # remote API.
+      client = <<-JS
+        const clients = require('restify-clients')
+
+        const client = clients.createJSONClient({ url: 'http://localhost:8080' })
+
+        client.get('/todo', function noop() {})
+        client.del('/todo/example', function noop() {})
+        JS
+
+      Noir::JSRouteExtractor.other_shared_extractor_framework?(client, :express).should be_true
+    end
+
+    it "keeps a test that stands up a real server and then calls it" do
+      # A client constructor only disqualifies a file that serves nothing of
+      # its own.
+      both = <<-JS
+        const express = require('express')
+        const clients = require('restify-clients')
+
+        const app = express()
+        app.get('/health', (req, res) => res.send('ok'))
+        JS
+
+      Noir::JSRouteExtractor.other_shared_extractor_framework?(both, :express).should be_false
+    end
+
+    it "leaves a marker-less fastify autoload plugin to fastify" do
+      # `@fastify/autoload` plugin modules import nothing — the instance
+      # arrives as a parameter, so the receiver name is the only evidence.
+      plugin = <<-JS
+        export const autoPrefix = '/_app';
+
+        export default async function (fastify) {
+          fastify.get('/status', async () => ({ status: 'ok' }));
+        }
+        JS
+
+      Noir::JSRouteExtractor.other_shared_extractor_framework?(plugin, :express).should be_true
+      Noir::JSRouteExtractor.other_shared_extractor_framework?(plugin, :fastify).should be_false
+    end
+  end
+end
+
+describe "Fresh project scoping" do
+  it "keeps Fresh off another framework's routes/ directory" do
+    # `routes/` is Remix's directory too (`app/routes/`), and Koa/Express
+    # projects routinely have one. Fresh claimed every `*/routes/*` in the
+    # scan, so Remix's `users.$id.tsx` surfaced as a Fresh endpoint named
+    # after the file.
+    root = File.tempname("noir-fresh-scope")
+
+    begin
+      site = File.join(root, "site")
+      FileUtils.mkdir_p(File.join(site, "routes"))
+      File.write(File.join(site, "deno.json"), %({"imports": {"$fresh/": "https://deno.land/x/fresh@1.6.8/"}}))
+      # A real Fresh route imports from `$fresh/` — that is what the
+      # detector keys on, so the synthetic project needs it too.
+      File.write(File.join(site, "routes", "about.tsx"), <<-TSX)
+        import { Handlers } from "$fresh/server.ts";
+
+        export const handler: Handlers = {
+          GET(_req, ctx) {
+            return ctx.render();
+          },
+        };
+        TSX
+
+      web = File.join(root, "web", "app", "routes")
+      FileUtils.mkdir_p(web)
+      File.write(File.join(root, "web", "package.json"), %({"dependencies": {"@remix-run/node": "^2.0.0"}}))
+      # The ordinary Remix route shape: a loader plus a default component.
+      # The default export is what Fresh reads as a page, which is how these
+      # modules ended up as `js_fresh` endpoints named after the file.
+      File.write(File.join(web, "users.$id.tsx"), <<-TSX)
+        import type { LoaderFunctionArgs } from "@remix-run/node";
+
+        export async function loader({ params }: LoaderFunctionArgs) {
+          return { id: params.id };
+        }
+
+        export default function User() {
+          return <h1>user</h1>;
+        }
+        TSX
+
+      endpoints = scan_tree(root)
+      fresh_sources = tech_sources(endpoints, "js_fresh")
+      fresh_sources.any?(&.includes?("/site/routes/about.tsx")).should be_true
+      fresh_sources.any?(&.includes?("/web/")).should be_false
+      # And nothing surfaces the Remix filename as a URL.
+      endpoints.map(&.url).none?(&.includes?(".$")).should be_true
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+end

--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -61,14 +61,56 @@ module Analyzer::Javascript
     VERB_KEY_SHORTHAND_RES  = HTTP_METHODS.map { |v| {v, /(^|[\{,\s])(?:async\s+)?#{v}\s*\(/} }.to_h
     VERB_KEY_PROPERTY_RES   = HTTP_METHODS.map { |v| {v, /(^|[\{,\s])#{v}\s*:/} }.to_h
 
+    # Directories holding a Fresh project manifest. A bare `deno.json` is not
+    # enough — a plain Deno project has one too — so it only counts when it
+    # references `$fresh/`.
+    private def fresh_project_roots : Array(String)
+      roots = [] of String
+      all_files.each do |file|
+        base = File.basename(file)
+        marked =
+          if ROOT_CONFIG_BASENAMES.includes?(base)
+            true
+          elsif DENO_MANIFEST_BASENAMES.includes?(base)
+            begin
+              read_file_content(file).matches?(FRESH_IMPORT_MARKER)
+            rescue
+              false
+            end
+          else
+            false
+          end
+        next unless marked
+        root = Noir::PathScope.normalize_root(File.dirname(file))
+        roots << root unless roots.includes?(root)
+      end
+      roots
+    end
+
     # Files that are framework plumbing rather than routes.
     SKIPPED_LEAVES = ["_app", "_layout", "_404", "_500", "_middleware"]
+
+    # A Fresh project is anchored by `fresh.config.{ts,js}`, or by a Deno
+    # manifest that pulls in `$fresh/`. Same shape the detector already
+    # treats as authoritative.
+    ROOT_CONFIG_BASENAMES   = ["fresh.config.ts", "fresh.config.js", "fresh.config.mjs"]
+    DENO_MANIFEST_BASENAMES = ["deno.json", "deno.jsonc"]
+    FRESH_IMPORT_MARKER     = /\$fresh\//
 
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
+      # `routes/` on its own is not a Fresh signal — Remix keeps its route
+      # modules in `app/routes/`, and Koa/Express/Fastify projects routinely
+      # have one too. Treating every `*/routes/*` in the scan as a Fresh
+      # file-system route meant Remix's `users.$id.tsx` and `users._index.tsx`
+      # surfaced as Fresh endpoints named after the file. Scope to the Fresh
+      # project root the same way the SvelteKit and Nitro analyzers do; with
+      # no marker found `path_under_project_roots?` waves everything through.
+      project_roots = fresh_project_roots
 
       parallel_file_scan(EXTENSIONS) do |path|
+        next unless path_under_project_roots?(path, project_roots)
         idx = path.index("/routes/")
         next if idx.nil?
 

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -811,9 +811,51 @@ module Noir
 
     SIBLING_FRAMEWORK_MARKER = Regex.union(OTHER_FRAMEWORK_MARKERS.values.flatten)
 
+    # Constructors that build an HTTP *client*. `client.get('/todo', cb)` is
+    # the same call shape as a route registration, so a client module reads as
+    # a server to the shared extractor: the Express analyzer reported
+    # `GET /todo` and `DELETE /todo/example` out of a restify-clients module
+    # that only calls a remote API.
+    #
+    # The restify analyzer already refused these; the check belongs here so
+    # every framework sharing the extractor gets it. It is deliberately
+    # limited to client *constructors* rather than client package names —
+    # a genuine route file may well `require('axios')` to call downstream
+    # services, and gating on that would drop its routes.
+    HTTP_CLIENT_CONSTRUCTOR_MARKER = Regex.union(
+      "restify-clients", "createJSONClient(", "createStringClient(", "createHttpClient("
+    )
+
+    # A `@fastify/autoload` plugin module names no framework at all — it
+    # receives the instance as a parameter:
+    #
+    #     export default async function (fastify) {
+    #       fastify.get('/status', handler)
+    #     }
+    #
+    # so no import marker fires and the shared extractor happily reads those
+    # registrations for whichever framework asked. Express reported `/status`
+    # and `/go` out of the fastify autoload fixture, without the `autoPrefix`
+    # the Fastify analyzer applies. The receiver name is the only evidence in
+    # the file, and `fastify` is unambiguous — nothing else calls its app
+    # instance that. Consulted only when the file imports no HTTP server.
+    FASTIFY_RECEIVER_MARKER =
+      /\bfastify\s*\.\s*(?:get|post|put|patch|delete|head|options|all|route|register)\s*\(/
+
     def self.other_shared_extractor_framework?(content : String, framework : Symbol) : Bool
       return false if content_matches?(content, OWN_EXTRACTOR_MARKER[framework])
       return true if content_matches?(content, OTHER_EXTRACTOR_MARKER[framework])
+      if framework != :fastify && !content_matches?(content, HTTP_SERVER_LIBRARY_MARKER) &&
+         content_matches?(content, FASTIFY_RECEIVER_MARKER)
+        return true
+      end
+      # Client constructors only disqualify a file that stands up no server of
+      # its own — a test that spins up an Express app and then calls it keeps
+      # its routes.
+      if content_matches?(content, HTTP_CLIENT_CONSTRUCTOR_MARKER) &&
+         !content_matches?(content, HTTP_SERVER_LIBRARY_MARKER)
+        return true
+      end
 
       content_matches?(content, SIBLING_FRAMEWORK_MARKER)
     end


### PR DESCRIPTION
Three JavaScript cross-framework claims, all the same shape as the earlier scoping work (#2420, #2422, #2424).

### Fresh claimed every `routes/` directory in the scan

`routes/` is Remix's directory too (`app/routes/`), and Koa/Express/Fastify projects routinely have one. So Remix route modules surfaced as Fresh endpoints named after the file:

```
js_fresh | GET /users._index   <- remix/app/routes/users._index.tsx
js_fresh | GET /users.$id      <- remix/app/routes/users.$id.tsx
```

It now scopes to the Fresh project root, anchored on `fresh.config.*` or a Deno manifest that pulls in `$fresh/` — the same evidence the detector already treats as authoritative. A bare `deno.json` isn't enough, since a plain Deno project has one. With no marker found the gate waves everything through, same as the SvelteKit and Nitro analyzers.

### An HTTP client read as a server

`client.get('/todo', cb)` is the same call shape as a route registration, so a restify-clients module read as an Express app:

```js
const clients = require('restify-clients')
const client = clients.createJSONClient({ url: 'http://localhost:8080' })
client.get('/todo', function noop() {})        // → reported as GET /todo
client.del('/todo/example', function noop() {})  // → reported as DELETE /todo/example
```

The restify analyzer already refused these; the check moves into the shared extractor so every framework using it benefits.

Two deliberate limits: it keys on client **constructors** rather than client package names — a genuine route file may well `require('axios')` to call downstream services, and gating on that would drop its routes — and it only disqualifies a file that stands up no server of its own, so a test that boots an Express app and then calls it keeps its routes.

### A marker-less `@fastify/autoload` plugin

These modules import nothing; the instance arrives as a parameter, so no marker fires and the shared extractor read the registrations for whichever framework asked:

```js
export const autoPrefix = '/_app';
export default async function (fastify) {
  fastify.get('/status', async () => ({ status: 'ok' }));
}
```

Express reported `/status` and `/go` out of the autoload fixture — without the `autoPrefix` the Fastify analyzer applies, so even the paths were wrong. The receiver name is the only evidence in the file, and `fastify` is unambiguous.

### Result

JavaScript cross-claims **9 → 3**. The three left are Koa claiming another Koa fixture, which is cross-file mount resolution working. TypeScript's remaining 29 are all same-framework for the same reason.

### Tests

`js_framework_scope_spec.cr`: the client module refused while a server-plus-client test keeps its routes, the autoload plugin left to Fastify, and a Fresh site beside a Remix app driven through the full detect → analyze pipeline. All three fail on `main`.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean