### PR TITLE
fix(analyzer/spec): gateway, proxy and IaC config analyzers — 9 FP/FN fixes

### DIFF
--- a/spec/functional_test/fixtures/specification/aws_cloudformation/template.yaml
+++ b/spec/functional_test/fixtures/specification/aws_cloudformation/template.yaml
@@ -17,6 +17,13 @@ Resources:
           Properties:
             Method: POST
             Path: /users
+        # `$default` is an API Gateway route selector, not a path. `/$default`
+        # is a URL no client ever requests, so it must not become an endpoint.
+        DefaultEvent:
+          Type: HttpApi
+          Properties:
+            Method: ANY
+            Path: /$default
 
   Api:
     Type: AWS::ApiGateway::RestApi

--- a/spec/functional_test/fixtures/specification/azure_functions/custom-prefix/Ping/function.json
+++ b/spec/functional_test/fixtures/specification/azure_functions/custom-prefix/Ping/function.json
@@ -1,0 +1,12 @@
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "ping",
+      "authLevel": "anonymous"
+    }
+  ]
+}

--- a/spec/functional_test/fixtures/specification/azure_functions/custom-prefix/host.json
+++ b/spec/functional_test/fixtures/specification/azure_functions/custom-prefix/host.json
@@ -1,0 +1,8 @@
+{
+  "version": "2.0",
+  "extensions": {
+    "http": {
+      "routePrefix": "gateway"
+    }
+  }
+}

--- a/spec/functional_test/fixtures/specification/caddy/Caddyfile
+++ b/spec/functional_test/fixtures/specification/caddy/Caddyfile
@@ -14,4 +14,15 @@ api.example.com {
         reverse_proxy api:8000
     }
     redir /old /new permanent
+
+    # Matcher-less forms. None of these names a route: the first argument is a
+    # response body, a redirect destination or the block's opening brace.
+    respond "Hello, world!"
+    redir https://www.example.com{uri} permanent
+    handle {
+        respond 404
+    }
+    route {
+        file_server
+    }
 }

--- a/spec/functional_test/fixtures/specification/cloudflare_wrangler/mixed-routes/wrangler.toml
+++ b/spec/functional_test/fixtures/specification/cloudflare_wrangler/mixed-routes/wrangler.toml
@@ -1,0 +1,10 @@
+# `routes` mixes a bare string with an inline table. That is valid TOML 1.0 and
+# is how wrangler documents the key, but the bundled TOML shard rejects it — the
+# analyzer falls back to scanning the array rather than dropping every route.
+name = "mixed"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+routes = [
+  "static.example.com/assets/*",
+  { pattern = "mixed.example.com/edge/*", zone_name = "example.com" }
+]

--- a/spec/functional_test/fixtures/specification/envoy/envoy-bootstrap.yaml
+++ b/spec/functional_test/fixtures/specification/envoy/envoy-bootstrap.yaml
@@ -1,0 +1,39 @@
+# Bootstrap layout: route_config lives under
+# static_resources.listeners[].filter_chains[].filters[].typed_config.
+# This is the everyday shape of an Envoy config file, and the shape a plain
+# `envoy.yaml` from the upstream docs uses.
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 10000
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: bootstrap_service
+                      domains: ["bootstrap.example.com"]
+                      routes:
+                        - match:
+                            prefix: "/bootstrap"
+                          route:
+                            cluster: bootstrap_cluster
+                        - match:
+                            path_separated_prefix: "/separated"
+                          route:
+                            cluster: separated_cluster
+  clusters:
+    - name: bootstrap_cluster
+      type: STRICT_DNS

--- a/spec/functional_test/fixtures/specification/istio_virtualservice/virtualservice.yaml
+++ b/spec/functional_test/fixtures/specification/istio_virtualservice/virtualservice.yaml
@@ -26,3 +26,21 @@ spec:
       route:
         - destination:
             host: legacy.default.svc.cluster.local
+---
+# `kind` quoted — the same manifest a Helm chart renders.
+apiVersion: networking.istio.io/v1
+kind: "VirtualService"
+metadata:
+  name: search-vs
+spec:
+  hosts:
+    - api.example.com
+  http:
+    - match:
+        - uri:
+            prefix: /v1/search
+          method:
+            exact: GET
+      route:
+        - destination:
+            host: search.default.svc.cluster.local

--- a/spec/functional_test/fixtures/specification/k8s_gateway_api/httproute.yaml
+++ b/spec/functional_test/fixtures/specification/k8s_gateway_api/httproute.yaml
@@ -30,3 +30,26 @@ spec:
             path:
               type: ReplaceFullPath
               replaceFullPath: /v1/legacy
+---
+# `kind` is quoted here, which is as valid as the bare form and is what Helm
+# charts emit. The header/queryParams matchers are conditions the route will
+# not fire without, so they are request params.
+apiVersion: gateway.networking.k8s.io/v1
+kind: "HTTPRoute"
+metadata:
+  name: search-route
+spec:
+  parentRefs:
+    - name: example-gateway
+  rules:
+    - matches:
+        - method: GET
+          path:
+            type: Exact
+            value: /v1/search
+          headers:
+            - name: X-Api-Version
+              value: "2"
+          queryParams:
+            - name: q
+              value: term

