### PR TITLE
fix(analyzer): legacy stacks (Classic ASP, WebForms, CFML) — 11 FP/FN fixes

### DIFF
--- a/spec/functional_test/fixtures/aspnet/webforms/Contact.aspx
+++ b/spec/functional_test/fixtures/aspnet/webforms/Contact.aspx
@@ -1,0 +1,11 @@
+<%@ Page Language="C#" CodeBehind="Contact.aspx.cs" Inherits="Contact" %>
+<html>
+<body>
+    <!-- A server-side form is what makes the page a POST target; the
+         code-behind reads only the query string. -->
+    <form id="frmContact" runat="server">
+        <asp:TextBox runat="server" ID="txtMessage" />
+        <asp:Button runat="server" ID="btnSend" Text="Send" />
+    </form>
+</body>
+</html>

--- a/spec/functional_test/fixtures/aspnet/webforms/Contact.aspx.cs
+++ b/spec/functional_test/fixtures/aspnet/webforms/Contact.aspx.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Web;
+
+public partial class Contact : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string topic = Request.QueryString["topic"];
+    }
+}

--- a/spec/functional_test/fixtures/cfml/coldbox/config/Router.cfc
+++ b/spec/functional_test/fixtures/cfml/coldbox/config/Router.cfc
@@ -2,6 +2,7 @@ component {
 
 	function configure() {
 		var sitePrefix = "/sites/:site";
+		var skipped = "new,edit";
 
 		// Verb-agnostic: the handler's allowedMethods decides.
 		route( "/", "main.index" );
@@ -25,6 +26,23 @@ component {
 
 		// Inline placeholder constraints must not leak into the URL
 		route( "/legacy/:id-numeric{2}" ).to( "main.legacy" );
+
+		// A group prefixes every route declared inside its closure, and
+		// `withAction` names one action per verb.
+		group( { pattern : "/admin" }, function( options ){
+			route( "/reports" ).to( "reports.index" );
+			route( "/reports/:id" ).withAction( { get : "show", delete : "remove" } );
+		} );
+
+		// A namespace is reachable only where a route mounts it; the mount
+		// itself is not a route.
+		route( "/v2" ).toNamespaceRouting( "v2" );
+		group( { namespace : "v2" }, function( options ){
+			route( "/ping" ).to( "diagnostics.ping" );
+		} );
+
+		// `except` passed by name rather than as a literal.
+		resources( resource = "tags", except = skipped );
 	}
 
 }

--- a/spec/functional_test/fixtures/cfml/coldbox/remote/Proxy.cfc
+++ b/spec/functional_test/fixtures/cfml/coldbox/remote/Proxy.cfc
@@ -1,0 +1,16 @@
+/**
+ * A ColdBox app's remote proxy. `access="remote"` methods stay callable
+ * over HTTP whatever framework fronts the application, and the framework
+ * router never mentions them — so the generic CFML analyzer still has to
+ * report these even though ColdBox owns the .cfm surface.
+ */
+component {
+
+	remote string function ping( string token = "" ) {
+		return "pong";
+	}
+
+	private function internalOnly() {
+	}
+
+}

--- a/spec/functional_test/testers/aspnet/webforms_spec.cr
+++ b/spec/functional_test/testers/aspnet/webforms_spec.cr
@@ -1,9 +1,10 @@
 require "../../func_spec.cr"
 
-# WebForms is file-path routed and every page answers both verbs, since
-# the framework posts back to the page's own URL. `.ascx` and `.master`
-# are param sources but never routes, so their reads are attributed to
-# the pages that compose them.
+# WebForms is file-path routed. A page answers POST when something proves
+# it can — a server-side form (its own or its master's), a read from the
+# form collection, or explicit postback handling — and GET only otherwise.
+# `.ascx` and `.master` are param sources but never routes, so their reads
+# are attributed to the pages that compose them.
 expected_endpoints = [
   # Code-behind resolved through `CodeFile="default.aspx.vb"` even though
   # the file on disk is `Default.aspx.vb`; `q`/`pageNo` come from the
@@ -32,13 +33,20 @@ expected_endpoints = [
     Param.new("pageNo", "", "form"),
   ]),
 
+  # Its own `<form runat="server">` makes the page a POST target even
+  # though nothing reads the form collection.
+  Endpoint.new("/Contact.aspx", "GET", [
+    Param.new("topic", "", "query"),
+  ]),
+  Endpoint.new("/Contact.aspx", "POST"),
+
   # Generic handler, read through an aliased receiver
-  # (`Dim req As HttpRequest = context.Request`).
+  # (`Dim req As HttpRequest = context.Request`). It reads only the query
+  # string and has no form, so it is not claimed as a POST target.
   Endpoint.new("/Image.ashx", "GET", [
     Param.new("strFullPath", "", "query"),
     Param.new("intSize", "", "query"),
   ]),
-  Endpoint.new("/Image.ashx", "POST"),
 
   # `<WebMethod()>` maps to POST /Service.asmx/Method. The directive
   # carries only `Class=`, so the implementation is found in App_Code
@@ -48,10 +56,10 @@ expected_endpoints = [
     Param.new("count", "", "form"),
   ]),
   Endpoint.new("/QuoteService.asmx/Ping", "POST"),
+  # No form, no master and no postback handling: GET only.
   Endpoint.new("/BugTest.aspx", "GET", [
     Param.new("RealParam", "", "query"),
   ]),
-  Endpoint.new("/BugTest.aspx", "POST"),
 ]
 
 FunctionalTester.new("fixtures/aspnet/webforms/", {

--- a/spec/functional_test/testers/cfml/coldbox_spec.cr
+++ b/spec/functional_test/testers/cfml/coldbox_spec.cr
@@ -46,6 +46,31 @@ expected_endpoints = [
 
   # A module's routes mount under its ModuleConfig entryPoint.
   Endpoint.new("/api/v1/status", "GET"),
+
+  # `group( { pattern : "/admin" }, ... )` prefixes the routes declared in
+  # its closure, and `withAction` names one action per verb.
+  Endpoint.new("/admin/reports", "GET"),
+  Endpoint.new("/admin/reports/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/admin/reports/:id", "DELETE", [Param.new("id", "", "path")]),
+
+  # A namespace group mounts where a route puts it. The mount itself
+  # (`route( "/v2" ).toNamespaceRouting( "v2" )`) is not a route.
+  Endpoint.new("/v2/ping", "GET"),
+
+  # `except = skipped` passes a local by name, so `new` and `edit` are
+  # dropped just as they would be for a literal.
+  Endpoint.new("/tags", "GET"),
+  Endpoint.new("/tags", "POST"),
+  Endpoint.new("/tags/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/tags/:id", "PUT", [Param.new("id", "", "path")]),
+  Endpoint.new("/tags/:id", "PATCH", [Param.new("id", "", "path")]),
+  Endpoint.new("/tags/:id", "DELETE", [Param.new("id", "", "path")]),
+
+  # A CFML framework owns the `.cfm` page surface, but `access="remote"`
+  # methods stay HTTP-callable and no framework analyzer emits them, so
+  # the generic analyzer runs alongside in components-only mode.
+  Endpoint.new("/remote/Proxy.cfc?method=ping", "GET", [Param.new("token", "", "query")]),
+  Endpoint.new("/remote/Proxy.cfc?method=ping", "POST", [Param.new("token", "", "form")]),
 ]
 
 FunctionalTester.new("fixtures/cfml/coldbox/", {

--- a/spec/unit_test/analyzer/legacy_scan_base_path_spec.cr
+++ b/spec/unit_test/analyzer/legacy_scan_base_path_spec.cr
@@ -1,0 +1,73 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+require "file_utils"
+
+# Convention filters ("this file is an `#include` fragment", "this
+# component is a test suite") were applied to the absolute path, so the
+# directory a checkout happened to live in decided whether its endpoints
+# were reported at all. Both analyzers now match on the scan-base-relative
+# path instead.
+private def scan_tree(root : String) : Array(Endpoint)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints
+ensure
+  CodeLocator.instance.clear("file_map")
+end
+
+private def write_file(path : String, content : String)
+  FileUtils.mkdir_p(File.dirname(path))
+  File.write(path, content)
+end
+
+describe "legacy analyzers and the scan base path" do
+  it "reports Classic ASP pages from a base path that contains an `inc` segment" do
+    root = File.tempname("noir-asp-base")
+    site = File.join(root, "inc", "site")
+
+    begin
+      write_file(File.join(site, "login.asp"), <<-ASP)
+        <%@ Language="VBScript" %>
+        <%
+          Dim user
+          user = Request.QueryString("user")
+          Response.Write user
+        %>
+        ASP
+
+      endpoints = scan_tree(site)
+      urls = endpoints.select { |endpoint| endpoint.details.technology == "asp_classic" }.map(&.url)
+
+      urls.should contain("/login.asp")
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+
+  it "reports CFML components from a base path that contains a `test` segment" do
+    root = File.tempname("noir-cfml-base")
+    app = File.join(root, "test", "app")
+
+    begin
+      write_file(File.join(app, "resources", "Echo.cfc"), <<-CFML)
+        component extends="taffy.core.resource" taffy:uri="/echo" {
+
+        	function get( string message = "" ) {
+        		return representationOf( { "message" : arguments.message } );
+        	}
+
+        }
+        CFML
+
+      endpoints = scan_tree(app)
+      urls = endpoints.select { |endpoint| endpoint.details.technology == "cfml_taffy" }.map(&.url)
+
+      urls.should contain("/echo")
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -38,6 +38,14 @@ def initialize_analyzers(logger : NoirLogger)
   analyzers
 end
 
+# CFML frameworks that own their application's route table.
+CFML_FRAMEWORK_TECHS = Set{
+  "cfml_taffy",
+  "cfml_coldbox",
+  "cfml_wheels",
+  "cfml_fw1",
+}
+
 def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
   filtered = techs.dup
 
@@ -50,20 +58,13 @@ def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
   # Laravel app — vanished with it. `Analyzer::Php::Php` now resolves URLs
   # against the document root, so the noise is gone at the source and the
   # generic analyzer can run alongside the framework one. See #2358.
-
-  # Same shape as php_pure: a CFML framework owns its route table, so the
-  # generic `.cfm`/`remote`-method analyzer is redundant noise once one is
-  # present.
-  cfml_frameworks = Set{
-    "cfml_taffy",
-    "cfml_coldbox",
-    "cfml_wheels",
-    "cfml_fw1",
-  }
-
-  if filtered.includes?("cfml_pure") && filtered.any? { |tech| cfml_frameworks.includes?(tech) }
-    filtered.reject!("cfml_pure")
-  end
+  #
+  # `cfml_pure` used to be dropped for the same reason and paid the same
+  # price — the `remote` methods on a ColdBox app's proxy components are
+  # HTTP-callable whatever framework fronts them, and no framework
+  # analyzer emits them. It now runs in components-only mode instead (see
+  # `CFML_FRAMEWORK_TECHS` below), which keeps those and still leaves the
+  # `.cfm` page surface to the framework that owns it.
 
   # Lumen and Laravel share enough surface (Illuminate namespaces, the `routes/`
   # convention) that the Laravel detector also fires on Lumen projects. When
@@ -148,6 +149,14 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
 
   # Run tech analyzers concurrently to avoid long stalls from a single analyzer
   selected_techs = filter_redundant_generic_techs(techs).select { |t| analyzer.has_key?(t) }
+
+  # A CFML framework owns the `.cfm` page surface, so the generic analyzer
+  # narrows to the half no framework analyzer covers: `access="remote"`
+  # methods on `.cfc` components.
+  if selected_techs.includes?("cfml_pure") && selected_techs.any? { |tech| CFML_FRAMEWORK_TECHS.includes?(tech) }
+    options[Analyzer::Cfml::Pure::COMPONENTS_ONLY_OPTION] = YAML::Any.new(true)
+  end
+
   mutex = Mutex.new
 
   # Pre-build extension index synchronously to avoid concurrent mutation in multiple threads/fibers

--- a/src/analyzer/analyzers/asp/classic.cr
+++ b/src/analyzer/analyzers/asp/classic.cr
@@ -123,8 +123,10 @@ module Analyzer::Asp
 
       return true if included.includes?(File.expand_path(path))
 
-      normalized = path.gsub(File::SEPARATOR, "/")
-      return true if normalized.matches?(INCLUDE_DIR_RE)
+      # Scan-base-relative, never absolute: the directory the checkout
+      # happens to live in must not decide whether its pages are
+      # fragments.
+      return true if base_relative_path(path).matches?(INCLUDE_DIR_RE)
 
       File.basename(path).matches?(INCLUDE_NAME_RE)
     end
@@ -154,10 +156,16 @@ module Analyzer::Asp
           header = http_header_name(name)
           headers << Param.new(header, "", "header") if header
         else
-          # Bare `Request("x")` searches QueryString, then Form, then
-          # Cookies — it is genuinely both, so report it as both rather
-          # than guessing.
-          ambiguous << name
+          # Bare `Request("x")` searches QueryString, Form, Cookies and
+          # then ServerVariables. An `HTTP_`-prefixed key can only come
+          # from the last of those, so it names an inbound header; the
+          # rest are genuinely both query and form, so report them as
+          # both rather than guessing.
+          if header = http_header_name(name)
+            headers << Param.new(header, "", "header")
+          else
+            ambiguous << name
+          end
         end
       end
 

--- a/src/analyzer/analyzers/aspnet/webforms.cr
+++ b/src/analyzer/analyzers/aspnet/webforms.cr
@@ -63,6 +63,31 @@ module Analyzer::Aspnet
     CS_SIGNATURE_RE   = /\b(?:public|internal)\s+(?:(?:static|virtual|override|async)\s+)*[\w<>\[\],.\s]+?\s+(\w+)\s*\(([^)]*)\)/
     WEBMETHOD_WINDOW  = 400
 
+    # Evidence that a page can act on a POST.
+    #
+    # `<form runat="server">` is the decisive one — the framework posts
+    # back to the page's own URL — but the tag name has to be matched
+    # loosely, because control libraries subclass `HtmlForm`: DNN's own
+    # `Default.aspx` carries `<dnn:Form ID="Form" runat="server">`, and an
+    # anchored `<form` missed it.
+    SERVER_FORM_RE = /<[\w:.]*form\b[^>]*\brunat\s*=\s*["']?server/i
+
+    # A content page's form belongs to its master page. The master is
+    # normally resolved and scanned, so `SERVER_FORM_RE` finds it there —
+    # but not always: CarrotCake's plugin pages name `~/Site1.Master` from
+    # a sibling project the scan base does not contain. Declaring a master
+    # is itself the evidence, since a master page without an `HtmlForm` is
+    # not a usable master.
+    CONTENT_PAGE_RE = /\bMasterPageFile\s*=|<asp:Content\b/i
+
+    # Code-behind evidence, for handlers and for pages whose markup carries
+    # no form at all. Reading — or merely enumerating — the form collection
+    # is conclusive: DNN's PayPal IPN receiver has no markup beyond its
+    # directive and does `foreach (string strName in this.Request.Form)`,
+    # which yields no literal parameter name but proves the page is a POST
+    # target. `Files` and `InputStream` are only ever populated by one.
+    POST_HANDLING_RE = /\bIsPostBack\b|__doPostBack|\bRequest\s*\.\s*(?:Form|Files|InputStream)\b/i
+
     # WebForms postback plumbing, not user-facing parameters.
     FRAMEWORK_FIELDS = Set{
       "__viewstate", "__viewstategenerator", "__viewstateencrypted",
@@ -111,19 +136,45 @@ module Analyzer::Aspnet
       end
 
       buckets = ParamBuckets.new
-      sources.each { |source| scan_source(source, buckets) }
+      postable = false
+      sources.each do |source|
+        scan_source(source, buckets)
+        postable ||= post_target?(source)
+      end
 
       urls = [url]
       urls << directory_url(url) if File.basename(path).downcase == DIRECTORY_INDEX
 
-      # A WebForms page with a server-side form answers both verbs by
-      # construction — the framework posts back to the page's own URL —
-      # and `IsPostBack` proves both paths share one handler rather than
-      # distinguishing them.
       urls.each do |page_url|
         @result << Endpoint.new(page_url, "GET", unique_params(buckets.query_side), details)
+      end
+
+      # A WebForms page with a server-side form answers both verbs by
+      # construction, and `IsPostBack` proves both paths share one handler
+      # rather than distinguishing them. Neither is universal, though:
+      # emitting POST for *every* page claimed a verb for pages that
+      # cannot act on it — DNN's `KeepAlive.aspx` is four lines of markup
+      # with no form, no code-behind read and nothing to post to.
+      postable ||= !buckets.body.empty?
+      return unless postable
+
+      urls.each do |page_url|
         @result << Endpoint.new(page_url, "POST", unique_params(buckets.body_side), details)
       end
+    end
+
+    # Whether this source proves the page it belongs to handles a POST.
+    private def post_target?(path : String) : Bool
+      content = read_file_content(path)
+      if markup?(path)
+        return true if content.matches?(SERVER_FORM_RE)
+        return true if content.matches?(CONTENT_PAGE_RE)
+      end
+
+      content.matches?(POST_HANDLING_RE)
+    rescue e
+      logger.debug "Error checking post handling in #{path}: #{e}"
+      false
     end
 
     # A page's params come from its own inline code, its code-behind, its
@@ -270,7 +321,7 @@ module Analyzer::Aspnet
         name = match[1]
         next if skip_field?(name)
 
-        buckets.add_ambiguous(name)
+        record_ambiguous(name, buckets)
       end
     rescue e
       logger.debug "Error scanning #{path}: #{e}"
@@ -282,11 +333,24 @@ module Analyzer::Aspnet
       when "form"        then buckets.body << Param.new(name, "", "form")
       when "cookies"     then buckets.shared << Param.new(name, "", "cookie")
       when "headers"     then buckets.shared << Param.new(name, "", "header")
-      when "params"      then buckets.add_ambiguous(name)
+      when "params"      then record_ambiguous(name, buckets)
       when "servervariables"
         if header = http_header_name(name)
           buckets.shared << Param.new(header, "", "header")
         end
+      end
+    end
+
+    # `Request[...]` and `Request.Params[...]` search QueryString, then
+    # Form, then Cookies, then ServerVariables. An `HTTP_`-prefixed key can
+    # only resolve through the last of those, so it names an inbound header
+    # — reporting it as a query *and* a form parameter invents two keys no
+    # client can send. DNN reads `context.Request["HTTP_ACCEPT"]` this way.
+    private def record_ambiguous(name : String, buckets : ParamBuckets)
+      if header = http_header_name(name)
+        buckets.shared << Param.new(header, "", "header")
+      else
+        buckets.add_ambiguous(name)
       end
     end
 

--- a/src/analyzer/analyzers/cfml/coldbox.cr
+++ b/src/analyzer/analyzers/cfml/coldbox.cr
@@ -34,9 +34,36 @@ module Analyzer::Cfml
     # Legacy tag-syntax registration, still present in older configs.
     ADD_ROUTE_RE = /(?<![\w.])addRoute\s*\(/i
 
+    # `group( { pattern : "/api" }, function( options ){ ... } )` prefixes
+    # every route declared inside the closure, and groups nest. Ignoring
+    # them is both a false positive and a false negative at once: ColdBox's
+    # own test harness declares `route( "/:user_id" )` inside
+    # `group( { pattern : "/runAWNsync" ... } )`, which was reported as
+    # `/:user_id` — a URL that answers nothing — while the real
+    # `/runAWNsync/:user_id` went unreported.
+    GROUP_CALL_RE = /(?<![\w.])group\s*\(/i
+
+    # A group may name a namespace instead of a path. Namespaces are not
+    # paths in themselves: they become reachable only where a route mounts
+    # them, so the mount pattern is what supplies the prefix.
+    NAMESPACE_MOUNT_RE = /\.\s*toNamespaceRouting\s*\(\s*["']([^"']+)["']/i
+    ADD_NAMESPACE_RE   = /(?<![\w.])addNamespace\s*\(/i
+
+    # `route( "/luis" ).toNamespaceRouting( "luis" )` — the mount pattern
+    # and the namespace it carries, in one statement.
+    NAMESPACE_ROUTE_RE = /(?<![\w.])route\s*\(\s*["']([^"']+)["']\s*\)\s*\.\s*toNamespaceRouting\s*\(\s*["']([^"']+)["']\s*\)/i
+
     # Chained builders that follow `route( ... )` up to the statement end.
     CHAINED_VERBS_RE = /\.\s*withVerbs\s*\(\s*["']([^"']+)["']/i
     CHAIN_LIMIT      = 400
+
+    # `route( "/x" ).withAction( { get : "show", post : "save" } )` binds
+    # one action per verb, so the struct's keys *are* the verbs the route
+    # answers. Without this a `route()` carrying only a `withAction` map
+    # fell back to GET — ColdBox's own harness registers `/invalid-restful`
+    # and `/invalid-main-method` as POST that way.
+    CHAINED_ACTIONS_RE = /\.\s*withAction\s*\(\s*\{([^}]*)\}/i
+    ACTION_VERB_RE     = /["']?(\w+)["']?\s*[:=]/
 
     # `var sitePrefix = "/sites/:site"` — referenced as `#siteprefix#`,
     # case-insensitively.
@@ -68,21 +95,27 @@ module Analyzer::Cfml
     ]
 
     @allowed_methods : Hash(String, Hash(String, Array(String)))? = nil
+    @namespace_mounts : Hash(String, String)? = nil
 
     def analyze
-      routers = cfml_components.select { |path| router_file?(path) } +
-                cfml_pages.select { |path| router_file?(path) }
+      routers = router_files
       return @result if routers.empty?
 
-      # Built once from every handler in the scan; worker fibers must not
-      # race to populate it.
+      # Both indexes are built once from every router/handler in the scan;
+      # worker fibers must not race to populate them.
       allowed_methods
+      @namespace_mounts = build_namespace_mounts(routers)
 
       parallel_analyze(routers) do |path|
         analyze_router(path)
       end
 
       @result
+    end
+
+    private def router_files : Array(String)
+      cfml_components.select { |path| router_file?(path) } +
+        cfml_pages.select { |path| router_file?(path) }
     end
 
     private def router_file?(path : String) : Bool
@@ -93,12 +126,14 @@ module Analyzer::Cfml
       content = strip_all_comments(read_file_content(path))
       prefix = module_prefix(path)
       locals = local_strings(content)
+      groups = group_blocks(content, locals)
 
-      extract_routes(content, path, prefix, locals)
-      extract_resources(content, path, prefix, locals)
+      extract_routes(content, path, prefix, locals, groups)
+      extract_resources(content, path, prefix, locals, groups)
     end
 
-    private def extract_routes(content : String, path : String, prefix : String, locals : Hash(String, String))
+    private def extract_routes(content : String, path : String, prefix : String,
+                               locals : Hash(String, String), groups : Array(Group))
       {ROUTE_CALL_RE, ADD_ROUTE_RE}.each do |pattern|
         content.scan(pattern) do |match|
           start = match.begin(0) || 0
@@ -112,18 +147,26 @@ module Analyzer::Cfml
           close_paren = matching_paren(content, open_paren)
           next unless close_paren
 
-          arguments = call_arguments(content[(open_paren + 1)...close_paren])
+          arguments = call_arguments(content[(open_paren + 1)...close_paren], locals)
           pattern_value = arguments["pattern"]? || arguments["0"]?
           next if pattern_value.nil? || pattern_value.empty?
 
           resolved = interpolate(pattern_value, locals)
           next unless resolved
 
-          url = build_url(prefix, resolved)
+          scoped = scoped_prefix(prefix, groups, start)
+          next unless scoped
+
+          url = build_url(scoped, resolved)
           next if url.empty?
 
           target = arguments["target"]? || arguments["1"]?
-          chain = content[(close_paren + 1), CHAIN_LIMIT]? || ""
+          chain = statement_chain(content, close_paren + 1)
+          # `route( "/luis" ).toNamespaceRouting( "luis" )` mounts a
+          # namespace at that pattern; it is not itself requestable, and
+          # the routes it exposes are emitted under the mount instead.
+          next if chain.matches?(NAMESPACE_MOUNT_RE)
+
           target ||= chained_target(chain)
 
           route_verbs(verb, chain, target).each do |method|
@@ -134,7 +177,8 @@ module Analyzer::Cfml
       end
     end
 
-    private def extract_resources(content : String, path : String, prefix : String, locals : Hash(String, String))
+    private def extract_resources(content : String, path : String, prefix : String,
+                                  locals : Hash(String, String), groups : Array(Group))
       content.scan(RESOURCES_RE) do |match|
         start = match.begin(0) || 0
         next unless statement_start?(content, start)
@@ -145,16 +189,19 @@ module Analyzer::Cfml
         close_paren = matching_paren(content, open_paren)
         next unless close_paren
 
-        arguments = call_arguments(content[(open_paren + 1)...close_paren])
+        scoped = scoped_prefix(prefix, groups, start)
+        next unless scoped
+
+        arguments = call_arguments(content[(open_paren + 1)...close_paren], locals)
         resource = arguments["resource"]? || arguments["0"]?
         next if resource.nil? || resource.empty?
 
         base = interpolate(arguments["pattern"]? || "/#{resource}", locals)
         next unless base
 
-        # `except` names the actions to drop. A non-literal value (a
-        # variable) is unresolvable, so nothing is dropped rather than
-        # guessing.
+        # `except` names the actions to drop. A value that resolves to
+        # neither a literal nor a declared local is unresolvable, so
+        # nothing is dropped rather than guessing.
         excluded = (arguments["except"]? || "").split(',').map(&.strip.downcase).reject(&.empty?).to_set
         only = (arguments["only"]? || "").split(',').map(&.strip.downcase).reject(&.empty?).to_set
 
@@ -164,7 +211,7 @@ module Analyzer::Cfml
           next if excluded.includes?(action)
           next if !only.empty? && !only.includes?(action)
 
-          url = build_url(prefix, "#{base}#{suffix}")
+          url = build_url(scoped, "#{base}#{suffix}")
           next if url.empty?
 
           @result << Endpoint.new(url, method, [] of Param, details)
@@ -172,6 +219,158 @@ module Analyzer::Cfml
           @result << Endpoint.new(url, "PATCH", [] of Param, details) if action == "update"
         end
       end
+    end
+
+    # A `group( options, closure )` call: the character range its closure
+    # occupies, and the path segment it contributes. A `nil` prefix means
+    # the group scopes its routes somewhere this scan cannot resolve, so
+    # the routes inside are dropped rather than reported at the root.
+    private record Group, start : Int32, stop : Int32, prefix : String?
+
+    private def group_blocks(content : String, locals : Hash(String, String)) : Array(Group)
+      groups = [] of Group
+
+      content.scan(GROUP_CALL_RE) do |match|
+        start = match.begin(0) || 0
+        next unless statement_start?(content, start)
+
+        open_paren = content.index('(', start)
+        next unless open_paren
+
+        close_paren = matching_paren(content, open_paren)
+        next unless close_paren
+
+        groups << Group.new(open_paren, close_paren,
+          group_prefix(content, open_paren, close_paren, locals))
+      end
+
+      groups
+    end
+
+    # The group's options struct is its first argument.
+    private def group_prefix(content : String, open_paren : Int32, close_paren : Int32,
+                             locals : Hash(String, String)) : String?
+      open_brace = content.index('{', open_paren)
+      # No options struct at all: the group only wraps the closure, so it
+      # contributes nothing to the path.
+      return "" if open_brace.nil? || open_brace > close_paren
+
+      close_brace = matching_brace(content, open_brace)
+      return "" if close_brace.nil? || close_brace > close_paren
+
+      options = call_arguments(content[(open_brace + 1)...close_brace], locals)
+
+      if pattern = options["pattern"]?
+        resolved = interpolate(pattern, locals)
+        return resolved.nil? ? nil : "/#{resolved.strip.strip('/')}"
+      end
+
+      if namespace = options["namespace"]?
+        # A namespace is reachable only where a route mounts it. With no
+        # mount in the scan there is no URL to report.
+        return namespace_mounts[namespace.downcase]?
+      end
+
+      # `{ handler : "x", action : "y" }` only retargets; the path is
+      # whatever the routes inside declare.
+      ""
+    end
+
+    # Path prefix in force at `index`: the module entry point plus every
+    # enclosing group, outermost first (groups are collected in source
+    # order, which is the same thing).
+    private def scoped_prefix(base : String, groups : Array(Group), index : Int32) : String?
+      return base if groups.empty?
+
+      prefix = base
+      groups.each do |group|
+        next unless index > group.start && index < group.stop
+        segment = group.prefix
+        return unless segment
+
+        prefix = "#{prefix}#{segment}"
+      end
+      prefix
+    end
+
+    # namespace name => the path a route mounts it at, across every router
+    # in the scan (a module may mount a namespace another module declares).
+    private def namespace_mounts : Hash(String, String)
+      @namespace_mounts ||= build_namespace_mounts(router_files)
+    end
+
+    private def build_namespace_mounts(routers : Array(String)) : Hash(String, String)
+      mounts = {} of String => String
+
+      routers.each do |path|
+        content = strip_all_comments(read_file_content(path))
+        collect_namespace_mounts(content, mounts)
+      rescue e
+        logger.debug "Error reading namespace mounts from #{path}: #{e}"
+      end
+
+      mounts
+    end
+
+    private def collect_namespace_mounts(content : String, mounts : Hash(String, String))
+      content.scan(NAMESPACE_ROUTE_RE) do |match|
+        mounts[match[2].downcase] = "/#{match[1].strip.strip('/')}"
+      end
+
+      # `addNamespace( pattern = "/luis", namespace = "luis" )`
+      content.scan(ADD_NAMESPACE_RE) do |match|
+        start = match.begin(0) || 0
+        next unless statement_start?(content, start)
+
+        open_paren = content.index('(', start)
+        next unless open_paren
+
+        close_paren = matching_paren(content, open_paren)
+        next unless close_paren
+
+        arguments = call_arguments(content[(open_paren + 1)...close_paren])
+        pattern = arguments["pattern"]? || arguments["0"]?
+        namespace = arguments["namespace"]? || arguments["1"]?
+        next if pattern.nil? || namespace.nil? || namespace.empty?
+
+        mounts[namespace.downcase] = "/#{pattern.strip.strip('/')}"
+      end
+    end
+
+    # The builder chain attached to a route call, bounded by the end of the
+    # statement: a `;`, or a line break not continued by a `.`.
+    #
+    # The bound is load-bearing. A fixed character window ran past the call
+    # into whatever followed, so a bare `route()` could inherit the `.to()`
+    # of a later statement — and once `toNamespaceRouting` became a
+    # suppression signal, three unrelated routes declared above ColdBox's
+    # namespace mount disappeared with it.
+    private def statement_chain(content : String, from : Int32) : String
+      window = content[from, CHAIN_LIMIT]? || ""
+      cut = window.size
+      after_newline = false
+
+      window.each_char_with_index do |char, index|
+        if char == ';'
+          cut = index
+          break
+        end
+
+        if after_newline
+          next if char.whitespace?
+
+          # A chain continues with `.`; anything else opens a new statement.
+          unless char == '.'
+            cut = index
+            break
+          end
+          after_newline = false
+        elsif char == '\n'
+          after_newline = true
+        end
+      end
+
+      window[0, cut]
     end
 
     # `route( "/x" ).to( "handler.action" )` and friends. Every `to*`
@@ -194,12 +393,26 @@ module Analyzer::Cfml
         return verbs unless verbs.empty?
       end
 
+      if match = chain.match(CHAINED_ACTIONS_RE)
+        verbs = action_verbs(match[1])
+        return verbs unless verbs.empty?
+      end
+
       if target
         verbs = allowed_for(target)
         return verbs unless verbs.empty?
       end
 
       ["GET"]
+    end
+
+    private def action_verbs(raw : String) : Array(String)
+      verbs = [] of String
+      raw.scan(ACTION_VERB_RE) do |entry|
+        verb = entry[1].upcase
+        verbs << verb if HTTP_VERBS.includes?(verb)
+      end
+      verbs.uniq!
     end
 
     private def split_verbs(raw : String) : Array(String)

--- a/src/analyzer/analyzers/cfml/pure.cr
+++ b/src/analyzer/analyzers/cfml/pure.cr
@@ -19,6 +19,9 @@ module Analyzer::Cfml
   class Pure < CfmlEngine
     analyzer_for "cfml_pure"
 
+    # Set by the dispatcher when a CFML framework owns the route table.
+    COMPONENTS_ONLY_OPTION = "cfml_pure_components_only"
+
     # Only unambiguous web-root directory names. Bare `public/` and
     # `www/` were tried and dropped: they collide with build output such
     # as `docs/public/`, the same false positive `FileHelper` documents.
@@ -80,17 +83,31 @@ module Analyzer::Cfml
     INTERPOLATION_RE = /#[^#\n]+#/
 
     def analyze
-      pages = cfml_pages.reject { |path| LIFECYCLE_PAGES.includes?(File.basename(path).downcase) }
-
       parallel_analyze(cfml_components) do |path|
         analyze_component(path)
       end
+
+      # With a CFML framework in the scan, the framework's route table
+      # decides which `.cfm` templates are reachable, and most of them are
+      # not: `views/`, `layouts/` and Wheels' `app/events/*.cfm` are
+      # rendered or invoked by the framework, never requested. The
+      # `remote` methods above are a different matter — they stay callable
+      # over HTTP whatever framework is in front of them, and no framework
+      # analyzer emits them, which is why this analyzer is narrowed here
+      # rather than dropped outright. See `filter_redundant_generic_techs`.
+      return @result if components_only?
+
+      pages = cfml_pages.reject { |path| LIFECYCLE_PAGES.includes?(File.basename(path).downcase) }
 
       parallel_analyze(pages) do |path|
         analyze_page(path)
       end
 
       @result
+    end
+
+    private def components_only? : Bool
+      any_to_bool(@options[COMPONENTS_ONLY_OPTION]?)
     end
 
     # `.cfc` — only `access="remote"` methods are reachable over HTTP.
@@ -225,16 +242,6 @@ module Analyzer::Cfml
           io << (char == '\n' || keep[index] ? char : ' ')
         end
       end
-    end
-
-    # TestBox names suites `<Something>Test.cfc` / `<Something>Spec.cfc`.
-    # The leading `.+` is load-bearing: a component named exactly
-    # `Test.cfc` is a demo, not a suite (fw1 ships one that declares a
-    # real `remote` method), and an anchored `ends_with?` swallowed it.
-    private def test_path?(path : String) : Bool
-      return true if path.includes?("/tests/") || path.includes?("/test/")
-
-      File.basename(path).matches?(TEST_COMPONENT_RE)
     end
   end
 end

--- a/src/analyzer/engines/cfml_engine.cr
+++ b/src/analyzer/engines/cfml_engine.cr
@@ -102,7 +102,12 @@ module Analyzer::Cfml
     end
 
     protected def cfml_test_path?(path : String) : Bool
-      return true if path.includes?("/tests/") || path.includes?("/test/")
+      # Scan-base-relative, never absolute. Checking the absolute path made
+      # the result depend on where the checkout happens to live: the same
+      # Taffy tree scanned from `/srv/test/app` reported zero endpoints
+      # instead of 23, because every component looked like a test suite.
+      relative = base_relative_path(path)
+      return true if relative.includes?("/tests/") || relative.includes?("/test/")
 
       File.basename(path).matches?(TEST_COMPONENT_RE)
     end
@@ -204,20 +209,37 @@ module Analyzer::Cfml
     # ..., named ones by their downcased name. Only literals resolve — a
     # value built at runtime is not something to report as a route.
     # `##` is CFML's escape for a literal `#`.
-    protected def call_arguments(raw : String) : Hash(String, String)
+    #
+    # `locals` additionally resolves a bare identifier against the string
+    # variables declared earlier in the same file. Route files hoist shared
+    # values into a local and pass them by name, which is invisible to a
+    # literals-only reading: ContentBox writes `var except = "new,edit";`
+    # and then `resources( resource = "authors", except = except )`, and
+    # without the lookup every one of its resource blocks reported a
+    # `/new` and an `/:id/edit` route that the framework never registers.
+    protected def call_arguments(raw : String, locals : Hash(String, String)? = nil) : Hash(String, String)
       arguments = {} of String => String
 
       split_arguments(raw).each_with_index do |chunk, index|
         if match = chunk.match(NAMED_ARGUMENT_RE)
-          if value = argument_literal(match[2])
+          if value = argument_literal(match[2]) || local_reference(match[2], locals)
             arguments[match[1].downcase] = value
           end
-        elsif value = argument_literal(chunk)
+        elsif value = argument_literal(chunk) || local_reference(chunk, locals)
           arguments[index.to_s] = value
         end
       end
 
       arguments
+    end
+
+    private def local_reference(raw : String, locals : Hash(String, String)?) : String?
+      return unless locals
+
+      identifier = raw.strip
+      return unless identifier.matches?(/\A[A-Za-z_]\w*\z/)
+
+      locals[identifier.downcase]?
     end
 
     protected def argument_literal(raw : String) : String?
@@ -246,6 +268,10 @@ module Analyzer::Cfml
 
     protected def matching_bracket(content : String, open_bracket : Int32) : Int32?
       matching_delimiter(content, open_bracket, BYTE_OPEN_BRACKET, BYTE_CLOSE_BRACKET)
+    end
+
+    protected def matching_brace(content : String, open_brace : Int32) : Int32?
+      matching_delimiter(content, open_brace, BYTE_OPEN_BRACE, BYTE_CLOSE_BRACE)
     end
 
     # Index of the delimiter closing the one at `open_index`.

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -220,8 +220,22 @@ class Analyzer
   # Keep `markers` unambiguous. Generic names like `public/` or `www/`
   # collide with build output (`docs/public/`) — the false positive
   # `FileHelper#get_public_files` documents.
-  def web_root_path(path : String, markers : Array(String)) : String
+  # The file's location relative to the configured scan base, `/`-separated
+  # and rooted with a leading `/`.
+  #
+  # Convention filters — "is this file under `includes/`?", "is this a test
+  # fixture?" — must be applied to this, never to the absolute path. A
+  # checkout that merely *lives* under a directory with a matching name
+  # otherwise matches every file in it: scanning the same Classic ASP site
+  # from `/srv/inc/site` instead of `/srv/site` dropped 33 of its 35
+  # endpoints, because every page looked like an `#include` fragment.
+  def base_relative_path(path : String) : String
     relative = get_relative_path(configured_base_for(path), path).gsub(File::SEPARATOR, "/")
+    relative.starts_with?("/") ? relative : "/#{relative}"
+  end
+
+  def web_root_path(path : String, markers : Array(String)) : String
+    relative = base_relative_path(path)
 
     best = -1
     markers.each do |marker|


### PR DESCRIPTION
Legacy enterprise stacks (Classic ASP, WebForms, CFML) — the analyzer family with the least real-world validation in the repo. Both design notes recorded as unresolved when these landed (#2326, #2340) are re-examined below.

## Corpus

Shallow clones, all scanned with the `--release` binary.

| repo | stack | `.asp/.aspx/.ashx/.asmx/.cfm/.cfc` files |
|---|---|---|
| `dnnsoftware/Dnn.Platform` | WebForms | 16 (+161 `.ascx`), 149 MB |
| `MacdonaldRobinson/FlexDotnetCMS` | WebForms | 80, 95 MB |
| `ninianne98/CarrotCakeCMS` | WebForms | 111, 27 MB |
| `PieterCooreman/QuickerSite` | Classic ASP | 395, 36 MB |
| `aspLite/aspLite` | Classic ASP | 17, 28 MB |
| `davecan/Sane`, `EitanBlumin/CRUDE-ASP`, `bairamkuliev/Website`, `ekede/WTS-Classic-ASP-MVC-Framework` | Classic ASP | 113 / 20 / 26 / 70 |
| `Ortus-Solutions/ContentBox` | ColdBox | 724, 35 MB |
| `ColdBox/coldbox-platform` | ColdBox | 646 |
| `cfwheels/cfwheels` | Wheels | 1697, 235 MB |
| `atuttle/Taffy` | Taffy | 155 |
| `framework-one/fw1` | FW/1 | 305 |

## Changes

| analyzer | FP / FN / perf | what was wrong | evidence |
|---|---|---|---|
| `asp_classic` | FP+FN | the `includes/`-directory fragment filter matched the **absolute** path, so the directory the checkout lives in decided whether its pages were routes | same tree scanned from `/srv/inc/site` vs `/srv/site`: **2 endpoints vs 33**. New unit spec `spec/unit_test/analyzer/legacy_scan_base_path_spec.cr` |
| `cfml_*` (engine) | FN | same bug in the test-suite filter (`/test/`, `/tests/` on the absolute path) | `Taffy` scanned from a base containing a `test` segment: **0 endpoints vs 23**. Same unit spec |
| `asp_classic` | FP | bare `Request("HTTP_…")` reported as query **and** form; it falls through to `ServerVariables`, so it is a header | no corpus instance in the ASP repos — applied for symmetry with the WebForms fix below, which does have one |
| `aspnet_webforms` | FP | every page emitted POST unconditionally | `Dnn.Platform/DNN Platform/Website/KeepAlive.aspx` (4 lines of markup, no form, no read), `…/Portals/_default/subhost.aspx`, `…/Install/install.aspx`, `…/Providers/…/Tabs.ashx`, `FlexDotnetCMS/WebApplication/Views/MediaTypeHandlers/LandingPage.aspx`, `aspLite/asplite/plugins/jpg/jpg.aspx`, `QuickerSite/showThumb.aspx`. **-13 phantom POST endpoints** across the corpus |
| `aspnet_webforms` | FP | `Request["HTTP_ACCEPT"]` reported as a query and a form parameter | `Dnn.Platform/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/FileUploader.ashx.cs:394` → now `accept:header` |
| `cfml_coldbox` | FP+FN | `group( { pattern : … }, closure )` prefixes were ignored | `coldbox-platform/test-harness/config/Router.cfc:145,153` → `/:user_id` (phantom) replaced by `/runAWNsync/:user_id` (missing); likewise `/test2/:id/:name` and `/test2/:id/:num/:name/:month` |
| `cfml_coldbox` | FP+FN | namespace groups emitted at the root, and the namespace **mount** emitted as a route | `Router.cfc:136,140` → `GET /luis` dropped, `/contactus`→`/luis/contactus`, `/contactus2`→`/luis/contactus2` |
| `cfml_coldbox` | FN | `.withAction( { get : …, options : … } )` did not supply verbs | `Router.cfc:154,161` → `OPTIONS /runAWNsync/:user_id`, `OPTIONS /health_check` recovered |
| `cfml_coldbox` | FP | the builder chain was a fixed 400-char window and ran into the next statement, so a bare `route()` inherited a later `.withVerbs()` | `Router.cfc:118` `routeRunner` → `POST /routeRunner/:id/:name` was inherited from `Router.cfc:127`'s `withVerbs("post")`; now `GET` (its target `main.returnTest` declares no `allowedMethods`) |
| `cfml_coldbox` | FP | `except`/`only`/`pattern` passed **by variable name** were unresolvable, so nothing was dropped | `ContentBox/modules/contentbox/modules/contentbox-api/modules/contentbox-api-v1/config/Router.cfc:26` `var except = "new,edit";` used at `:32,39,50,61,73,84,101,118,124,135,141` → **-22 phantom `…/new` and `…/:id/edit` endpoints** |
| `cfml_pure` | FN | dropped wholesale when a CFML framework was detected, losing `access="remote"` methods no framework analyzer emits | `coldbox-platform/test-harness/remote/MyProxy.cfc`, `…/remote/Echo.cfc`, `fw1/examples/remote/remote/Test.cfc` → **+8 endpoints**. Now runs components-only instead of being dropped |
| all six | perf | nothing meaningful to win — see below | |

### The web-root anchor, per stack

The brief asked whether each stack's document-root anchor survives a real layout. Measured:

* **Classic ASP** — `wwwroot/`, `inetpub/`. Neither occurs in any of the five ASP corpus repos; every one of them puts the site at the repo root, and the repo-relative path is the right answer there. `global.asa` was considered as an IIS application-root anchor (the analogue of WebForms' `Global.asax`) but only **1** of the five repos ships one, and it sits at the repo root where it would change nothing. Not worth the risk; left alone.
* **WebForms** — the `Global.asax` anchor holds. DNN's `DNN Platform/Website/Global.asax` correctly roots `Default.aspx` at `/Default.aspx`, and CarrotCake's per-project `Global.asax` files root each plugin separately. It does **not** cover pages outside any web root (DNN's `Providers/…` tree, which is deployed into the web root at install time), which still report their repo-relative path — including a space in the URL. Left as-is: the deployment target is not statically knowable, and a repo-relative path is at least locatable.
* **CFML** — unchanged. The existing note (anchoring on `Application.cfc` collapses Taffy's 20 example apps onto a single `/index.cfm`) is still correct; Taffy ships 20 `Application.cfc` files under `examples/` alone.

### Comment/quote masking

Checked as the brief asked; the tag/script masking in `CfmlEngine` holds on the corpus (`strip_cfml_comments` nesting, `strip_script_comments` doubled-quote handling, `attributes_before_body` braces-inside-values). No mask bug found — the ColdBox defects above were all in route composition, not in masking. The one masking-adjacent defect was the unbounded chain window, fixed here.

## Perf

Five runs each, page cache warm, `--release`, full scan.

| repo | before (s) | after (s) |
|---|---|---|
| `Dnn.Platform` (149 MB) | 1.635 1.628 1.622 1.606 1.625 | 1.629 1.609 1.623 1.633 1.625 |
| `CarrotCakeCMS` (27 MB) | 0.234 0.234 0.239 0.233 0.239 | 0.234 0.230 0.233 0.235 0.232 |
| `FlexDotnetCMS` (95 MB) | 0.236 0.235 0.237 0.232 0.236 | 0.232 0.231 0.234 0.233 0.232 |
| `QuickerSite` (36 MB) | 0.164 0.159 0.162 0.160 0.162 | 0.165 0.165 0.159 0.167 0.159 |
| `ContentBox` (35 MB) | 0.089 0.086 0.085 0.085 0.086 | 0.090 0.087 0.090 0.088 0.089 |
| `cfwheels` (235 MB) | 0.148 0.150 0.151 0.154 0.147 | 0.157 0.157 0.160 0.157 0.157 |

**There is no perf work in this PR, and I am not claiming any.** Isolated with `--only-techs`, all six analyzers run in single-digit milliseconds even on the largest repo — the wall clock above is dominated by the file walk and by other languages in the tree (`Dnn.Platform` is mostly JS/C#). The only measurable movement is `cfwheels` +6 ms and `ContentBox` +3 ms, which is `cfml_pure`'s component pass now running alongside the framework analyzer instead of not running at all. That is the price of the `remote`-method recovery above, and it is stated rather than hidden.

## Fixture A/B

`noir_ab.sh` over `spec/functional_test/fixtures`, per-fixture-directory. Two files changed, 16 lines (14 added, 2 removed):

**`aspnet__webforms.txt`** (+2 / -2)
- `- POST /BugTest.aspx []`, `- POST /Image.ashx []` — neither has a form, a master or a form read; `Image.ashx` reads only the query string.
- `+ GET /Contact.aspx [query:topic]`, `+ POST /Contact.aspx []` — new fixture locking the positive branch: its own `<form runat="server">` makes it a POST target even though nothing reads the form collection.

**`cfml__coldbox.txt`** (+12 / -0)
- `+ GET|DELETE /admin/reports…` — new `group( { pattern : "/admin" } )` block, with `withAction` supplying `DELETE`.
- `+ GET /v2/ping` — namespace group resolved through its mount; the mount `route( "/v2" ).toNamespaceRouting( "v2" )` correctly emits nothing.
- `+ /tags` resource set without `new`/`edit` — `except = skipped` passed by variable name.
- `+ GET|POST /remote/Proxy.cfc?method=ping` — `cfml_pure` components-only mode running alongside `cfml_coldbox`.

No other fixture moved.

## Found and deliberately not fixed

* **JScript Classic ASP.** `strip_vbscript_comments` treats `'` as a comment start, which is correct for VBScript and wrong for JScript (`'…'` is a string literal there), and JScript's `//` comments are not stripped at all. **No `<%@ Language="JScript" %>` page exists anywhere in the corpus**, so I have no way to validate a fix; I did not want to pad this with a synthetic fixture and call it validation.
* **`web.config` `<httpHandlers>` / `<handlers>` and URL routing.** Paths mapped there with no file behind them are still missed (FN). This is a new extraction surface rather than a fix, and belongs in its own change.
* **`__VIEWSTATE` / `__EVENTTARGET` / `__EVENTARGUMENT`.** The brief calls these real POST params for any page with a server-side form. They remain suppressed as `FRAMEWORK_FIELDS`: they are framework plumbing with fixed names, and adding three constant parameters to every WebForms POST endpoint is noise, not surface. Noting the disagreement rather than silently ignoring it.
* **`Application.cfc` as a `remote` endpoint.** `cfml_pure` does not exclude `Application.cfc` from the component pass even though CF blocks direct invocation of it. No corpus repo has a `remote` method there, so there is nothing to fix against; flagging it as a latent FP.
* **FW/1 `section.item` convention routes.** FW/1's real surface is `/index.cfm?action=main.default` / `/index.cfm/main/default` over every public controller method; only the explicit `routes` array is extracted today, which is why `framework-one/fw1` yields 6 endpoints from 305 files. A genuine FN, but expanding every controller method into a route is a design decision with a large blast radius and wants its own PR.
* **DNN's `Providers/…` pages report a repo-relative URL containing a space.** Discussed under the web-root section; not statically resolvable.
* **`.asp` files under `Tests/` and `Data/Migrations/` in `davecan/Sane` are emitted as endpoints.** They are, strictly, requestable `.asp` files under the document root, so I left them; flagging that a reader may see them as noise.

## Gates

`crystal spec spec/unit_test` (4367 examples), `crystal spec spec/functional_test` (22578 examples), `crystal tool format`, `lib/ameba/bin/ameba.cr` (1835 files) — each run in its own command, all green.

