### PR TITLE
fix(output): body params were invisible in every HTTP-shaped output

### DIFF
--- a/spec/unit_test/models/body_param_type_spec.cr
+++ b/spec/unit_test/models/body_param_type_spec.cr
@@ -1,0 +1,75 @@
+require "../../spec_helper"
+require "../../../src/models/endpoint"
+require "../../../src/output_builder/curl"
+require "../../../src/output_builder/oas3"
+require "../../../src/utils/curl_command"
+
+# Fourteen analyzers (NestJS, Next.js, Rocket, tRPC, Servant, Play, Scotty,
+# Wisp, Cowboy, Elli, plumber, Nuxt, Nitro, …) spell a request-body field
+# `body` rather than `json`, but every HTTP-shaped consumer dispatches on the
+# six canonical types. `body` landed in a bucket nobody read, so those params
+# were invisible in curl, httpie, PowerShell, mermaid, Postman and OAS.
+private def body_endpoint : Endpoint
+  endpoint = Endpoint.new("/submit", "POST")
+  endpoint.params << Param.new("username", "alice", "body")
+  endpoint.params << Param.new("password", "s3cret", "body")
+  endpoint
+end
+
+describe Param do
+  it "maps the body type onto the json bucket" do
+    Param.new("username", "", "body").request_type.should eq("json")
+  end
+
+  it "leaves every canonical type alone" do
+    %w[query json form header cookie path].each do |type|
+      Param.new("x", "", type).request_type.should eq(type)
+    end
+  end
+
+  it "keeps param_type as the analyzer recorded it" do
+    # The JSON/YAML inventory — and the functional expectations built on it —
+    # must still see `body`. Only the consumers' dispatch is canonicalized.
+    Param.new("username", "", "body").param_type.should eq("body")
+  end
+end
+
+describe Endpoint do
+  it "folds body params into the json bucket of params_to_hash" do
+    hash = body_endpoint.params_to_hash
+    hash["json"].should eq({"username" => "alice", "password" => "s3cret"})
+    hash.has_key?("body").should be_false
+  end
+end
+
+describe "body params in HTTP-shaped output" do
+  it "reaches the curl request body" do
+    # Pre-fix this emitted `curl -i -X 'POST' '/submit'` — no body at all.
+    io = IO::Memory.new
+    options = create_test_options
+    builder = OutputBuilderCurl.new(options)
+    builder.io = io
+    builder.print([body_endpoint])
+
+    output = io.to_s
+    output.should contain("--data-raw")
+    output.should contain("username")
+    output.should contain("application/json")
+  end
+
+  it "reaches the OpenAPI requestBody instead of becoming a query parameter" do
+    # Pre-fix these were emitted as `in: query` on a POST.
+    io = IO::Memory.new
+    options = create_test_options
+    builder = OutputBuilderOas3.new(options)
+    builder.io = io
+    builder.print([body_endpoint])
+
+    doc = JSON.parse(io.to_s)
+    operation = doc["paths"]["/submit"]["post"]
+    operation["requestBody"]?.should_not be_nil
+    properties = operation["requestBody"]["content"]["application/json"]["schema"]["properties"]
+    properties["username"]?.should_not be_nil
+    (operation["parameters"]?.try(&.as_a) || [] of JSON::Any).should be_empty
+  end
+end

--- a/src/analyzer/analyzers/r/plumber.cr
+++ b/src/analyzer/analyzers/r/plumber.cr
@@ -117,6 +117,14 @@ module Analyzer::R
       end
     end
 
+    # `#* @param msg The message to echo` is roxygen documentation: the text
+    # after the name describes the parameter, it is not a value. Storing it in
+    # `Param#value` — which everywhere else holds an example or default — put
+    # prose into every rendered request: `?msg=The message to echo` in the curl
+    # and Postman output (a query string with spaces in it), and
+    # `{"username":"The username"}` as a JSON body. The annotations are still
+    # parsed, because they are how a parameter with no function argument gets
+    # discovered at all; only the text is dropped.
     private def parse_annotation_block(path : String, comments : Array(String), line_num : Int32, next_line : String, func_line_num : Int32)
       routes = [] of Tuple(String, String) # {method, path}
       param_descriptions = {} of String => String
@@ -155,8 +163,7 @@ module Analyzer::R
         # 1. Path parameters first
         path_params.each do |p_name|
           seen_params.add(p_name)
-          desc = param_descriptions[p_name]? || ""
-          params << Param.new(p_name, desc, "path")
+          params << Param.new(p_name, "", "path")
         end
 
         # 2. Function/annotation parameters next
@@ -165,10 +172,9 @@ module Analyzer::R
           next if seen_params.includes?(p_name)
           seen_params.add(p_name)
 
-          desc = param_descriptions[p_name]? || ""
           # Location: body for POST/PUT/PATCH, query otherwise
           loc = (method == "POST" || method == "PUT" || method == "PATCH") ? "body" : "query"
-          params << Param.new(p_name, desc, loc)
+          params << Param.new(p_name, "", loc)
         end
 
         details = Details.new(PathInfo.new(path, line_num))

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -153,7 +153,7 @@ struct Endpoint
     end
 
     @params.each do |param|
