### PR TITLE
fix(analyzer/csharp): stop cross-project and cross-DTO route contamination

### DIFF
--- a/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api/Program.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api/Program.cs
@@ -5,6 +5,15 @@ using Microsoft.AspNetCore.Routing;
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
+// A documented usage example must not register a route:
+//
+/// <example>
+/// <code>
+/// app.MapGet("/doc-only/{id}", ([FromRoute] string id) => id);
+/// </code>
+/// </example>
+// app.MapPost("/commented-out", () => Results.Ok());
+
 app.MapGet("/users", () => Results.Ok());
 app.MapGet("/users/{id:int}", (int id) => Results.Ok(id));
 app.MapPost("/users", (CreateUserRequest req) => Results.Created($"/users/{req.Name}", req));
@@ -27,6 +36,10 @@ var nested = app.MapGroup("/nested").MapGroup("/v2");
 v1.MapGet("/products/{sku}", ([FromRoute(Name = "sku")] string productSku, [FromHeader(Name = "X-Mode")] string mode) => Results.Ok());
 nested.MapPost("/orders", ([FromBody] CreateOrderRequest order) => Results.Ok(order));
 app.MapGroup("/inline").MapPost("/submit", (CreateUserRequest req) => Results.Ok(req));
+
+// An untyped lambda parameter only binds against the RequestDelegate
+// overload, i.e. it is the HttpContext — never a query value.
+app.MapGet("/raw", async context => await context.Response.WriteAsync("ok"));
 
 app.Run();
 

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/Controllers/BanksController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/Controllers/BanksController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Demo.Controllers
+{
+    // [AcceptVerbs] declares one action answering several verbs, optionally at
+    // its own route. [From*(Name = "…")] rebinds a parameter to the name the
+    // client actually sends. A `{id=5}` segment carries a template default,
+    // which is not part of the URL.
+    [Route("banks")]
+    public class BanksController : ControllerBase
+    {
+        [AcceptVerbs("PUT", "PATCH")]
+        public IActionResult Update(string accountNumber) => Ok(accountNumber);
+
+        [AcceptVerbs("PUT", "POST", Route = "transfer")]
+        public IActionResult Transfer([FromForm] string amount) => Ok(amount);
+
+        [HttpGet("branch/{branchId}")]
+        public IActionResult Branch([FromRoute(Name = "branchId")] string internalBranchKey) =>
+            Ok(internalBranchKey);
+
+        [HttpGet("page/{page=5}")]
+        public IActionResult Page(int page) => Ok(page);
+
+        [HttpGet("audit")]
+        public IActionResult Audit([FromHeader(Name = "X-Tenant")] string tenant) => Ok(tenant);
+    }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceA/Controllers/AlphaController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceA/Controllers/AlphaController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ServiceA.Controllers
+{
+    public class AlphaController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceA/Program.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceA/Program.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddControllersWithViews();
+
+var app = builder.Build();
+
+// Only ServiceA's controllers answer on this template.
+app.MapControllerRoute(
+    name: "service-a",
+    pattern: "a/{controller}/{action}");
+
+app.MapControllers();
+app.Run();

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceA/ServiceA.csproj
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceA/ServiceA.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
+  </ItemGroup>
+</Project>

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceB/Controllers/BetaController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceB/Controllers/BetaController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ServiceB.Controllers
+{
+    public class BetaController : Controller
+    {
+        public IActionResult Show(int id)
+        {
+            return View();
+        }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceB/Program.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceB/Program.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddControllersWithViews();
+
+var app = builder.Build();
+
+// Only ServiceB's controllers answer on this template.
+app.MapControllerRoute(
+    name: "service-b",
+    pattern: "b/{controller}/{action}/{id?}");
+
+app.MapControllers();
+app.Run();

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceB/ServiceB.csproj
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_solution/ServiceB/ServiceB.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
+  </ItemGroup>
+</Project>

--- a/spec/functional_test/fixtures/csharp/carter/Modules/DirectorsModule.cs
+++ b/spec/functional_test/fixtures/csharp/carter/Modules/DirectorsModule.cs
@@ -1,0 +1,34 @@
+using Carter;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System.Threading.Tasks;
+
+namespace CarterDemo.Modules
+{
+    // Derives from Carter's `CarterModule` base rather than implementing
+    // `ICarterModule`, and hangs every route off the constructor base path.
+    public class DirectorsModule : CarterModule
+    {
+        public DirectorsModule() : base("/directors")
+        {
+        }
+
+        public override void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapGet("/", (ILogger<DirectorsModule> logger) => "directors");
+
+            // A generic Map<Verb> registration.
+            app.MapPut<Person>("/", (Person person) => "updated");
+
+            app.MapGet("/qs", (string name, int[] numbers) => name);
+
+            // app.MapDelete("/commented-out", () => "never registered");
+        }
+    }
+
+    public class Person
+    {
+        public string Name { get; set; }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/fastendpoints/Features/Archive/Endpoint.cs
+++ b/spec/functional_test/fixtures/csharp/fastendpoints/Features/Archive/Endpoint.cs
@@ -1,0 +1,20 @@
+using FastEndpoints;
+
+namespace MyApp.Features.Archive;
+
+// A feature-local request DTO whose name collides with other feature folders'
+// DTOs. Resolution must stay inside this file, not union every same-named type
+// in the solution.
+public class Request
+{
+    public string ArchiveId { get; set; } = string.Empty;
+}
+
+public class Endpoint : Endpoint<Request>
+{
+    public override void Configure()
+    {
+        Post("/archive");
+        AllowAnonymous();
+    }
+}

--- a/spec/functional_test/fixtures/csharp/fastendpoints/Features/Restore/Endpoint.cs
+++ b/spec/functional_test/fixtures/csharp/fastendpoints/Features/Restore/Endpoint.cs
@@ -1,0 +1,17 @@
+using FastEndpoints;
+
+namespace MyApp.Features.Restore;
+
+public class Request
+{
+    public string RestoreToken { get; set; } = string.Empty;
+}
+
+public class Endpoint : Endpoint<Request>
+{
+    public override void Configure()
+    {
+        Post("/restore");
+        AllowAnonymous();
+    }
+}

--- a/spec/functional_test/testers/csharp/aspnet_core_minimal_api_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_minimal_api_spec.cr
@@ -34,6 +34,9 @@ expected_endpoints = [
   Endpoint.new("/inline/submit", "POST", [
     Param.new("req", "", "json"),
   ]),
+  # `async context => …` is the RequestDelegate overload: `context` is the
+  # HttpContext, not a query value.
+  Endpoint.new("/raw", "GET"),
 ]
 
 tester = FunctionalTester.new("fixtures/csharp/aspnet_core_minimal_api/", {
@@ -44,6 +47,17 @@ tester = FunctionalTester.new("fixtures/csharp/aspnet_core_minimal_api/", {
 tester.perform_tests
 
 describe "ASP.NET Core Minimal API analyzer edge cases" do
+  it "does not register routes written inside comments" do
+    tester.app.endpoints.any?(&.url.includes?("doc-only")).should be_false
+    tester.app.endpoints.any?(&.url.includes?("commented-out")).should be_false
+  end
+
+  it "drops an untyped lambda parameter instead of reporting it as a query param" do
+    raw = tester.app.endpoints.find { |e| e.url == "/raw" && e.method == "GET" }
+    raw.should_not be_nil
+    raw.as(Endpoint).params.empty?.should be_true
+  end
+
   it "marks minimal API routes with the dedicated technology" do
     users = tester.app.endpoints.find { |e| e.url == "/users" && e.method == "GET" }
     users.should_not be_nil

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_modern_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_modern_spec.cr
@@ -31,6 +31,20 @@ file_download_head = Endpoint.new("/Files/{id}/Download", "HEAD", [Param.new("id
 file_search_get = Endpoint.new("/Files/Search", "GET", [Param.new("q", "", "query")])
 file_search_post = Endpoint.new("/Files/Search", "POST", [Param.new("q", "", "query")])
 
+# [AcceptVerbs] declares one action answering several verbs, at the
+# conventional route or at an explicit `Route = "…"`.
+banks_update_put = Endpoint.new("/banks", "PUT", [Param.new("accountNumber", "", "form")])
+banks_update_patch = Endpoint.new("/banks", "PATCH", [Param.new("accountNumber", "", "form")])
+banks_transfer_put = Endpoint.new("/banks/transfer", "PUT", [Param.new("amount", "", "form")])
+banks_transfer_post = Endpoint.new("/banks/transfer", "POST", [Param.new("amount", "", "form")])
+
+# `[FromRoute(Name = "branchId")] string internalBranchKey` binds the route
+# value, so the parameter is `branchId`; `{page=5}` carries a template default
+# that is not part of the URL.
+banks_branch = Endpoint.new("/banks/branch/{branchId}", "GET", [Param.new("branchId", "", "path")])
+banks_page = Endpoint.new("/banks/page/{page}", "GET", [Param.new("page", "", "path")])
+banks_audit = Endpoint.new("/banks/audit", "GET", [Param.new("X-Tenant", "", "header")])
+
 expected_endpoints = [
   articles_list,
   article_get,
@@ -41,6 +55,13 @@ expected_endpoints = [
   file_download_head,
   file_search_get,
   file_search_post,
+  banks_update_put,
+  banks_update_patch,
+  banks_transfer_put,
+  banks_transfer_post,
+  banks_branch,
+  banks_page,
+  banks_audit,
 ]
 
 tester = FunctionalTester.new("fixtures/csharp/aspnet_core_mvc_modern/", {
@@ -67,6 +88,22 @@ describe "ASP.NET Core MVC modern controller edge cases" do
     list = tester.app.endpoints.find { |e| e.url == "/articles" && e.method == "GET" }
     list.should_not be_nil
     list.as(Endpoint).params.any? { |p| p.name == "cancellationToken" }.should be_false
+  end
+
+  it "emits one endpoint per verb listed in [AcceptVerbs]" do
+    tester.app.endpoints.count { |e| e.url == "/banks" }.should eq 2
+    tester.app.endpoints.count { |e| e.url == "/banks/transfer" }.should eq 2
+  end
+
+  it "uses the explicit [From*(Name = ...)] binding name, not the C# identifier" do
+    branch = tester.app.endpoints.find! { |e| e.url == "/banks/branch/{branchId}" }
+    branch.params.map(&.name).sort!.should eq(["branchId"])
+  end
+
+  it "strips a route-template default value from the URL and the param name" do
+    tester.app.endpoints.any?(&.url.includes?("{page=5}")).should be_false
+    page = tester.app.endpoints.find! { |e| e.url == "/banks/page/{page}" }
+    page.params.map(&.name).should eq(["page"])
   end
 
   it "records callees from an expression-bodied action body" do

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_solution_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_solution_spec.cr
@@ -1,0 +1,28 @@
+require "../../func_spec.cr"
+
+# One solution, two web projects, each declaring its own conventional route
+# template. A `MapControllerRoute` in ServiceA's Program.cs says nothing about
+# a controller compiled into ServiceB, so neither template may cross over.
+#
+# Before conventional routes were scoped to the owning `.csproj` directory,
+# this fixture produced four endpoints: the cross-product of both templates
+# with both controllers (`/a/Beta/Show` and `/b/Alpha/Index` are phantoms).
+expected_endpoints = [
+  Endpoint.new("/a/Alpha/Index", "GET"),
+  Endpoint.new("/b/Beta/Show/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+]
+
+tester = FunctionalTester.new("fixtures/csharp/aspnet_core_mvc_solution/", {
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+
+tester.perform_tests
+
+describe "ASP.NET Core MVC conventional-route project scoping" do
+  it "does not apply one project's route template to another project's controller" do
+    tester.app.endpoints.any? { |e| e.url == "/a/Beta/Show" }.should be_false
+    tester.app.endpoints.any? { |e| e.url == "/b/Alpha/Index" }.should be_false
+  end
+end

--- a/spec/functional_test/testers/csharp/carter_spec.cr
+++ b/spec/functional_test/testers/csharp/carter_spec.cr
@@ -33,6 +33,16 @@ expected_endpoints = [
   Endpoint.new("/admin/notify", "POST", [
     Param.new("subject", "", "form"),
   ]),
+  # `class DirectorsModule : CarterModule` with `: base("/directors")` — every
+  # route in the module hangs off the constructor base path.
+  Endpoint.new("/directors", "GET"),
+  Endpoint.new("/directors", "PUT", [
+    Param.new("person", "", "json"),
+  ]),
+  Endpoint.new("/directors/qs", "GET", [
+    Param.new("name", "", "query"),
+    Param.new("numbers", "", "query"),
+  ]),
 ]
 
 tester = FunctionalTester.new("fixtures/csharp/carter/", {
@@ -44,6 +54,18 @@ tester.perform_tests
 describe "Carter analyzer edge cases" do
   it "does not surface routes from /test/ fixtures" do
     tester.app.endpoints.any?(&.url.includes?("test-only")).should be_false
+  end
+
+  it "claims CarterModule-derived modules instead of leaving them to the minimal-API analyzer" do
+    directors = tester.app.endpoints.find { |e| e.url == "/directors" && e.method == "GET" }
+    directors.should_not be_nil
+    directors.as(Endpoint).details.technology.should eq "cs_carter"
+    # The un-prefixed route the minimal-API analyzer used to emit.
+    tester.app.endpoints.any? { |e| e.url == "/qs" }.should be_false
+  end
+
+  it "ignores a commented-out route registration" do
+    tester.app.endpoints.any?(&.url.includes?("commented-out")).should be_false
   end
 
   it "marks Carter modules with the cs_carter technology" do

--- a/spec/functional_test/testers/csharp/fastendpoints_spec.cr
+++ b/spec/functional_test/testers/csharp/fastendpoints_spec.cr
@@ -27,6 +27,14 @@ expected_endpoints = [
     Param.new("Payload", "", "json"),
     Param.new("SessionId", "", "cookie"),
   ]),
+  # Two feature folders each declaring `class Request` — the vertical-slice
+  # layout FastEndpoints documents. Each endpoint keeps its own DTO.
+  Endpoint.new("/archive", "POST", [
+    Param.new("ArchiveId", "", "json"),
+  ]),
+  Endpoint.new("/restore", "POST", [
+    Param.new("RestoreToken", "", "json"),
+  ]),
 ]
 
 tester = FunctionalTester.new("fixtures/csharp/fastendpoints/", {
@@ -41,6 +49,14 @@ describe "FastEndpoints analyzer edge cases" do
     status = tester.app.endpoints.find { |e| e.url == "/status" && e.method == "GET" }
     status.should_not be_nil
     status.as(Endpoint).params.empty?.should be_true
+  end
+
+  it "resolves a same-named request DTO per feature folder, not as a union" do
+    archive = tester.app.endpoints.find! { |e| e.url == "/archive" && e.method == "POST" }
+    archive.params.map(&.name).sort!.should eq(["ArchiveId"])
+
+    restore = tester.app.endpoints.find! { |e| e.url == "/restore" && e.method == "POST" }
+    restore.params.map(&.name).sort!.should eq(["RestoreToken"])
   end
 
   it "ignores commented-out verb calls inside Configure()" do

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -29,9 +29,25 @@ module Analyzer::CSharp
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-      route_patterns_by_base = load_route_patterns_by_base
-      analyze_controllers(route_patterns_by_base, include_callee)
+      project_roots = Common.project_roots(get_files_by_extension(".csproj"))
+      route_patterns_by_scope = load_route_patterns_by_scope(project_roots)
+      analyze_controllers(route_patterns_by_scope, project_roots, include_callee)
       @result
+    end
+
+    # Conventional routing is declared per project, so scope the collected
+    # `MapControllerRoute` templates to the `.csproj` directory that owns the
+    # declaring `Program.cs`/`Startup.cs`, falling back to the configured scan
+    # base for files outside any project.
+    #
+    # Keying on the scan base alone cross-products every template in a
+    # solution with every controller in it: dotnet/aspnetcore, scanned as one
+    # project, produced routes like
+    # `/ConventionalTransformerRoute/{controller}/Login` by applying one
+    # sample's template to another sample's controller — 138 of its 738
+    # `cs_aspnet_core_mvc` endpoints were such phantoms.
+    private def route_scope_for(file : String, project_roots : Array(String)) : String
+      Common.project_root_for(file, project_roots) || configured_base_for(file)
     end
 
     private def extract_params_from_block(block : String) : Array(Param)
@@ -87,8 +103,8 @@ module Analyzer::CSharp
       params.uniq(&.name)
     end
 
-    private def load_route_patterns_by_base : Hash(String, Array(String))
-      patterns_by_base = Hash(String, Array(String)).new do |hash, key|
+    private def load_route_patterns_by_scope(project_roots : Array(String)) : Hash(String, Array(String))
+      patterns_by_scope = Hash(String, Array(String)).new do |hash, key|
         hash[key] = [] of String
       end
       files = get_files_by_extension(".cs").select do |file|
@@ -99,22 +115,22 @@ module Analyzer::CSharp
       files.each do |file|
         begin
           content = read_file_content(file)
-          patterns_by_base[configured_base_for(file)].concat(extract_route_patterns(content))
+          patterns_by_scope[route_scope_for(file, project_roots)].concat(extract_route_patterns(content))
         rescue e
           logger.debug "Failed to read #{file}: #{e.message}"
         end
       end
 
       @base_paths.each do |base_path|
-        patterns_by_base[base_path] << DEFAULT_ROUTE if patterns_by_base[base_path].empty?
+        patterns_by_scope[base_path] << DEFAULT_ROUTE if patterns_by_scope[base_path].empty?
       end
 
-      patterns_by_base.each do |base_path, patterns|
+      patterns_by_scope.each do |scope, patterns|
         patterns << DEFAULT_ROUTE if patterns.empty?
-        patterns_by_base[base_path] = patterns.uniq
+        patterns_by_scope[scope] = patterns.uniq
       end
 
-      patterns_by_base
+      patterns_by_scope
     end
 
     private def extract_route_patterns(content : String) : Array(String)
@@ -150,7 +166,8 @@ module Analyzer::CSharp
       patterns
     end
 
-    private def analyze_controllers(route_patterns_by_base : Hash(String, Array(String)), include_callee : Bool)
+    private def analyze_controllers(route_patterns_by_scope : Hash(String, Array(String)),
+                                    project_roots : Array(String), include_callee : Bool)
       controller_files = get_files_by_extension(".cs").select do |file|
         base = File.basename(file)
         next false if Common.csharp_test_path?(file)
@@ -158,7 +175,7 @@ module Analyzer::CSharp
       end
 
       controller_files.each do |file|
-        route_patterns = route_patterns_by_base[configured_base_for(file)]? || [DEFAULT_ROUTE]
+        route_patterns = route_patterns_by_scope[route_scope_for(file, project_roots)]? || [DEFAULT_ROUTE]
         analyze_controller_file(file, route_patterns, include_callee)
       end
     end
@@ -203,9 +220,15 @@ module Analyzer::CSharp
           attr_line, advance = stitch_multiline_attribute(lines, i)
           line = attr_line if advance > 0
 
-          verb, verb_route, route_attr, found_attribute = collect_verb_route(line, route_attr)
-          explicit_endpoint_attribute ||= found_attribute
-          verb_routes << {verb, verb_route} if verb
+          if accept = collect_accept_verbs(line, route_attr)
+            accept_verbs, accept_route = accept
+            accept_verbs.each { |accept_verb| verb_routes << {accept_verb, accept_route} }
+            explicit_endpoint_attribute = true
+          else
+            verb, verb_route, route_attr, found_attribute = collect_verb_route(line, route_attr)
+            explicit_endpoint_attribute ||= found_attribute
+            verb_routes << {verb, verb_route} if verb
+          end
           non_action_attribute = true if line.includes?("[NonAction")
 
           # Skip the continuation lines we just consumed; they're
@@ -278,7 +301,7 @@ module Analyzer::CSharp
     # returns `{line, 0}` so the existing fast path is preserved.
     private def stitch_multiline_attribute(lines : Array(String), start : Int32) : Tuple(String, Int32)
       line = lines[start]
-      return {line, 0} unless line =~ /\[(Http(Post|Get|Put|Delete|Patch|Head|Options)|Route)\b/
+      return {line, 0} unless line =~ /\[(Http(Post|Get|Put|Delete|Patch|Head|Options)|Route|AcceptVerbs)\b/
 
       # The attribute closes when paren+bracket depth returns to
       # zero. If the opening line is already balanced (paren and
@@ -303,6 +326,37 @@ module Analyzer::CSharp
       end
 
       {joined, idx - start}
+    end
+
+    # `[AcceptVerbs("PUT", "PATCH")]` / `[AcceptVerbs("PUT", Route = "Bank")]`
+    # declares an action answering several verbs at one route — the MVC
+    # equivalent of stacking `[HttpPut]` and `[HttpPatch]`. It was ignored
+    # entirely, so such actions fell back to the conventional GET route.
+    ACCEPT_VERBS_RE       = /\[AcceptVerbs\s*\(([^\]]*)\)\s*\]/
+    ACCEPT_VERBS_ROUTE_RE = /\bRoute\s*=\s*@?"([^"]+)"/
+    ACCEPT_VERB_TOKENS    = %w[GET POST PUT DELETE PATCH HEAD OPTIONS]
+
+    private def collect_accept_verbs(line : String, route_attr : String) : Tuple(Array(String), String)?
+      match = ACCEPT_VERBS_RE.match(line)
+      return unless match
+
+      args = match[1]
+      route = ACCEPT_VERBS_ROUTE_RE.match(args).try(&.[1]) || route_attr
+      verbs = [] of String
+      args.scan(/@?"([^"]+)"/) do |literal|
+        token = literal[1].upcase
+        next unless ACCEPT_VERB_TOKENS.includes?(token)
+        verbs << token unless verbs.includes?(token)
+      end
+      # `HttpMethods.Put`-style arguments carry the verb as an identifier.
+      args.scan(/\bHttpMethods\s*\.\s*([A-Za-z]+)/) do |token|
+        upcased = token[1].upcase
+        next unless ACCEPT_VERB_TOKENS.includes?(upcased)
+        verbs << upcased unless verbs.includes?(upcased)
+      end
+      return if verbs.empty?
+
+      {verbs, route}
     end
 
     # Attribute name carrying each verb, for `extract_attribute_route`.
@@ -385,6 +439,7 @@ module Analyzer::CSharp
       default_param_type = default_param_type(http_method)
 
       split_csharp_parameters(param_list).each do |param_def|
+        explicit_name = Common.explicit_binding_name(param_def)
         cleaned_def, param_type = normalize_param_definition(param_def)
         next if cleaned_def.empty?
         next if param_type == "service"
@@ -402,7 +457,7 @@ module Analyzer::CSharp
             next if type_token && Common.csharp_service_type?(type_token)
           end
 
-          parameters << Param.new(param_name, "", param_type || default_param_type)
+          parameters << Param.new(explicit_name || param_name, "", param_type || default_param_type)
         end
       end
 
@@ -590,16 +645,16 @@ module Analyzer::CSharp
         next unless raw
 
         optional = raw.ends_with?("?")
-        name = raw.split(":").first
-        name = name.gsub(/\?$/, "")
+        name = Common.route_placeholder_name(raw)
 
         if optional && !param_names.includes?(name)
           result = result.gsub("/{#{raw}}", "")
           result = result.gsub("{#{raw}}/", "")
           result = result.gsub("{#{raw}}", "")
-        elsif optional
-          cleaned = raw.gsub("?", "")
-          result = result.gsub("{#{raw}}", "{#{cleaned}}")
+        elsif optional || raw.includes?('=')
+          # `{id?}` -> `{id}` and `{id=5}` -> `{id}`: a default value belongs
+          # to the route template, not to the URL a client sends.
+          result = result.gsub("{#{raw}}", "{#{raw.split('=').first.rstrip('?')}}")
         end
       end
 
@@ -633,10 +688,7 @@ module Analyzer::CSharp
       route.scan(placeholder_regex) do |match|
         raw = match[1]? || match[0]
         next unless raw
-        cleaned = raw.split(":").first
-        cleaned = cleaned.gsub(/\?$/, "")
-        cleaned = cleaned.lstrip("*")
-        keys << cleaned
+        keys << Common.route_placeholder_name(raw)
       end
 
       keys.uniq

--- a/src/analyzer/analyzers/csharp/carter.cr
+++ b/src/analyzer/analyzers/csharp/carter.cr
@@ -1,22 +1,45 @@
 require "../../../models/analyzer"
 require "./common"
+require "./minimal_api_support"
 
 module Analyzer::CSharp
   # Extracts endpoints from Carter (https://github.com/CarterCommunity/Carter)
-  # modules — classes implementing `ICarterModule` that register
-  # minimal-API routes inside `AddRoutes(IEndpointRouteBuilder)`.
+  # modules. A Carter module is a class that either implements
+  # `ICarterModule` or derives from the `CarterModule` base class, and
+  # registers minimal-API routes inside `AddRoutes(IEndpointRouteBuilder)`.
   #
-  # The extraction is scoped to each `AddRoutes` body so that
-  # MapGroup prefixes don't leak across modules, and so that files
-  # owned by the `cs_aspnet_core_mvc` analyzer (which skips
-  # `ICarterModule` files) are not double-counted with a stale tech
-  # tag.
+  # `CarterModule` additionally takes a **base path** through its constructor
+  # (`public DirectorsModule() : base("/directors")`), which every route in
+  # that module hangs off. Modules using that base were previously invisible
+  # to this analyzer (it required the literal string `ICarterModule`), so they
+  # fell through to `cs_aspnet_core_minimal_api`, which emitted their routes
+  # without the base path — `GET /` and `GET /qs` instead of `GET /directors`
+  # and `GET /directors/qs`.
+  #
+  # Route parsing itself is the same job the minimal-API analyzer does, so it
+  # runs on the shared `MinimalApiSupport` helpers with the module base path
+  # passed in as a prefix. That also brings delegate parameter binding,
+  # `MapGroup` composition, method-group handlers and generic
+  # `MapPut<T>("/x", …)` registrations to Carter, none of which the previous
+  # hand-rolled copy supported.
+  #
+  # Extraction is scoped to each module's `AddRoutes` body so MapGroup
+  # prefixes and base paths don't leak between modules declared in one file.
   class Carter < Analyzer
     analyzer_for "cs_carter"
 
     include Common
+    include MinimalApiSupport
 
-    MAP_METHODS = %w[Get Post Put Delete Patch Head Options]
+    # `class X : ICarterModule` / `class X : CarterModule` / with generics or
+    # extra interfaces in the base list.
+    MODULE_CLASS_RE = /\bclass\s+(\w+)(?:\s*<[^>]*>)?\s*:[^{]*\bI?CarterModule\b/
+
+    # `public DirectorsModule() : base("/directors")` — Carter's constructor
+    # base path. `base()` with no literal leaves the prefix empty.
+    BASE_PATH_RE = /:\s*base\s*\(\s*@?"([^"]*)"/
+
+    ADD_ROUTES_RE = /\bAddRoutes\s*\(/
 
     def analyze
       include_callee = callees_needed?
@@ -26,329 +49,110 @@ module Analyzer::CSharp
         next if Common.csharp_test_path?(file)
 
         content = read_file_content(file)
-        next unless content.includes?("ICarterModule")
+        next unless Common.carter_module_source?(content)
 
-        lines = content.lines
-        masked_lines = Noir::CSharpLexer.new(content).masked_lines
-        each_add_routes_block(lines, masked_lines) do |block_lines, block_start_index|
-          group_prefixes = extract_map_group_prefixes(block_lines)
-          analyze_add_routes_block(block_lines, block_start_index, file, lines, masked_lines, group_prefixes, include_callee)
-        end
+        analyze_carter_file(file, content, include_callee)
       end
 
       @result
     end
 
-    private def each_add_routes_block(lines : Array(String), masked_lines : Array(String), &)
-      i = 0
-      while i < lines.size
-        line = lines[i]
-        if add_routes_signature?(line)
-          _, end_index = build_signature(lines, masked_lines, i)
-          body_start = end_index
-          block_lines, body_end = collect_method_body_lines(lines, body_start)
-          yield block_lines, body_start
-          i = body_end
-        end
-        i += 1
-      end
-    end
+    private def analyze_carter_file(file : String, content : String, include_callee : Bool)
+      lexer = Noir::CSharpLexer.new(content)
+      # Comment-blanked, string-preserving view: a commented-out
+      # `//app.MapPut<Person>("/", …)` must not register a route, but the live
+      # route literals still have to be readable.
+      lines = lexer.code_lines
+      masked_lines = lexer.masked_lines
 
-    private def add_routes_signature?(line : String) : Bool
-      return false unless line.includes?("AddRoutes")
-      line.includes?("public") || line.includes?("void")
-    end
-
-    private def collect_method_body_lines(lines : Array(String), start_index : Int32) : Tuple(Array(String), Int32)
-      collected = [] of String
-      brace = 0
-      started = false
-      index = start_index
-
-      while index < lines.size
-        line = lines[index]
-        brace += line.count('{') - line.count('}')
-        if !started && line.includes?("{")
-          started = true
-          collected << line
-          if brace <= 0 && line.includes?("}")
-            return {collected, index}
-          end
-          index += 1
-          next
-        end
-
-        if started
-          collected << line
-          if brace <= 0
-            return {collected, index}
-          end
-        end
-
-        index += 1
-      end
-
-      {collected, index}
-    end
-
-    private def analyze_add_routes_block(block_lines : Array(String), block_start_index : Int32, file : String, file_lines : Array(String), masked_lines : Array(String), group_prefixes : Hash(String, String), include_callee : Bool)
-      map_regex = /(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"]+)"/m
-      chained_group_map_regex = /MapGroup\s*\(\s*"([^"]+)"\s*\)\s*\.Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"]+)"/m
-      map_methods_block_regex = /(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MapMethods\s*\(\s*"([^"]+)"\s*,\s*([\s\S]+?)=>/m
-      chained_group_map_methods_regex = /MapGroup\s*\(\s*"([^"]+)"\s*\)\s*\.MapMethods\s*\(\s*"([^"]+)"\s*,\s*([\s\S]+?)=>/m
-
-      block_lines.each_with_index do |line, local_index|
-        absolute_index = block_start_index + local_index
-
-        if route_builder_line?(line)
-          block = extract_map_block(block_lines, local_index)
-          if chained_match = chained_group_map_regex.match(block)
-            http_method = chained_match[2].upcase
-            route = join_route_parts(chained_match[1], chained_match[3])
-          elsif match = map_regex.match(block)
-            receiver = match[1]?
-            http_method = match[2].upcase
-            route = apply_group_prefix(match[3], receiver, group_prefixes)
-          else
-            route = nil
-            http_method = nil
-          end
-
-          if route && http_method
-            extra_params = extract_params_from_block(block)
-            extra_params.concat(extract_bind_params_from_file(block, file_lines, masked_lines))
-            endpoint = build_endpoint_from_route(route, http_method, file, absolute_index + 1, extra_params)
-            if endpoint
-              attach_csharp_callees(endpoint, block, file, absolute_index + 1, include_callee)
-              @result << endpoint
-            end
-          end
-        end
-
-        if line.includes?("MapMethods")
-          block = extract_map_block(block_lines, local_index)
-          route = nil
-          methods = [] of String
-
-          if chained_match = chained_group_map_methods_regex.match(block)
-            route = join_route_parts(chained_match[1], chained_match[2])
-            methods_section = chained_match[3]
-            methods = methods_section.scan(/"([A-Za-z]+)"/).map(&.[1]?.to_s.upcase).reject(&.empty?).uniq!
-          elsif match = block.match(/(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MapMethods\s*\(\s*"([^"]+)"\s*,\s*new[^{]*\{([^}]*)\}/m)
-            receiver = match[1]?
-            route = apply_group_prefix(match[2], receiver, group_prefixes)
-            methods = match[3].split(",").map(&.gsub(/["\s]/, "").upcase).reject(&.empty?).uniq!
-          elsif match = map_methods_block_regex.match(block)
-            receiver = match[1]?
-            route = apply_group_prefix(match[2], receiver, group_prefixes)
-            methods_section = match[3]
-            methods = methods_section.scan(/"([A-Za-z]+)"/).map(&.[1]?.to_s.upcase).reject(&.empty?).uniq!
-          end
-
-          if route && methods.size > 0
-            extra_params = extract_params_from_block(block)
-            extra_params.concat(extract_bind_params_from_file(block, file_lines, masked_lines))
-            methods.each do |method|
-              endpoint = build_endpoint_from_route(route, method, file, absolute_index + 1, extra_params)
-              if endpoint
-                attach_csharp_callees(endpoint, block, file, absolute_index + 1, include_callee)
-                @result << endpoint
-              end
-            end
-          end
+      each_module(lines, masked_lines) do |prefix, class_start, class_end|
+        each_add_routes_body(lines, masked_lines, class_start, class_end) do |body_start, body_end|
+          analyze_add_routes_body(file, lines, masked_lines, body_start, body_end, prefix, include_callee)
         end
       end
     end
 
-    private def route_builder_line?(line : String) : Bool
-      MAP_METHODS.any? { |verb| line.includes?("Map#{verb}") }
-    end
-
-    private def extract_map_group_prefixes(block_lines : Array(String)) : Hash(String, String)
-      prefixes = Hash(String, String).new
-      group_assignment_regex = /(?:var\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\.MapGroup\s*\(\s*"([^"]+)"\s*\)/
-
-      block_lines.each_with_index do |line, idx|
-        # The assignment can only match a line that mentions `MapGroup`. Skipping
-        # the rest keeps the unbounded identifier captures from backtracking across
-        # a long token run (e.g. a multi-kilobyte route literal), which is O(n²).
-        next unless line.includes?("MapGroup")
-
-        # The `var x =` head may sit on the previous line
-        # (`var g =\n  app.MapGroup("/x")`), so match over a two-line window. The
-        # window is bounded, so it can't reintroduce the cross-block backtracking
-        # the per-line guard removed. A single-line assignment matched again from
-        # the next line's window just rewrites the same key with the same value.
-        window = idx > 0 ? "#{block_lines[idx - 1]}\n#{line}" : line
-        window.scan(group_assignment_regex) do |match|
-          variable = match[1]
-          parent = match[2]
-          prefix = match[3]
-          parent_prefix = prefixes[parent]? || ""
-          prefixes[variable] = join_route_parts(parent_prefix, prefix)
-        end
-      end
-
-      prefixes
-    end
-
-    private def apply_group_prefix(route : String, receiver : String?, group_prefixes : Hash(String, String)) : String
-      return route unless receiver
-      prefix = group_prefixes[receiver]?
-      return route unless prefix
-      join_route_parts(prefix, route)
-    end
-
-    private def join_route_parts(*parts : String) : String
-      clean_parts = parts.compact_map do |part|
-        clean = part.strip.gsub(/^\//, "").gsub(/\/$/, "")
-        clean.empty? ? nil : clean
-      end
-      return "/" if clean_parts.empty?
-      "/" + clean_parts.join("/")
-    end
-
-    private def extract_map_block(lines : Array(String), start_index : Int32) : String
-      io = String::Builder.new
-      paren_depth = 0
-      brace_depth = 0
-      i = start_index
-
-      while i < lines.size
-        line = lines[i]
-        paren_depth += line.count('(') - line.count(')')
-        brace_depth += line.count('{') - line.count('}')
-        io << line
-        io << '\n'
-
-        if paren_depth <= 0 && brace_depth <= 0 && line.includes?(";")
-          break
-        end
-
-        i += 1
-      end
-
-      io.to_s
-    end
-
-    private def extract_params_from_block(block : String) : Array(Param)
-      params = [] of Param
-      query_regex = /Request\.Query\["([^"]+)"\]/
-      header_regex = /Request\.Headers\["([^"]+)"\]/
-      cookie_regex = /Request\.Cookies\["([^"]+)"\]/
-      form_regex = /Request\.Form\["([^"]+)"\]/
-      json_property_regex = /GetProperty\s*\(\s*"([^"]+)"\s*\)/
-
-      block.scan(query_regex) do |match|
-        key = match[1]? || match[0]
-        params << Param.new(key, "", "query") if key && !key.empty?
-      end
-      block.scan(header_regex) do |match|
-        key = match[1]? || match[0]
-        params << Param.new(key, "", "header") if key && !key.empty?
-      end
-      block.scan(cookie_regex) do |match|
-        key = match[1]? || match[0]
-        params << Param.new(key, "", "cookie") if key && !key.empty?
-      end
-      block.scan(form_regex) do |match|
-        key = match[1]? || match[0]
-        params << Param.new(key, "", "form") if key && !key.empty?
-      end
-      block.scan(json_property_regex) do |match|
-        key = match[1]? || match[0]
-        params << Param.new(key, "", "json") if key && !key.empty?
-      end
-
-      params.uniq(&.name)
-    end
-
-    private def extract_bind_params_from_file(block : String, lines : Array(String), masked_lines : Array(String)) : Array(Param)
-      return [] of Param unless block.includes?("Bind(") || block.includes?("BindAsync(")
-
-      params = [] of Param
+    # Yields `{base_path, class_body_start, class_body_end}` for every Carter
+    # module class in the file. Classes are located by their base list, so a
+    # module nested inside a plain holder class (`static class Outer { class
+    # HomeModule : ICarterModule { … } }`) is still found.
+    private def each_module(lines : Array(String), masked_lines : Array(String), &)
       lines.each_with_index do |line, index|
-        next unless line.includes?("Bind(") || line.includes?("BindAsync(")
-        next unless line.includes?("public") || line.includes?("private") || line.includes?("protected") || line.includes?("internal") || line.includes?("static")
+        next unless (masked_lines[index]? || line).includes?("class")
+        next unless line.matches?(MODULE_CLASS_RE)
 
-        _, end_idx = build_signature(lines, masked_lines, index)
-        body = extract_method_block(lines, masked_lines, end_idx)
-        params.concat(extract_params_from_block(body))
-      end
-
-      params.uniq(&.name)
-    end
-
-    private def build_endpoint_from_route(raw_route : String, http_method : String, file : String, line : Int32, extra_params : Array(Param) = [] of Param) : Endpoint?
-      return if raw_route.empty?
-
-      route = normalize_route(raw_route)
-      params = build_path_params(route)
-      extra_params.each do |param|
-        params << param unless params.any? { |p| p.name == param.name && p.param_type == param.param_type }
-      end
-      route = prune_optional_placeholders(route, params)
-
-      details = Details.new(PathInfo.new(file, line))
-      endpoint = Endpoint.new(route, http_method, details)
-      params.each { |param| endpoint.params << param }
-      endpoint
-    end
-
-    private def normalize_route(route : String) : String
-      normalized = route.strip
-      normalized = normalized.gsub(/^\//, "").gsub(/\/+/, "/")
-      normalized = "/" + normalized unless normalized.starts_with?("/")
-      normalized = "/" if normalized == "//" || normalized == "/"
-      normalized
-    end
-
-    private def build_path_params(route : String) : Array(Param)
-      extract_route_placeholders(route).map do |name|
-        Param.new(name, "", "path")
+        class_end = block_end(masked_lines, index)
+        prefix = module_base_path(lines, index, class_end)
+        yield prefix, index, class_end
       end
     end
 
-    private def prune_optional_placeholders(route : String, parameters : Array(Param)) : String
-      param_names = parameters.map(&.name)
-      result = route.dup
-
-      placeholder_regex = /\{([^}]+)\}/
-      route.scan(placeholder_regex) do |match|
-        raw = match[1]? || match[0]
-        next unless raw
-
-        optional = raw.ends_with?("?")
-        name = raw.split(":").first
-        name = name.gsub(/\?$/, "")
-
-        if optional && !param_names.includes?(name)
-          result = result.gsub("/{#{raw}}", "")
-          result = result.gsub("{#{raw}}/", "")
-          result = result.gsub("{#{raw}}", "")
-        elsif optional
-          cleaned = raw.gsub("?", "")
-          result = result.gsub("{#{raw}}", "{#{cleaned}}")
+    # The constructor base path declared inside the module class body. Only
+    # the module's own constructor can carry it, and a `: base("…")` clause
+    # appears nowhere else in a Carter module, so the first match within the
+    # class body wins.
+    private def module_base_path(lines : Array(String), class_start : Int32, class_end : Int32) : String
+      (class_start..Math.min(class_end, lines.size - 1)).each do |idx|
+        line = lines[idx]
+        next unless line.includes?("base")
+        if match = BASE_PATH_RE.match(line)
+          return match[1]
         end
       end
-
-      result
+      ""
     end
 
-    private def extract_route_placeholders(route : String) : Array(String)
-      keys = [] of String
-      placeholder_regex = /\{([^}]+)\}/
-
-      route.scan(placeholder_regex) do |match|
-        raw = match[1]? || match[0]
-        next unless raw
-        cleaned = raw.split(":").first
-        cleaned = cleaned.gsub(/\?$/, "")
-        cleaned = cleaned.lstrip("*")
-        keys << cleaned
+    private def each_add_routes_body(lines : Array(String), masked_lines : Array(String),
+                                     class_start : Int32, class_end : Int32, &)
+      idx = class_start
+      limit = Math.min(class_end, lines.size - 1)
+      while idx <= limit
+        line = lines[idx]
+        if line.matches?(ADD_ROUTES_RE) && (line.includes?("public") || line.includes?("void"))
+          _, sig_end = build_signature(lines, masked_lines, idx)
+          body_end = block_end(masked_lines, sig_end)
+          yield sig_end, Math.min(body_end, limit)
+          idx = body_end
+        end
+        idx += 1
       end
+    end
 
-      keys.uniq
+    private def analyze_add_routes_body(file : String, lines : Array(String), masked_lines : Array(String),
+                                        body_start : Int32, body_end : Int32,
+                                        prefix : String, include_callee : Bool)
+      body_text = lines[body_start..Math.min(body_end, lines.size - 1)].join('\n')
+      group_prefixes = extract_map_group_prefixes(body_text)
+
+      idx = body_start
+      while idx <= body_end && idx < lines.size
+        line = lines[idx]
+        if route_builder_line?(line)
+          block = extract_map_block(lines, idx)
+          extract_endpoints_from_map_block(block, group_prefixes, file, idx + 1,
+            lines, masked_lines, include_callee, prefix).each do |endpoint|
+            @result << endpoint
+          end
+        end
+        idx += 1
+      end
+    end
+
+    # Index of the line closing the brace block that opens at or after
+    # `start_index`. Counting runs over the masked twin so a `}` inside a
+    # string literal can't close the block early.
+    private def block_end(masked_lines : Array(String), start_index : Int32) : Int32
+      depth = 0
+      started = false
+      idx = start_index
+      while idx < masked_lines.size
+        masked = masked_lines[idx]
+        depth += masked.count('{') - masked.count('}')
+        started ||= masked.includes?("{")
+        return idx if started && depth <= 0
+        idx += 1
+      end
+      masked_lines.size - 1
     end
   end
 end

--- a/src/analyzer/analyzers/csharp/cli.cr
+++ b/src/analyzer/analyzers/csharp/cli.cr
@@ -63,7 +63,7 @@ module Analyzer::CSharp
     # detector uses). Cocona is matched via its `using Cocona` / `CoconaApp.*`
     # forms for the same reason ("Cocona" alone is specific enough as a
     # substring, but we keep the same regex shape for consistency).
-    CLI_LIB_MARKERS  = ["System.CommandLine", "CliFx", "Spectre.Console.Cli", "McMaster.Extensions.CommandLineUtils"]
+    CLI_LIB_MARKERS  = /System\.CommandLine|CliFx|Spectre\.Console\.Cli|McMaster\.Extensions\.CommandLineUtils/
     CLP_NAMESPACE    = /\busing\s+CommandLine\b|\bCommandLine\.Parser\b|\bParser\.Default\.ParseArguments\b/
     COCONA_NAMESPACE = /\busing\s+Cocona\b|\bCoconaApp\.(?:Create|Run)\b/
     WEB_HOST_RE      = /\bWebApplication\.(?:Create(?:Builder|SlimBuilder|EmptyBuilder)?|CreateDefault)\b|\bnew\s+HttpListener\b|\.MapGet\s*\(|\.MapControllers\s*\(|\[\s*ApiController\s*\]|:\s*ControllerBase\b|\bHost\.CreateDefaultBuilder\b/
@@ -97,8 +97,8 @@ module Analyzer::CSharp
     end
 
     private def cli_library?(content : String) : Bool
-      CLI_LIB_MARKERS.any? { |m| content.includes?(m) } ||
-        content.matches?(CLP_NAMESPACE) || content.matches?(COCONA_NAMESPACE)
+      content_matches?(content, CLI_LIB_MARKERS) ||
+        content_matches?(content, CLP_NAMESPACE) || content_matches?(content, COCONA_NAMESPACE)
     end
 
     private def cli_evidence?(content : String) : Bool

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -48,6 +48,62 @@ module Analyzer::CSharp::Common
     content.matches?(ASPNET_FRAMEWORK_NAMESPACE_RE)
   end
 
+  # A Carter module is either `class X : ICarterModule` or
+  # `class X : CarterModule` — the latter being Carter's abstract base, which
+  # adds a constructor base path (`: base("/directors")`) and the request
+  # filters. Both shapes own their `AddRoutes` body, so the Carter analyzer
+  # claims them and the minimal-API analyzer skips them.
+  #
+  # `\bCarterModule\b` alone does not match inside `ICarterModule` (`I` and `C`
+  # are both word characters), hence the explicit optional `I`.
+  CARTER_MODULE_RE = /\bI?CarterModule\b/
+
+  def self.carter_module_source?(content : String) : Bool
+    content.matches?(CARTER_MODULE_RE)
+  end
+
+  # Directories that own a `.csproj`, longest first. A .NET *project* is the
+  # unit that owns a routing table: `MapControllerRoute` in one project's
+  # `Program.cs` says nothing about a controller compiled into a sibling
+  # project, even though both sit under one configured scan base.
+  def self.project_roots(csproj_paths : Array(String)) : Array(String)
+    roots = csproj_paths.map { |path| File.dirname(path) }
+    roots.uniq!
+    roots.sort_by! { |dir| -dir.size }
+    roots
+  end
+
+  # The longest project root containing `path`, or nil when the file sits
+  # outside every discovered project (no `.csproj` in the scan at all, the
+  # shape most fixtures and single-file samples have).
+  def self.project_root_for(path : String, roots : Array(String)) : String?
+    roots.find do |root|
+      path == root || path.starts_with?("#{root}/")
+    end
+  end
+
+  # `[FromRoute(Name = "organizationId")] Guid sponsoringOrgId` binds the
+  # *route* value `organizationId`; the C# identifier is only the local name.
+  # Reporting the identifier invents a parameter the client cannot send and
+  # hides the one it must.
+  EXPLICIT_BINDING_NAME_RE = /\[From(?:Query|Route|Body|Header|Form|Cookie)\s*\(\s*(?:[A-Za-z]+\s*(?:=|:)\s*)?@?"([^"]+)"/
+
+  def self.explicit_binding_name(param_def : String) : String?
+    EXPLICIT_BINDING_NAME_RE.match(param_def).try(&.[1])
+  end
+
+  # Strips a route-template placeholder down to its bare parameter name:
+  # `{id:int}` → `id`, `{slug?}` → `slug`, `{*catchAll}` → `catchAll`,
+  # `{id=5}` → `id` (a default value), `{**slug:regex(a=b)}` → `slug`.
+  #
+  # The `=default` form was previously kept verbatim, so a template like
+  # `/items/{id=5}` emitted a parameter literally named `id=5`.
+  def self.route_placeholder_name(raw : String) : String
+    name = raw.split(':').first
+    name = name.split('=').first
+    name.strip.lstrip('*').rstrip('?')
+  end
+
   # `IFormFile`/`IFormFileCollection`/`IFormCollection` are interfaces but
   # bind from the request body (file upload / form), not from DI — keep
   # them as request inputs even though they match the interface rule below.
@@ -66,9 +122,15 @@ module Analyzer::CSharp::Common
   # common domain/entity names (e.g. `Client`, `Provider`, `Factory`) are
   # left out so request DTOs aren't dropped by mistake. Interface-typed
   # DI is caught separately by the `I<Pascal>` rule.
+  #
+  # `Handler` and `DataSource` joined the list after a minimal-API sweep:
+  # Bitwarden injects `AccessRequestEndpointsHandler handler` straight into its
+  # handler delegates and Carter's sample injects `EndpointDataSource`, both of
+  # which surfaced as query parameters. Neither suffix names a request DTO in
+  # practice.
   SERVICE_TYPE_SUFFIXES = %w[
     Repository Service Services Manager Mediator Mapper Accessor
-    Dispatcher Publisher DbContext Context Logger
+    Dispatcher Publisher DbContext Context Logger Handler DataSource
   ]
 
   # Heuristic for whether a parameter's *type* names a dependency-injected

--- a/src/analyzer/analyzers/csharp/fastendpoints.cr
+++ b/src/analyzer/analyzers/csharp/fastendpoints.cr
@@ -9,12 +9,21 @@ module Analyzer::CSharp
 
     alias RequestTypeKey = Tuple(String, String)
 
+    # One `class Request { … }` declaration: where it was found and the
+    # request properties it contributes.
+    private record RequestTypeDef, file : String, params : Array(Param)
+
     # `Endpoint<TRequest>`, `Endpoint<TRequest, TResponse>`,
     # `EndpointWithoutRequest`, `EndpointWithoutRequest<TResponse>`,
     # and the `Ep` short alias all subclass the FastEndpoints
     # endpoint primitive. Any class matching one of these as a
     # base is a candidate.
     BASE_TYPE_REGEX = /:\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*,\s*)*(Endpoint(?:WithoutRequest)?(?:<[^>]*>)?|Ep<[^>]*>)/
+
+    # Whole-file gate. One JIT-compiled union beats the two `String#includes?`
+    # scans it replaces, and it also refuses files that merely mention the word
+    # "Endpoint" without declaring a FastEndpoints class.
+    ENDPOINT_SOURCE_RE = /\bFastEndpoints\b|:\s*(?:[A-Za-z_][\w.]*\s*,\s*)*(?:Endpoint(?:WithoutRequest)?\b|Ep\s*<)/
 
     VERB_CALL_REGEX       = /\b(Get|Post|Put|Patch|Delete|Options|Head)\s*\(\s*"([^"]+)"/m
     VERBS_CALL_REGEX      = /\bVerbs\s*\(\s*([^)]*)\)/m
@@ -25,26 +34,69 @@ module Analyzer::CSharp
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       cs_files = get_files_by_extension(".cs").reject { |f| Common.csharp_test_path?(f) }
-      request_types = build_request_type_index(cs_files)
-
+      # One pass picks the FastEndpoints sources and, from the same content,
+      # the request-DTO names their `Endpoint<TRequest>` bases refer to. Only
+      # those DTOs are worth indexing: the old code extracted the property
+      # list of *every* type declaration in the scan — ~28k of them in
+      # dotnet/aspnetcore, none of which FastEndpoints ever looks up.
+      endpoint_files = [] of String
+      wanted = Set(String).new
       cs_files.each do |file|
         next unless File.exists?(file)
-
         content = read_file_content(file)
-        next unless content.includes?("Endpoint") || content.includes?("FastEndpoints")
+        # Same literal prerequisite the old gate had, kept as a cheap
+        # short-circuit ahead of the structural union.
+        next unless content.includes?("Endpoint")
+        next unless content_matches?(content, ENDPOINT_SOURCE_RE)
 
-        analyze_file(file, content, include_callee, request_types)
+        endpoint_files << file
+        collect_request_types(content, wanted)
+      end
+      return @result if endpoint_files.empty?
+
+      request_types = build_request_type_index(cs_files, wanted)
+
+      endpoint_files.each do |file|
+        analyze_file(file, read_file_content(file), include_callee, request_types)
       end
 
       @result
     end
 
-    private def build_request_type_index(files : Array(String)) : Hash(RequestTypeKey, Array(Param))
-      index = Hash(RequestTypeKey, Array(Param)).new
+    # Request-DTO names referenced by an `Endpoint<TRequest[, TResponse]>` base
+    # in this source.
+    private def collect_request_types(content : String, wanted : Set(String))
+      content.each_line do |line|
+        next unless class_declaration_with_endpoint_base?(line)
+        base_match = BASE_TYPE_REGEX.match(line)
+        next unless base_match
+        base = base_match[1]
+        next if base.starts_with?("EndpointWithoutRequest")
+        if type_name = extract_request_type(base)
+          wanted << type_name
+        end
+      end
+    end
+
+    # Indexes every request-DTO candidate by `{base, type name}` — but keeps
+    # the *declarations* apart instead of unioning their properties.
+    #
+    # FastEndpoints' idiomatic vertical-slice layout gives every feature
+    # folder its own `Request`/`Response` pair, so a repo-wide union of
+    # everything named `Request` is catastrophic: FastEndpoints' own test
+    # harness holds 55 distinct `class Request`, and each of its endpoints was
+    # emitted with the ~110-property union of all of them. `resolve_request_params`
+    # picks one declaration per lookup instead.
+    private def build_request_type_index(files : Array(String), wanted : Set(String)) : Hash(RequestTypeKey, Array(RequestTypeDef))
+      index = Hash(RequestTypeKey, Array(RequestTypeDef)).new
+      return index if wanted.empty?
+
+      wanted_re = Regex.union(wanted.to_a.map { |name| /\b#{Regex.escape(name)}\b/ })
       type_decl_regex = /(?:class|record(?:\s+struct)?|struct)\s+([A-Za-z_][A-Za-z0-9_]*)\b/
       files.each do |file|
         next unless File.exists?(file)
         content = read_file_content(file)
+        next unless content_matches?(content, wanted_re)
         base_path = configured_base_for(file)
         lines = content.lines
         i = 0
@@ -53,15 +105,24 @@ module Analyzer::CSharp
           if match = type_decl_regex.match(line)
             type_name = match[1]
             block, end_index = extract_request_type_block(lines, i)
-            params = extract_props_from_block(block)
-            if !params.empty?
+            # Property extraction is the expensive half; only the DTOs an
+            # `Endpoint<TRequest>` actually names are worth it. The block is
+            # still measured for every type so the traversal — and therefore
+            # which declarations are seen at all — does not depend on `wanted`.
+            params = wanted.includes?(type_name) ? extract_props_from_block(block) : [] of Param
+            unless params.empty?
               key = {base_path, type_name}
-              existing = index[key]? || [] of Param
-              merged = existing.dup
-              params.each do |p|
-                merged << p unless merged.any? { |e| e.name == p.name }
+              defs = index[key] ||= [] of RequestTypeDef
+              # A type declared twice in one file (partial class, or the same
+              # name in two namespaces of one file) is still one declaration
+              # site; union those.
+              if existing_idx = defs.index { |d| d.file == file }
+                merged = defs[existing_idx].params.dup
+                params.each { |p| merged << p unless merged.any? { |e| e.name == p.name } }
+                defs[existing_idx] = RequestTypeDef.new(file, merged)
+              else
+                defs << RequestTypeDef.new(file, params)
               end
-              index[key] = merged
             end
             i = end_index
           end
@@ -71,7 +132,33 @@ module Analyzer::CSharp
       index
     end
 
-    private def analyze_file(file : String, content : String, include_callee : Bool, request_types : Hash(RequestTypeKey, Array(Param)))
+    # Resolves `Endpoint<TRequest>` to one declaration of `TRequest`, nearest
+    # first: the endpoint's own file, then its directory (the vertical-slice
+    # feature folder), then a repo-unique declaration. When several unrelated
+    # declarations share the name and none is nearby, the type is ambiguous —
+    # emitting nothing beats emitting every candidate's properties at once.
+    private def resolve_request_params(index : Hash(RequestTypeKey, Array(RequestTypeDef)),
+                                       base_path : String,
+                                       type_name : String?,
+                                       file : String) : Array(Param)
+      return [] of Param unless type_name
+      defs = index[{base_path, type_name}]?
+      return [] of Param if defs.nil? || defs.empty?
+
+      if same_file = defs.find { |d| d.file == file }
+        return same_file.params
+      end
+
+      dir = File.dirname(file)
+      same_dir = defs.select { |d| File.dirname(d.file) == dir }
+      return same_dir.first.params if same_dir.size == 1
+
+      return defs.first.params if defs.size == 1
+
+      [] of Param
+    end
+
+    private def analyze_file(file : String, content : String, include_callee : Bool, request_types : Hash(RequestTypeKey, Array(RequestTypeDef)))
       base_path = configured_base_for(file)
       lines = content.lines
       i = 0
@@ -89,7 +176,7 @@ module Analyzer::CSharp
             if configure_block
               routes, methods = parse_configure(configure_block)
               if !routes.empty? && !methods.empty?
-                request_params = request_type ? (request_types[{base_path, request_type}]? || [] of Param) : [] of Param
+                request_params = resolve_request_params(request_types, base_path, request_type, file)
                 routes.each do |route|
                   methods.each do |http_method|
                     endpoint = build_endpoint(route, http_method, file, i + 1, request_params)
@@ -261,8 +348,7 @@ module Analyzer::CSharp
       route.scan(/\{([^}\/]+)\}/) do |match|
         raw = match[1]? || ""
         next if raw.empty?
-        cleaned = raw.split(":").first.gsub(/\?$/, "")
-        cleaned = cleaned.lstrip("*")
+        cleaned = Common.route_placeholder_name(raw)
         next if cleaned.empty?
         params << Param.new(cleaned, "", "path") unless params.any? { |p| p.name == cleaned }
       end
@@ -290,7 +376,12 @@ module Analyzer::CSharp
         io << '\n'
         brace += line.count('{') - line.count('}')
         paren += line.count('(') - line.count(')')
-        started ||= brace > 0
+        # A body that opens *and* closes on the declaration line
+        # (`public partial class AdminLogin : JsonSerializerContext { }`) leaves
+        # `brace` at 0, so `brace > 0` alone never marked the block as started
+        # and the scan ran on until some *later* type's closing brace — merging
+        # that type's properties into this one and skipping its declaration.
+        started ||= brace > 0 || line.includes?("{")
         # Record / positional record - end on `);` outside any brace.
         if !started && line.includes?(";") && paren <= 0 && line.includes?(")")
           break

--- a/src/analyzer/analyzers/csharp/httplistener.cr
+++ b/src/analyzer/analyzers/csharp/httplistener.cr
@@ -74,11 +74,14 @@ module Analyzer::CSharp
       @result
     end
 
+    # One JIT-compiled union in place of up to five Rabin-Karp passes over the
+    # whole file — the gate runs on every `.cs` file in the scan.
+    LISTENER_MARKER_RE = /HttpListener/
+    PATH_MARKER_RE     = /AbsolutePath|LocalPath|PathAndQuery|RawUrl/
+
     private def httplistener_related_source?(content : String) : Bool
-      return true if content.includes?("HttpListener")
-      content.includes?("HttpMethod") &&
-        (content.includes?("AbsolutePath") || content.includes?("LocalPath") ||
-          content.includes?("PathAndQuery") || content.includes?("RawUrl"))
+      return true if content_matches?(content, LISTENER_MARKER_RE)
+      content.includes?("HttpMethod") && content_matches?(content, PATH_MARKER_RE)
     end
 
     private def analyze_file(file : String, content : String, include_callee : Bool)
@@ -87,8 +90,7 @@ module Analyzer::CSharp
       # strings/comments/chars for structural brace counting. Both views come
       # from the same scan, so we avoid lexing the source twice.
       lexer = Noir::CSharpLexer.new(content)
-      clean_source = strip_comments_preserving_strings(content, lexer)
-      clean_lines = clean_source.lines
+      clean_lines = lexer.code_lines
       masked_lines = lexer.masked_lines
       method_vars, path_vars = extract_request_aliases(clean_lines)
 
@@ -198,18 +200,6 @@ module Analyzer::CSharp
       end
     rescue e
       logger.debug "csharp httplistener: failed to analyze #{file}: #{e.message}"
-    end
-
-    private def strip_comments_preserving_strings(source : String, lexer : Noir::CSharpLexer) : String
-      chars = source.chars
-      lexer.tokens.each do |token|
-        next unless token.kind == :comment
-
-        (token.start...token.end).each do |idx|
-          chars[idx] = chars[idx] == '\n' ? '\n' : ' '
-        end
-      end
-      chars.join
     end
 
     private def extract_request_aliases(lines : Array(String)) : Tuple(Array(String), Array(String))

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -12,21 +12,34 @@ module Analyzer::CSharp::MinimalApiSupport
     "IServiceProvider", "ILogger", "ILoggerFactory", "LinkGenerator",
   }
 
+  # `Map<Verb>` may carry an explicit generic argument — Carter's
+  # `app.MapPut<Person>("/", …)` and the typed `MapGet<T>` helpers some
+  # libraries ship. Without the optional `<…>` the route literal was never
+  # reached and the registration produced no endpoint at all.
+  MAP_VERB_ROUTE_RE = /(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?Map(Get|Post|Put|Delete|Patch|Head|Options)\s*(?:<[^<>()]*>\s*)?\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?@?"([^"]+)"/m
+  MAP_METHODS_RE    = /(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MapMethods\s*(?:<[^<>()]*>\s*)?\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?@?"([^"]+)"\s*,\s*([\s\S]+?)(?:=>|\);)/m
+  MAP_CALL_RE       = /\bMap(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*(?:<[^<>()]*>\s*)?\(/
+  MAP_ANY_PREFIX_RE = /\.?\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*(?:<[^<>()]*>\s*)?\(/
+
   private def analyze_minimal_api_files(include_callee : Bool)
     get_files_by_extension(".cs").each do |file|
       next unless File.exists?(file)
       next if Common.csharp_test_path?(file)
 
       content = read_file_content(file)
-      next if content.includes?("ICarterModule")
+      # Carter modules register minimal-API routes too, but under a module
+      # base path this analyzer can't see — `cs_carter` owns them.
+      next if Common.carter_module_source?(content)
       next unless minimal_api_source?(content)
 
       analyze_minimal_api_content(file, content, include_callee)
     end
   end
 
+  MINIMAL_API_MARKER_RE = /\.\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)\s*(?:<[^<>()]*>\s*)?\(/
+
   private def minimal_api_source?(content : String) : Bool
-    content.matches?(/\.\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)\s*\(/) ||
+    content_matches?(content, MINIMAL_API_MARKER_RE) ||
       (content.matches?(/\.\s*Map\s*\(/) && minimal_api_context?(content))
   end
 
@@ -37,9 +50,15 @@ module Analyzer::CSharp::MinimalApiSupport
   end
 
   private def analyze_minimal_api_content(file : String, content : String, include_callee : Bool)
-    group_prefixes = extract_map_group_prefixes(content)
-    lines = content.lines
-    masked_lines = Noir::CSharpLexer.new(content).masked_lines
+    lexer = Noir::CSharpLexer.new(content)
+    # Scan comment-blanked source: ASP.NET Core's own libraries carry
+    # `/// app.MapGet("/from-route/{id}", …)` inside `<example>` XML docs and
+    # `// app.MapGet("/form-todo", …)` in explanatory comments, each of which
+    # the raw scan emitted as a real endpoint. Line numbers and column offsets
+    # are preserved, so reported locations are unchanged.
+    lines = lexer.code_lines
+    masked_lines = lexer.masked_lines
+    group_prefixes = extract_map_group_prefixes(lexer.code_source)
 
     lines.each_with_index do |line, index|
       next unless route_builder_line?(line)
@@ -63,9 +82,12 @@ module Analyzer::CSharp::MinimalApiSupport
                                                line : Int32,
                                                file_lines : Array(String),
                                                masked_lines : Array(String),
-                                               include_callee : Bool) : Array(Endpoint)
+                                               include_callee : Bool,
+                                               route_prefix : String = "") : Array(Endpoint)
     route, methods = extract_route_and_methods(block, group_prefixes)
     return [] of Endpoint unless route && methods.size > 0
+
+    route = join_route_parts(route_prefix, route) unless route_prefix.empty?
 
     extra_params = extract_params_from_block(block)
     extra_params.concat(extract_bind_params_from_file(block, file_lines, masked_lines))
@@ -104,7 +126,7 @@ module Analyzer::CSharp::MinimalApiSupport
     end
 
     inline_prefix = extract_inline_group_prefix(block, group_prefixes)
-    if match = block.match(/(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?@?"([^"]+)"/m)
+    if match = block.match(MAP_VERB_ROUTE_RE)
       receiver = match[1]?
       route = apply_group_prefix(match[3], receiver, group_prefixes)
       route = join_route_parts(inline_prefix, route) unless inline_prefix.empty?
@@ -124,7 +146,7 @@ module Analyzer::CSharp::MinimalApiSupport
   private def extract_map_methods_route(block : String, group_prefixes : Hash(String, String)) : Tuple(String?, Array(String))
     inline_prefix = extract_inline_group_prefix(block, group_prefixes)
 
-    if match = block.match(/(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MapMethods\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?@?"([^"]+)"\s*,\s*([\s\S]+?)(?:=>|\);)/m)
+    if match = block.match(MAP_METHODS_RE)
       receiver = match[1]?
       route = apply_group_prefix(match[2], receiver, group_prefixes)
       route = join_route_parts(inline_prefix, route) unless inline_prefix.empty?
@@ -147,7 +169,7 @@ module Analyzer::CSharp::MinimalApiSupport
   end
 
   private def extract_inline_group_prefix(block : String, group_prefixes : Hash(String, String)) : String
-    map_index = block.index(/\.?\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*\(/)
+    map_index = block.index(MAP_ANY_PREFIX_RE)
     return "" unless map_index
 
     prefix_source = block[0...map_index]
@@ -336,6 +358,12 @@ module Analyzer::CSharp::MinimalApiSupport
       .split(/\s+/).last? || ""
     type_name = type_name.split(".").last
 
+    # A lambda parameter with no type annotation only compiles against the
+    # `RequestDelegate` overload — `endpoints.MapGet("/headers", async context
+    # => …)` — so the name is the HttpContext, never a bound request value.
+    # Every such registration used to contribute a phantom `query` param.
+    return if type_name.empty? && param_type.nil?
+
     return if service_binding?(type_name, cleaned, param_type)
 
     if route_params.includes?(name)
@@ -433,14 +461,16 @@ module Analyzer::CSharp::MinimalApiSupport
       next unless raw
 
       optional = raw.ends_with?("?")
-      name = raw.split(":").first.gsub(/\?$/, "")
+      name = Common.route_placeholder_name(raw)
 
       if optional && !param_names.includes?(name)
         result = result.gsub("/{#{raw}}", "")
         result = result.gsub("{#{raw}}/", "")
         result = result.gsub("{#{raw}}", "")
-      elsif optional
-        result = result.gsub("{#{raw}}", "{#{raw.gsub("?", "")}}")
+      elsif optional || raw.includes?('=')
+        # `{id?}` -> `{id}` and `{id=5}` -> `{id}`: a default value is part of
+        # the route *template*, never of the URL a client sends.
+        result = result.gsub("{#{raw}}", "{#{raw.split('=').first.rstrip('?')}}")
       end
     end
 
@@ -453,8 +483,7 @@ module Analyzer::CSharp::MinimalApiSupport
       raw = match[1]? || match[0]
       next unless raw
 
-      cleaned = raw.split(":").first.gsub(/\?$/, "").lstrip("*")
-      keys << cleaned
+      keys << Common.route_placeholder_name(raw)
     end
 
     keys.uniq
@@ -493,7 +522,7 @@ module Analyzer::CSharp::MinimalApiSupport
   # split on commas while respecting nested parens/brackets/braces/generics
   # and string literals.
   private def map_call_arguments(block : String) : Array(String)
-    m = block.match(/\bMap(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*\(/)
+    m = block.match(MAP_CALL_RE)
     return [] of String unless m
 
     open = block.index('(', m.begin)
@@ -535,7 +564,7 @@ module Analyzer::CSharp::MinimalApiSupport
       next unless line.includes?(name)
       next unless line.matches?(decl)
       # The `Map*("/x", Name)` line also references the handler — skip it.
-      next if line.matches?(/\bMap(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*\(/)
+      next if line.matches?(MAP_CALL_RE)
 
       sig, end_idx = build_signature(lines, masked_lines, idx)
       block, body_idx, skip_first = extract_callable_body(lines, masked_lines, end_idx)

--- a/src/analyzer/analyzers/csharp/signalr.cr
+++ b/src/analyzer/analyzers/csharp/signalr.cr
@@ -87,11 +87,19 @@ module Analyzer::CSharp
         end
       end
 
+      # A file is worth lexing only if it declares a hub base or a type named
+      # in a `MapHub<T>` mount. `includes?("Hub")` alone matched every file
+      # that so much as mentions `IHubContext`, and each of those paid for a
+      # full `CSharpLexer` pass.
+      mounted_re = map_hub_types.empty? ? nil : Regex.union(map_hub_types.to_a.map { |t| /\b#{Regex.escape(t)}\b/ })
+
       # Pass 2 — hub classes and their callable methods.
       files.each do |path|
         begin
           content = read_file_content(path)
-          next unless content.includes?("Hub")
+          next unless content.includes?("class")
+          next unless content_matches?(content, HUB_CLASS) ||
+                      (mounted_re && content_matches?(content, mounted_re))
           collect_hubs(content, path, hubs, map_hub_types)
         rescue e
           logger.debug "Error analyzing SignalR hub in #{path}: #{e}"

--- a/src/detector/detectors/csharp/aspnet_core_minimal_api.cr
+++ b/src/detector/detectors/csharp/aspnet_core_minimal_api.cr
@@ -4,11 +4,16 @@ module Detector::CSharp
   class AspNetCoreMinimalApi < Detector
     detector_for "cs_aspnet_core_minimal_api", extensions: %w[.cs]
 
+    CARTER_MODULE = /\bI?CarterModule\b/
+    MAP_VERB      = /\.\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)\s*(?:<[^<>()]*>\s*)?\(/
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".cs")
-      return false if file_contents.includes?("ICarterModule")
+      # Carter modules (`: ICarterModule` / `: CarterModule`) register
+      # minimal-API routes under a module base path — `cs_carter` owns them.
+      return false if content_matches?(file_contents, CARTER_MODULE)
 
-      has_http_map = content_matches?(file_contents, /\.\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)\s*\(/)
+      has_http_map = content_matches?(file_contents, MAP_VERB)
       has_generic_map = content_matches?(file_contents, /\.\s*Map\s*\(/) && minimal_api_context?(file_contents)
 
       has_http_map || has_generic_map

--- a/src/detector/detectors/csharp/carter.cr
+++ b/src/detector/detectors/csharp/carter.cr
@@ -11,6 +11,8 @@ module Detector::CSharp
     # surface to `ICarterModule.AddRoutes` blocks tagged as
     # `cs_carter`, and the analyzer skips files the MVC analyzer
     # already owns.
+    CARTER_MODULE = /\bI?CarterModule\b/
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.ends_with?(".csproj") || filename.ends_with?(".props") || filename.ends_with?(".targets")
         return true if file_contents.includes?("Include=\"Carter\"") ||
@@ -19,7 +21,10 @@ module Detector::CSharp
       end
 
       return false unless filename.ends_with?(".cs")
-      file_contents.includes?("using Carter") || file_contents.includes?("ICarterModule")
+      # `CarterModule` is Carter's abstract base class (base path + filters);
+      # `ICarterModule` the bare interface. Both declare a Carter module, and
+      # a module deriving from the base never has to name the interface.
+      file_contents.includes?("using Carter") || content_matches?(file_contents, CARTER_MODULE)
     end
   end
 end

--- a/src/minilexers/csharp_lexer.cr
+++ b/src/minilexers/csharp_lexer.cr
@@ -47,6 +47,8 @@ module Noir
     @tokens : Array(CSharpToken)?
     @skip_ranges : Array(Range(Int32, Int32))?
     @masked_lines : Array(String)?
+    @code_lines : Array(String)?
+    @code_source : String?
 
     def initialize(source : String)
       @chars = source.chars
@@ -56,6 +58,8 @@ module Noir
       @tokens = nil
       @skip_ranges = nil
       @masked_lines = nil
+      @code_lines = nil
+      @code_source = nil
       scan
     end
 
@@ -422,6 +426,40 @@ module Noir
         end
         masked_str.lines
       end
+    end
+
+    # The source with **comments only** blanked to spaces — string and char
+    # literals are kept intact. Line count and every column index are
+    # preserved, so a caller can keep reporting the original line number while
+    # scanning text that a commented-out (or documentation-example) route can
+    # no longer reach.
+    #
+    # `masked_lines` is the wrong tool for that job: it also blanks the string
+    # literals a route extractor needs to read. ASP.NET Core's own source
+    # carries `/// app.MapGet("/from-route/{id}", …)` inside `<example>` XML
+    # docs, which a raw scan happily emits as an endpoint.
+    def code_source : String
+      @code_source ||= begin
+        if @spans.none? { |(kind, _, _)| kind == :comment }
+          # No comments at all — the common case for generated or terse
+          # sources. Skip the char-array copy entirely.
+          String.build(@size) { |io| @chars.each { |c| io << c } }
+        else
+          chars = @chars.dup
+          @spans.each do |(kind, start, finish)|
+            next unless kind == :comment
+            (start...finish).each do |idx|
+              next if idx >= @size
+              chars[idx] = ' ' unless chars[idx] == '\n'
+            end
+          end
+          String.build(@size) { |io| chars.each { |c| io << c } }
+        end
+      end
+    end
+
+    def code_lines : Array(String)
+      @code_lines ||= code_source.lines
     end
 
     # ---- token stream ------------------------------------------------------


### PR DESCRIPTION
C# / .NET analyzer family sweep: `aspnet_core_mvc`, `minimal_apis` /
`minimal_api_support`, `carter`, `fastendpoints`, `signalr`, `httplistener`,
`cli`, `common`, plus the `cs_carter` / `cs_aspnet_core_minimal_api` detectors
and `Noir::CSharpLexer`.

Corpus (shallow clones, scanned with the `--release` binary):
`dotnet/aspnetcore` (10 571 `.cs`), `bitwarden/server` (5 112),
`jellyfin/jellyfin` (2 122), `FastEndpoints/FastEndpoints` (889),
`ThreeMammals/Ocelot` (754), `dotnet/eShop` (528),
`CarterCommunity/Carter` (96).

## 1. Changes

| analyzer | kind | what was wrong | evidence |
|---|---|---|---|
| `aspnet_core_mvc` | FP | Conventional `MapControllerRoute` templates were keyed on the **scan base**, so every template in a solution applied to every controller in it. Now scoped to the `.csproj` directory owning the declaring `Program.cs`/`Startup.cs`. | `aspnetcore` **738 → 116** `cs_aspnet_core_mvc` endpoints (all `cs_*` techs: 1005 → 375; non-C# techs unchanged at 74, so no collateral drop). Phantoms killed include `/ConventionalTransformerRoute/{controller}/Login` (68), `/Product/*` (37, from `src/Mvc/test/WebSites/RoutingWebSite/Startup.cs:39` `pattern: "Product/{action}"`), `/DataTokensRoute/Account/*` (28), `/{area}/Account/*` (17), and every `/{page}` variant (from `RoutingWebSite`'s `{controller}/{action}/{page}`). Real routes survive: `/Home/Delete/{id}` from `src/ProjectTemplates/Web.ItemTemplates/content/MvcController/HomeController.cs:67` is still emitted; only its foreign-template twins `/Home/Delete` and `/Home/Delete/{page}` are gone. |
| `fastendpoints` | FP | `Endpoint<TRequest>` was resolved by unioning **every** type named `TRequest` in the scan. FastEndpoints' vertical-slice layout puts a `class Request` in each feature folder. Declarations are now kept apart and resolved nearest-first (same file → same directory → repo-unique → ambiguous ⇒ none). | `FastEndpoints/TestHarness` holds **55** distinct `class Request` (`grep -c 'class Request\b'`). `GET /customer/save` (`TestHarness/Web/[Features]/Customers/Create/Endpoint.cs:23`) went from **110 params** to the 5 its own DTO declares (`cID, CreatedBy, CustomerName, PhoneNumbers, HasCreatePermission`). 77 endpoints changed params in that repo. |
| `fastendpoints` | FP/FN | `extract_request_type_block` never marked a body as *started* when it opened and closed on the declaration line (`public partial class AdminLogin : JsonSerializerContext { }`), so the scan ran on to a later type's closing brace — merging that type's properties into this one and skipping its declaration entirely. | `TestHarness/Web/[Features]/Admin/Login/Models.cs:7` swallowed `class Request` at line 12. `POST /admin/login` now reports `UserName, Password`; before the fix it reported nothing resolvable. |
| `carter` | FN + FP | `class X : CarterModule` (Carter's base class, which carries the module base path as `: base("/directors")`) was not recognised — the analyzer required the literal `ICarterModule`. Those files fell through to the minimal-API analyzer, which emitted the routes **without** the base path and under the wrong tech. | `Carter/samples/CarterSample/Features/Directors/DirectorsModule.cs:8` — `GET /`, `POST /`, `GET /qs` (`<cs_aspnet_core_minimal_api>`) replaced by `GET /directors`, `POST /directors`, `PUT /directors`, `GET /directors/qs` (`<cs_carter>`). |
| `carter` | FN | Generic `MapPut<Person>("/", …)` did not match the verb regex, so the registration produced nothing. | `DirectorsModule.cs:47` → `PUT /directors` is new. |
| `carter` | FN | Carter had a hand-rolled copy of the minimal-API route parser and never extracted handler-delegate parameters. It now runs on the shared `MinimalApiSupport` helpers (−200 duplicated lines). | `ActorsModule.cs:55` `POST /actors` gained `json:actor`; `CastMemberModule.cs:7` `POST /castmembers` gained `json:castMember`; `ActorsModule.cs:33` `PUT /actors/{id}` gained `json:actor`. |
| `minimal_api_support` (+ `carter`) | FP | Route registrations were read out of comments. | `aspnetcore/src/Mvc/Mvc.Core/src/FromRouteAttribute.cs:24` is `/// app.MapGet("/from-route/{id}", …)` inside an `<example>` XML doc; `aspnetcore/src/OpenApi/src/Services/OpenApiDocumentService.cs:708` is a `//` explanatory comment. Both were emitted as endpoints. |
| `minimal_api_support` | FP | An untyped lambda parameter only compiles against the `RequestDelegate` overload, so its name is the HttpContext — never a bound value. It was emitted as a `query` param. | `aspnetcore/src/Servers/Kestrel/stress/Program.cs:436` `endpoints.MapGet("/headers", async context => …)`. 12 endpoints in `aspnetcore`, 4 in `bitwarden/server` lost a phantom `query:context` / `query:x`. |
| `aspnet_core_mvc` | FP | `[From*(Name = "…")]` was ignored, so the C# identifier was reported instead of the name the client sends. | `bitwarden/server/src/Api/Controllers/SelfHosted/SelfHostedOrganizationSponsorshipsController.cs:94` — `[FromRoute(Name = "organizationId")] Guid sponsoringOrgId` reported a phantom `path:sponsoringOrgId`. `src/Api/Controllers/DevicesController.cs:285` `GET /devices/knowndevice` reported `DeviceIdentifier`/`Email` instead of `X-Device-Identifier`/`X-Request-Email`. |
| `aspnet_core_mvc` | FN | `[AcceptVerbs("PUT", "PATCH")]` / `[AcceptVerbs("PUT", Route = "Bank")]` was not handled at all, so the action fell back to a conventional GET route. | `aspnetcore/src/Mvc/test/WebSites/RoutingWebSite/Controllers/BanksController.cs:26`. Under a test path in the corpus, so covered by a new fixture rather than a corpus count. |
| `aspnet_core_mvc`, `minimal_api_support`, `fastendpoints` | FP | A route-template default value (`{id=5}`) was kept verbatim in both the URL and the parameter name. | `FastEndpoints/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs:1092` emitted `/swagger-review/default-route-value/{id=5}` with a param literally named `id=5`. |
| `common` | FP | `Handler` / `DataSource` added to the DI-service type suffixes. | `bitwarden/server/bitwarden_license/src/Services/Pam/Api/Endpoints/AccessRequestEndpoints.cs:17` injects `AccessRequestEndpointsHandler handler` into the handler delegate (6 endpoints carried `query:handler`); `Carter/samples/CarterSample/Features/Graph/GraphModule.cs:7` injects `EndpointDataSource`. |
| `fastendpoints` | perf | Indexed the property list of **every** type declaration in the scan. Now collects the DTO names an `Endpoint<TRequest>` actually references in the same pass that picks the FastEndpoints sources, and only extracts properties for those. | ~28 k type declarations in `aspnetcore`, none of which FastEndpoints looks up. |
| `signalr` | perf | Lexed every file containing the substring `Hub` (which matches anything mentioning `IHubContext`). Now requires a hub-class base match or a type named in a `MapHub<T>` mount before paying for a `CSharpLexer` pass. | detection byte-identical on all 7 repos. |
| `httplistener`, `cli` | perf | Whole-file gates were chains of `String#includes?`; collapsed into single precompiled unions via `content_matches?`. `httplistener` also drops its private comment-stripper in favour of the lexer's cached `code_lines`. | detection byte-identical on all 7 repos. |

New shared pieces: `Noir::CSharpLexer#code_source` / `#code_lines` (comments
blanked, string literals preserved, line/column offsets intact) and
`Common.{carter_module_source?, project_roots, project_root_for,
explicit_binding_name, route_placeholder_name}`.

## 2. Perf

`./bin/noir -b <repo>`, `--release` build, warm page cache, **7 interleaved
A/B runs** (baseline and patched alternating, so machine drift cancels);
medians below.

| repo | `.cs` files | before | after | |
|---|---|---|---|---|
| `bitwarden/server` | 5 112 | 2.71 s | **2.20 s** | −19 % |
| `dotnet/aspnetcore` | 10 571 | 3.69 s | **3.24 s** | −12 % |
| `jellyfin/jellyfin` | 2 122 | 0.70 s | **0.61 s** | −13 % |
| `FastEndpoints` | 889 | 0.33 s | 0.31 s | noise |

An earlier, quieter measurement of the same binaries (5 runs each,
non-interleaved) gave aspnetcore 2.88 → 2.53 s and server 2.66 → 2.19 s, i.e.
the same direction and rough magnitude. The FastEndpoints repo is a wash: it
genuinely needs almost every DTO it declares, so the lazy index buys nothing
there and only the merged gate pass shows up.

Note the C# analyzers are **not** parallelised by this PR. `parallel_analyze`
would not help: there is no `preview_mt` build, so its workers are cooperative
fibers on one thread, and file content already comes from the in-memory
`CodeLocator` cache — there is no blocking I/O left to overlap. The wins above
are all "do less work per file".

## 3. Fixture A/B diff

`noir_ab.sh` over `spec/functional_test/fixtures`, per-directory, before vs
after. Only C# files differ; every line is intended:

* `csharp__aspnet_core_mvc.txt` (13 lines), `csharp__aspnet_core_mvc_callees.txt`
  (1 line) — phantom `context` params dropped. Every one traces to an untyped
  lambda in the fixture (`Program.cs:23,29,34` are `async context =>`).
* `csharp__fastendpoints_multi_base.txt` (2 lines) — `/a/users` now reports
  `Name` and `/b/users` reports `Email`; before, both carried the union
  `{Email, Name}`. The existing base-path key never actually separated them,
  because both services resolve to the same configured base when the fixture
  root is scanned as one project.
* `csharp__aspnet_core_minimal_api.txt`, `csharp__aspnet_core_mvc_modern.txt`,
  `csharp__carter.txt`, `csharp__fastendpoints.txt`, and the new
  `csharp__aspnet_core_mvc_solution.txt` — additions from the new fixture code
  listed below, not drift.

New fixtures + specs:

* `csharp/aspnet_core_mvc_solution/` (+ spec) — two projects, each with its own
  `.csproj` and conventional template. Baseline binary emits 4 endpoints (the
  cross-product); patched emits 2.
* `csharp/aspnet_core_mvc_modern/Controllers/BanksController.cs` —
  `[AcceptVerbs]` with and without `Route =`, `[FromRoute(Name = …)]`,
  `[FromHeader(Name = …)]`, `{page=5}`.
* `csharp/carter/Modules/DirectorsModule.cs` — `: CarterModule` with
  `: base("/directors")`, generic `MapPut<Person>`, a commented-out route.
* `csharp/fastendpoints/Features/{Archive,Restore}/Endpoint.cs` — two feature
  folders each declaring `class Request`. Baseline binary gives both endpoints
  `{ArchiveId, RestoreToken}`; patched keeps them separate.
* `csharp/aspnet_core_minimal_api/Program.cs` — an XML-doc `<example>` route, a
  commented-out registration, and an `async context =>` handler.

## 4. Found but deliberately not fixed

* **Complex-typed minimal-API params on body-less verbs.** `MapGet("/graph",
  (DfaGraphWriter graphWriter, EndpointDataSource endpointDataSource, …))` —
  DI collaborators reported as query params. I implemented and measured a rule
  that drops unattributed complex types on GET/HEAD/DELETE/OPTIONS: it removed
  ~10 real DI phantoms but introduced ~5 genuine FNs, because enums *are*
  query-bindable (`aspnetcore/src/OpenApi/sample/Endpoints/MapEnumsEndpoints.cs:16`
  binds `PascalCaseStatus status` from the query string) and so are types with
  a `TryParse`/`BindAsync`. Roughly break-even, with a new FN class, so I
  reverted it and took only the two high-precision type suffixes (`Handler`,
  `DataSource`) instead. `DfaGraphWriter`, `TodoDb` and `GraphServiceClient`
  remain FPs.
* **No `CSharpEngine`.** The brief offered one, gated on an empty A/B diff.
  Measurement showed the premise does not hold here: `get_files_by_extension`
  is already an in-memory index and `read_file_content` already reads through
  the detector cache, so there is no repeated directory walk or repeated read
  to remove, and (see §2) an engine worker pool cannot parallelise CPU work in
  this build. The `Common` module is already the Java-style shared-helper shape
  the brief pointed at. I spent the budget on the gates and the lazy index
  instead, which are measurable. Migration remains open if a `preview_mt` build
  lands.
* **Test-path heuristics.** `Ocelot/testing/Authentication/AuthenticationSteps.cs`
  yields `GET /connect` and `POST /token`; `aspnetcore/src/SignalR/perf/Microbenchmarks/
  DefaultHubActivatorBenchmark.cs` yields `ws://MyHub/Addition`. Adding
  `/testing/`, `/perf/` or `*Benchmark.cs` to `Common.csharp_test_path?` would
  affect every C# analyzer and every language sharing that shape; out of scope
  for this PR.
* **Nested query objects in FastEndpoints DTOs.** `GET /benchmark/query-binding`
  reports `query:Query` where the real surface is `Query.Id`, `Query.FirstName`,
  … The analyzer does not expand nested request types. Pre-existing; the params
  it used to report came from the repo-wide union, not from expansion, so this
  PR does not regress it — it just makes the gap visible.
* **`{id:int}` route constraints** stay in the emitted URL (`/x/{id:int}`), as
  before. Only the *parameter name* is normalised. Changing URL shape would
  touch far more output than this sweep justifies.

## 5. Gates

Each run in its own command:

* `crystal spec spec/unit_test` — 4 357 examples, 0 failures
* `crystal spec spec/functional_test` — 22 492 examples, 0 failures
* `crystal tool format` — clean
* `crystal run lib/ameba/bin/ameba.cr` — 1 832 inspected, 0 failures