--- a/spec/functional_test/fixtures/specification/netlify/_redirects
+++ b/spec/functional_test/fixtures/specification/netlify/_redirects
@@ -1,0 +1,5 @@
+# Netlify redirect rules. The first field is the source.
+/home                          /                              301
+/blog/*                        /posts/:splat                  301
+https://old.example.com/legacy https://new.example.com/legacy 301!
+/api/*                         /.netlify/functions/:splat     200

--- a/spec/functional_test/fixtures/specification/netlify/netlify.toml
+++ b/spec/functional_test/fixtures/specification/netlify/netlify.toml
@@ -1,0 +1,17 @@
+[build]
+  publish = "dist"
+
+[[redirects]]
+  from = "/toml-api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200
+
+# Context overrides are just as reachable once that context is deployed.
+[[context.production.redirects]]
+  from = "/prod-only"
+  to = "/x"
+  status = 301
+
+[[edge_functions]]
+  path = "/edge/*"
+  function = "hello"

--- a/spec/functional_test/testers/specification/azure_functions_spec.cr
+++ b/spec/functional_test/testers/specification/azure_functions_spec.cr
@@ -1,8 +1,12 @@
 require "../../func_spec.cr"
 
+# The Functions host serves HTTP triggers under a route prefix: `api` unless
+# `host.json` overrides it. `CreateUser`/`ListUsers` have no `host.json` and so
+# take the host default; `custom-prefix` sets `routePrefix: gateway`.
 expected_endpoints = [
-  Endpoint.new("/users", "GET"),
-  Endpoint.new("/users", "POST"),
+  Endpoint.new("/api/users", "GET"),
+  Endpoint.new("/api/users", "POST"),
+  Endpoint.new("/gateway/ping", "GET"),
 ]
 
 FunctionalTester.new("fixtures/specification/azure_functions/", {

--- a/spec/functional_test/testers/specification/caddy_spec.cr
+++ b/spec/functional_test/testers/specification/caddy_spec.cr
@@ -1,5 +1,9 @@
 require "../../func_spec.cr"
 
+# The fixture also carries `respond "Hello, world!"`, `redir
+# https://www.example.com{uri} permanent`, `handle {` and `route {`. None of
+# those has a matcher token, so none may produce an endpoint — they used to
+# surface as `/"Hello,`, `https://www.example.com{uri}` and `/{`.
 expected_endpoints = [
   Endpoint.new("/v1/*", "ANY"),
   Endpoint.new("/admin/*", "ANY"),

--- a/spec/functional_test/testers/specification/cloudflare_wrangler_spec.cr
+++ b/spec/functional_test/testers/specification/cloudflare_wrangler_spec.cr
@@ -1,8 +1,15 @@
 require "../../func_spec.cr"
 
+# A wrangler route pattern is host-qualified (`example.com/api/*`). The host is
+# routing context, not part of the request path, so it becomes a
+# `wrangler-host` tag and the endpoint carries the path alone.
 expected_endpoints = [
-  Endpoint.new("/api.example.com/*", "ANY"),
-  Endpoint.new("/example.com/api/*", "ANY"),
+  Endpoint.new("/*", "ANY"),
+  Endpoint.new("/api/*", "ANY"),
+  # mixed-routes/wrangler.toml: `routes` mixes a bare string with an inline
+  # table, which the bundled TOML shard rejects — recovered by the fallback.
+  Endpoint.new("/assets/*", "ANY"),
+  Endpoint.new("/edge/*", "ANY"),
 ]
 
 FunctionalTester.new("fixtures/specification/cloudflare_wrangler/", {

--- a/spec/functional_test/testers/specification/envoy_spec.cr
+++ b/spec/functional_test/testers/specification/envoy_spec.cr
@@ -12,6 +12,10 @@ require "../../func_spec.cr"
 #   JSON (virtual_hosts at top level):
 #     - prefix match                  → /api         GET
 #     - path match with :method header → /health      GET
+#   YAML (bootstrap: static_resources.listeners[].filter_chains[].filters[].
+#         typed_config.route_config.virtual_hosts):
+#     - prefix match                  → /bootstrap   GET
+#     - path_separated_prefix match   → /separated   GET
 
 expected_endpoints = [
   # ── YAML ──────────────────────────────────────────────────────────────────
@@ -26,6 +30,9 @@ expected_endpoints = [
   # ── JSON ──────────────────────────────────────────────────────────────────
   Endpoint.new("/api", "GET"),
   Endpoint.new("/status", "GET"),
+  # ── YAML bootstrap ────────────────────────────────────────────────────────
+  Endpoint.new("/bootstrap", "GET"),
+  Endpoint.new("/separated", "GET"),
 ]
 
 FunctionalTester.new("fixtures/specification/envoy/", {

--- a/spec/functional_test/testers/specification/istio_virtualservice_spec.cr
+++ b/spec/functional_test/testers/specification/istio_virtualservice_spec.cr
@@ -5,6 +5,8 @@ expected_endpoints = [
   Endpoint.new("/v1/users", "POST"),
   Endpoint.new("/v2/.*", "ANY"),
   Endpoint.new("/v1/legacy", "ANY"),
+  # Second document declares `kind: "VirtualService"` (quoted).
+  Endpoint.new("/v1/search", "GET"),
 ]
 
 FunctionalTester.new("fixtures/specification/istio_virtualservice/", {

--- a/spec/functional_test/testers/specification/k8s_gateway_api_spec.cr
+++ b/spec/functional_test/testers/specification/k8s_gateway_api_spec.cr
@@ -1,10 +1,20 @@
 require "../../func_spec.cr"
 
+search = Endpoint.new("/v1/search", "GET")
+# `headers` / `queryParams` matchers are conditions the route will not fire
+# without, so they are request params.
+search.params = [
+  Param.new("X-Api-Version", "2", "header"),
+  Param.new("q", "term", "query"),
+]
+
 expected_endpoints = [
   Endpoint.new("/v1/users", "GET"),
   Endpoint.new("/v1/users", "POST"),
   Endpoint.new("/v2/.*", "ANY"),
   Endpoint.new("/v1/legacy", "ANY"),
+  # Second document declares `kind: "HTTPRoute"` (quoted).
+  search,
 ]
 
 FunctionalTester.new("fixtures/specification/k8s_gateway_api/", {

--- a/spec/functional_test/testers/specification/kong_spec.cr
+++ b/spec/functional_test/testers/specification/kong_spec.cr
@@ -3,7 +3,9 @@ require "../../func_spec.cr"
 expected_endpoints = [
   Endpoint.new("/v1/users", "GET"),
   Endpoint.new("/v1/users", "POST"),
-  Endpoint.new("/~/admin/.*", "ANY"),
+  # `~` selects Kong 3.x regex mode; it is a marker, not a path segment, so the
+  # URL is `/admin/.*` and the mode is carried by the `kong-path-type` tag.
+  Endpoint.new("/admin/.*", "ANY"),
   Endpoint.new("/v1/orders", "GET"),
   Endpoint.new("/v1/orders", "POST"),
 ]

--- a/spec/functional_test/testers/specification/netlify_spec.cr
+++ b/spec/functional_test/testers/specification/netlify_spec.cr
@@ -1,0 +1,21 @@
+require "../../func_spec.cr"
+
+# A `_redirects` source may be a bare path or a fully-qualified URL for a
+# domain-level rule. The scheme and host of the latter are routing context, not
+# part of the request path — the host lands in a `netlify-host` tag and the
+# endpoint carries `/legacy`, not `https://old.example.com/legacy`.
+expected_endpoints = [
+  Endpoint.new("/home", "ANY"),
+  Endpoint.new("/blog/*", "ANY"),
+  Endpoint.new("/legacy", "ANY"),
+  Endpoint.new("/api/*", "ANY"),
+  Endpoint.new("/toml-api/*", "ANY"),
+  # `[[context.production.redirects]]`
+  Endpoint.new("/prod-only", "ANY"),
+  Endpoint.new("/edge/*", "ANY"),
+]
+
+FunctionalTester.new("fixtures/specification/netlify/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/specification/traefik_spec.cr
+++ b/spec/functional_test/testers/specification/traefik_spec.cr
@@ -1,10 +1,11 @@
 require "../../func_spec.cr"
 
+# A rule with no `Method()` matcher matches every verb, so it is `ANY`.
 expected_endpoints = [
-  Endpoint.new("/v1", "GET"),
+  Endpoint.new("/v1", "ANY"),
   Endpoint.new("/admin", "GET"),
-  Endpoint.new("/foo", "GET"),
-  Endpoint.new("/bar", "GET"),
+  Endpoint.new("/foo", "ANY"),
+  Endpoint.new("/bar", "ANY"),
   Endpoint.new("/compose", "DELETE"),
   Endpoint.new("/ing", "POST"),
   Endpoint.new("/toml", "PUT"),

--- a/spec/unit_test/analyzer/specification/azure_functions_spec.cr
+++ b/spec/unit_test/analyzer/specification/azure_functions_spec.cr
@@ -2,11 +2,13 @@ require "../../../spec_helper"
 require "../../../../src/models/code_locator"
 require "../../../../src/analyzer/analyzers/specification/azure_functions"
 
-private def analyze_azure(content : String, function_dir = "MyFunc")
+private def analyze_azure(content : String, function_dir = "MyFunc", host_json : String? = nil)
   dir = File.tempname("azure_function")
   Dir.mkdir_p(File.join(dir, function_dir))
   path = File.join(dir, function_dir, "function.json")
   File.write(path, content)
+  host_path = File.join(dir, "host.json")
+  File.write(host_path, host_json) if host_json
   locator = CodeLocator.instance
   locator.clear "azure-functions-spec"
   locator.push "azure-functions-spec", path
@@ -17,6 +19,7 @@ private def analyze_azure(content : String, function_dir = "MyFunc")
 ensure
   if dir
     File.delete(path) if path && File.exists?(path)
+    File.delete(host_path) if host_path && File.exists?(host_path)
     Dir.delete(File.join(dir, function_dir)) if Dir.exists?(File.join(dir, function_dir))
     Dir.delete(dir) if Dir.exists?(dir)
   end
@@ -44,8 +47,8 @@ describe "Azure Functions Analyzer" do
       JSON
 
     endpoints.map { |e| {e.url, e.method} }.sort!.should eq([
-      {"/users/{id?}", "GET"},
-      {"/users/{id?}", "POST"},
+      {"/api/users/{id?}", "GET"},
+      {"/api/users/{id?}", "POST"},
     ])
     endpoints.each { |e| tag_descriptions(e, "azure-auth-level").should eq ["function"] }
   end
@@ -60,8 +63,32 @@ describe "Azure Functions Analyzer" do
       JSON
 
     endpoints.size.should eq 1
-    endpoints[0].url.should eq "/Healthcheck"
+    endpoints[0].url.should eq "/api/Healthcheck"
     endpoints[0].method.should eq "GET"
+  end
+
+  it "honours a routePrefix override in host.json" do
+    endpoints = analyze_azure(<<-JSON, "Users", %({"version":"2.0","extensions":{"http":{"routePrefix":"gateway"}}}))
+      {
+        "bindings": [
+          {"type": "httpTrigger", "methods": ["get"], "route": "users"}
+        ]
+      }
+      JSON
+
+    endpoints.map(&.url).should eq ["/gateway/users"]
+  end
+
+  it "drops the prefix entirely when host.json sets routePrefix to an empty string" do
+    endpoints = analyze_azure(<<-JSON, "Users", %({"extensions":{"http":{"routePrefix":""}}}))
+      {
+        "bindings": [
+          {"type": "httpTrigger", "methods": ["get"], "route": "users"}
+        ]
+      }
+      JSON
+
+    endpoints.map(&.url).should eq ["/users"]
   end
 
   it "defaults method to ANY when methods are not declared" do

--- a/spec/unit_test/analyzer/specification/cloudflare_wrangler_spec.cr
+++ b/spec/unit_test/analyzer/specification/cloudflare_wrangler_spec.cr
@@ -35,17 +35,34 @@ describe "Cloudflare Wrangler Analyzer" do
       zone_name = "example.com"
       TOML
 
-    endpoints.map(&.url).sort!.should eq ["api.example.com/*", "example.com/api/*"]
+    # A route pattern is host-qualified; the host is routing context, not part
+    # of the request path.
+    endpoints.map(&.url).sort!.should eq ["/*", "/api/*"]
+    endpoints.map { |e| tag_descriptions(e, "wrangler-host") }.sort!.should eq [["api.example.com"], ["example.com"]]
     endpoints.each do |endpoint|
       endpoint.method.should eq "ANY"
       tag_descriptions(endpoint, "wrangler-zone").should eq ["example.com"]
     end
   end
 
+  it "recovers routes from a mixed-type array the TOML shard rejects" do
+    endpoints = analyze_wrangler <<-TOML
+      name = "api"
+      compatibility_date = "2024-01-01"
+      routes = [
+        "static.example.com/assets/*",
+        { pattern = "edge.example.com/edge/*", zone_name = "example.com" }
+      ]
+      TOML
+
+    endpoints.map(&.url).sort!.should eq ["/assets/*", "/edge/*"]
+  end
+
   it "extracts JSON-formatted routes" do
     endpoints = analyze_wrangler(%({"name":"api","routes":[{"pattern":"app.example.com/*","zone_name":"example.com"}]}), ".jsonc")
     endpoints.size.should eq 1
-    endpoints[0].url.should eq "app.example.com/*"
+    endpoints[0].url.should eq "/*"
+    tag_descriptions(endpoints[0], "wrangler-host").should eq ["app.example.com"]
   end
 
   it "handles wrangler.jsonc with comments" do
@@ -61,6 +78,7 @@ describe "Cloudflare Wrangler Analyzer" do
       }
       JSONC
     endpoints.size.should eq 1
-    endpoints[0].url.should eq "api.example.com/*"
+    endpoints[0].url.should eq "/*"
+    tag_descriptions(endpoints[0], "wrangler-host").should eq ["api.example.com"]
   end
 end

--- a/spec/unit_test/detector/specification/envoy_spec.cr
+++ b/spec/unit_test/detector/specification/envoy_spec.cr
@@ -34,6 +34,31 @@ describe "Detect Envoy route config" do
     locator.all("envoy-json").should eq ["envoy.json"]
   end
 
+  it "detects a bootstrap config that nests route_config under a listener filter" do
+    locator = CodeLocator.instance
+    locator.clear "envoy-yaml"
+
+    bootstrap = <<-YAML
+      static_resources:
+        listeners:
+          - name: listener_0
+            filter_chains:
+              - filters:
+                  - name: envoy.filters.network.http_connection_manager
+                    typed_config:
+                      route_config:
+                        virtual_hosts:
+                          - name: local_service
+                            domains: ["*"]
+                            routes:
+                              - match:
+                                  prefix: "/"
+      YAML
+
+    instance.detect("envoy.yaml", bootstrap).should be_true
+    locator.all("envoy-yaml").should eq ["envoy.yaml"]
+  end
+
   it "rejects yaml without virtual_hosts/domains markers" do
     instance.detect("app.yaml", "version: '3.9'\nservices:\n  app:\n    image: test").should be_false
   end

--- a/spec/unit_test/detector/specification/istio_virtualservice_spec.cr
+++ b/spec/unit_test/detector/specification/istio_virtualservice_spec.cr
@@ -29,6 +29,11 @@ describe "Detect Istio VirtualService manifest" do
     locator.all("istio-virtualservice-spec").should eq ["mesh/api.yaml"]
   end
 
+  it "detects a VirtualService manifest with a quoted kind" do
+    src = vs.sub("kind: VirtualService", %(kind: "VirtualService"))
+    instance.detect("mesh/quoted.yaml", src).should be_true
+  end
+
   it "rejects non-VirtualService Istio resources" do
     src = <<-YAML
       apiVersion: networking.istio.io/v1

--- a/spec/unit_test/detector/specification/k8s_gateway_api_spec.cr
+++ b/spec/unit_test/detector/specification/k8s_gateway_api_spec.cr
@@ -27,6 +27,11 @@ describe "Detect Kubernetes Gateway API manifests" do
     locator.all("k8s-gateway-api-spec").should eq ["routes/api.yaml"]
   end
 
+  it "detects an HTTPRoute manifest with a quoted kind" do
+    src = httproute.sub("kind: HTTPRoute", %(kind: "HTTPRoute"))
+    instance.detect("routes/quoted.yaml", src).should be_true
+  end
+
   it "rejects non-HTTPRoute resources" do
     src = <<-YAML
       apiVersion: gateway.networking.k8s.io/v1

--- a/src/analyzer/analyzers/specification/aws_cloudformation.cr
+++ b/src/analyzer/analyzers/specification/aws_cloudformation.cr
@@ -66,6 +66,11 @@ module Analyzer::Specification
           path = props["Path"]?.try(&.as_s?)
           method = props["Method"]?.try(&.as_s?)
           next if path.nil? || path.empty?
+          # `$default` (and the WebSocket `$connect` / `$disconnect` keys) are
+          # API Gateway route selectors, not paths — `/$default` is a URL no
+          # client ever requests. SAM writes them with and without the leading
+          # slash. The Terraform analyzer already drops the same keys.
+          next if path.lchop('/').starts_with?('$')
 
           resolved_method = (method.nil? || method.empty?) ? METHOD_ANY : method.upcase
           kind = event_type == "HttpApi" ? "httpapi" : "rest"

--- a/src/analyzer/analyzers/specification/azure_functions.cr
+++ b/src/analyzer/analyzers/specification/azure_functions.cr
@@ -6,16 +6,48 @@ module Analyzer::Specification
 
     METHOD_ANY = "ANY"
 
+    # The Functions host serves every HTTP-triggered function under a route
+    # prefix. `host.json` may override it (`""` disables it entirely), but when
+    # the key is absent the host still applies `api` — so a function with
+    # `"route": "products/{id}"` answers on `/api/products/{id}`, not
+    # `/products/{id}`.
+    DEFAULT_ROUTE_PREFIX = "api"
+
     def analyze
+      # `host.json` sits at the function-app root, one level above each
+      # function's own directory, and is shared by every function in the app.
+      # Resolve it once per app root instead of per function.
+      prefixes = {} of String => String
+
       each_spec_file_with_details("azure-functions-spec") do |path, details|
         content = read_file_content(path)
-        process_doc(JSON.parse(content), path, details)
+        app_root = File.dirname(File.dirname(path))
+        prefix = prefixes[app_root] ||= route_prefix_for(app_root)
+        process_doc(JSON.parse(content), path, prefix, details)
       end
 
       @result
     end
 
-    private def process_doc(doc : JSON::Any, path : String, details : Details)
+    # Reads `extensions.http.routePrefix` (Functions v2+) or the v1 `http.routePrefix`
+    # from the app's `host.json`. An unreadable or absent file leaves the host default.
+    private def route_prefix_for(app_root : String) : String
+      host_json = File.join(app_root, "host.json")
+      return DEFAULT_ROUTE_PREFIX unless File.exists?(host_json)
+
+      doc = JSON.parse(read_file_content(host_json))
+      http = doc["extensions"]?.try(&.as_h?).try(&.["http"]?) || doc["http"]?
+      value = http.try(&.as_h?).try(&.["routePrefix"]?).try(&.as_s?)
+      return DEFAULT_ROUTE_PREFIX if value.nil?
+
+      value.strip('/')
+    rescue e
+      @logger.debug "Azure Functions analyzer failed to read #{host_json}"
+      @logger.debug_sub e
+      DEFAULT_ROUTE_PREFIX
+    end
+
+    private def process_doc(doc : JSON::Any, path : String, route_prefix : String, details : Details)
       bindings = doc["bindings"]?.try(&.as_a?)
       return unless bindings
 
@@ -32,7 +64,7 @@ module Analyzer::Specification
         methods = [METHOD_ANY] if methods.empty?
 
         route = binding_h["route"]?.try(&.as_s?) || function_name
-        normalized_path = route.starts_with?('/') ? route : "/#{route}"
+        normalized_path = compose_path(route_prefix, route)
 
         auth_level = binding_h["authLevel"]?.try(&.as_s?)
 
@@ -43,6 +75,12 @@ module Analyzer::Specification
           @result << endpoint
         end
       end
+    end
+
+    private def compose_path(route_prefix : String, route : String) : String
+      cleaned = route.starts_with?('/') ? route : "/#{route}"
+      return cleaned if route_prefix.empty?
+      "/#{route_prefix}#{cleaned}"
     end
 
     private def extract_methods(node : JSON::Any?) : Array(String)

--- a/src/analyzer/analyzers/specification/caddy.cr
+++ b/src/analyzer/analyzers/specification/caddy.cr
@@ -13,7 +13,7 @@ module Analyzer::Specification
     NAMED_MATCH_OPEN = /^(@[A-Za-z_]\w*)\s*\{?/
     METHOD_RE        = /^method\s+(.+)/
     PATH_RE          = /^path\s+(.+)/
-    HANDLE_REF_RE    = /^handle\s+(@[A-Za-z_]\w*)\s*\{?/
+    HANDLE_REF_RE    = /^(?:handle(?:_path)?|route)\s+(@[A-Za-z_]\w*)\s*\{?/
     SITE_BLOCK_RE    = /^([A-Za-z0-9_.:\/@*?-]+(?:\s*,\s*[A-Za-z0-9_.:\/@*?-]+)*)\s*\{$/
 
     def analyze
@@ -93,30 +93,32 @@ module Analyzer::Specification
 
         if m = HANDLE_OPEN_RE.match(line)
           kind = m[1]? == "_path" ? "handle_path" : "handle"
-          emit_endpoint(m[2], METHOD_ANY, kind, site_hosts, source_path, line_no)
+          emit_endpoint(m[2], METHOD_ANY, kind, site_hosts, source_path, line_no) if path_matcher?(m[2])
           depth += brace_delta(line)
           next
         end
 
         if m = ROUTE_OPEN_RE.match(line)
-          emit_endpoint(m[1], METHOD_ANY, "route", site_hosts, source_path, line_no)
+          emit_endpoint(m[1], METHOD_ANY, "route", site_hosts, source_path, line_no) if path_matcher?(m[1])
           depth += brace_delta(line)
           next
         end
 
         if m = REDIR_RE.match(line)
-          emit_endpoint(m[1], METHOD_ANY, "redir", site_hosts, source_path, line_no, target: m[2])
+          # `redir [<matcher>] <to> [<code>]`. Without a matcher the first
+          # argument is the *destination* — `redir https://example.com{uri}
+          # permanent` describes where traffic goes, not a route this server
+          # serves, so emitting it produced a phantom absolute-URL endpoint.
+          emit_endpoint(m[1], METHOD_ANY, "redir", site_hosts, source_path, line_no, target: m[2]) if path_matcher?(m[1])
           depth += brace_delta(line)
           next
         end
 
         if m = RESPOND_RE.match(line)
-          target = m[1]
-          # `respond` may be invoked with a status code (no path). Skip
-          # bare-status forms so we don't surface "200" as a URL.
-          unless target.matches?(/\A\d+\z/)
-            emit_endpoint(target, METHOD_ANY, "respond", site_hosts, source_path, line_no)
-          end
+          # `respond [<matcher>] <status>|<body>`. Only a matcher token names a
+          # route; the far more common `respond "Hello, world!"` / `respond 404`
+          # forms carry a body or status and used to surface as `/"Hello,`.
+          emit_endpoint(m[1], METHOD_ANY, "respond", site_hosts, source_path, line_no) if path_matcher?(m[1])
           depth += brace_delta(line)
           next
         end
@@ -128,6 +130,14 @@ module Analyzer::Specification
           site_hosts = [] of String
         end
       end
+    end
+
+    # An inline Caddyfile matcher token is `*`, or a path starting with `/`
+    # (a named `@matcher` is handled separately by `HANDLE_REF_RE`). Anything
+    # else in that argument position is a body, a destination, a status code
+    # or the block's opening brace — `handle {` used to emit `/{`.
+    private def path_matcher?(token : String) : Bool
+      token == "*" || token.starts_with?('/')
     end
 
     # Net brace movement for the line. A bare `{` opens (+1), a bare

--- a/src/analyzer/analyzers/specification/cloudflare_wrangler.cr
+++ b/src/analyzer/analyzers/specification/cloudflare_wrangler.cr
@@ -7,6 +7,19 @@ module Analyzer::Specification
 
     METHOD_ANY = "ANY"
 
+    # A route pattern is `[scheme://]<host><path>` — `example.com/api/*`,
+    # `*.example.com/*`, `https://example.com/api/*`.
+    ROUTE_PATTERN_RE = /\A(?:[a-z][a-z0-9+.-]*:\/\/)?([^\/]+)(\/.*)?\z/i
+
+    # Fallback for a `wrangler.toml` the TOML shard refuses. `pattern = "..."`
+    # only ever appears inside a `routes` entry in a wrangler config, so it can
+    # be scanned document-wide; the bare-string form has no such marker and is
+    # recovered from inside the `routes = [ … ]` array only.
+    TOML_PATTERN_RE      = /(?:^|[\s{,])pattern\s*=\s*"([^"]+)"/m
+    TOML_ROUTES_ARRAY_RE = /^\s*routes\s*=\s*\[([^\]]*)\]/m
+    TOML_INLINE_TABLE_RE = /\{[^}]*\}/
+    TOML_STRING_RE       = /"([^"]+)"/
+
     def analyze
       each_spec_file_with_details("cloudflare-wrangler-spec") do |path, details|
         content = read_file_content(path)
@@ -21,12 +34,36 @@ module Analyzer::Specification
     end
 
     private def process_toml(content : String, details : Details)
-      doc = TOML.parse(content)
+      doc = begin
+        TOML.parse(content)
+      rescue e
+        # The bundled TOML shard predates TOML 1.0 and rejects a mixed-type
+        # array, which is exactly how wrangler documents `routes`:
+        # `routes = ["example.com/*", { pattern = "...", zone_name = "..." }]`.
+        # One such array used to cost every route in the file, so fall back to
+        # scanning the `pattern` assignments rather than dropping the config.
+        logger.debug "Cloudflare wrangler TOML parse failed, falling back to pattern scan: #{e}"
+        process_toml_fallback(content, details)
+        return
+      end
+
       routes = doc["routes"]?
       return unless routes
       arr = routes.as_a?
       return unless arr
       arr.each { |entry| emit_toml_route(entry, details) }
+    end
+
+    private def process_toml_fallback(content : String, details : Details)
+      content.scan(TOML_PATTERN_RE) { |m| register_endpoint(m[1], nil, details) }
+
+      content.scan(TOML_ROUTES_ARRAY_RE) do |m|
+        # Inline tables were already covered by the `pattern =` scan above;
+        # dropping them here leaves only the bare-string route entries.
+        m[1].gsub(TOML_INLINE_TABLE_RE, "").scan(TOML_STRING_RE) do |s|
+          register_endpoint(s[1], nil, details)
+        end
+      end
     end
 
     private def process_json(content : String, details : Details)
@@ -70,10 +107,29 @@ module Analyzer::Specification
     private def register_endpoint(pattern : String?, zone : String?, details : Details)
       return if pattern.nil? || pattern.empty?
 
-      endpoint = Endpoint.new(pattern, METHOD_ANY, details)
+      host, path = split_route_pattern(pattern)
+
+      endpoint = Endpoint.new(path, METHOD_ANY, details)
       endpoint.add_tag(Tag.new("wrangler-scope", "route", "cloudflare_wrangler_analyzer"))
+      endpoint.add_tag(Tag.new("wrangler-host", host, "cloudflare_wrangler_analyzer")) if host && !host.empty?
       endpoint.add_tag(Tag.new("wrangler-zone", zone, "cloudflare_wrangler_analyzer")) if zone && !zone.empty?
       @result << endpoint
+    end
+
+    # A wrangler route pattern is host-qualified: `example.com/api/*`. The host
+    # is routing context, not part of the request path, so keeping it inline
+    # produced URLs like `/example.com/api/*` — a path no request ever carries.
+    # Split it out and keep it as a tag.
+    private def split_route_pattern(pattern : String) : Tuple(String?, String)
+      trimmed = pattern.strip
+      return {nil, trimmed} if trimmed.starts_with?('/')
+
+      if m = ROUTE_PATTERN_RE.match(trimmed)
+        path = m[2]? || "/"
+        return {m[1], path}
+      end
+
+      {nil, trimmed}
     end
 
     private def strip_jsonc_comments(content : String) : String

--- a/src/analyzer/analyzers/specification/envoy.cr
+++ b/src/analyzer/analyzers/specification/envoy.cr
@@ -2,18 +2,36 @@ require "../../engines/specification_engine"
 
 module Analyzer::Specification
   # Extracts HTTP endpoints from Envoy proxy route configuration files
-  # (YAML or JSON). Handles three layout variants:
-  #   - `route_config.virtual_hosts[]` (Envoy bootstrap / static RouteConfiguration)
-  #   - `virtual_hosts[]` at top level (xDS RDS RouteConfiguration)
-  #   - `resources[].virtual_hosts[]` (xDS resource array)
+  # (YAML or JSON). `virtual_hosts` is collected from wherever it sits in the
+  # document, because Envoy nests it differently per layout:
+  #   - at the root (xDS RDS RouteConfiguration)
+  #   - under `route_config` (standalone static RouteConfiguration)
+  #   - under `resources[]` (xDS resource array)
+  #   - under `static_resources.listeners[].filter_chains[].filters[].
+  #     typed_config.route_config` (bootstrap config — the everyday shape;
+  #     30 of the 31 `virtual_hosts` YAMLs in envoyproxy/envoy look like this)
   #
   # For each route the analyzer extracts:
-  #   - Path from `match.prefix`, `match.path`, or `match.safe_regex.regex`
+  #   - Path from `match.prefix`, `match.path`, `match.path_separated_prefix`
+  #     or `match.safe_regex.regex`
   #   - HTTP method from `match.headers[]` where `name: ":method"`
   #   - An additional endpoint for `route.prefix_rewrite` when it differs
   #     from the matched path
   class Envoy < SpecificationEngine
     analyzer_for "envoy"
+
+    # See the detector's constant of the same name: a bound that only exists so
+    # a pathologically nested document can't blow the stack. Real configs sit
+    # around depth 8.
+    MAX_SEARCH_DEPTH = 32
+
+    # Hoisted so the per-node lookups in the walks below do not rebuild the
+    # wrappers on every mapping they visit.
+    VIRTUAL_HOSTS_KEY = YAML::Any.new("virtual_hosts")
+    DOMAINS_KEY       = YAML::Any.new("domains")
+    ROUTES_KEY        = YAML::Any.new("routes")
+    MATCH_KEY         = YAML::Any.new("match")
+    ROUTE_KEY         = YAML::Any.new("route")
 
     def analyze
       each_spec_file_with_details("envoy-yaml") do |path, details|
@@ -32,58 +50,54 @@ module Analyzer::Specification
     # ── YAML processing ──────────────────────────────────────────────────────
 
     private def process_yaml(data : YAML::Any, details : Details)
-      extract_virtual_hosts_yaml(data).each do |vh|
-        next unless vh.as_h?
-        if routes_node = vh["routes"]?
+      virtual_hosts = [] of YAML::Any
+      collect_virtual_hosts_yaml(data, virtual_hosts)
+
+      virtual_hosts.each do |vh|
+        next unless vh_h = vh.as_h?
+        domains = domain_list_yaml(vh_h[DOMAINS_KEY]?)
+        if routes_node = vh_h[ROUTES_KEY]?
           if routes = routes_node.as_a?
-            routes.each { |route| process_route_yaml(route, details) }
+            routes.each { |route| process_route_yaml(route, domains, details) }
           end
         end
       end
     end
 
-    private def extract_virtual_hosts_yaml(data : YAML::Any) : Array(YAML::Any)
-      if rc = data["route_config"]?
-        if vh = rc["virtual_hosts"]?
-          return vh.as_a? || [] of YAML::Any
-        end
-      end
+    private def collect_virtual_hosts_yaml(data : YAML::Any, sink : Array(YAML::Any), depth : Int32 = 0)
+      return if depth > MAX_SEARCH_DEPTH
 
-      if vh = data["virtual_hosts"]?
-        return vh.as_a? || [] of YAML::Any
-      end
-
-      result = [] of YAML::Any
-      if resources = data["resources"]?
-        if arr = resources.as_a?
-          arr.each do |resource|
-            next unless resource.as_h?
-            if vh = resource["virtual_hosts"]?
-              if vharr = vh.as_a?
-                result.concat(vharr)
-              end
-            end
-          end
+      if node = data.as_h?
+        if vh = node[VIRTUAL_HOSTS_KEY]?.try(&.as_a?)
+          sink.concat(vh)
         end
+        node.each_value { |value| collect_virtual_hosts_yaml(value, sink, depth + 1) }
+      elsif arr = data.as_a?
+        arr.each { |value| collect_virtual_hosts_yaml(value, sink, depth + 1) }
       end
-      result
     end
 
-    private def process_route_yaml(route : YAML::Any, details : Details)
-      return unless route.as_h?
-      return unless match = route["match"]?
+    private def domain_list_yaml(node : YAML::Any?) : Array(String)
+      return [] of String if node.nil?
+      return [] of String unless arr = node.as_a?
+      arr.compact_map(&.as_s?).reject { |d| d.empty? || d == "*" }
+    end
+
+    private def process_route_yaml(route : YAML::Any, domains : Array(String), details : Details)
+      return unless route_h = route.as_h?
+      return unless match = route_h[MATCH_KEY]?
 
       path = extract_path_yaml(match)
       return if path.nil? || path.empty?
 
       method = extract_method_yaml(match) || "GET"
       url = build_url(path)
-      @result << Endpoint.new(url, method, details)
+      emit(url, method, domains, details)
 
-      if (route_action = route["route"]?) && route_action.as_h?
+      if (route_action = route_h[ROUTE_KEY]?) && route_action.as_h?
         if rewrite = route_action["prefix_rewrite"]?.try(&.as_s?)
           rewritten_url = build_url(rewrite)
-          @result << Endpoint.new(rewritten_url, method, details) unless rewritten_url == url
+          emit(rewritten_url, method, domains, details) unless rewritten_url == url
         end
       end
     end
@@ -95,6 +109,11 @@ module Analyzer::Specification
       end
       if path = match["path"]?.try(&.as_s?)
         return path
+      end
+      # `path_separated_prefix` matches the prefix on a `/` boundary. It is a
+      # distinct match type in the proto, so a route that uses it was invisible.
+      if separated = match["path_separated_prefix"]?.try(&.as_s?)
+        return separated
       end
       if (safe_regex = match["safe_regex"]?) && safe_regex.as_h?
         return safe_regex["regex"]?.try(&.as_s?)
@@ -125,58 +144,54 @@ module Analyzer::Specification
     # ── JSON processing ───────────────────────────────────────────────────────
 
     private def process_json(data : JSON::Any, details : Details)
-      extract_virtual_hosts_json(data).each do |vh|
-        next unless vh.as_h?
-        if routes_node = vh["routes"]?
+      virtual_hosts = [] of JSON::Any
+      collect_virtual_hosts_json(data, virtual_hosts)
+
+      virtual_hosts.each do |vh|
+        next unless vh_h = vh.as_h?
+        domains = domain_list_json(vh_h["domains"]?)
+        if routes_node = vh_h["routes"]?
           if routes = routes_node.as_a?
-            routes.each { |route| process_route_json(route, details) }
+            routes.each { |route| process_route_json(route, domains, details) }
           end
         end
       end
     end
 
-    private def extract_virtual_hosts_json(data : JSON::Any) : Array(JSON::Any)
-      if rc = data["route_config"]?
-        if vh = rc["virtual_hosts"]?
-          return vh.as_a? || [] of JSON::Any
-        end
-      end
+    private def collect_virtual_hosts_json(data : JSON::Any, sink : Array(JSON::Any), depth : Int32 = 0)
+      return if depth > MAX_SEARCH_DEPTH
 
-      if vh = data["virtual_hosts"]?
-        return vh.as_a? || [] of JSON::Any
-      end
-
-      result = [] of JSON::Any
-      if resources = data["resources"]?
-        if arr = resources.as_a?
-          arr.each do |resource|
-            next unless resource.as_h?
-            if vh = resource["virtual_hosts"]?
-              if vharr = vh.as_a?
-                result.concat(vharr)
-              end
-            end
-          end
+      if node = data.as_h?
+        if vh = node["virtual_hosts"]?.try(&.as_a?)
+          sink.concat(vh)
         end
+        node.each_value { |value| collect_virtual_hosts_json(value, sink, depth + 1) }
+      elsif arr = data.as_a?
+        arr.each { |value| collect_virtual_hosts_json(value, sink, depth + 1) }
       end
-      result
     end
 
-    private def process_route_json(route : JSON::Any, details : Details)
-      return unless route.as_h?
-      return unless match = route["match"]?
+    private def domain_list_json(node : JSON::Any?) : Array(String)
+      return [] of String if node.nil?
+      return [] of String unless arr = node.as_a?
+      arr.compact_map(&.as_s?).reject { |d| d.empty? || d == "*" }
+    end
+
+    private def process_route_json(route : JSON::Any, domains : Array(String), details : Details)
+      return unless route_h = route.as_h?
+      return unless match = route_h["match"]?
 
       path = extract_path_json(match)
       return if path.nil? || path.empty?
 
       method = extract_method_json(match) || "GET"
       url = build_url(path)
-      @result << Endpoint.new(url, method, details)
+      emit(url, method, domains, details)
 
-      if (route_action = route["route"]?) && route_action.as_h?
+      if (route_action = route_h["route"]?) && route_action.as_h?
         if rewrite = route_action["prefix_rewrite"]?.try(&.as_s?)
           rewritten_url = build_url(rewrite)
-          @result << Endpoint.new(rewritten_url, method, details) unless rewritten_url == url
+          emit(rewritten_url, method, domains, details) unless rewritten_url == url
         end
       end
     end
@@ -188,6 +203,9 @@ module Analyzer::Specification
       end
       if path = match["path"]?.try(&.as_s?)
         return path
+      end
+      if separated = match["path_separated_prefix"]?.try(&.as_s?)
+        return separated
       end
       if (safe_regex = match["safe_regex"]?) && safe_regex.as_h?
         return safe_regex["regex"]?.try(&.as_s?)
@@ -221,6 +239,15 @@ module Analyzer::Specification
     # optimizer always normalises paths to `/`-prefixed strings.
     private def build_url(path : String) : String
       path
+    end
+
+    # The optimizer dedupes on (method, url), so emitting one endpoint per
+    # domain would drop every domain but the first. Fold them into a single
+    # comma-joined tag instead — same shape as the kamal and apisix analyzers.
+    private def emit(url : String, method : String, domains : Array(String), details : Details)
+      endpoint = Endpoint.new(url, method, details)
+      endpoint.add_tag(Tag.new("envoy-domain", domains.join(", "), "envoy_analyzer")) unless domains.empty?
+      @result << endpoint
     end
   end
 end

--- a/src/analyzer/analyzers/specification/k8s_gateway_api.cr
+++ b/src/analyzer/analyzers/specification/k8s_gateway_api.cr
@@ -90,10 +90,35 @@ module Analyzer::Specification
       method_node = match_h[YAML::Any.new("method")]?
       method = resolve_method(method_node)
 
-      emit_endpoint(path_value, method, path_type, hosts, "match", details)
+      # `headers` / `queryParams` matchers are request conditions the route
+      # will not fire without, so they are attack surface in exactly the way a
+      # declared param is — the route is unreachable without sending them.
+      params = collect_params(match_h)
+
+      emit_endpoint(path_value, method, path_type, hosts, "match", details, params)
 
       if url_rewrite && !url_rewrite.empty? && url_rewrite != path_value
-        emit_endpoint(url_rewrite, method, path_type, hosts, "rewrite", details)
+        emit_endpoint(url_rewrite, method, path_type, hosts, "rewrite", details, params)
+      end
+    end
+
+    private def collect_params(match_h : Hash(YAML::Any, YAML::Any)) : Array(Param)
+      params = [] of Param
+      collect_matcher_params(match_h[YAML::Any.new("headers")]?, "header", params)
+      collect_matcher_params(match_h[YAML::Any.new("queryParams")]?, "query", params)
+      params
+    end
+
+    private def collect_matcher_params(node : YAML::Any?, param_type : String, params : Array(Param))
+      return if node.nil?
+      return unless arr = node.as_a?
+
+      arr.each do |entry|
+        next unless entry_h = entry.as_h?
+        name = entry_h[YAML::Any.new("name")]?.try(&.as_s?)
+        next if name.nil? || name.empty?
+        value = entry_h[YAML::Any.new("value")]?.try(&.as_s?) || ""
+        params << Param.new(name, value, param_type)
       end
     end
 
@@ -111,10 +136,10 @@ module Analyzer::Specification
       METHOD_ANY
     end
 
-    private def emit_endpoint(path : String, method : String, path_type : String, hosts : Array(String), origin : String, details : Details)
+    private def emit_endpoint(path : String, method : String, path_type : String, hosts : Array(String), origin : String, details : Details, params : Array(Param) = [] of Param)
       hosts = [""] if hosts.empty?
       hosts.each do |host|
-        endpoint = Endpoint.new(path, method, details)
+        endpoint = Endpoint.new(path, method, params.dup, details)
         endpoint.add_tag(Tag.new("gateway-path-type", path_type.downcase, "k8s_gateway_api_analyzer"))
         endpoint.add_tag(Tag.new("gateway-host", host, "k8s_gateway_api_analyzer")) unless host.empty?
         endpoint.add_tag(Tag.new("gateway-source", origin, "k8s_gateway_api_analyzer"))

--- a/src/analyzer/analyzers/specification/kong.cr
+++ b/src/analyzer/analyzers/specification/kong.cr
@@ -76,7 +76,11 @@ module Analyzer::Specification
       paths.each do |path|
         # We currently model Kong route path mode as regex (`~...`) vs non-regex.
         # Non-regex routes (including exact `=...`) are tagged as `prefix`.
-        path_type = path.starts_with?("~") ? "regex" : "prefix"
+        regex = path.starts_with?("~")
+        path_type = regex ? "regex" : "prefix"
+        # In Kong 3.x the leading `~` is the marker that selects regex mode, not
+        # a path segment; leaving it in produced URLs like `/~/status/\d+`.
+        path = path.lchop('~') if regex
         methods.each do |method|
           endpoint = Endpoint.new(path, method, details)
           endpoint.add_tag(Tag.new("kong-path-type", path_type, "kong_analyzer"))

--- a/src/analyzer/analyzers/specification/netlify.cr
+++ b/src/analyzer/analyzers/specification/netlify.cr
@@ -7,6 +7,11 @@ module Analyzer::Specification
 
     DEFAULT_METHOD = "ANY"
 
+    # A `_redirects` / `netlify.toml` source may be a bare path (`/blog/*`) or a
+    # fully-qualified URL for a domain-level rule
+    # (`https://old.example.com/*  https://new.example.com/:splat  301!`).
+    ABSOLUTE_SOURCE_RE = /\A[a-z][a-z0-9+.-]*:\/\/([^\/]+)(\/.*)?\z/i
+
     def analyze
       each_spec_file("netlify-redirects") do |path|
         parse_redirects_file(path)
@@ -20,8 +25,8 @@ module Analyzer::Specification
     end
 
     private def parse_redirects_file(path : String)
-      lines = File.read_lines(path)
-      lines.each_with_index do |line, index|
+      content = read_file_content(path)
+      content.each_line.with_index do |line, index|
         stripped = line.strip
         next if stripped.empty?
         next if stripped.starts_with?('#')
@@ -39,23 +44,17 @@ module Analyzer::Specification
     private def parse_toml_file(path : String)
       doc = TOML.parse_file(path)
 
-      if redirects = doc["redirects"]?
-        redirects.as_a?.try do |items|
-          items.each do |item|
-            if from = item["from"]?.try(&.as_s?)
-              add_endpoint(from, path, nil) unless from.empty?
-            end
-          end
-        end
-      end
+      collect_redirects(doc["redirects"]?, path)
+      collect_edge_functions(doc["edge_functions"]?, path)
 
-      if edge_functions = doc["edge_functions"]?
-        edge_functions.as_a?.try do |items|
-          items.each do |item|
-            if route_path = item["path"]?.try(&.as_s?)
-              add_endpoint(route_path, path, nil) unless route_path.empty?
-            end
-          end
+      # Context overrides (`[[context.production.redirects]]`,
+      # `[[context.deploy-preview.redirects]]`, …) carry rules that exist only
+      # for that deploy context but are just as reachable once deployed.
+      if contexts = doc["context"]?.try(&.as_h?)
+        contexts.each_value do |ctx|
+          next unless ctx_h = ctx.as_h?
+          collect_redirects(ctx_h["redirects"]?, path)
+          collect_edge_functions(ctx_h["edge_functions"]?, path)
         end
       end
     rescue e
@@ -63,13 +62,55 @@ module Analyzer::Specification
       @logger.debug_sub e
     end
 
+    private def collect_redirects(node : TOML::Any?, path : String)
+      node.try(&.as_a?).try do |items|
+        items.each do |item|
+          if from = item["from"]?.try(&.as_s?)
+            add_endpoint(from, path, nil) unless from.empty?
+          end
+        end
+      end
+    end
+
+    private def collect_edge_functions(node : TOML::Any?, path : String)
+      node.try(&.as_a?).try do |items|
+        items.each do |item|
+          if route_path = item["path"]?.try(&.as_s?)
+            add_endpoint(route_path, path, nil) unless route_path.empty?
+          end
+        end
+      end
+    end
+
     private def add_endpoint(route : String, source : String, line : Int32?)
+      host, path = split_source(route)
+      return if path.nil?
+
       details = if line
                   Details.new(PathInfo.new(source, line))
                 else
                   Details.new(PathInfo.new(source))
                 end
-      @result << Endpoint.new(route, DEFAULT_METHOD, details)
+      endpoint = Endpoint.new(path, DEFAULT_METHOD, details)
+      endpoint.add_tag(Tag.new("netlify-host", host, "netlify_analyzer")) if host
+      @result << endpoint
+    end
+
+    # A scheme-qualified source names another host; the scheme and host are not
+    # part of the request path, so keeping them inline produced URLs like
+    # `http://https://old.example.com/*`. Split the host into a tag and emit the
+    # path. A source without a scheme is left alone — including the slash-less
+    # `geps/by-state/` form that turns up in real `_redirects` files — because
+    # there is no way to tell a relative path from a host name there.
+    private def split_source(route : String) : Tuple(String?, String?)
+      trimmed = route.strip
+      return {nil, trimmed} unless trimmed.includes?("://")
+
+      if m = ABSOLUTE_SOURCE_RE.match(trimmed)
+        return {m[1], m[2]? || "/"}
+      end
+
+      {nil, nil}
     end
   end
 end

--- a/src/analyzer/analyzers/specification/traefik.cr
+++ b/src/analyzer/analyzers/specification/traefik.cr
@@ -5,6 +5,8 @@ module Analyzer::Specification
   class Traefik < SpecificationEngine
     analyzer_for "traefik"
 
+    METHOD_ANY = "ANY"
+
     def analyze
       # Shared across every file so one route defined in two providers
       # (a TOML and a YAML dynamic-config pair) is emitted once.
@@ -152,7 +154,10 @@ module Analyzer::Specification
         end
 
         paths = ["/"] of String if paths.empty?
-        methods = ["GET"] of String if methods.empty?
+        # A rule with no `Method()` matcher matches every verb. `GET` claimed
+        # the route answered one verb and hid the rest; `ANY` is the label the
+        # rest of this analyzer group already uses for an unfiltered route.
+        methods = [METHOD_ANY] of String if methods.empty?
 
         paths.each do |path|
           methods.each do |method|

--- a/src/detector/detectors/specification/envoy.cr
+++ b/src/detector/detectors/specification/envoy.cr
@@ -12,6 +12,21 @@ module Detector::Specification
     VIRTUAL_HOSTS_MARKER = /virtual_hosts/
     DOMAINS_MARKER       = /domains/
 
+    # Envoy puts `virtual_hosts` at whatever depth the surrounding message
+    # implies: at the document root for a standalone RouteConfiguration, one
+    # level down under `route_config`, inside `resources[]` for an RDS
+    # response, and — by far the most common in practice — buried under
+    # `static_resources.listeners[].filter_chains[].filters[].typed_config.
+    # route_config` in a bootstrap config. Searching the document instead of
+    # enumerating layouts is what lets a plain `envoy.yaml` be recognised at
+    # all. The bound only exists so a pathologically nested document can't
+    # blow the stack; real configs sit around depth 8.
+    MAX_SEARCH_DEPTH = 32
+
+    # Hoisted so the per-node lookup in the walk below does not rebuild the
+    # wrapper on every mapping it visits.
+    VIRTUAL_HOSTS_KEY = YAML::Any.new("virtual_hosts")
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless content_matches?(file_contents, VIRTUAL_HOSTS_MARKER) &&
                           content_matches?(file_contents, DOMAINS_MARKER)
@@ -33,33 +48,19 @@ module Detector::Specification
       false
     end
 
-    private def find_virtual_hosts_yaml(data : YAML::Any) : Bool
-      # A non-mapping root (array/scalar) makes String-key `[]?` raise; guard it
-      # — the detector runs in a worker fiber with no rescue, so a raise there
-      # kills the worker and loses results for this file.
-      return false unless data.as_h?
-      # route_config.virtual_hosts (Envoy bootstrap / static config)
-      if (rc = data["route_config"]?) && rc.as_h?
-        if vh = rc["virtual_hosts"]?
-          return virtual_hosts_valid_yaml?(vh)
-        end
-      end
+    # A non-mapping node makes String-key `[]?` raise, so every lookup goes
+    # through `as_h?` — the detector runs in a worker fiber with no rescue, and
+    # a raise there kills the worker and loses results for this file.
+    private def find_virtual_hosts_yaml(data : YAML::Any, depth : Int32 = 0) : Bool
+      return false if depth > MAX_SEARCH_DEPTH
 
-      # virtual_hosts at top level (RDS RouteConfiguration)
-      if vh = data["virtual_hosts"]?
-        return virtual_hosts_valid_yaml?(vh)
-      end
-
-      # xDS resources array: resources[].virtual_hosts
-      if resources = data["resources"]?
-        if arr = resources.as_a?
-          arr.each do |resource|
-            next unless resource.as_h?
-            if vh = resource["virtual_hosts"]?
-              return virtual_hosts_valid_yaml?(vh)
-            end
-          end
+      if node = data.as_h?
+        if vh = node[VIRTUAL_HOSTS_KEY]?
+          return true if virtual_hosts_valid_yaml?(vh)
         end
+        node.each_value { |value| return true if find_virtual_hosts_yaml(value, depth + 1) }
+      elsif arr = data.as_a?
+        arr.each { |value| return true if find_virtual_hosts_yaml(value, depth + 1) }
       end
 
       false
@@ -75,27 +76,16 @@ module Detector::Specification
       false
     end
 
-    private def find_virtual_hosts_json(data : JSON::Any) : Bool
-      return false unless data.as_h?
-      if (rc = data["route_config"]?) && rc.as_h?
-        if vh = rc["virtual_hosts"]?
-          return virtual_hosts_valid_json?(vh)
-        end
-      end
+    private def find_virtual_hosts_json(data : JSON::Any, depth : Int32 = 0) : Bool
+      return false if depth > MAX_SEARCH_DEPTH
 
-      if vh = data["virtual_hosts"]?
-        return virtual_hosts_valid_json?(vh)
-      end
-
-      if resources = data["resources"]?
-        if arr = resources.as_a?
-          arr.each do |resource|
-            next unless resource.as_h?
-            if vh = resource["virtual_hosts"]?
-              return virtual_hosts_valid_json?(vh)
-            end
-          end
+      if node = data.as_h?
+        if vh = node["virtual_hosts"]?
+          return true if virtual_hosts_valid_json?(vh)
         end
+        node.each_value { |value| return true if find_virtual_hosts_json(value, depth + 1) }
+      elsif arr = data.as_a?
+        arr.each { |value| return true if find_virtual_hosts_json(value, depth + 1) }
       end
 
       false

--- a/src/detector/detectors/specification/istio_virtualservice.cr
+++ b/src/detector/detectors/specification/istio_virtualservice.cr
@@ -9,8 +9,11 @@ module Detector::Specification
 
     # Every `.yaml`/`.yml` in the tree reaches these guards. Both must
     # match, so they stay separate probes rather than a union.
-    ISTIO_API_PREFIX_MARKER     = /networking\.istio\.io\//
-    VIRTUAL_SERVICE_KIND_MARKER = /kind: VirtualService/
+    ISTIO_API_PREFIX_MARKER = /networking\.istio\.io\//
+    # `kind: "VirtualService"` is as valid as the bare form and is what Helm
+    # charts and generators emit; the marker has to allow the quotes or the
+    # whole manifest is dropped before the parse ever runs.
+    VIRTUAL_SERVICE_KIND_MARKER = /kind:[ \t]*["']?VirtualService/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)

--- a/src/detector/detectors/specification/k8s_gateway_api.cr
+++ b/src/detector/detectors/specification/k8s_gateway_api.cr
@@ -10,7 +10,10 @@ module Detector::Specification
     # Every `.yaml`/`.yml` in the tree reaches these guards. Both must
     # match, so they stay separate probes rather than a union.
     GATEWAY_API_PREFIX_MARKER = /gateway\.networking\.k8s\.io\//
-    HTTP_ROUTE_KIND_MARKER    = /kind: HTTPRoute/
+    # `kind: "HTTPRoute"` is as valid as the bare form and is what Helm charts
+    # and generators emit; the marker has to allow the quotes or the whole
+    # manifest is dropped before the parse ever runs.
+    HTTP_ROUTE_KIND_MARKER = /kind:[ \t]*["']?HTTPRoute/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)


### PR DESCRIPTION
Accuracy sweep over the gateway / proxy / IaC / serverless-config analyzers in
`src/analyzer/analyzers/specification/` (nginx, apache_httpd, envoy, traefik, caddy, kong,
apisix, k8s_ingress, k8s_gateway_api, istio_virtualservice, terraform, serverless_framework,
vercel, netlify, cloudflare_wrangler, aws_cdk, aws_cloudformation, azure_functions, kamal)
and their detectors. Nine fixes, each with a fixture and a spec.

## Corpus

Shallow clones, scanned with the `--release` binary:

| repo | size | before | after |
|---|---|---|---|
| envoyproxy/envoy | 230M | 201 | **239** |
| istio/istio | 61M | 198 | 200 |
| cloudflare/workers-sdk | 53M | 159 | 158 |
| traefik/traefik | 50M | 102 | 102 (40 re-labelled) |
| kubernetes-sigs/gateway-api | 23M | 267 | 265 |
| aws/serverless-application-model | 92M | 44 | 43 |
| Kong/deck | 8.1M | 45 | 42 |
| apache/apisix, kubernetes/ingress-nginx, caddyserver/caddy, serverless/examples, basecamp/kamal | — | unchanged | unchanged |

Counts are after noir's global `(method, url)` dedup, so they understate per-file changes;
the normalized line sets are what I diffed.

## Changes

| analyzer | FP / FN / perf | what was wrong | evidence |
|---|---|---|---|
| envoy (+detector) | FN | `virtual_hosts` was only looked for at the document root, under `route_config`, or under `resources[]`. The layout every real config file uses nests it under `static_resources.listeners[].filter_chains[].filters[].typed_config.route_config`, so the detector never fired. Now the parsed document is searched; the signature (array of mappings each carrying `domains`) is unchanged, only its assumed position is gone. | 30 of the 31 `virtual_hosts` YAMLs in envoyproxy/envoy were bootstrap-shaped and produced nothing, incl. `envoy/configs/envoy-demo.yaml:25`. envoy 201 → 239 endpoints (41 new normalized lines), e.g. `configs/front-proxy_envoy.yaml` `/service/1`, `/service/2`; `test/config/integration/server.yaml` `/websocket`, `/test/`. |
| envoy | FN | `match.path_separated_prefix` is a distinct route match type and was never read. | New fixture `envoy/envoy-bootstrap.yaml` → `GET /separated`. |
| envoy | — | `virtual_hosts[].domains` was discarded; now an `envoy-domain` tag (comma-joined, because the optimizer dedupes on `(method, url)` and one-endpoint-per-domain would drop all but the first). | — |
| caddy | FP | `handle` / `handle_path` / `route` / `redir` / `respond` all take an **optional** matcher. With no matcher the first token is a body, a destination or the block's `{`, and all of them became URLs. | `respond "Hello, world!"` → `/"Hello,`; `redir https://www.example.com{uri} permanent` → `https://www.example.com{uri}`; `handle {` / `route {` → `/{`. All four are in the extended `caddy/Caddyfile` fixture and now emit nothing. |
| caddy | FN | named-matcher resolution (`handle @api`) only covered `handle`; `handle_path @x` and `route @x` were silently dropped. | Regex widened; covered by the same fixture. |
| cloudflare_wrangler | FP | a route pattern is host-qualified (`example.com/api/*`). Emitting it verbatim gave `/example.com/api/*`, a path no request carries. Host (and scheme) now split into a `wrangler-host` tag. | `workers-sdk/packages/playground-preview-worker/wrangler.json` produced `/*.cloudflarepreviews.com/*` and `/playground.devprod.cloudflare.dev/*`. The old functional spec asserted the broken form. |
| cloudflare_wrangler | FN | a `routes` array mixing bare strings with inline tables is valid TOML 1.0 and is how wrangler documents the key, but the bundled TOML shard rejects it — one such array cost **every** route in the file. Falls back to scanning the array. | New fixture `cloudflare_wrangler/mixed-routes/wrangler.toml` → `/assets/*`, `/edge/*` (0 before). |
| azure_functions | FN (wrong path) | the Functions host prepends `api` to every HTTP trigger unless `host.json` overrides it. noir emitted `/products/{id}` for a URL the app serves at `/api/products/{id}`. Now resolves `extensions.http.routePrefix` (or v1 `http.routePrefix`) from the app root's `host.json`, once per app root; explicit `""` disables it. | Fixture `azure_functions/` `/users` → `/api/users`; new `azure_functions/custom-prefix/` (`routePrefix: gateway`) → `/gateway/ping`. |
| netlify | FP | a domain-level rule writes its source as a full URL. That went straight into the URL field, so noir reported `http://https://old.example.com/*`. Host now split into a `netlify-host` tag. | `gateway-api/netlify.toml` produced 3 such lines; `workers-sdk/packages/pages-shared/__tests__/metadata-generator/fixtures/_redirects:6` produced `https://lol.com`. |
| netlify | FN | `[[context.<name>.redirects]]` / `[[context.<name>.edge_functions]]` were skipped entirely. | New fixture `netlify/netlify.toml` → `/prod-only`. |
| kong | FP (wrong path) | Kong 3.x selects regex mode with a leading `~`; it is a marker, not a path segment. `~/status/\d+` came out as `/~/status/\d+`. The mode was already on the `kong-path-type` tag. | `deck/convert/testdata/3/output-expected.yaml`, `deck/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml`. 3 of 45 deck endpoints corrected. |
| k8s_gateway_api, istio_virtualservice (detectors) | FN | both gated on the literal `kind: HTTPRoute` / `kind: VirtualService`. `kind: "HTTPRoute"` is equally valid and is what Helm charts render — the manifest was dropped before the parse ran. | Second document added to each fixture with a quoted `kind` → `/v1/search` in both. |
| k8s_gateway_api | FN | `matches[].headers` and `matches[].queryParams` are conditions the route will not fire without; they were read as nothing. | Fixture → `GET /v1/search [header:X-Api-Version, query:q]`. |
| aws_cloudformation | FP | `Path: /$default` on a SAM `HttpApi` event names the API's default route, not a path. The Terraform analyzer already drops the same `$`-prefixed keys. | `serverless-application-model/tests/translator/input/explicit_http_api_default_path.yaml` emitted `/$default`. |
| traefik | FN | a rule with no `Method()` matcher matches every verb; the analyzer defaulted to `GET`, claiming the route answered one verb and hiding the rest. `ANY` is what Kong, APISIX, Caddy and k8s Gateway API already use for an unfiltered route. | traefik/traefik: 40 of 102 endpoints re-labelled `GET` → `ANY`, e.g. `integration/fixtures/multiple_provider.toml` `/file`, `pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml` `/bir`. Count unchanged. |

## Perf

No perf claim. The Envoy change replaces three fixed lookups with a full-document search, so I
measured it against a binary built from the base commit on the same machine, page cache warm,
5 runs each:

| repo | base | this branch |
|---|---|---|
| envoyproxy/envoy (230M) | 2.95 2.85 2.84 2.81 2.82 | 2.87 2.88 2.85 2.92 3.10 |
| istio/istio (61M) | 1.32 1.38 1.08 1.16 1.06 | 1.03 1.05 1.01 0.98 0.99 |
| cloudflare/workers-sdk (53M) | 2.05 2.32 2.22 1.96 2.00 | 1.94 1.97 1.96 1.94 1.93 |
| traefik/traefik (50M) | 0.56 0.57 0.57 0.58 0.60 | 0.59 0.60 0.60 0.59 0.59 |
| kubernetes-sigs/gateway-api (23M) | 0.16 ×5 | 0.16 ×5 |

These are noisy — the base run-to-run spread on istio and workers-sdk is wider than any
difference between the two binaries — so I read this as "no measurable change either way",
not as a win. Earlier, uncontrolled measurements suggested a ~10% envoy/istio regression;
that turned out to be machine drift and disappeared once both binaries were timed back to
back. The document search does allocate less than the first version of it: the `YAML::Any`
key wrappers are hoisted to constants instead of being rebuilt at every mapping node.

The only file volume the search ever touches is what already passes the detector's
`virtual_hosts` + `domains` content gate: 792K across 171 files in envoy, 1.1M across 42 in
istio.

## Fixture A/B

`noir_ab.sh` over `spec/functional_test/fixtures`, per-directory: **23 changed lines across 7
files, plus 1 new file.** Every one is intended:

- `azure_functions`: `GET|POST /users` → `/api/users`, plus `GET /gateway/ping` from the new
  `custom-prefix` app. The host prefix is real; the old paths were not served.
- `cloudflare_wrangler`: `/api.example.com/*` → `/*`, `/example.com/api/*` → `/api/*`, plus
  `/assets/*` and `/edge/*` from the new mixed-array fixture.
- `envoy`: `+GET /bootstrap`, `+GET /separated` from the new bootstrap fixture.
- `istio_virtualservice`, `k8s_gateway_api`: `+GET /v1/search` from the quoted-`kind` document;
  the Gateway API one carries the two new matcher params.
- `kong`: `/~/admin/.*` → `/admin/.*`.
- `traefik`: `/v1`, `/foo`, `/bar` `GET` → `ANY` (no `Method()` matcher in those rules).
- `netlify`: new snapshot file — the analyzer had no fixture or functional spec at all before.
- `caddy` and `aws_cloudformation` snapshots are **unchanged** even though both fixtures grew,
  which is the point: the added lines must emit nothing.

## Gates

`crystal spec spec/unit_test` (4363 examples), `crystal spec spec/functional_test` (22460
examples), `crystal tool format`, `ameba` (1832 files) — each run in its own command, all green.

## Found and deliberately not fixed

- **Multi-host endpoints are silently collapsed.** nginx, apache_httpd, caddy, k8s_ingress,
  k8s_gateway_api and istio_virtualservice emit one endpoint per host, and the optimizer's
  `(method, url)` dedup then keeps only the first — so `server_name a.example.com
  b.example.com` reports only `a.example.com`. The kamal/apisix pattern (one comma-joined tag)
  fixes it. I did it for the Envoy code I was already rewriting and left the other six alone
  rather than churn six analyzers' tag output in a PR that is mostly about paths.
- **Terraform has no `aws_lb_listener_rule` / ALB path-condition support.** That is new
  capability, not a defect in what exists; the detector's marker list would need widening too.
- **Vercel emits an endpoint for every `headers` rule source** (e.g. `/(.*)`). A header rule
  is not a route, but its source does describe a reachable path space and it is tagged
  `vercel-rule=header`, so I left the judgement call alone.
- **Netlify `_redirects` query conditions are dropped.** `/store id=:id /blog/:id 200` emits
  `/store` with no `id` query param.
- **Serverless Framework stage composition is uniform across event types.** `provider.stage`
  is prefixed to both `http` (REST) and `httpApi` paths; for an HTTP API on the implicit
  `$default` stage there is no prefix in the real URL. I could not tell the two apart from the
  config alone without modelling `provider.httpApi`, so I left it.
- **`caddyserver/caddy` was a poor corpus.** Its Caddyfiles live in `.caddyfiletest` files,
  which noir does not (and should not) claim, so the Caddy fixes were validated against
  hand-built Caddyfiles reproducing upstream idioms rather than against the repo.
- The Envoy `MAX_SEARCH_DEPTH = 32` bound is a stack guard, not a tuning knob; real configs
  bottom out around depth 10. I did not try to tighten it, because istio's `configdump.json`
  route configs sit deeper and lowering it would trade correctness for noise-level time.
