### PR TITLE
fix(output/oas): a catch-all placeholder is one variable, not nested braces

### DIFF
--- a/spec/unit_test/output_builder/oas_common_spec.cr
+++ b/spec/unit_test/output_builder/oas_common_spec.cr
@@ -64,6 +64,19 @@ describe OutputBuilderOasCommon do
       # Play routes spell a constrained param `$path<.+>`.
       helper.test_normalize_oas_path("/files/$path<.+>").should eq("/files/{path}")
     end
+
+    it "collapses catch-all placeholders that keep the star inside the braces" do
+      # Armeria writes the rest-of-path capture as `{*filePath}`, Salvo as
+      # `{**path}`, ASP.NET and Spring as `{*slug}`. The `*` passes used to run
+      # inside the existing placeholder and emit the nested, unbalanced
+      # `{{filePath}}` / `{{wildcard}{path}}` — not path templates at all, and
+      # their declared `filePath` / `path` parameters bound to nothing.
+      helper.test_normalize_oas_path("/annotated/files/{*filePath}")
+        .should eq("/annotated/files/{filePath}")
+      helper.test_normalize_oas_path("/assets/{**path}").should eq("/assets/{path}")
+      # A bare `*` segment still becomes a named variable.
+      helper.test_normalize_oas_path("/files/*").should eq("/files/{wildcard}")
+    end
   end
 
   describe "#extract_unmapped_path_parameters" do

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -46,6 +46,17 @@ module OutputBuilderOasCommon
       "{#{angle_placeholder_name(match[1], match[2], declared_path_params)}}"
     end
     path = path.gsub(/<(\w+)>/, "{\\1}")
+
+    # Catch-all placeholders keep the rest-of-path marker inside the braces:
+    # Armeria `{*filePath}`, Salvo `{**path}`, ASP.NET and Spring `{*slug}`.
+    # The variable is the name; the stars only say how much of the path it
+    # eats — which a path template has no way to express anyway. Without this
+    # the `*` passes below ran *inside* the existing placeholder and produced
+    # the nested, unbalanced `{{filePath}}` and `{{wildcard}{path}}`: not path
+    # templates at all, and their declared `filePath` / `path` parameters no
+    # longer bound to anything.
+    path = path.gsub(/\{\*+(\w+)\}/, "{\\1}")
+
     path = path.gsub(/\*(\w+)/, "{\\1}")
     path = path.gsub(/:(\w+)/, "{\\1}")
 


### PR DESCRIPTION
Armeria spells its rest-of-path capture `{*filePath}`, Salvo `{**path}`, ASP.NET and Spring `{*slug}` — the star sits **inside** the placeholder. The `*` passes in `normalize_oas_path` didn't know that and ran on the contents:

```
/annotated/files/{*filePath}  ->  /annotated/files/{{filePath}}
/assets/{**path}              ->  /assets/{{wildcard}{path}}
```

Neither is a path template. `{filePath` isn't a legal variable name, and the operation's declared `filePath` / `path` parameters no longer bound to anything in the path — the exact "required path parameter with nothing to bind to" shape that makes an OpenAPI document fail validation.

```console
# after
$ noir -b fixtures/java/armeria -f oas3 | jq '.paths | keys[]' | grep file
"/annotated/files/{filePath}"
$ noir -b fixtures/rust/salvo_builder -f oas3 | jq '.paths | keys[]' | grep assets
"/assets/{path}"
```

The variable is the name; the stars only say how much of the path it eats, which a path template has no way to express anyway. Collapsing `{*name}` / `{**name}` to `{name}` before the `*` passes fixes both. Bare `*` segments still become `{wildcard}`, and `/api/*/v1/*` still gets distinct names.

### How it was found

Checked OAS **semantics** rather than parseability across all 661 fixture projects:

- every path rooted at `/`
- every template name a legal variable name
- every path parameter `required: true`
- no duplicate `(name, in)` on an operation
- every template variable backed by a declared parameter, and no declared path parameter without a matching template

These two were the only failures. OAS3 output is now clean on all 661. (The OAS2 sweep flags `in: body` — that's Swagger 2.0's own vocabulary, not a defect.)

### Tests

`oas_common_spec.cr` gains the two catch-all spellings plus a bare `*` regression guard. It fails on `main`.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 0 failures
- `crystal tool format --check` and ameba clean