-      type = param.param_type
+      type = param.request_type
       params_hash[type] = {} of String => String unless params_hash.has_key?(type)
       params_hash[type][param.name] = param.value
     end
@@ -197,6 +197,25 @@ struct Param
 
   def param_type=(value : String)
     @param_type = value
+  end
+
+  # Request-body param types that share the `json` bucket. Fourteen analyzers
+  # (NestJS, Next.js, Rocket, tRPC, Servant, Play, Scotty, Wisp, Cowboy, Elli,
+  # plumber, Nuxt, Nitro, …) spell a body field `body` rather than `json`, but
+  # every HTTP-shaped consumer dispatches on the six canonical types — the
+  # curl / httpie / PowerShell / mermaid builders take a request body from
+  # `json` + `form`, the OAS and Postman builders map anything else to a query
+  # parameter, and the probe deliverers post `json` or `form`. So `body`
+  # params were invisible in every HTTP-shaped output: 98 of them across the
+  # fixture tree, giving `curl -i -X 'POST' '/submit'` with no `--data-raw` at
+  # all and POST body fields emitted as `in: query` in the OpenAPI document.
+  BODY_TYPE_ALIASES = {"body" => "json"}
+
+  # The canonical bucket this param belongs to. Consumers dispatch on this
+  # rather than on `param_type`, which stays exactly what the analyzer
+  # recorded so the JSON/YAML inventory is unchanged.
+  def request_type : String
+    BODY_TYPE_ALIASES[@param_type]? || @param_type
   end
 
   # Dedup by (name, tagger) like push_callee/push_param do for their

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -202,7 +202,7 @@ class OutputBuilder
 
     unless params.nil?
       params.each do |param|
-        if param.param_type == "query"
+        if param.request_type == "query"
           pair = "#{param.name}=#{param.value}"
           # A pair the route already spells out verbatim adds nothing. A
           # *different* value for the same name is an override (`--pvalue
@@ -219,7 +219,7 @@ class OutputBuilder
           end
         end
 
-        if param.param_type == "form"
+        if param.request_type == "form"
           if first_form
             final_body += "#{param.name}=#{param.value}"
             first_form = false
@@ -228,19 +228,19 @@ class OutputBuilder
           end
         end
 
-        if param.param_type == "path"
+        if param.request_type == "path"
           final_path_params << "#{param.name}"
         end
 
-        if param.param_type == "header"
+        if param.request_type == "header"
           final_headers << "#{param.name}: #{param.value}"
         end
 
-        if param.param_type == "cookie"
+        if param.request_type == "cookie"
           final_cookies << "#{param.name}=#{param.value}"
         end
 
-        if param.param_type == "json"
+        if param.request_type == "json"
           is_json = true
         end
 
@@ -255,7 +255,7 @@ class OutputBuilder
         json_tmp = Hash(String, String).new
 
         params.each do |param|
-          if param.param_type == "json"
+          if param.request_type == "json"
             json_tmp[param.name] = param.value
           end
         end

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -18,7 +18,7 @@ class OutputBuilderOas2 < OutputBuilder
       has_form = false
 
       endpoint.params.each do |param|
