### PR TITLE
fix(analyzer/php): close the last two cross-framework route claims

### DIFF
--- a/spec/unit_test/analyzer/php_framework_relevance_spec.cr
+++ b/spec/unit_test/analyzer/php_framework_relevance_spec.cr
@@ -1,6 +1,7 @@
 require "../../spec_helper"
 require "../../../src/analyzer/analyzers/php/slim"
 require "../../../src/analyzer/analyzers/php/laminas"
+require "../../../src/analyzer/analyzers/php/cakephp"
 
 # Every PHP analyzer is fed every `.php` file in the scan, so each one's
 # relevance gate is the only thing keeping it off the other frameworks' route
@@ -15,6 +16,13 @@ end
 class LaminasRelevanceHarness < Analyzer::Php::Laminas
   def relevant?(path : String, content : String) : Bool
     laminas_relevant?(path, content)
+  end
+end
+
+# CakePHP gates on the `config/routes.php` path, which Hyperf uses too.
+class CakePhpHyperfHarness < Analyzer::Php::CakePHP
+  def hyperf?(content : String) : Bool
+    content.matches?(HYPERF_MARKER_RE)
   end
 end
 
@@ -39,6 +47,26 @@ private LUMEN_ROUTES = <<-PHP
   <?php
   $router->get('/health', 'HealthController@index');
   $router->put('/users/{id}', 'UserController@update');
+  PHP
+
+private MEZZIO_ROUTES = <<-PHP
+  <?php
+  use Mezzio\\Application;
+
+  return function (Application $app) {
+      $app->get('/docs/commented', DocsHandler::class, 'docs');
+      $app->delete('/api/users/{id}', DeleteUserHandler::class);
+  };
+  PHP
+
+private HYPERF_ROUTES = <<-'PHP'
+  <?php
+  use Hyperf\\HttpServer\\Router\\Router;
+
+  Router::get('/items/{itemId}', [App\\Controller\\ItemController::class, 'show']);
+  Router::addGroup('/api/v1', function () {
+      Router::get('/me', [App\\Controller\\AuthController::class, 'me']);
+  });
   PHP
 
 describe "PHP cross-framework relevance gates" do
@@ -71,6 +99,33 @@ describe "PHP cross-framework relevance gates" do
       harness.relevant?(CODEIGNITER_ROUTES).should be_false
       harness.relevant?(CAKEPHP_ROUTES).should be_false
       harness.relevant?(LUMEN_ROUTES).should be_false
+    end
+
+    it "does not claim a Mezzio route table" do
+      # Mezzio registers on `$app->get('/x', Handler::class)` — the same
+      # expression Slim uses — so Slim reported Mezzio's routes as its own.
+      # `Laminas\\` is deliberately not a disqualifier: Slim apps pull in
+      # `Laminas\\Diactoros` for PSR-7 all the time.
+      harness.relevant?(MEZZIO_ROUTES).should be_false
+      harness.relevant?(<<-'PHP').should be_true
+        <?php
+        use Slim\\Factory\\AppFactory;
+        use Laminas\\Diactoros\\ResponseFactory;
+
+        $app = AppFactory::create();
+        $app->get('/status', function ($req, $res) { return $res; });
+        PHP
+    end
+  end
+
+  describe Analyzer::Php::CakePHP do
+    harness = CakePhpHyperfHarness.new(create_test_options)
+
+    it "recognizes a Hyperf route table so it can step aside" do
+      # Hyperf keeps its routes at `config/routes.php` too and writes
+      # `Router::get(...)`, a call shape CakePHP 3 also used.
+      harness.hyperf?(HYPERF_ROUTES).should be_true
+      harness.hyperf?(CAKEPHP_ROUTES).should be_false
     end
   end
 

--- a/src/analyzer/analyzers/php/cakephp.cr
+++ b/src/analyzer/analyzers/php/cakephp.cr
@@ -20,11 +20,19 @@ module Analyzer::Php
       endpoints
     end
 
