### PR TITLE
fix(analyzer/spec): correct OAS3/OpenRPC server base paths, RAML {version}, HAR/mitmproxy/ZAP capture params; parse OpenAPI documents once

### DIFF
--- a/spec/functional_test/fixtures/specification/har_http2/chrome.har
+++ b/spec/functional_test/fixtures/specification/har_http2/chrome.har
@@ -1,0 +1,58 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "entries": [
+      {
+        "startedDateTime": "2026-07-30T00:00:00.000Z",
+        "time": 24,
+        "request": {
+          "method": "POST",
+          "url": "https://shop.example.com/api/cart?promo=summer",
+          "httpVersion": "http/2.0",
+          "headers": [
+            {"name": ":authority", "value": "shop.example.com"},
+            {"name": ":method", "value": "POST"},
+            {"name": ":path", "value": "/api/cart?promo=summer"},
+            {"name": ":scheme", "value": "https"},
+            {"name": "content-length", "value": "31"},
+            {"name": "content-type", "value": "application/json"},
+            {"name": "x-request-id", "value": "8f2c"},
+            {"name": "x-request-id", "value": "8f2c"}
+          ],
+          "cookies": [
+            {"name": "session", "value": "abc"},
+            {"name": "session", "value": "abc"}
+          ],
+          "queryString": [
+            {"name": "promo", "value": "summer"}
+          ],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"sku\":\"A-1\",\"quantity\":2}"
+          },
+          "headersSize": -1,
+          "bodySize": 31
+        },
+        "response": {
+          "status": 201,
+          "statusText": "",
+          "httpVersion": "http/2.0",
+          "headers": [
+            {"name": "content-type", "value": "application/json"}
+          ],
+          "cookies": [],
+          "content": {"size": 2, "mimeType": "application/json", "text": "{}"},
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 2
+        },
+        "cache": {},
+        "timings": {"send": 1, "wait": 22, "receive": 1}
+      }
+    ]
+  }
+}

--- a/spec/functional_test/fixtures/specification/oas3/server_urls/bare_host_server.yml
+++ b/spec/functional_test/fixtures/specification/oas3/server_urls/bare_host_server.yml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+info:
+  title: Bare Host Server
+  version: 1.0.0
+servers:
+  - url: api.example.com/hosted
+paths:
+  /tickets:
+    get:
+      summary: List tickets
+      responses:
+        '200':
+          description: OK

--- a/spec/functional_test/fixtures/specification/oas3/server_urls/protocol_relative.yml
+++ b/spec/functional_test/fixtures/specification/oas3/server_urls/protocol_relative.yml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+info:
+  title: Protocol Relative Server
+  version: 1.0.0
+servers:
+  - url: //api.example.com/edge
+paths:
+  /banners:
+    get:
+      summary: List banners
+      responses:
+        '200':
+          description: OK

--- a/spec/functional_test/fixtures/specification/oas3/server_urls/unusable_server.yml
+++ b/spec/functional_test/fixtures/specification/oas3/server_urls/unusable_server.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: Unusable Server Entry
+  version: 1.0.0
+servers:
+  - description: cloud integration
+    url: https://terminal.example.com/sync
+  - description: local hosting, address filled in by the operator
+    url: <local-terminal-IP-address>
+paths:
+  /diagnosis:
+    post:
+      summary: Run diagnosis
+      responses:
+        '200':
+          description: OK

--- a/spec/functional_test/testers/etc/multi_techs_spec.cr
+++ b/spec/functional_test/testers/etc/multi_techs_spec.cr
@@ -7,12 +7,12 @@ expected_endpoints = [
   Endpoint.new("/update", "POST"),
   Endpoint.new("/query", "POST", [Param.new("query", "", "form")]),
   Endpoint.new("/socket", "GET"),
-  Endpoint.new("/pets", "GET"),
-  Endpoint.new("/pets", "POST", [
+  Endpoint.new("/v1/pets", "GET"),
+  Endpoint.new("/v1/pets", "POST", [
     Param.new("name", "", "json"),
   ]),
-  Endpoint.new("/pets/{petId}", "GET", [Param.new("petId", "", "path")]),
-  Endpoint.new("/pets/{petId}", "PUT", [
+  Endpoint.new("/v1/pets/{petId}", "GET", [Param.new("petId", "", "path")]),
+  Endpoint.new("/v1/pets/{petId}", "PUT", [
     Param.new("petId", "", "path"),
     Param.new("breed", "", "json"),
     Param.new("name", "", "json"),

--- a/spec/functional_test/testers/specification/har_http2_spec.cr
+++ b/spec/functional_test/testers/specification/har_http2_spec.cr
@@ -1,0 +1,21 @@
+require "../../func_spec.cr"
+
+# A browser HAR is recorded over HTTP/2, where the request line is re-encoded
+# as the `:authority` / `:method` / `:path` / `:scheme` pseudo-headers. Those
+# are not parameters any request can set, and neither are `content-length` /
+# `host`. A repeated header or cookie is one parameter, not two.
+expected_endpoints = [
+  Endpoint.new("https://shop.example.com/api/cart", "POST", [
+    Param.new("promo", "summer", "query"),
+    Param.new("content-type", "application/json", "header"),
+    Param.new("x-request-id", "8f2c", "header"),
+    Param.new("session", "abc", "cookie"),
+    Param.new("sku", "", "json"),
+    Param.new("quantity", "", "json"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/specification/har_http2/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/specification/har_spec.cr
+++ b/spec/functional_test/testers/specification/har_spec.cr
@@ -1,8 +1,9 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
+  # `Host` is transport-level, not a request parameter — the Burp and Caido
+  # analyzers already skip it and HAR now agrees.
   Endpoint.new("https://www.hahwul.com/", "GET", [
-    Param.new("Host", "www.hahwul.com", "header"),
     Param.new("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:123.0) Gecko/20100101 Firefox/123.0", "header"),
     Param.new("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8", "header"),
     Param.new("_ga", "GA1.1.1310623768.1671977578", "cookie"),

--- a/spec/functional_test/testers/specification/oas3_spec.cr
+++ b/spec/functional_test/testers/specification/oas3_spec.cr
@@ -1,16 +1,18 @@
 require "../../func_spec.cr"
 
+# `servers: [{url: 'https://api.example.com/v1'}]` puts every operation under
+# `/v1`, exactly the way OAS2's `basePath` and RAML's `baseUri` already do.
 expected_endpoints = [
-  Endpoint.new("/pets", "GET", [
+  Endpoint.new("/v1/pets", "GET", [
     Param.new("query", "", "query"),
     Param.new("sort", "", "query"),
     Param.new("cookie", "", "cookie"),
   ]),
-  Endpoint.new("/pets", "POST", [
+  Endpoint.new("/v1/pets", "POST", [
     Param.new("name", "", "json"),
   ]),
-  Endpoint.new("/pets/{petId}", "GET", [Param.new("petId", "", "path")]),
-  Endpoint.new("/pets/{petId}", "PUT", [
+  Endpoint.new("/v1/pets/{petId}", "GET", [Param.new("petId", "", "path")]),
+  Endpoint.new("/v1/pets/{petId}", "PUT", [
     Param.new("petId", "", "path"),
     Param.new("breed", "", "json"),
     Param.new("name", "", "json"),
@@ -35,6 +37,19 @@ FunctionalTester.new("fixtures/specification/oas3/no_servers/", {
 ], {
   "url" => YAML::Any.new("https://api.example.com"),
 }).perform_tests
+
+# A `servers[].url` is a URL, not a path. A protocol-relative entry contributes
+# only its path (`//api.example.com/edge` → `/edge`), a bare host is not a path
+# at all, and an unresolved placeholder is skipped in favour of the next usable
+# entry instead of becoming a leading URL segment.
+FunctionalTester.new("fixtures/specification/oas3/server_urls/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, [
+  Endpoint.new("/edge/banners", "GET"),
+  Endpoint.new("/sync/diagnosis", "POST"),
+  Endpoint.new("/tickets", "GET"),
+]).perform_tests
 
 FunctionalTester.new("fixtures/specification/oas3/multiple_docs/", {
   :techs     => 1,
@@ -112,10 +127,10 @@ FunctionalTester.new("fixtures/specification/oas3/tab_in_block_scalar/", {
   :techs     => 1,
   :endpoints => 2,
 }, [
-  Endpoint.new("/widgets", "GET", [
+  Endpoint.new("/v1/widgets", "GET", [
     Param.new("state", "", "query"),
   ]),
-  Endpoint.new("/widgets", "POST", [
+  Endpoint.new("/v1/widgets", "POST", [
     Param.new("name", "", "json"),
     Param.new("color", "", "json"),
   ]),

--- a/spec/functional_test/testers/specification/raml_spec.cr
+++ b/spec/functional_test/testers/specification/raml_spec.cr
@@ -42,44 +42,40 @@ FunctionalTester.new("fixtures/specification/raml_nested/", {
   :endpoints => nested_endpoints.size,
 }, nested_endpoints).perform_tests
 
+# RAML reserves `{version}` in `baseUri` for the root `version` property, so
+# `baseUri: https://api.example.com/api/{version}` with `version: v2` is served
+# at `/api/v2` — and `version` is then no longer a path parameter.
 advanced_endpoints = [
-  Endpoint.new("/api/{version}/users", "GET", [
+  Endpoint.new("/api/v2/users", "GET", [
     Param.new("Authorization", "", "header"),
     Param.new("page", "", "query"),
     Param.new("per_page", "", "query"),
-    Param.new("version", "", "path"),
   ]),
-  Endpoint.new("/api/{version}/users", "POST", [
+  Endpoint.new("/api/v2/users", "POST", [
     Param.new("Authorization", "", "header"),
     Param.new("name", "", "json"),
     Param.new("email", "", "json"),
-    Param.new("version", "", "path"),
   ]),
-  Endpoint.new("/api/{version}/users/{userId}", "GET", [
+  Endpoint.new("/api/v2/users/{userId}", "GET", [
     Param.new("Authorization", "", "header"),
-    Param.new("version", "", "path"),
     Param.new("userId", "", "path"),
   ]),
-  Endpoint.new("/api/{version}/users/{userId}", "PUT", [
+  Endpoint.new("/api/v2/users/{userId}", "PUT", [
     Param.new("Authorization", "", "header"),
     Param.new("name", "", "json"),
     Param.new("status", "", "json"),
-    Param.new("version", "", "path"),
     Param.new("userId", "", "path"),
   ]),
-  Endpoint.new("/api/{version}/users/{userId}", "DELETE", [
+  Endpoint.new("/api/v2/users/{userId}", "DELETE", [
     Param.new("Authorization", "", "header"),
-    Param.new("version", "", "path"),
     Param.new("userId", "", "path"),
   ]),
-  Endpoint.new("/api/{version}/users/search", "GET", [
+  Endpoint.new("/api/v2/users/search", "GET", [
     Param.new("q", "", "query"),
-    Param.new("version", "", "path"),
   ]),
-  Endpoint.new("/api/{version}/reports", "GET", [
+  Endpoint.new("/api/v2/reports", "GET", [
     Param.new("from", "", "query"),
     Param.new("to", "", "query"),
-    Param.new("version", "", "path"),
   ]),
 ]
 

--- a/spec/functional_test/testers/specification/zap_sites_tree_spec.cr
+++ b/spec/functional_test/testers/specification/zap_sites_tree_spec.cr
@@ -6,7 +6,10 @@ expected_endpoints = [
   Endpoint.new("/about/", "GET"),
   Endpoint.new("/zz", "GET"),
   Endpoint.new("/zz/", "DELETE"),
-  Endpoint.new("/111", "PUT"),
+  # ZAP records the URL a node was reached with, query string included. Only
+  # the path used to be kept, so every query parameter ZAP had already
+  # discovered was thrown away.
+  Endpoint.new("/111", "PUT", [Param.new("q", "", "query")]),
   Endpoint.new("/about/", "POST", [Param.new("data", "", "form"), Param.new("id", "", "form")]),
 ]
 

--- a/spec/unit_test/analyzer/specification/mitmproxy_spec.cr
+++ b/spec/unit_test/analyzer/specification/mitmproxy_spec.cr
@@ -65,7 +65,10 @@ describe "Mitmproxy Analyzer" do
     endpoints = analyze_flows([flow(request)])
     endpoints.size.should eq 1
     ep = endpoints.first
-    ep.url.should eq "/api/users?active=1"
+    # The query string is reported as `query` params, so it does not belong in
+    # the URL as well — keeping it there duplicated every parameter and split
+    # one endpoint into one per captured value.
+    ep.url.should eq "/api/users"
     ep.method.should eq "GET"
 
     query = ep.params.select { |p| p.param_type == "query" }
@@ -73,7 +76,7 @@ describe "Mitmproxy Analyzer" do
     query.first.value.should eq "1"
 
     headers = ep.params.select { |p| p.param_type == "header" }.map(&.name)
-    headers.should contain "Host"
+    headers.should_not contain "Host"
     headers.should contain "Cookie"
 
     cookies = ep.params.select { |p| p.param_type == "cookie" }.map { |p| {p.name, p.value} }
@@ -222,6 +225,45 @@ describe "Mitmproxy Analyzer" do
     ensure
       File.delete(path) if File.exists?(path)
     end
+  end
+
+  it "drops HTTP/2 pseudo-headers and transport headers" do
+    request = {
+      "method"  => "POST".as(Tnetstring::Value),
+      "scheme"  => "https".as(Tnetstring::Value),
+      "host"    => "example.com".as(Tnetstring::Value),
+      "port"    => 443_i64.as(Tnetstring::Value),
+      "path"    => "/api/cart".as(Tnetstring::Value),
+      "headers" => [
+        header(":authority", "example.com"),
+        header(":method", "POST"),
+        header(":path", "/api/cart"),
+        header(":scheme", "https"),
+        header("content-length", "12"),
+        header("X-Request-Id", "8f2c"),
+      ] of Tnetstring::Value,
+    } of String => Tnetstring::Value
+
+    endpoints = analyze_flows([flow(request)])
+    headers = endpoints.first.params.select { |p| p.param_type == "header" }.map(&.name)
+    headers.should eq ["X-Request-Id"]
+  end
+
+  it "emits absolute URLs when no --url is supplied" do
+    request = {
+      "method" => "GET".as(Tnetstring::Value),
+      "scheme" => "https".as(Tnetstring::Value),
+      "host"   => "shop.example.com".as(Tnetstring::Value),
+      "port"   => 443_i64.as(Tnetstring::Value),
+      "path"   => "/api/orders?page=2".as(Tnetstring::Value),
+    } of String => Tnetstring::Value
+
+    # Previously a capture scanned without `--url` produced nothing at all,
+    # which is the opposite of what pointing noir at a dump is for. HAR falls
+    # back to the absolute URL in the same situation.
+    endpoints = analyze_flows([flow(request)], url: "")
+    endpoints.map(&.url).should eq ["https://shop.example.com/api/orders"]
+    endpoints.first.params.select { |p| p.param_type == "query" }.map(&.name).should eq ["page"]
   end
 
   it "ignores non-http flows" do

--- a/src/analyzer/analyzers/specification/har.cr
+++ b/src/analyzer/analyzers/specification/har.cr
@@ -52,11 +52,12 @@ module Analyzer::Specification
 
           is_websocket = websocket_request?(entry.request, request_uri)
           entry.request.headers.each do |header|
-            endpoint.params << Param.new(header.name, header.value, "header")
+            next if skipped_header?(header.name)
+            add_param_once(endpoint, Param.new(header.name, header.value, "header"))
           end
 
           entry.request.cookies.each do |cookie|
-            endpoint.params << Param.new(cookie.name, cookie.value, "cookie")
+            add_param_once(endpoint, Param.new(cookie.name, cookie.value, "cookie"))
           end
 
           add_post_data_params(endpoint, entry.request)
@@ -292,6 +293,20 @@ module Analyzer::Specification
         names << name unless name.empty?
       end
       names.uniq
+    end
+
+    # Headers that are not request parameters. A browser HAR is recorded over
+    # HTTP/2 or HTTP/3, where the request line is re-encoded as the `:method`
+    # `:scheme` `:authority` `:path` pseudo-headers — every Chrome/Firefox
+    # export carries them, and emitting them as params claims four parameters
+    # per endpoint that no request can actually set. `host` and
+    # `content-length` are the HTTP/1 equivalents and are already skipped by
+    # the Burp and Caido analyzers.
+    private def skipped_header?(name : String) : Bool
+      normalized = name.strip.downcase
+      return true if normalized.empty?
+      return true if normalized.starts_with?(':')
+      normalized == "host" || normalized == "content-length"
     end
 
     private def add_param_once(endpoint : Endpoint, param : Param)

--- a/src/analyzer/analyzers/specification/mitmproxy.cr
+++ b/src/analyzer/analyzers/specification/mitmproxy.cr
@@ -70,17 +70,30 @@ module Analyzer::Specification
       port = port_raw.is_a?(Int64) ? port_raw : nil
 
       base_url = build_url(scheme, host, port)
-      full_url = base_url + raw_path
+      # The query string is emitted as `query` params below, so it does not
+      # belong in the URL as well: leaving it in duplicated every parameter
+      # and split one endpoint into one-per-captured-value
+      # (`/search?q=a`, `/search?q=b`, …). HAR reports `uri.path` for the
+      # same reason.
+      path_only, _ = split_query(raw_path)
+      path_only = "/" if path_only.empty?
+      full_url = base_url + path_only
 
-      # Match HAR's filter semantics: only emit endpoints that fall
-      # under the user-provided --url. Without a URL we cannot infer
-      # what slice of the capture the user cares about.
-      return if @url.empty? || !full_url.includes?(@url)
+      # Match HAR's semantics. With `--url` the capture is filtered down to
+      # that origin and the prefix is stripped; without one, HAR emits the
+      # absolute URL rather than dropping the flow — a mitmproxy dump scanned
+      # on its own used to produce zero endpoints, which is the whole reason
+      # someone points noir at one.
+      if @url.empty?
+        endpoint_path = full_url
+      else
+        return unless (base_url + raw_path).includes?(@url)
 
-      # Strip the user URL as a LEADING prefix only — gsub removed every
-      # occurrence, mangling paths where the prefix recurs (e.g. a redirect param).
-      endpoint_path = full_url.starts_with?(@url) ? full_url[@url.size..]? || "" : full_url
-      endpoint_path = "/#{endpoint_path}" unless endpoint_path.starts_with?("/")
+        # Strip the user URL as a LEADING prefix only — gsub removed every
+        # occurrence, mangling paths where the prefix recurs (e.g. a redirect param).
+        endpoint_path = full_url.starts_with?(@url) ? full_url[@url.size..]? || "" : full_url
+      end
+      endpoint_path = "/#{endpoint_path}" unless endpoint_path.starts_with?("/") || endpoint_path.includes?("://")
       endpoint_path = "/" if endpoint_path.empty?
       endpoint = Endpoint.new(endpoint_path, method)
 
@@ -95,9 +108,16 @@ module Analyzer::Specification
           hvalue = stringify(entry[1])
           next unless hname && hvalue
 
-          endpoint.params << Param.new(hname, hvalue, "header")
-
           lname = hname.downcase
+          # A mitmproxy capture of an HTTP/2 or HTTP/3 flow carries the
+          # request line as `:method` / `:scheme` / `:authority` / `:path`
+          # pseudo-headers. They are not parameters a request can set, and
+          # `host` / `content-length` are the HTTP/1 equivalents the Burp and
+          # Caido analyzers already skip.
+          unless lname.starts_with?(':') || lname == "host" || lname == "content-length"
+            endpoint.params << Param.new(hname, hvalue, "header")
+          end
+
           case lname
           when "content-type"
             content_type = hvalue

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -88,39 +88,6 @@ module Analyzer::Specification
       url
     end
 
-    private def server_base_path(server_urls : Array(String)) : String
-      server_urls.each do |server_url|
-        next if server_url.empty?
-
-        if server_url.starts_with?("http")
-          next if @url.empty?
-          user_uri = URI.parse(@url)
-          source_uri = URI.parse(server_url)
-          return combine_base_url(source_uri.path) if user_uri.host == source_uri.host
-        elsif server_url.starts_with?("/")
-          return combine_base_url(server_url)
-        else
-          return combine_base_url("/#{server_url}")
-        end
-      rescue
-        next
-      end
-
-      @url
-    end
-
-    private def combine_base_url(path : String) : String
-      return @url if path.empty?
-      return path if @url.empty?
-      if @url.ends_with?("/") && path.starts_with?("/")
-        @url + path[1..]
-      elsif !@url.ends_with?("/") && !path.starts_with?("/")
-        "#{@url}/#{path}"
-      else
-        @url + path
-      end
-    end
-
     # Walks an OAS3 schema, emitting one Param per top-level property.
     # Follows `$ref` and flattens `allOf` so referenced/composed schemas
     # surface their members.

--- a/src/analyzer/analyzers/specification/openrpc.cr
+++ b/src/analyzer/analyzers/specification/openrpc.cr
@@ -120,44 +120,16 @@ module Analyzer::Specification
       params << param
     end
 
-    # Mirrors the OAS3 analyzer's server handling so `--url` behaves the same
-    # across spec families: an absolute server URL only contributes its path
-    # when its host matches the user-supplied URL.
+    # Shares the OAS3 analyzer's `servers` handling so `--url` behaves the same
+    # across spec families: an absolute server URL contributes only its path,
+    # and with `--url` supplied only the matching host contributes at all.
     private def base_path_for(root : JSON::Any) : String
-      servers = root["servers"]?.try(&.as_a?)
-      if servers
-        servers.each do |server_obj|
-          server_url = server_obj["url"]?.try(&.as_s?) || ""
-          next if server_url.empty?
-
-          if server_url.starts_with?("http")
-            next if @url.empty?
-            user_uri = URI.parse(@url)
-            source_uri = URI.parse(server_url)
-            return combine_base_url(source_uri.path) if user_uri.host == source_uri.host
-          elsif server_url.starts_with?("/")
-            return combine_base_url(server_url)
-          else
-            return combine_base_url("/#{server_url}")
-          end
-        rescue
-          next
-        end
+      if servers = root["servers"]?.try(&.as_a?)
+        base = server_base_path(servers.map { |server_obj| server_obj["url"]?.try(&.as_s?) || "" })
+        return base unless base == @url
       end
 
       @url.empty? ? DEFAULT_RPC_PATH : @url
-    end
-
-    private def combine_base_url(path : String) : String
-      return @url if path.empty?
-      return path if @url.empty?
-      if @url.ends_with?("/") && path.starts_with?("/")
-        @url + path[1..]
-      elsif !@url.ends_with?("/") && !path.starts_with?("/")
-        "#{@url}/#{path}"
-      else
-        @url + path
-      end
     end
 
     # Follows a `$ref` chain to its target, guarding against cycles. Returns the

--- a/src/analyzer/analyzers/specification/raml.cr
+++ b/src/analyzer/analyzers/specification/raml.cr
@@ -91,6 +91,7 @@ module Analyzer::Specification
     private def base_path_from(yaml_obj : YAML::Any) : String
       base_uri = base_uri_value(yaml_obj[YAML::Any.new("baseUri")]?)
       return "" if base_uri.empty?
+      base_uri = resolve_base_uri_parameters(base_uri, yaml_obj)
       if base_uri.starts_with?("http")
         begin
           uri = URI.parse(base_uri)
@@ -100,6 +101,31 @@ module Analyzer::Specification
         end
       end
       base_uri.rstrip('/')
+    end
+
+    # RAML reserves `{version}` in `baseUri` for the root `version` property,
+    # so `baseUri: http://host/{version}` with `version: v1` is served at
+    # `/v1`. Other placeholders can carry a `default` under
+    # `baseUriParameters`. Without this the literal `{version}` leaked into
+    # every endpoint URL (`/{version}/songs` instead of `/v1/songs`).
+    private def resolve_base_uri_parameters(base_uri : String, yaml_obj : YAML::Any) : String
+      return base_uri unless base_uri.includes?('{')
+
+      resolved = base_uri
+      if version = yaml_obj[YAML::Any.new("version")]?.try { |node| node.as_s? || node.as_i?.try(&.to_s) || node.as_f?.try(&.to_s) }
+        resolved = resolved.gsub("{version}", version) unless version.empty?
+      end
+
+      if parameters = yaml_obj[YAML::Any.new("baseUriParameters")]?.try(&.as_h?)
+        parameters.each do |name, definition|
+          next unless definition_h = definition.as_h?
+          next unless default = definition_h[YAML::Any.new("default")]?.try(&.as_s?)
+          next if default.empty?
+          resolved = resolved.gsub("{#{name}}", default)
+        end
+      end
+
+      resolved
     end
 
     # `baseUri` is normally a scalar URL, but RAML lets you annotate it,

--- a/src/analyzer/analyzers/specification/zap_sites_tree.cr
+++ b/src/analyzer/analyzers/specification/zap_sites_tree.cr
@@ -31,20 +31,31 @@ module Analyzer::Specification
         method = node["method"].as_s?.try(&.upcase) || "GET"
 
         if !path.empty?
-          uri = URI.parse(path)
-          params = [] of Param
-          if data = node["data"]?.try(&.as_s?)
-            begin
-              data.split("&").each do |param|
-                param_name = param.split("=")[0]
-                params << Param.new(param_name.to_s, "", "form")
-              end
-            rescue e
-              logger.debug "Failed to parse ZAP query params for #{path}: #{e}"
-            end
+          uri = begin
+            URI.parse(path)
+          rescue e
+            logger.debug "Failed to parse ZAP site URL '#{path}': #{e}"
+            nil
           end
 
-          @result << Endpoint.new(uri.path, method, params, details)
+          if uri
+            params = [] of Param
+
+            # A ZAP sites tree stores the URL a node was reached with, query
+            # string included. Only `uri.path` was kept, so every query
+            # parameter ZAP had already discovered was thrown away — the node
+            # for `/search?q=noir&page=2` produced a bare `/search` with no
+            # params at all.
+            if query = uri.query
+              add_named_params(query, "query", params)
+            end
+
+            if data = node["data"]?.try(&.as_s?)
+              add_named_params(data, "form", params)
+            end
+
+            @result << Endpoint.new(uri.path, method, params, details)
+          end
         end
       end
 
@@ -52,6 +63,17 @@ module Analyzer::Specification
         children.each do |child|
           process_node(child, details)
         end
+      end
+    end
+
+    # Splits an `a=1&b=2` payload into named params of `param_type`, skipping
+    # blanks and repeats.
+    private def add_named_params(payload : String, param_type : String, params : Array(Param))
+      payload.split('&').each do |pair|
+        name = pair.split('=', 2).first.strip
+        next if name.empty?
+        next if params.any? { |existing| existing.name == name && existing.param_type == param_type }
+        params << Param.new(name, "", param_type)
       end
     end
   end

--- a/src/analyzer/engines/specification_engine.cr
+++ b/src/analyzer/engines/specification_engine.cr
@@ -1,5 +1,6 @@
 require "../../models/analyzer"
 require "../../models/code_locator"
+require "uri"
 
 module Analyzer::Specification
   # Base for the specification-format analyzers (OpenAPI, Postman, HAR,
@@ -77,6 +78,85 @@ module Analyzer::Specification
     protected def each_spec_file_with_details(key : String, &block : String, Details -> Nil) : Nil
       each_spec_file(key) do |path|
         block.call(path, Details.new(PathInfo.new(path)))
+      end
+    end
+
+    # `scheme://` prefix of an absolute URL. `//host/path` is deliberately not
+    # matched here — it is protocol-relative and handled separately.
+    ABSOLUTE_SERVER_URL = /\A[A-Za-z][A-Za-z0-9+.\-]*:\/\//
+
+    # Turns an OpenAPI-style `servers[].url` list into the base path every
+    # endpoint in the document hangs off. Shared by OAS3 and OpenRPC, which
+    # use the same `servers` object.
+    #
+    # The first entry that yields a usable path wins, mirroring how OAS2's
+    # single `basePath` and RAML's single `baseUri` behave.
+    protected def server_base_path(server_urls : Array(String)) : String
+      server_urls.each do |server_url|
+        path = server_url_path(server_url)
+        next if path.nil?
+        return combine_base_url(path)
+      rescue
+        next
+      end
+
+      @url
+    end
+
+    # The path a single `servers[].url` contributes, or nil when the entry
+    # contributes nothing (unusable, or a host the user did not ask about).
+    protected def server_url_path(server_url : String) : String?
+      return if server_url.empty?
+
+      # Absolute (`https://host/v1`) and protocol-relative (`//host/v1`) URLs
+      # both carry an authority; only the path part belongs in the endpoint
+      # URL. Treating the whole thing as a path is what produced base paths
+      # like `/api.openapi-generator.tech`.
+      absolute = server_url.matches?(ABSOLUTE_SERVER_URL)
+      if absolute || server_url.starts_with?("//")
+        uri = URI.parse(absolute ? server_url : "http:#{server_url}")
+        # With `--url` supplied, a multi-host document should only contribute
+        # the server the user actually pointed at.
+        unless @url.empty?
+          return unless URI.parse(@url).host == uri.host
+        end
+        return uri.path
+      end
+
+      return server_url if server_url.starts_with?('/')
+
+      # An unrooted relative reference such as `api/v1` is a legal server URL,
+      # but a bare host (`api.example.com/v1`) or an unresolved placeholder
+      # (`<local-terminal-IP-address>`) is not a path — rooting either invents
+      # a leading segment no request ever carries.
+      return unless relative_server_path?(server_url)
+      "/#{server_url}"
+    end
+
+    # True when an unrooted `servers[].url` reads as a path rather than as a
+    # host or a placeholder. `.` and `:` in the first segment mean a hostname
+    # or a `host:port`; anything outside the unreserved URL characters (plus
+    # the `{}` of a server variable) means the document left a placeholder in.
+    private def relative_server_path?(server_url : String) : Bool
+      first = server_url.split('/', 2).first
+      return false if first.empty?
+      return false if first.includes?('.') || first.includes?(':')
+      first.each_char.all? do |char|
+        char.ascii_alphanumeric? || "-_~%{}".includes?(char)
+      end
+    end
+
+    # Joins the user-supplied `--url` with a document-declared base path
+    # without doubling or dropping the separator.
+    protected def combine_base_url(path : String) : String
+      return @url if path.empty?
+      return path if @url.empty?
+      if @url.ends_with?("/") && path.starts_with?("/")
+        @url + path[1..]
+      elsif !@url.ends_with?("/") && !path.starts_with?("/")
+        "#{@url}/#{path}"
+      else
+        @url + path
       end
     end
   end

--- a/src/detector/detectors/specification/oas2.cr
+++ b/src/detector/detectors/specification/oas2.cr
@@ -9,38 +9,34 @@ module Detector::Specification
     # analyzer pass. Must keep running after first match.
     detector_for "oas2", extensions: %w[.json .yaml .yml], idempotent: false
 
-    # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate.
-    SWAGGER_MARKER = /swagger/
+    # See `Detector::Specification::Oas3` for why the YAML gate is anchored at
+    # column 0 and stands in for the parse. A bare `/swagger/` matched every
+    # OpenAPI 3 document that links to its own `swagger.yaml` origin — 67 of
+    # the 493 openapi-directory documents in the perf corpus — and each one
+    # paid for a full YAML parse only to be rejected.
+    SWAGGER2_YAML_MARKER = /^["']?swagger["']?[ \t]*:[ \t]*["']?2\./m
+    SWAGGER2_JSON_MARKER = /"swagger"[ \t]*:[ \t]*"2\./
 
     def detect(filename : String, file_contents : String) : Bool
-      check = false
-      return false unless content_matches?(file_contents, SWAGGER_MARKER)
-
       if filename.ends_with?(".json")
+        return false unless content_matches?(file_contents, SWAGGER2_JSON_MARKER)
         begin
           data = JSON.parse(file_contents)
           if data["swagger"].as_s.includes? "2."
-            check = true
-            locator = CodeLocator.instance
-            locator.push("swagger-json", filename)
+            CodeLocator.instance.push("swagger-json", filename)
+            return true
           end
         rescue e
           logger.debug "OAS2 JSON detection failed for #{filename}: #{e}"
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-        begin
-          data = parse_yaml(file_contents)
-          if data["swagger"].as_s.includes? "2."
-            check = true
-            locator = CodeLocator.instance
-            locator.push("swagger-yaml", filename)
-          end
-        rescue e
-          logger.debug "OAS2 YAML detection failed for #{filename}: #{e}"
+        if content_matches?(file_contents, SWAGGER2_YAML_MARKER)
+          CodeLocator.instance.push("swagger-yaml", filename)
+          return true
         end
       end
 
-      check
+      false
     end
   end
 end

--- a/src/detector/detectors/specification/oas3.cr
+++ b/src/detector/detectors/specification/oas3.cr
@@ -9,38 +9,47 @@ module Detector::Specification
     # analyzer pass. Must keep running after first match.
     detector_for "oas3", extensions: %w[.json .yaml .yml], idempotent: false
 
-    # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate.
-    OPENAPI_MARKER = /openapi/
+    # Every `.json`/`.yaml`/`.yml` in the tree reaches this gate. A bare
+    # `/openapi/` matched any document that merely *mentions* OpenAPI — an
+    # `x-origin: {url: .../openapi.yaml}` block, a description, a `swagger`
+    # document that links to its own OAS3 conversion — and each of those paid
+    # for a full YAML/JSON parse before being rejected.
+    #
+    # In YAML a key at column 0 is a root key: a block scalar's content must be
+    # indented past the key that introduces it, so an `openapi: 3.x` line
+    # starting at column 0 cannot be anything but the document's version field.
+    # That makes the anchored match as strong as the parse it replaces, so the
+    # YAML branch registers on the regex alone and lets the analyzer — which
+    # parses the document anyway — be the one that reads it. Previously every
+    # OpenAPI document in the tree was parsed twice: once to decide, once to
+    # analyze, with the first parse thrown away.
+    OPENAPI3_YAML_MARKER = /^["']?openapi["']?[ \t]*:[ \t]*["']?3\./m
+
+    # JSON gets no such structural guarantee — `"openapi": "3.0.0"` can sit
+    # nested inside a wrapper document — so the JSON branch keeps parsing and
+    # checking the root key, and the regex only serves as a cheap pre-gate.
+    OPENAPI3_JSON_MARKER = /"openapi"[ \t]*:[ \t]*"3\./
 
     def detect(filename : String, file_contents : String) : Bool
-      check = false
-      return false unless content_matches?(file_contents, OPENAPI_MARKER)
-
       if filename.ends_with?(".json")
+        return false unless content_matches?(file_contents, OPENAPI3_JSON_MARKER)
         begin
           data = JSON.parse(file_contents)
           if data["openapi"].as_s.includes? "3."
-            check = true
-            locator = CodeLocator.instance
-            locator.push("oas3-json", filename)
+            CodeLocator.instance.push("oas3-json", filename)
+            return true
           end
         rescue e
           logger.debug "OAS3 JSON detection failed for #{filename}: #{e}"
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-        begin
-          data = parse_yaml(file_contents)
-          if data["openapi"].as_s.includes? "3."
-            check = true
-            locator = CodeLocator.instance
-            locator.push("oas3-yaml", filename)
-          end
-        rescue e
-          logger.debug "OAS3 YAML detection failed for #{filename}: #{e}"
+        if content_matches?(file_contents, OPENAPI3_YAML_MARKER)
+          CodeLocator.instance.push("oas3-yaml", filename)
+          return true
         end
       end
 
-      check
+      false
     end
   end
 end


### PR DESCRIPTION
An FP/FN/perf sweep over the API-description and traffic-capture analyzers in
`src/analyzer/analyzers/specification/` and their detectors.

These formats have deterministic ground truth — the document states exactly which
operations, paths and parameters exist — so the audit was mechanical rather than
by eye: a Python extractor derives the expected `METHOD url` set (and the
query/header/cookie param set) straight from each document, and that set is
diffed against noir's JSON output, one document per scan.

Corpus: `APIs-guru/openapi-directory` (sampled), `OAI/OpenAPI-Specification`,
`raml-org/raml-examples`, `asyncapi/spec`, `smithy-lang/smithy`,
`microsoft/typespec`, `googleapis/googleapis`, `grpc/grpc-go`.

## Changes

| analyzer | FP / FN / perf | what was wrong | evidence |
|---|---|---|---|
| `oas3`, `openrpc` | FP + wrong URL | An absolute `servers[].url` was skipped entirely unless `--url` was given with a matching host, so its path was dropped; the routine then fell through to whatever came next, which could be a protocol-relative URL read as a path, a bare host, or an unresolved placeholder. | 59 of 165 sampled `openapi-directory` OAS3 docs, 2945 of 8761 operations, carried a wrong URL → 0 after. `adyen.com/CheckoutService-v71/71/openapi.yaml` `/sessions` → `/v71/sessions`; `ote-godaddy.com/agreements/1.0.0/openapi.yaml` `/api.ote-godaddy.com/v1/agreements` → `/v1/agreements`; `adyen.com/TerminalAPI-v1/1/openapi.yaml` `/<local-terminal-IP-address>/admin` → `/sync/admin`; `microsoft.com/cognitiveservices-Prediction/2.0/openapi.yaml` `/none/customvision/...` → `/customvision/...` |
| `raml` | FN + wrong URL | RAML reserves `{version}` in `baseUri` for the root `version` property. It was left literal, and `version` was additionally reported as a path param no caller can vary. | `raml-examples/others/world-music-api/api.raml:4` — `/{version}/songs` → `/v1/songs`; 7 endpoints changed across the corpus |
| `har` | FP | Every header became a param, including the HTTP/2 `:method` `:scheme` `:authority` `:path` pseudo-headers that every Chrome/Firefox export carries, plus `Host` / `Content-Length` (which Burp and Caido already skip). Headers and cookies also bypassed `add_param_once`, so a repeated header rendered as two conflicting values. | `spec/functional_test/fixtures/specification/har_http2/chrome.har` (new); existing `specification/har` fixture drops `header:Host` |
| `mitmproxy` | FN | `return if @url.empty?` — scanning a capture on its own produced **zero** endpoints. HAR answers the same question by reporting the absolute URL. | `spec/unit_test/analyzer/specification/mitmproxy_spec.cr` "emits absolute URLs when no --url is supplied" |
| `mitmproxy` | FP | The query string stayed in the endpoint URL while also being reported as `query` params, duplicating them and splitting one endpoint into one per captured value (`/search?q=a`, `/search?q=b`, …). Pseudo-headers as above. | same spec file |
| `zap_sites_tree` | FN | ZAP records the URL a node was reached with, query string included; only `uri.path` was kept, so parameters ZAP had already discovered were discarded. `URI.parse` was also unguarded, so one malformed node URL aborted the rest of the file. | `spec/functional_test/fixtures/specification/zap/` — `PUT /111` gained `query:q` |
| `oas2` + `oas3` detectors | perf | Both gated on a bare substring, then fully parsed the document to read one root key and threw the parse away; the analyzer parses it again immediately after. The loose gate also made the OAS2 detector fully parse every OAS3 document that links to its own `swagger.yaml` origin. | see table below |

## Perf

Measured with `just build-release`, page cache warm (one discarded run first),
three runs each. Corpora carved out of `APIs-guru/openapi-directory`; the
detector change was isolated by reverting only the two detector files and
rebuilding, so these numbers exclude the accuracy fixes above.

| corpus | size | before | after | speedup | output diff |
|---|---|---|---|---|---|
| 493 OAS3 `.yaml` | 114 MB | 3.99 / 4.02 / 3.93 s | 2.34 / 2.32 / 2.33 s | **1.71×** | 0 lines (18487 endpoints) |
| 434 OAS2 `.yaml` | 41 MB | 1.41 / 1.37 / 1.44 s | 0.84 / 0.84 / 0.84 s | **1.68×** | 0 lines (9302 endpoints) |
| 240 OAS `.json` | 27 MB | 0.46 / 0.46 / 0.45 s | 0.46 / 0.47 / 0.46 s | none (by design) | 0 lines (5353 endpoints) |

The JSON path deliberately keeps its parse: `"openapi": "3.0.0"` can sit nested
inside a wrapper document, so there is no structural guarantee to trade the
parse for. In YAML there is — a key at column 0 is a root key, because a block
scalar's content must be indented past the key that introduces it.

Also timed, no regression: 5151 `.proto` from `googleapis` + `grpc-go` (33 MB),
0.93 s before and after.

## Fixture A/B

`noir_ab.sh` over `spec/functional_test/fixtures`, per fixture directory,
before vs after. Five existing snapshots changed, plus one new file for the new
`har_http2` fixture:

- `specification__oas3.txt` (+1 line, 12 changed) — `/pets` → `/v1/pets` etc. from
  the `servers` fix. The added line is `GET /v1/gems`: `multiple_docs/first.yml`
  declares `servers: https://api.example.com/v1`, so its `/gems` is a different
  endpoint from the one in `no_servers/` and `nil_cast/`, which have no `servers`.
  The two used to collapse into one. Three more lines come from the new
  `server_urls/` fixture.
- `etc__multi_techs.txt` (4 changed) — same fix, same fixture document.
- `specification__raml_advanced.txt` (7 changed) — `{version}` → `v2`, and
  `path:version` correctly gone.
- `specification__har.txt` (1 changed) — `header:Host` dropped.
- `specification__zap.txt` (1 changed) — `PUT /111` gained `query:q`.
- `specification__har_http2.txt` — new fixture.

## Found and deliberately not fixed

- **The optimizer drops any param whose name contains a space.**
  `src/optimizer/optimizer.cr:291` filters them out for every analyzer, with a
  documented rationale (a space breaks the curl builder and makes the emitted
  OAS document invalid). A query parameter named `ip address` is legal on the
  wire — it just needs percent-encoding — so this is a real FN:
  `openapi-directory/APIs/mist.com/0.37.7/openapi.yaml:68010` declares
  `name: ip address` in `query`, and it is missing from all 10 endpoints that
  reference it. Fixing it means changing a global policy shared by every
  analyzer and fixing the curl/OAS emitters that depend on it, which is well
  outside a spec-analyzer PR. Flagging it rather than half-fixing it.
- **OAS 3.1 `webhooks` and `callbacks` produce no endpoints.** Both describe
  routes the *caller* implements rather than routes the documented API serves,
  so whether noir should emit them is a product question, not a bug. Not
  touched.
- **`graphql_sdl_parser`'s interpolated root-type alternation.** The brief
  flagged its cost; it is `Regex.new(...)` built once per document, not per
  evaluation, so it is one PCRE2 compile per SDL file. Left alone —
  the correctness side (`extend type`, directives, custom root names) is
  already handled.
- **Param-level accuracy for OAS is otherwise clean.** Across the same 320-doc
  sample, every query/header/cookie divergence other than the space-named case
  was a security-scheme-derived param that noir emits by design (`Authorization`,
  `apiKey`-in-query, `apiKey`-in-cookie). No FN found in `$ref` resolution,
  path-level vs operation-level `parameters` merging, `requestBody` content
  types, or `allOf`/`oneOf`/`anyOf` flattening.
- **Honest limits on the numbers.** The ground-truth extractor is PyYAML-based
  and rejects one corpus document (`versioneye.com/v1/openapi.yaml`, a
  `tag:yaml.org,2002:value` construct libyaml accepts) — noir is right there and
  the harness is wrong. Wall-clock figures are ±0.05 s run to run.

## Gates

`crystal spec spec/unit_test` (4359 ✓), `crystal spec spec/functional_test`
(22436 ✓), `crystal tool format --check`, `ameba` (1832 inspected, 0 failures) —
each run in its own command.