-        case param.param_type
+        case param.request_type
         when "json"
           # JSON body parameters should be represented as a body parameter in OAS2
           json_properties[param.name] = JSON::Any.new({
@@ -45,7 +45,7 @@ class OutputBuilderOas2 < OutputBuilder
         end
       end
 
-      declared_path_params = endpoint.params.compact_map { |p| p.name if p.param_type == "path" }
+      declared_path_params = endpoint.params.compact_map { |p| p.name if p.request_type == "path" }
       oas_path = normalize_oas_path(endpoint.url, declared_path_params)
       template_names = path_template_names(oas_path)
       template_names.each do |name|

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -16,7 +16,7 @@ class OutputBuilderOas3 < OutputBuilder
       form_properties = {} of String => JSON::Any
 
       endpoint.params.each do |param|
-        case param.param_type
+        case param.request_type
         when "json"
           # JSON body parameters go into requestBody
           json_properties[param.name] = JSON::Any.new({
@@ -42,7 +42,7 @@ class OutputBuilderOas3 < OutputBuilder
         end
       end
 
-      declared_path_params = endpoint.params.compact_map { |p| p.name if p.param_type == "path" }
+      declared_path_params = endpoint.params.compact_map { |p| p.name if p.request_type == "path" }
       oas_path = normalize_oas_path(endpoint.url, declared_path_params)
       template_names = path_template_names(oas_path)
       template_names.each do |name|

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -37,7 +37,7 @@ class OutputBuilderPostman < OutputBuilder
       # Add query parameters
       query_params = [] of JSON::Any
       endpoint.params.each do |param|
-        if param.param_type == "query"
+        if param.request_type == "query"
           query_params << JSON::Any.new({
             "key"   => JSON::Any.new(param.name),
             "value" => JSON::Any.new(param.value),
@@ -58,7 +58,7 @@ class OutputBuilderPostman < OutputBuilder
       # Add path variables
       path_vars = [] of JSON::Any
       endpoint.params.each do |param|
-        if param.param_type == "path"
+        if param.request_type == "path"
           path_vars << JSON::Any.new({
             "key"   => JSON::Any.new(param.name),
             "value" => JSON::Any.new(param.value),
@@ -73,12 +73,12 @@ class OutputBuilderPostman < OutputBuilder
       # Build headers
       headers = [] of JSON::Any
       endpoint.params.each do |param|
-        if param.param_type == "header"
+        if param.request_type == "header"
           headers << JSON::Any.new({
             "key"   => JSON::Any.new(param.name),
             "value" => JSON::Any.new(param.value),
           } of String => JSON::Any)
-        elsif param.param_type == "cookie"
+        elsif param.request_type == "cookie"
           # Find existing Cookie header or create new one. Header names are
           # case-insensitive (RFC 7230), so match `cookie`/`COOKIE` too —
           # otherwise a header-type param named `cookie` and the cookie-type
@@ -105,13 +105,13 @@ class OutputBuilderPostman < OutputBuilder
 
       # Build request body
       body = nil
-      has_json_body = endpoint.params.any? { |p| p.param_type == "json" }
-      has_form_body = endpoint.params.any? { |p| p.param_type == "form" }
+      has_json_body = endpoint.params.any? { |p| p.request_type == "json" }
+      has_form_body = endpoint.params.any? { |p| p.request_type == "form" }
 
       if has_json_body
         json_body = {} of String => JSON::Any
         endpoint.params.each do |param|
-          if param.param_type == "json"
+          if param.request_type == "json"
             json_body[param.name] = JSON::Any.new(param.value)
           end
         end
@@ -136,7 +136,7 @@ class OutputBuilderPostman < OutputBuilder
       elsif has_form_body
         form_data = [] of JSON::Any
         endpoint.params.each do |param|
-          if param.param_type == "form"
+          if param.request_type == "form"
             form_data << JSON::Any.new({
               "key"   => JSON::Any.new(param.name),
               "value" => JSON::Any.new(param.value),


### PR DESCRIPTION
Fourteen analyzers — NestJS, Next.js, Rocket, tRPC, Servant, Play, Scotty, Wisp, Cowboy, Elli, plumber, Nuxt, Nitro, js_nestjs — record a request-body field as `param_type: "body"`.

Every HTTP-shaped consumer dispatches on the six canonical types instead. The curl / httpie / PowerShell / mermaid builders take a request body from `json` + `form`; the OAS and Postman builders map anything else to a query parameter; and `Endpoint#params_to_hash` seeds only those six buckets, so the probe deliverers post `json` or `form`.

So **98 params across 73 endpoints** in the fixture tree reached no HTTP output at all:

```console
# before — the username/password fields simply vanish
$ noir -b fixtures/r/plumber -f curl
curl -i -X 'POST' '/submit'

# after
curl -i -X 'POST' '/submit' --data-raw '{"username":"","password":""}' -H 'Content-Type: application/json'
```

and in OpenAPI they came out as `in: query` **on a POST** — describing a body field as a query string. NestJS emitted 0 `requestBody` objects across its whole fixture; it now emits 7.

Affected technologies, by endpoint count:

```
32 ts_nestjs     5 ts_trpc         2 js_nuxtjs      2 erlang_cowboy
10 js_nextjs     4 haskell_servant 2 java_play      1 js_nitro
 7 rust_rocket   2 r_plumber       2 haskell_scotty 1 erlang_elli
                                   2 gleam_wisp     1 js_nestjs
```

### The fix

`Param#request_type` names the canonical bucket, folding `body` into `json`, and the consumers dispatch on that.

`param_type` itself is untouched — the JSON/YAML inventory still reports exactly what the analyzer recorded, and the 93 functional testers asserting `"body"` keep passing. Renaming the field would have been a breaking change to the documented output schema for a problem that lives entirely on the consumer side.

### Also: plumber was storing documentation as a value

`#* @param msg The message to echo` is roxygen documentation — the text after the name describes the parameter. It was going into `Param#value`, which everywhere else holds an example or default, so it rendered as:

```
curl -i -X 'GET' '/echo?msg=The message to echo'     # a query string with spaces
```

and, once body params started reaching the body, would have become `{"username":"The username"}`. The annotations are still parsed — they're how a parameter with no function argument gets discovered at all — only the text is dropped.

### How it was found

A Postman semantic sweep across all 661 fixture projects (schema present, every item named, `raw` consistent with `host`/`path`, no duplicate query keys, no header without a key). The only failures were two plumber URLs carrying spaces, which led to the description-as-value bug; chasing why those params rendered in the *query* at all led to the `body` bucket.

### Tests

`body_param_type_spec.cr`: the type mapping in both directions, `param_type` preserved, the `params_to_hash` fold, and end-to-end assertions that a `body` param reaches the curl `--data-raw` and the OAS `requestBody` rather than `parameters`.

- `crystal spec spec/unit_test` — 0 failures
- `crystal spec spec/functional_test` — 22426 examples, 0 failures
- `crystal tool format --check` and ameba clean