+    # Hyperf keeps its route table at `config/routes.php` too, and writes it
+    # as `Router::get('/items/{itemId}', …)` — a call shape CakePHP 3 also
+    # used, so the verb matchers below hit it. In a repo holding both, CakePHP
+    # reported Hyperf's routes as its own. `Hyperf\` is unambiguous: the file
+    # imports `Hyperf\HttpServer\Router\Router`, and CakePHP never names it.
+    HYPERF_MARKER_RE = /Hyperf\\/
+
     private def analyze_routes_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       include_callee = callees_needed?
       begin
         content = read_file_content(path)
+        return endpoints if content.matches?(HYPERF_MARKER_RE)
         endpoints = analyze_routes_content(content, "", path, include_callee)
       rescue e
         logger.debug "Error analyzing routes file #{path}: #{e}"

--- a/src/analyzer/analyzers/php/slim.cr
+++ b/src/analyzer/analyzers/php/slim.cr
@@ -53,7 +53,18 @@ module Analyzer::Php
 
     VERB_CALL_RECEIVER_RE = /\$(\w+)->(?:get|post|put|patch|delete|options|head|map|group)\s*\(/i
 
+    # Mezzio registers its programmatic routes on `$app->get('/x', Handler::class)`
+    # — the same expression Slim uses — so Slim read Mezzio's route table as
+    # its own. `Mezzio\` is the one unambiguous marker: a Mezzio application
+    # names it, and Slim never does.
+    #
+    # `Laminas\` deliberately isn't on this list. Slim apps pull in
+    # `Laminas\Diactoros` for PSR-7 all the time, so excluding on it would
+    # drop their routes.
+    MEZZIO_MARKER_RE = /Mezzio\\/
+
     private def slim_relevant?(content : String) : Bool
+      return false if content.matches?(MEZZIO_MARKER_RE) && !content.matches?(RELEVANCE_MARKER_RE)
       return true if content.matches?(RELEVANCE_MARKER_RE)
       # Verb/map/group registrations are always `$var->method(`. Skip the
       # heavier verb regex when no `->` call shape is present.


### PR DESCRIPTION
Two more PHP framework pairs that share a convention — same shape as #2419, #2423.

### CakePHP was reading Hyperf's route table

CakePHP gates on the `config/routes.php` path, and Hyperf keeps its route table at exactly that path:

```php
use Hyperf\HttpServer\Router\Router;

Router::get('/items/{itemId}', [App\Controller\ItemController::class, 'show']);
Router::addGroup('/api/v1', function () {
    Router::get('/me', [App\Controller\AuthController::class, 'me']);
});
```

`Router::get(...)` is a call shape CakePHP 3 also used, so the verb matchers hit it and `GET /items/{itemId}` / `GET /me` came out as `php_cakephp`. The file imports `Hyperf\HttpServer\Router\Router`, which CakePHP never names.

### Slim was reading Mezzio's

Mezzio registers programmatic routes on `$app->get('/x', Handler::class)` — the same expression Slim uses — so three Mezzio routes surfaced as `php_slim`.

`Mezzio\` is the disqualifier. **`Laminas\` deliberately is not**: Slim apps pull in `Laminas\Diactoros` for PSR-7 all the time, and excluding on it would drop their routes. A spec pins that case.

### Result

Cross-**framework** claims across the PHP fixture tree are now **zero** (from 20 before #2419).

What the measurement harness still reports:

- `php_pure`, which treats any `.php` as a servable file by design;
- a CLI binary-name difference — the synthetic `cli://<binary>/…` host is derived from the scan root's directory name, so the same command reads `cli://php` under a whole-tree scan and `cli://cli_symfony` under a per-project one. That's a naming question for the CLI endpoint design (#2203), not a cross-framework claim, so it's left alone here.

Every framework's own fixture keeps its full endpoint set (cakephp 18, cakephp_callees 11, hyperf 10, slim 12, slim_callees 6, laminas 30 — all unchanged).

### Tests

`php_framework_relevance_spec.cr` gains the Mezzio case (refused) alongside a Slim app that uses `Laminas\Diactoros` (still claimed), and the Hyperf marker in both directions.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean