### PR TITLE
perf(analyzer): cut redundant parses, char-array rebuilds and whole-file includes? scans (1.5–1.7x on large repos)

### DIFF
--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -7,6 +7,13 @@ module Analyzer::Go
 
     IMPORT_MARKER = "github.com/beego/beego"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     # Crystal recompiles an interpolated regex literal on every evaluation
     # (a full PCRE2 JIT compile), and this fixed accessor set used to be
     # rebuilt for every line — precompile it once at load time.
@@ -53,7 +60,7 @@ module Analyzer::Go
                   next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
-                    next unless content.includes?(IMPORT_MARKER)
+                    next unless content_matches?(content, IMPORT_MARKER_RE)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/cli.cr
+++ b/src/analyzer/analyzers/go/cli.cr
@@ -33,6 +33,23 @@ module Analyzer::Go
     # precompiled `Regex.union` (PCRE2 JIT) checks all nine in a single pass.
     FRAMEWORK_IMPORTS_RE = Regex.union(FRAMEWORK_IMPORTS)
 
+    # Cheap pre-gate applied to the RAW file, before the comment strip.
+    #
+    # `GoEngine.strip_comments` materialises an `Array(Char)` of the whole
+    # file and rebuilds it character by character; running it on every
+    # `.go` file in a monorepo — 15k of them in kubernetes, of which a
+    # couple of hundred have any CLI surface — was the whole cost of this
+    # analyzer. Stripping only ever replaces characters with `' '` or
+    # `'\n'` and never changes the character count, so a literal with no
+    # whitespace in it can appear in the stripped text only if it already
+    # appears, unchanged, in the raw text. Every branch of `cli_evidence?`
+    # requires one of these literals verbatim (`FLAG_IMPORT_RE` is the
+    # literal `"flag"`; `OS_ARG_INDEX_RE` needs an adjacent `os.Args`), so
+    # a file that misses all of them cannot pass `cli_evidence?` after the
+    # strip either. Files that do match still go through the full,
+    # comment-aware gate below.
+    RAW_CLI_EVIDENCE_RE = Regex.union(FRAMEWORK_IMPORTS + [%("flag"), "os.Args"])
+
     # Per-framework matchers for the scan dispatch below, which asks the
     # same questions again once `cli_evidence?` has let a file through.
     KONG_IMPORT_RE       = Regex.union("github.com/alecthomas/kong")
@@ -141,7 +158,9 @@ module Analyzer::Go
           # patterns below are shape-based, so a commented-out or merely
           # documented registration read as a live one. Line numbers are
           # preserved, so PathInfo stays accurate.
-          content = GoEngine.strip_comments(read_file_content(path))
+          raw = read_file_content(path)
+          next unless content_matches?(raw, RAW_CLI_EVIDENCE_RE)
+          content = GoEngine.strip_comments(raw)
           next unless cli_evidence?(content)
 
           binary = go_binary_name(modules, path)

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -9,6 +9,13 @@ module Analyzer::Go
 
     IMPORT_MARKER = "github.com/valyala/fasthttp"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     def analyze
       # Source Analysis
       begin
@@ -41,7 +48,7 @@ module Analyzer::Go
             next if GoEngine.go_test_file?(path)
             if File.exists?(path)
               content = read_file_content(path)
-              next unless content.includes?(IMPORT_MARKER)
+              next unless content_matches?(content, IMPORT_MARKER_RE)
               last_endpoint = Endpoint.new("", "")
 
               # Tree-sitter pre-pass: fasthttp has no groups, so we just

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -7,6 +7,13 @@ module Analyzer::Go
 
     IMPORT_MARKER = "github.com/gogf/gf"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -35,7 +42,7 @@ module Analyzer::Go
                   next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
-                    next unless content.includes?(IMPORT_MARKER)
+                    next unless content_matches?(content, IMPORT_MARKER_RE)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/go_restful.cr
+++ b/src/analyzer/analyzers/go/go_restful.cr
@@ -20,6 +20,13 @@ module Analyzer::Go
 
     IMPORT_MARKER = "github.com/emicklei/go-restful"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     def analyze
       file_contents = read_package_file_contents
       package_function_bodies = collect_package_function_bodies(file_contents)
@@ -44,7 +51,7 @@ module Analyzer::Go
                   next unless File.exists?(path)
 
                   content = file_contents[path]? || read_file_content(path)
-                  next unless content.includes?(IMPORT_MARKER)
+                  next unless content_matches?(content, IMPORT_MARKER_RE)
 
                   ts_routes = Noir::TreeSitterGoRouteExtractor.extract_go_restful_routes(content)
                   next if ts_routes.empty?

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -7,6 +7,13 @@ module Analyzer::Go
 
     IMPORT_MARKER = "goyave.dev/goyave"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -40,7 +47,7 @@ module Analyzer::Go
                   next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
-                    next unless content.includes?(IMPORT_MARKER)
+                    next unless content_matches?(content, IMPORT_MARKER_RE)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -7,6 +7,13 @@ module Analyzer::Go
 
     IMPORT_MARKER = "github.com/zeromicro/go-zero"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     # Crystal recompiles an interpolated regex literal on every evaluation
     # (a full PCRE2 JIT compile). The accessor set is fixed, so precompile
     # the per-accessor matchers once at load time.
@@ -51,7 +58,7 @@ module Analyzer::Go
                     content = read_file_content(path)
                     # `.api` files are gozero's DSL (no Go imports);
                     # only gate `.go` files on the import marker.
-                    next if File.extname(path) == ".go" && !content.includes?(IMPORT_MARKER)
+                    next if File.extname(path) == ".go" && !content_matches?(content, IMPORT_MARKER_RE)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/http.cr
+++ b/src/analyzer/analyzers/go/http.cr
@@ -9,15 +9,30 @@ module Analyzer::Go
 
     def analyze
       # Source Analysis
-      # We only need the file_contents cache (and the side-effect of having
-      # walked with the import marker). Groups are irrelevant for net/http.
-      _, file_contents = collect_package_groups_ts(import_marker: IMPORT_MARKER)
+      # Groups are irrelevant for net/http — this analyzer only ever wanted
+      # the `{path => source}` cache. It used to get it from
+      # `collect_package_groups_ts`, whose group fixpoint it then threw
+      # away: that cost one `extract_engine_names_and_groups` tree-sitter
+      # parse per `net/http`-importing file plus at least two
+      # `extract_groups` parses per file in every multi-file package.
+      # `read_package_file_contents` builds the identical hash (same
+      # extension index, same `_test.go` filter, same reads) with no
+      # parses at all.
+      file_contents = read_package_file_contents
       package_function_bodies = collect_package_function_bodies(file_contents)
       package_method_bodies = collect_package_controller_method_bodies(file_contents)
       framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
+      # `route_dirs` exists only to bound the two request-param pre-passes
+      # below, and those maps are consulted exclusively from
+      # `params_for_routes`, which returns immediately when the file
+      # produced no route. A directory whose candidate files cannot yield
+      # a net/http route (`net_http_route_source?` is the extractor's own
+      # necessary condition) is therefore never looked up — including it
+      # only bought a tree-sitter parse of every `.go` file in it.
       route_dirs = Set(String).new
       file_contents.each do |path, content|
         dir = File.dirname(path)
+        next unless Noir::TreeSitterGoRouteExtractor.net_http_route_source?(content)
         if framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["HandleFunc", "Handle"])
           route_dirs << dir
         end
@@ -45,10 +60,19 @@ module Analyzer::Go
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)
                     next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["HandleFunc", "Handle"])
+
+                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_net_http_routes(content)
+                    # With no route in the file the line loop below is a
+                    # no-op by construction: it only ever appends to
+                    # `last_endpoint`, and `add_param_to_endpoint` (plus
+                    # the body-param branch) require a non-empty URL,
+                    # which the seed endpoint never has. Bail before
+                    # splitting the file into lines.
+                    next if ts_routes.empty?
+
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_net_http_routes(content)
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                     ts_routes.each do |r|
                       routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -8,6 +8,13 @@ module Analyzer::Go
 
     IMPORT_MARKER = "github.com/julienschmidt/httprouter"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     PARAM_PATTERNS = [
       {"ByName(", /ByName\s*\(\s*[\"']([^\"']+)[\"']\s*\)/, "path"},
       {"Query().Get(", /Query\(\)\s*\.\s*Get\s*\(\s*[\"']([^\"']+)[\"']\s*\)/, "query"},
@@ -52,7 +59,7 @@ module Analyzer::Go
                   next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
-                    next unless content.includes?(IMPORT_MARKER)
+                    next unless content_matches?(content, IMPORT_MARKER_RE)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -14,6 +14,13 @@ module Analyzer::Go
 
     IMPORT_MARKER = "github.com/danielgtaylor/huma"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     # Tags we lift from Input struct fields onto endpoint params.
     PARAM_TAG_KINDS = {
       "path"   => "path",
@@ -103,7 +110,7 @@ module Analyzer::Go
                   next unless File.exists?(path)
 
                   content = file_contents_cache[path]? || read_file_content(path)
-                  next unless content.includes?(IMPORT_MARKER)
+                  next unless content_matches?(content, IMPORT_MARKER_RE)
 
                   dir = File.dirname(path)
                   structs = package_structs[dir]? || Hash(String, Array(StructField)).new

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -7,6 +7,13 @@ module Analyzer::Go
     HTTP_METHODS  = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]
     IMPORT_MARKER = "github.com/kataras/iris"
 
+    # One precompiled matcher instead of a `String#includes?` scan per
+    # `.go` file: `includes?` runs Rabin-Karp over the whole buffer and
+    # the marker is absent in the overwhelming majority of files in a
+    # polyglot repo, so every one of them pays the full scan. See
+    # `Analyzer#content_matches?`.
+    IMPORT_MARKER_RE = Regex.union(IMPORT_MARKER)
+
     def analyze
       # Iris uses `.Party(...)` for route groups; pass that into both the
       # engine's fixpoint group collection and the per-file extractor.
@@ -33,7 +40,7 @@ module Analyzer::Go
                   next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
-                    next unless content.includes?(IMPORT_MARKER)
+                    next unless content_matches?(content, IMPORT_MARKER_RE)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/java/cli.cr
+++ b/src/analyzer/analyzers/java/cli.cr
@@ -51,7 +51,27 @@ module Analyzer::Java
     JOPT_ACCEPTS_ALL = /\b(\w+)\.acceptsAll\s*\(\s*(?:Arrays\.asList|List\.of|Collections\.singletonList)\s*\(\s*"([^"]+)"/
 
     LIB_MARKERS      = ["picocli.", "org.kohsuke.args4j", "com.beust.jcommander", "org.apache.commons.cli", "com.github.rvesse.airline", "io.airlift.airline", "joptsimple."]
+    LIB_MARKERS_RE   = Regex.union(LIB_MARKERS)
     WEB_FRAMEWORK_RE = /\bimport\s+(?:org\.springframework|jakarta\.ws\.rs|javax\.ws\.rs|io\.quarkus|io\.micronaut|io\.javalin|io\.vertx|com\.linecorp\.armeria|io\.dropwizard|spark\.|org\.apache\.struts)/
+
+    CLI_GATE_RE = /@Command\b|@Parameter\b|new\s+JCommander|new\s+CmdLineParser|new\s+Options\s*\(/
+
+    # Cheap pre-gate applied to the RAW file, before the comment strip.
+    #
+    # `strip_comments` materialises an `Array(Char)` of the whole file and
+    # rebuilds it character by character; running it on all 8,658 `.java`
+    # files in spring-boot to then reject 97% of them on the gate below was
+    # the bulk of this analyzer. Stripping only replaces characters with
+    # `' '` or `'\n'` and never changes the character count, so a literal
+    # with no whitespace in it can appear in the stripped text only if it
+    # already appears, unchanged, in the raw text. Each alternative of the
+    # real gate requires one of these literals verbatim (the `new\s+X`
+    # forms require `X`; the `\s`-carrying parts are deliberately not
+    # relied on, since blanking a comment *can* manufacture whitespace).
+    # Files that pass still go through the full, comment-aware gate.
+    RAW_CLI_MARKERS_RE = Regex.union(
+      LIB_MARKERS + ["@Command", "@Parameter", "JCommander", "CmdLineParser", "Options"]
+    )
 
     def analyze
       endpoints = {} of String => Endpoint
@@ -62,8 +82,10 @@ module Analyzer::Java
         next unless File.exists?(path)
 
         begin
-          content = strip_comments(read_file_content(path))
-          next unless LIB_MARKERS.any? { |m| content.includes?(m) } || content.matches?(/@Command\b|@Parameter\b|new\s+JCommander|new\s+CmdLineParser|new\s+Options\s*\(/)
+          raw = read_file_content(path)
+          next unless content_matches?(raw, RAW_CLI_MARKERS_RE)
+          content = strip_comments(raw)
+          next unless content_matches?(content, LIB_MARKERS_RE) || content_matches?(content, CLI_GATE_RE)
 
           binary = java_binary_name(content, path)
           root_url = "cli://#{binary}"

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -76,6 +76,9 @@ module Analyzer::Java
       @result
     end
 
+    APPLICATION_PATH_RE = Regex.union("ApplicationPath")
+    WS_RS_PACKAGE_RE    = Regex.union("jakarta.ws.rs", "javax.ws.rs")
+
     private def application_base_paths_for(file_list : Array(String)) : Hash(ApplicationBaseKey, String)
       base_paths = Hash(ApplicationBaseKey, String).new
       application_packages = Hash(String, Array(ApplicationBaseKey)).new { |hash, key| hash[key] = [] of ApplicationBaseKey }
@@ -86,8 +89,10 @@ module Analyzer::Java
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
         content = read_file_content(path)
-        next unless content.includes?("ApplicationPath")
-        next unless content.includes?("jakarta.ws.rs") || content.includes?("javax.ws.rs")
+        # One precompiled matcher per gate instead of a `String#includes?`
+        # scan per `.java` file — this walks the whole Java source set.
+        next unless content_matches?(content, APPLICATION_PATH_RE)
+        next unless content_matches?(content, WS_RS_PACKAGE_RE)
         next if claimed_by_derivative?(content)
 
         Noir::TreeSitter.parse_java(content) do |root|
@@ -332,10 +337,11 @@ module Analyzer::Java
     # Frameworks that ride on JAX-RS but ship their own analyzer.
     # Listing them here keeps the JAX-RS analyzer the fallback for
     # vanilla Jersey / RESTEasy resources without double-counting.
-    DERIVATIVE_MARKERS = ["io.quarkus", "io.dropwizard"]
+    DERIVATIVE_MARKERS    = ["io.quarkus", "io.dropwizard"]
+    DERIVATIVE_MARKERS_RE = Regex.union(DERIVATIVE_MARKERS)
 
     private def claimed_by_derivative?(content : String) : Bool
-      DERIVATIVE_MARKERS.any? { |marker| content.includes?(marker) }
+      content_matches?(content, DERIVATIVE_MARKERS_RE)
     end
 
     # Build the cross-file `@BeanParam` index for `path`. Same

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -462,9 +462,17 @@ module Analyzer::Java
       action
     end
 
+    # Neither branch can hold without one of these two literals, so the
+    # union is an exact pre-gate — and it replaces two `String#includes?`
+    # scans of every `.java` file in the tree with one precompiled pass.
+    SERVLET_MARKERS_RE = Regex.union("@WebServlet", "HttpServlet")
+    AT_WEBSERVLET_RE   = Regex.union("@WebServlet")
+    HTTPSERVLET_RE     = Regex.union("HttpServlet")
+
     private def servlet_source?(content : String) : Bool
-      content.includes?("@WebServlet") ||
-        (content.includes?("HttpServlet") && !!content.match(/\bextends\s+HttpServlet\b/))
+      return false unless content_matches?(content, SERVLET_MARKERS_RE)
+      content_matches?(content, AT_WEBSERVLET_RE) ||
+        (content_matches?(content, HTTPSERVLET_RE) && !!content.match(/\bextends\s+HttpServlet\b/))
     end
 
     private def java_package_name(content : String) : String?

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -13,6 +13,62 @@ module Analyzer::Java
     REGEX_ROUTER_CODE_BLOCK = /route\(\)?.*?\);/m
     REGEX_ROUTE_CALL        = /((?:andRoute|route)\s*\(|\.)\s*(?:RequestPredicates\.)?(GET|POST|DELETE|PUT|PATCH|HEAD|OPTIONS)\s*\(/
 
+    SPRING_WEB_BIND_PACKAGE      = "org.springframework.web.bind.annotation."
+    FEIGN_CLIENT_PACKAGE         = "org.springframework.cloud.openfeign.FeignClient"
+    SPRING_HTTP_EXCHANGE_PACKAGE = "org.springframework.web.service.annotation."
+
+    # Every `content.includes?(...)` below used to be its own Rabin-Karp
+    # pass over the whole file. This analyzer asks ~30 such questions per
+    # `.java` file across three walks, and on a monorepo the overwhelming
+    # majority of files answer "no" to all of them. One precompiled
+    # `Regex.union` (PCRE2 JIT, via `content_matches?`) is the same
+    # predicate in a single pass — see the note on `Analyzer#content_matches?`.
+    WEBSOCKET_BINDING_RE = Regex.union(
+      "org.springframework.web.socket.config.annotation",
+      "WebSocketMessageBrokerConfigurer",
+      "@EnableWebSocketMessageBroker",
+    )
+    MESSAGE_MAPPING_BINDING_RE = Regex.union(
+      "org.springframework.messaging.handler.annotation",
+      "@MessageMapping",
+      "@SubscribeMapping",
+    )
+    RESOURCE_HANDLER_BINDING_RE = Regex.union("ResourceHandlerRegistry", "addResourceHandler")
+
+    # The OR of every marker the annotation branch keys off. A file that
+    # misses this cannot set any of the individual flags, so the per-flag
+    # scans only run for the handful of files that get past it.
+    ANY_BINDING_RE = Regex.union(
+      SPRING_WEB_BIND_PACKAGE,
+      FEIGN_CLIENT_PACKAGE, "@FeignClient",
+      SPRING_HTTP_EXCHANGE_PACKAGE,
+      "@HttpExchange", "@GetExchange", "@PostExchange",
+      "@PutExchange", "@PatchExchange", "@DeleteExchange",
+      "RouteLocatorBuilder", "PredicateSpec", "org.springframework.cloud.gateway",
+      "org.springframework.web.socket.config.annotation",
+      "WebSocketMessageBrokerConfigurer", "@EnableWebSocketMessageBroker",
+      "org.springframework.messaging.handler.annotation",
+      "@MessageMapping", "@SubscribeMapping",
+      "ResourceHandlerRegistry", "addResourceHandler",
+    )
+
+    # `build_spring_indexes` gate: neither index can want a file that
+    # mentions neither marker.
+    STOMP_PREFIX_RE           = Regex.union("setApplicationDestinationPrefixes")
+    SPRING_WEB_BIND_RE        = Regex.union(SPRING_WEB_BIND_PACKAGE)
+    META_ANNOTATION_RE        = Regex.union("@interface")
+    SPRING_INDEX_PRESCREEN_RE = Regex.union("setApplicationDestinationPrefixes", SPRING_WEB_BIND_PACKAGE)
+
+    # `collect_interface_route_index` gates.
+    INTERFACE_OR_ABSTRACT_RE  = Regex.union("interface", "abstract")
+    INTERFACE_ROUTE_MARKER_RE = Regex.union(
+      SPRING_WEB_BIND_PACKAGE,
+      SPRING_HTTP_EXCHANGE_PACKAGE,
+      "@HttpExchange", "@GetExchange", "@PostExchange",
+      "@PutExchange", "@PatchExchange", "@DeleteExchange",
+      "@RequestMapping", "@GetMapping", "@PostMapping",
+    )
+
     alias SpringRouteMapping = Noir::TreeSitterJavaRouteExtractor::ClassMapping
     alias SpringRoute = Noir::TreeSitterJavaRouteExtractor::Route
     alias PackageScopeKey = Tuple(String, String)
@@ -106,27 +162,14 @@ module Analyzer::Java
 
         # Only files that mention Spring MVC / Feign bindings carry
         # annotation-based routes. Reactive `router().route()` files
-        # land in the `else` branch below.
-        spring_web_bind_package = "org.springframework.web.bind.annotation."
-        feign_client_package = "org.springframework.cloud.openfeign.FeignClient"
-        http_exchange_package = "org.springframework.web.service.annotation."
-        has_spring_bindings = content.includes?(spring_web_bind_package)
-        has_feign_bindings = content.includes?(feign_client_package) || content.includes?("@FeignClient")
-        has_http_exchange_bindings = http_exchange_bindings?(content, http_exchange_package)
-        has_gateway_bindings = content.includes?("RouteLocatorBuilder") ||
-                               content.includes?("PredicateSpec") ||
-                               content.includes?("org.springframework.cloud.gateway")
-        has_websocket_bindings = content.includes?("org.springframework.web.socket.config.annotation") ||
-                                 content.includes?("WebSocketMessageBrokerConfigurer") ||
-                                 content.includes?("@EnableWebSocketMessageBroker")
-        has_message_mapping_bindings = content.includes?("org.springframework.messaging.handler.annotation") ||
-                                       content.includes?("@MessageMapping") ||
-                                       content.includes?("@SubscribeMapping")
-        has_resource_handler_bindings = content.includes?("ResourceHandlerRegistry") ||
-                                        content.includes?("addResourceHandler")
+        # land in the `else` branch below. `ANY_BINDING_RE` is the OR of
+        # every marker the branch below keys off, so one pass decides
+        # whether the per-flag scans are worth running at all.
+        if content_matches?(content, ANY_BINDING_RE)
+          has_websocket_bindings = content_matches?(content, WEBSOCKET_BINDING_RE)
+          has_message_mapping_bindings = content_matches?(content, MESSAGE_MAPPING_BINDING_RE)
+          has_resource_handler_bindings = content_matches?(content, RESOURCE_HANDLER_BINDING_RE)
 
-        if has_spring_bindings || has_feign_bindings || has_http_exchange_bindings || has_gateway_bindings ||
-           has_websocket_bindings || has_message_mapping_bindings || has_resource_handler_bindings
           # Single tree-sitter parse for the whole file — every
           # extraction below pulls from the same root so a
           # controller with N routes pays for 1 parse instead of
@@ -388,15 +431,17 @@ module Analyzer::Java
       stomp_prefixes = Hash(String, Array(String)).new
       meta_index = SpringMetaAnnotationIndex.new
       project_roots = Set(String).new
-      spring_web_bind_package = "org.springframework.web.bind.annotation."
 
       java_files.each do |path|
         project_root = project_root_for(path)
         project_roots << project_root
 
         content = read_file_content(path)
-        needs_stomp = content.includes?("setApplicationDestinationPrefixes")
-        needs_meta = content.includes?(spring_web_bind_package) && content.includes?("@interface")
+        # One union pass rejects the files that can feed neither index
+        # before the two individual scans run.
+        next unless content_matches?(content, SPRING_INDEX_PRESCREEN_RE)
+        needs_stomp = content_matches?(content, STOMP_PREFIX_RE)
+        needs_meta = content_matches?(content, SPRING_WEB_BIND_RE) && content_matches?(content, META_ANNOTATION_RE)
         next unless needs_stomp || needs_meta
 
         Noir::TreeSitter.parse_java(content) do |root|
@@ -436,8 +481,6 @@ module Analyzer::Java
     private def collect_interface_route_index(java_files : Array(String),
                                               meta_annotation_index : SpringMetaAnnotationIndex) : SpringInterfaceRouteIndex
       index = SpringInterfaceRouteIndex.new
-      spring_web_bind_package = "org.springframework.web.bind.annotation."
-      http_exchange_package = "org.springframework.web.service.annotation."
 
       # `java_files` is already extension-filtered and test-path-free.
       java_files.each do |path|
@@ -447,10 +490,8 @@ module Analyzer::Java
         # classes that concrete controllers extend. Files with neither
         # keyword — the bulk of controller classes — can't contribute, so
         # skip the parse before the annotation gate below.
-        next unless content.includes?("interface") || content.includes?("abstract")
-        next unless content.includes?(spring_web_bind_package) || http_exchange_bindings?(content, http_exchange_package) ||
-                    content.includes?("@RequestMapping") ||
-                    content.includes?("@GetMapping") || content.includes?("@PostMapping")
+        next unless content_matches?(content, INTERFACE_OR_ABSTRACT_RE)
+        next unless content_matches?(content, INTERFACE_ROUTE_MARKER_RE)
 
         Noir::TreeSitter.parse_java(content) do |root|
           package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
@@ -466,16 +507,6 @@ module Analyzer::Java
       end
 
       index
-    end
-
-    private def http_exchange_bindings?(content : String, package_name : String) : Bool
-      content.includes?(package_name) ||
-        content.includes?("@HttpExchange") ||
-        content.includes?("@GetExchange") ||
-        content.includes?("@PostExchange") ||
-        content.includes?("@PutExchange") ||
-        content.includes?("@PatchExchange") ||
-        content.includes?("@DeleteExchange")
     end
 
     private def visible_meta_annotation_mappings(path : String,

--- a/src/analyzer/analyzers/python/cli.cr
+++ b/src/analyzer/analyzers/python/cli.cr
@@ -110,17 +110,23 @@ module Analyzer::Python
       @result
     end
 
+    # The seven literal markers below were seven separate Rabin-Karp
+    # passes over the whole file, run for every `.py` in the tree. One
+    # precompiled union is the same predicate in a single pass. The
+    # remaining tests go through `content_matches?` so PCRE2 skips its
+    # per-call UTF-8 revalidation of the buffer. The gate is a pure OR,
+    # so collapsing and reordering its terms cannot change the answer.
+    CLI_LITERAL_MARKERS_RE = Regex.union(
+      "argparse.ArgumentParser", "click.command", "click.group",
+      "typer.Typer", "fire.Fire", "getopt.getopt", "docopt",
+    )
+
     private def cli_entrypoint?(content : String) : Bool
-      return true if content.includes?("argparse.ArgumentParser")
-      return true if content.matches?(DECORATOR_CMD_RE) || content.includes?("click.command") ||
-                     content.includes?("click.group")
-      return true if content.includes?("typer.Typer")
-      return true if content.includes?("fire.Fire")
-      return true if content.includes?("getopt.getopt")
-      return true if content.includes?("docopt")
-      return true if content.matches?(ABSL_DEFINE_CALL_RE)
-      return true if content.matches?(CLEO_IMPORT_RE) && content.matches?(CLEO_COMMAND_CLASS_ANYWHERE_RE)
-      content.matches?(SYS_ARGV_RE) && content.matches?(MAIN_GUARD_RE)
+      return true if content_matches?(content, CLI_LITERAL_MARKERS_RE)
+      return true if content_matches?(content, DECORATOR_CMD_RE)
+      return true if content_matches?(content, ABSL_DEFINE_CALL_RE)
+      return true if content_matches?(content, CLEO_IMPORT_RE) && content_matches?(content, CLEO_COMMAND_CLASS_ANYWHERE_RE)
+      content_matches?(content, SYS_ARGV_RE) && content_matches?(content, MAIN_GUARD_RE)
     end
 
     private def python_binary_name(content : String, path : String) : String

--- a/src/analyzer/analyzers/python/http_server.cr
+++ b/src/analyzer/analyzers/python/http_server.cr
@@ -41,6 +41,11 @@ module Analyzer::Python
     # across query/form/json access, so one cache serves all three).
     @var_access_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
 
+    STDLIB_SERVER_MARKERS_RE = Regex.union(
+      "http.server", "HTTPServer", "BaseHTTPRequestHandler",
+      "SimpleHTTPRequestHandler", "wsgiref.simple_server",
+    )
+
     private def var_access_regexes(var : ::String) : Tuple(Regex, Regex)
       @var_access_regex_cache[var] ||= {
         /#{Regex.escape(var)}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/,
@@ -53,8 +58,13 @@ module Analyzer::Python
         @logger.debug "Analyzing #{path}"
 
         source = read_file_content(path)
+        # None of these markers can straddle a newline, so "some line
+        # contains one" is exactly "the file contains one" — one
+        # precompiled union pass over the buffer replaces five
+        # `String#includes?` scans per line, and the `lines` array is only
+        # built for files that actually pass.
+        next unless content_matches?(source, STDLIB_SERVER_MARKERS_RE)
         lines = source.lines
-        next unless lines.any? { |l| l.includes?("http.server") || l.includes?("HTTPServer") || l.includes?("BaseHTTPRequestHandler") || l.includes?("SimpleHTTPRequestHandler") || l.includes?("wsgiref.simple_server") }
 
         analyze_file(path, lines, source, current_base_path)
       end

--- a/src/analyzer/analyzers/ruby/actioncable.cr
+++ b/src/analyzer/analyzers/ruby/actioncable.cr
@@ -42,6 +42,11 @@ module Analyzer::Ruby
     # it explicitly (a standalone cable server still serves `/cable`).
     DEFAULT_MOUNT = "cable"
 
+    # Whole-buffer gates for the per-file loop below, one precompiled
+    # matcher instead of a `String#includes?` scan per `.rb` file.
+    CABLE_MOUNT_MARKER_RE = Regex.union("ActionCable.server")
+    CHANNEL_MARKER_RE     = Regex.union("Channel")
+
     def analyze
       mount = nil.as(String?)
       channels = [] of ChannelInfo
@@ -54,11 +59,15 @@ module Analyzer::Ruby
           begin
             content = read_file_content(path)
 
-            if mount.nil? && (m = content.match(CABLE_MOUNT))
+            # `CABLE_MOUNT` cannot match without the literal
+            # `ActionCable.server` in the buffer, so the cheap union gate
+            # in front of it is exact — and it keeps PCRE2 from
+            # revalidating the UTF-8 of every `.rb` file in the repo.
+            if mount.nil? && content_matches?(content, CABLE_MOUNT_MARKER_RE) && (m = content.match(CABLE_MOUNT))
               mount = m[1].strip.lstrip('/')
             end
 
-            collect_channels(content, path, channels) if content.includes?("Channel")
+            collect_channels(content, path, channels) if content_matches?(content, CHANNEL_MARKER_RE)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
             next

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -170,8 +170,13 @@ module Analyzer::Ruby
       GrapeIndex.new(grape, inherited)
     end
 
+    # `Grape::API` is absent from almost every `.rb` file in a large repo,
+    # so `String#includes?` scanned each one end to end. One precompiled
+    # matcher via `content_matches?` is the same test in a single pass.
+    GRAPE_API_MARKER_RE = Regex.union("Grape::API")
+
     private def grape_api_file?(content : String, grape_classes : Set(String)) : Bool
-      return true if content.includes?("Grape::API")
+      return true if content_matches?(content, GRAPE_API_MARKER_RE)
       # With no Grape classes anywhere in the project, the per-line membership
       # loop below can only ever miss, so skip it. This is the common case when
       # the whole-tree scan runs over a non-Grape repo (e.g. a Rails app, where

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -147,6 +147,10 @@ module Analyzer::Specification
 
     private def parse_messages(content : String) : Hash(String, MessageFields)
       messages = {} of String => MessageFields
+      # One character array for the whole file, shared by every message's
+      # brace match (see `find_matching_delimiter`). Built lazily so a
+      # `.proto` with no message declarations pays nothing.
+      chars = nil.as(Array(Char)?)
 
       # Find message blocks using brace matching (supports nested messages/enums)
       content.scan(/\bmessage\s+(\w+)\s*\{/m) do |match|
@@ -154,7 +158,8 @@ module Analyzer::Specification
         start_pos = match.begin(0) || 0
         brace_pos = content.index('{', start_pos)
         next if brace_pos.nil?
-        msg_body = extract_brace_block(content, brace_pos)
+        file_chars = (chars ||= content.chars)
+        msg_body = extract_brace_block(content, brace_pos, file_chars)
         next if msg_body.nil?
 
         fields = [] of Param
@@ -179,21 +184,30 @@ module Analyzer::Specification
     end
 
     private def parse_services(content : String, file_path : String, package : String, registry : Hash(String, MessageFields))
+      # As in `parse_messages`: one shared character array for the file.
+      # `content_lines` is likewise shared — `find_line_number` used to
+      # re-walk every line of the document once per rpc method.
+      chars = nil.as(Array(Char)?)
+      content_lines = nil.as(Array(String)?)
+
       # Find service blocks using brace matching
       content.scan(/\bservice\s+(\w+)\s*\{/m) do |service_match|
         service_name = service_match[1]
         start_pos = service_match.begin(0) || 0
         brace_pos = content.index('{', start_pos)
         next if brace_pos.nil?
-        service_body = extract_brace_block(content, brace_pos)
+        file_chars = (chars ||= content.chars)
+        service_body = extract_brace_block(content, brace_pos, file_chars)
         next if service_body.nil?
 
-        parse_rpc_methods(service_body, file_path, package, service_name, registry, content)
+        file_lines = (content_lines ||= content.lines)
+        parse_rpc_methods(service_body, file_path, package, service_name, registry, file_lines)
       end
     end
 
-    private def extract_brace_block(content : String, open_pos : Int32) : String?
-      close = find_matching_delimiter(content, open_pos, '{', '}')
+    private def extract_brace_block(content : String, open_pos : Int32,
+                                    chars : Array(Char) = content.chars) : String?
+      close = find_matching_delimiter(chars, open_pos, '{', '}')
       return if close.nil?
       content[(open_pos + 1)..(close - 1)]
     end
@@ -203,16 +217,23 @@ module Analyzer::Specification
     # a delimiter inside them can't shift the depth. Works for `{}` and `[]`
     # (the array form of `additional_bindings`).
     private def find_matching_delimiter(content : String, open_pos : Int32, open_char : Char, close_char : Char) : Int32?
-      # This walks whole message/service bodies per character, and Crystal's
-      # `String#[](Int)` is O(n) per access on non-ASCII content (no cached
-      # char->byte index) — materialize once and index the array instead.
-      # `String#index` below returns CHAR indices, so positions stay
-      # consistent; the returned index is a CHAR index.
-      chars = content.chars
+      find_matching_delimiter(content.chars, open_pos, open_char, close_char)
+    end
+
+    # `chars` overload: the caller owns the materialised character array.
+    #
+    # This used to take the `String` and call `content.chars` itself, which
+    # meant one `Array(Char)` the size of the whole file per message and per
+    # service — O(messages x file size). `kubernetes`' 339 KB
+    # `core/v1/generated.proto` alone paid for ~500 of them. Callers that
+    # scan a buffer repeatedly now build the array once and hand it in.
+    # Positions in and out are CHAR indices, as before.
+    private def find_matching_delimiter(chars : Array(Char), open_pos : Int32, open_char : Char, close_char : Char) : Int32?
+      size = chars.size
       depth = 0
       pos = open_pos
       in_string = false
-      while pos < chars.size
+      while pos < size
         ch = chars[pos]
         if in_string
           # A quote closes the string only when preceded by an EVEN number of
@@ -226,15 +247,21 @@ module Analyzer::Specification
             end
             in_string = false if bs.even?
           end
-        elsif ch == '/' && pos + 1 < chars.size && chars[pos + 1] == '/'
+        elsif ch == '/' && pos + 1 < size && chars[pos + 1] == '/'
           # Line comment: skip to EOL so a stray delimiter can't shift state.
-          nl = content.index('\n', pos)
-          pos = nl.nil? ? chars.size : nl
+          nl = pos
+          while nl < size && chars[nl] != '\n'
+            nl += 1
+          end
+          pos = nl
           next
-        elsif ch == '/' && pos + 1 < chars.size && chars[pos + 1] == '*'
+        elsif ch == '/' && pos + 1 < size && chars[pos + 1] == '*'
           # Block comment: skip to the closing */.
-          close = content.index("*/", pos + 2)
-          pos = close.nil? ? chars.size : close + 2
+          cur = pos + 2
+          while cur + 1 < size && !(chars[cur] == '*' && chars[cur + 1] == '/')
+            cur += 1
+          end
+          pos = cur + 1 < size ? cur + 2 : size
           next
         elsif ch == '"'
           in_string = true
@@ -249,7 +276,8 @@ module Analyzer::Specification
       nil
     end
 
-    private def parse_rpc_methods(service_body : String, file_path : String, package : String, service_name : String, registry : Hash(String, MessageFields), full_content : String)
+    private def parse_rpc_methods(service_body : String, file_path : String, package : String, service_name : String, registry : Hash(String, MessageFields), full_content_lines : Array(String))
+      body_chars = nil.as(Array(Char)?)
       # Find each rpc definition and its associated options block
       service_body.scan(/\brpc\s+(\w+)\s*\(\s*(stream\s+)?(\.?\w+(?:\.\w+)*)\s*\)\s*returns\s*\(\s*(stream\s+)?(\.?\w+(?:\.\w+)*)\s*\)/m) do |rpc_match|
         method_name = rpc_match[1]
@@ -263,13 +291,14 @@ module Analyzer::Specification
         if remaining =~ /\A\s*\{/
           brace_pos = service_body.index('{', rpc_end)
           if brace_pos
-            block = extract_brace_block(service_body, brace_pos)
+            service_chars = (body_chars ||= service_body.chars)
+            block = extract_brace_block(service_body, brace_pos, service_chars)
             options_block = block || ""
           end
         end
 
         # Find line number using word boundary match
-        line_number = find_line_number(full_content, method_name)
+        line_number = find_line_number(full_content_lines, method_name)
         details = Details.new(PathInfo.new(file_path, line_number))
 
         # Extract params from request message (resolved across imported files)
@@ -439,6 +468,7 @@ module Analyzer::Specification
     # no-colon, colon, and array (`[ {...}, {...} ]`) forms.
     private def each_additional_binding_body(rule_body : String, & : String ->)
       keyword = "additional_bindings"
+      rule_chars = nil.as(Array(Char)?)
       pos = 0
       while idx = rule_body.index(keyword, pos)
         cur = idx + keyword.size
@@ -452,29 +482,32 @@ module Analyzer::Specification
         case rule_body[cur]
         when '['
           # Array form: iterate each top-level { ... } object inside the [ ... ].
-          array_close = find_matching_delimiter(rule_body, cur, '[', ']')
+          body_chars = (rule_chars ||= rule_body.chars)
+          array_close = find_matching_delimiter(body_chars, cur, '[', ']')
           next if array_close.nil?
           inner = rule_body[(cur + 1)...array_close]
+          inner_chars = inner.chars
           obj_pos = 0
           while obj_open = inner.index('{', obj_pos)
-            obj_close = find_matching_delimiter(inner, obj_open, '{', '}')
+            obj_close = find_matching_delimiter(inner_chars, obj_open, '{', '}')
             break if obj_close.nil?
             yield inner[(obj_open + 1)...obj_close]
             obj_pos = obj_close + 1
           end
         when '{'
-          if body = extract_brace_block(rule_body, cur)
+          body_chars = (rule_chars ||= rule_body.chars)
+          if body = extract_brace_block(rule_body, cur, body_chars)
             yield body
           end
         end
       end
     end
 
-    private def find_line_number(content : String, method_name : String) : Int32?
+    private def find_line_number(lines : Array(String), method_name : String) : Int32?
       # Hoisted out of the loop: an interpolated regex literal recompiles
       # (PCRE2 JIT) on every evaluation, i.e. once per line.
       rpc_regex = /\brpc\s+#{Regex.escape(method_name)}\s*\(/
-      content.each_line.with_index do |line, index|
+      lines.each_with_index do |line, index|
         next unless line.includes?(method_name)
         if line =~ rpc_regex
           return index + 1

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -3006,30 +3006,32 @@ module Noir
     # aliased `h "net/http"`, etc). Mirrors the logic in GoCalleeExtractor
     # but kept private here to avoid widening any public surface and to stay
     # isolated from other miniparsers.
-    private def collect_http_aliases(source : String) : Set(String)
+    # `root` is passed in so the caller's parse is reused: this used to
+    # open its own `parse_go` and its only caller then opened a second
+    # one over the same buffer, i.e. two full tree-sitter parses per
+    # candidate `.go` file.
+    private def collect_http_aliases(root : LibTreeSitter::TSNode, source : String) : Set(String)
       aliases = Set(String).new
-      Noir::TreeSitter.parse_go(source) do |root|
-        walk(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "import_spec"
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "import_spec"
 
-          alias_name : String? = nil
-          import_path : String? = nil
-          Noir::TreeSitter.each_named_child(node) do |child|
-            case Noir::TreeSitter.node_type(child)
-            when "package_identifier"
-              alias_name = Noir::TreeSitter.node_text(child, source)
-            when "interpreted_string_literal", "raw_string_literal"
-              txt = Noir::TreeSitter.node_text(child, source)
-              import_path = unquote_like(txt)
-            end
+        alias_name : String? = nil
+        import_path : String? = nil
+        Noir::TreeSitter.each_named_child(node) do |child|
+          case Noir::TreeSitter.node_type(child)
+          when "package_identifier"
+            alias_name = Noir::TreeSitter.node_text(child, source)
+          when "interpreted_string_literal", "raw_string_literal"
+            txt = Noir::TreeSitter.node_text(child, source)
+            import_path = unquote_like(txt)
           end
-
-          next unless path = import_path
-          next unless path == "net/http"
-          name = alias_name || "http"
-          next if name.empty? || name == "_" || name == "."
-          aliases << name
         end
+
+        next unless path = import_path
+        next unless path == "net/http"
+        name = alias_name || "http"
+        next if name.empty? || name == "_" || name == "."
+        aliases << name
       end
       if aliases.empty? && source.includes?("net/http")
         aliases << "http"
@@ -3070,13 +3072,31 @@ module Noir
     # the handler decides at runtime) or the concrete verb when the modern
     # "METHOD /path" pattern form is used. Callers (the go_http analyzer) are
     # responsible for fanning ANY via `fan_out_verbs`.
+    # `decode_net_http_registration` accepts a registration only when the
+    # selector field is the identifier `Handle` or `HandleFunc`. An
+    # identifier is a single contiguous token, so a file that does not
+    # contain the substring `Handle` anywhere cannot produce a route here
+    # — and 15,800 of kubernetes' 17,874 `.go` files don't. Checking that
+    # first keeps the tree-sitter parse for the files that can actually
+    # match.
+    NET_HTTP_HANDLE_MARKER_RE = Regex.union("Handle")
+
+    # Necessary condition for `extract_net_http_routes` to return
+    # anything. Exposed so callers can skip the per-directory pre-passes
+    # that only ever feed net/http route resolution.
+    def net_http_route_source?(source : String) : Bool
+      NET_HTTP_HANDLE_MARKER_RE.matches?(source, options: Noir::TextFile::MATCH_OPTIONS)
+    end
+
     def extract_net_http_routes(source : String,
                                 external_string_values : Hash(String, String) = Hash(String, String).new) : Array(Route)
       routes = [] of Route
-      http_aliases = collect_http_aliases(source)
-      return routes if http_aliases.empty?
+      return routes unless net_http_route_source?(source)
 
       Noir::TreeSitter.parse_go(source) do |root|
+        http_aliases = collect_http_aliases(root, source)
+        next if http_aliases.empty?
+
         string_values = collect_string_values(root, source)
         external_string_values.each { |k, v| string_values[k] ||= v }
 

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -1,4 +1,5 @@
 require "../utils/text_file"
+require "./extraction_result_cache"
 
 module Noir
   # Shared file-level import-graph traversal for cross-file route /
@@ -25,6 +26,37 @@ module Noir
   module ImportGraph
     @@sibling_source_roots_cache = Hash(String, Array(String)).new
     @@sibling_source_roots_mutex = Mutex.new
+
+    IMPORT_RESOLUTION_MAX_ENTRIES = 262_144
+    PACKAGE_SIBLINGS_MAX_ENTRIES  =  32_768
+
+    @@import_resolution_cache = Hash(String, Array(String)).new
+    @@import_resolution_order = [] of String
+    @@import_resolution_mutex = Mutex.new
+
+    @@package_siblings_cache = Hash(String, Array(String)).new
+    @@package_siblings_order = [] of String
+    @@package_siblings_mutex = Mutex.new
+
+    DIRECTORY_MAX_ENTRIES = 262_144
+
+    @@directory_cache = Hash(String, Bool).new
+    @@directory_mutex = Mutex.new
+
+    # Filesystem-derived memos must not survive into a second scan of a
+    # different tree in the same process (`--diff`, library use).
+    Noir::ExtractionResultCache.register_clearer do
+      @@sibling_source_roots_mutex.synchronize { @@sibling_source_roots_cache.clear }
+      @@import_resolution_mutex.synchronize do
+        @@import_resolution_cache.clear
+        @@import_resolution_order.clear
+      end
+      @@package_siblings_mutex.synchronize do
+        @@package_siblings_cache.clear
+        @@package_siblings_order.clear
+      end
+      @@directory_mutex.synchronize { @@directory_cache.clear }
+    end
 
     # An import declaration extracted from a source file.
     #
@@ -68,7 +100,7 @@ module Noir
       visit.call(path)
 
       package_dir = File.dirname(path)
-      safe_glob("#{package_dir}/*.#{extension}") do |sibling|
+      package_siblings(package_dir, extension).each do |sibling|
         next if sibling == path
         visit.call(sibling)
       end
@@ -76,28 +108,127 @@ module Noir
       return if package_name.empty?
       source_root = source_root_for(path, package_name)
       return unless source_root
-      sibling_roots = sibling_source_roots(source_root)
 
       imports.each do |imp|
-        relative = imp.path.gsub(".", "/")
-        if imp.wildcard?
-          ([source_root] + sibling_roots).each do |root|
-            dir = File.join(root, relative)
-            next unless Dir.exists?(dir)
-            safe_glob("#{dir}/*.#{extension}") { |match| visit.call(match) }
-          end
+        resolve_import(source_root, imp, extension).each { |file| visit.call(file) }
+      end
+    end
+
+    # Files an import declaration resolves to, under `source_root` and
+    # its sibling module roots.
+    #
+    # Memoized. The resolution is a pure function of
+    # `(source_root, import, extension)` — `sibling_source_roots` is
+    # itself derived from `source_root` — while the inputs repeat
+    # heavily: every controller in a module imports the same JDK and
+    # framework classes, and each one used to re-probe
+    # `1 + sibling_roots.size` paths per import. On `spring-boot`
+    # (386 `src/main/java` roots) that was ~500k `access(2)` calls,
+    # a quarter of the whole `java_spring` analyzer.
+    private def self.resolve_import(source_root : String,
+                                    imp : ImportRef,
+                                    extension : String) : Array(String)
+      relative = imp.path.gsub(".", "/")
+      kind = imp.wildcard? ? "wildcard" : "single"
+      cache_key = "#{kind} #{extension} #{source_root} #{relative}"
+      @@import_resolution_mutex.synchronize do
+        if cached = @@import_resolution_cache[cache_key]?
+          return cached
+        end
+      end
+
+      sibling_roots = sibling_source_roots(source_root)
+      last_sep = relative.rindex('/')
+      relative_dir = last_sep ? relative[0, last_sep] : ""
+      resolved = [] of String
+      if imp.wildcard?
+        ([source_root] + sibling_roots).each do |root|
+          dir = File.join(root, relative)
+          next unless directory?(dir)
+          safe_glob("#{dir}/*.#{extension}") { |match| resolved << match }
+        end
+      else
+        # `File.exists?(root/pkg/Name.ext)` can only be true when
+        # `root/pkg` is a directory, and the package directory is shared
+        # by every class in that package — so the memoised directory test
+        # collapses a whole package's worth of misses into one `stat`.
+        # A JDK import like `java.util.List` otherwise probed every one of
+        # spring-boot's sibling module roots, per importing file.
+        file = File.join(source_root, "#{relative}.#{extension}")
+        if directory?(File.join(source_root, relative_dir)) && File.exists?(file)
+          resolved << file
         else
-          file = File.join(source_root, "#{relative}.#{extension}")
-          if File.exists?(file)
-            visit.call(file)
-          else
-            sibling_roots.each do |root|
-              sibling_file = File.join(root, "#{relative}.#{extension}")
-              visit.call(sibling_file) if File.exists?(sibling_file)
-            end
+          sibling_roots.each do |root|
+            next unless directory?(File.join(root, relative_dir))
+            sibling_file = File.join(root, "#{relative}.#{extension}")
+            resolved << sibling_file if File.exists?(sibling_file)
           end
         end
       end
+
+      @@import_resolution_mutex.synchronize do
+        store_capped(@@import_resolution_cache, @@import_resolution_order, cache_key, resolved, IMPORT_RESOLUTION_MAX_ENTRIES)
+      end
+    end
+
+    # Same-package siblings for one directory. Every file in a package
+    # asks the identical question, so one `Dir.glob` per directory
+    # replaces one per file.
+    private def self.package_siblings(package_dir : String, extension : String) : Array(String)
+      cache_key = "#{extension} #{package_dir}"
+      @@package_siblings_mutex.synchronize do
+        if cached = @@package_siblings_cache[cache_key]?
+          return cached
+        end
+      end
+
+      siblings = [] of String
+      safe_glob("#{package_dir}/*.#{extension}") { |sibling| siblings << sibling }
+
+      @@package_siblings_mutex.synchronize do
+        store_capped(@@package_siblings_cache, @@package_siblings_order, cache_key, siblings, PACKAGE_SIBLINGS_MAX_ENTRIES)
+      end
+    end
+
+    # Memoised `Dir.exists?`. See the call site for why the directory
+    # test is an exact short-circuit for the file test.
+    private def self.directory?(path : String) : Bool
+      @@directory_mutex.synchronize do
+        if cached = @@directory_cache[path]?
+          return cached
+        end
+      end
+      exists = Dir.exists?(path)
+      @@directory_mutex.synchronize do
+        if @@directory_cache.size >= DIRECTORY_MAX_ENTRIES
+          @@directory_cache.clear
+        end
+        @@directory_cache[path] = exists
+      end
+      exists
+    end
+
+    # FIFO-capped insert-or-keep; the caller holds the store's mutex.
+    # Keeps the memos from growing without bound on a monorepo while
+    # staying large enough that the working set never thrashes.
+    private def self.store_capped(store : Hash(String, Array(String)),
+                                  order : Array(String),
+                                  key : String,
+                                  value : Array(String),
+                                  max_entries : Int32) : Array(String)
+      unless store.has_key?(key)
+        if store.size >= max_entries
+          drop = store.size // 2
+          drop.times do
+            old = order.shift?
+            break unless old
+            store.delete(old)
+          end
+        end
+        store[key] = value
+        order << key
+      end
+      store[key]
     end
 
     # Infer the source root by stripping the package path from the


### PR DESCRIPTION
Cross-cutting, **detection-neutral** analyzer performance work. Scope was chosen by profiling, not
by a file list: everything here came out of `sample(1)` call graphs taken while scanning real
repositories, and nothing was changed on suspicion alone.

**Both neutrality checks are empty.** The per-fixture-directory A/B diff over the whole
`spec/functional_test/fixtures` tree (664 snapshot files) is empty, and re-scanning all eight
corpus repos before and after and diffing the normalized `METHOD url [params]` line sets is also
empty (6,809 lines). No fixtures or specs were added, because no behaviour changed.

## Corpus

Shallow clones, scanned with `./bin/noir scan -b <repo> -f json --no-log`.

| repo | size | why |
|---|---|---|
| `kubernetes/kubernetes` | 396 MB, 25,682 files, 17,874 `.go`, 137 `.proto` | Go monorepo + huge OpenAPI documents |
| `spring-boot` | 79 MB, 8,658 `.java`, 386 `src/main/java` roots | multi-module JVM |
| `grafana/grafana` | 301 MB | genuine polyglot monorepo (Go + TS) |
| `gitlabhq/gitlabhq` | 917 MB | polyglot monorepo (Ruby + JS + Go) |
| `django`, `rails`, `fastapi`, `flask` | 3–74 MB | smaller single-language checks |

## End-to-end wall clock

`--release` build (`just build-release`), page cache warm, 5 interleaved runs of the base binary
and the new binary per repo, `min` reported (medians tracked within 0.05 s of min throughout).

| repo | before | after | speedup |
|---|---|---|---|
| kubernetes | 4.75 s | 2.80 s | **1.70×** |
| grafana | 4.14 s | 2.50 s | **1.66×** |
| spring-boot | 4.17 s | 2.78 s | **1.50×** |
| gitlabhq | 3.44 s | 3.25 s | 1.06× |
| django | 1.33 s | 1.25 s | 1.06× |
| rails | 0.31 s | 0.29 s | 1.07× |
| fastapi | 0.38 s | 0.37 s | 1.03× |
| flask | 0.11 s | 0.11 s | 1.01× |

The last five are honestly flat: their remaining cost is the detector's file walk and reads (see
*Found but not fixed*), not analyzer work. Absolute times move a few percent between sessions on
this machine, which is why every number in this PR is from an interleaved A/B of the two binaries
rather than from separate runs.

## Per-analyzer wall clock

Measured with `--only-techs <tech>`, interleaved base vs new, min of 3. Subtract the repo's
detection floor (`--only-techs php_pure`, shown first) to read the analyzer's own cost.

| repo | tech | before | after |
|---|---|---|---|
| kubernetes | *(floor)* `php_pure` | 0.18 s | 0.18 s |
| kubernetes | `go_http` | 2.46 s | **1.29 s** |
| kubernetes | `go_cli` | 1.07 s | **0.68 s** |
| kubernetes | `grpc` | 0.51 s | **0.20 s** |
| kubernetes | `go_restful` | 0.66 s | 0.59 s |
| grafana | *(floor)* | 0.19 s | 0.19 s |
| grafana | `go_http` | 2.29 s | **0.89 s** |
| spring-boot | *(floor)* | 0.22 s | 0.22 s |
| spring-boot | `java_spring` | 2.27 s | **1.36 s** |
| spring-boot | `java_cli` | 0.74 s | **0.56 s** |
| spring-boot | `java_jaxrs` | 0.81 s | 0.68 s |
| spring-boot | `java_jsp` | 0.65 s | 0.59 s |
| gitlabhq | `ruby_actioncable` | 1.40 s | 1.30 s |
| django | `python_cli` | 0.29 s | 0.24 s |

`grpc` at 0.20 s against a 0.18 s floor means the analyzer's own cost on 2.2 MB of `.proto` is now
essentially zero.

## Changes

| analyzer | kind | what was wrong | evidence |
|---|---|---|---|
| `java/spring.cr` | perf | ~30 `String#includes?` passes over every `.java` file across three walks (main pass, `build_spring_indexes`, `collect_interface_route_index`). Now precompiled `Regex.union` via `content_matches?`, with one `ANY_BINDING_RE` union in front of the per-flag scans. | `sample`: `Analyzer::Java::Spring#analyze` 197 + `http_exchange_bindings?` 134 samples in `String#index`; after, 2. spring-boot 2.27 s → 1.86 s |
| `miniparsers/import_graph.cr` | perf | `related_files` re-probed the filesystem per importing file: one `Dir.glob` of the package dir + `1 + sibling_roots.size` `File.exists?` per import. spring-boot has 386 `src/main/java` roots, so `java.util.List` cost one `access(2)` per sibling module per importing file. Memoized per `(source_root, import, extension)`, plus a memoized `Dir.exists?` short-circuit on the package directory and a per-directory sibling glob. | `sample`: 514 `access` samples under `related_files`, 27 % of `java_spring`. 1.86 s → 1.42 s |
| `go/http.cr` + `miniparsers/go_route_extractor_ts.cr` | perf | Three redundancies: (a) `collect_package_groups_ts` was called only for its `{path => source}` cache and its group fixpoint discarded — 1 + 2N tree-sitter parses per package; (b) `extract_net_http_routes` parsed the buffer, then `collect_http_aliases` parsed it again; (c) no cheap gate before the parse, and the request-param pre-passes covered every `.go` file in every candidate directory. | `sample`: `ts_parser_parse_string` 1,112 samples split 423 / 373 / 204 / 104 across the four parse sites. kubernetes `go_http` 2.46 s → 1.29 s, grafana 2.29 s → 0.89 s |
| `go/cli.cr`, `java/cli.cr` | perf | Both ran their `Array(Char)` comment stripper over every source file in the tree, then rejected ~97 % on the CLI-evidence gate. | `sample`: `Analyzer::Go::Cli#analyze` 523 samples, of which `String#chars` 116 + `Char#to_s`/`String::Builder` 66. kubernetes `go_cli` 1.07 s → 0.68 s; spring-boot `java_cli` 0.74 s → 0.56 s |
| `specification/grpc.cr` | perf | `find_matching_delimiter` called `content.chars` itself, so each message and each service block allocated an `Array(Char)` the size of the whole file — O(messages × file size). `find_line_number` re-walked every line of the document once per rpc method. | `sample`: `Analyzer::Specification::Grpc#find_matching_delimiter` 237 samples, 204 of them in `String#chars` / `Array(Char)#push`. kubernetes `grpc` 0.51 s → 0.20 s |
| 9 × `go/*.cr` | perf | `content.includes?(IMPORT_MARKER)` per `.go` file; the marker is absent from nearly all of them. | `sample`: `go_restful.cr` 91 samples in `String#index`; after, 0 |
| `java/jaxrs.cr`, `java/jsp.cr`, `python/cli.cr`, `python/http_server.cr`, `ruby/grape.cr`, `ruby/actioncable.cr` | perf | Same shape: `includes?` chains / un-gated `content.match` over whole buffers, once per file in the tree. `python/http_server.cr` additionally built a `lines` array for every `.py` file before testing five markers per line. | `sample`: `ruby/grape.cr:43` 39, `Ruby::ActionCable#analyze` 37, `Python::Cli#analyze` 46, `python/http_server.cr:52` 23 samples in `String#index` |

### Why each of these is neutral, not just measured-to-be-neutral

The empty A/B diff is evidence, not proof, so the two gates that could in principle drop a file
were derived rather than guessed:

* **Comment-strip pre-gates (`go/cli.cr`, `java/cli.cr`).** `strip_comments` only ever replaces
  characters with `' '` or `'\n'` and never changes the character count. A literal containing no
  whitespace can therefore appear in the stripped text only if it already appears, unchanged, in
  the raw text. Each branch of both evidence gates requires such a literal verbatim
  (`FLAG_IMPORT_RE` is the literal `"flag"`; `\bos\.Args\s*\[` needs an adjacent `os.Args`), so a
  raw pre-gate built from those literals cannot reject a file the real gate would accept. Where a
  pattern's only whitespace-free part is weak (`new\s+Options\s*\(` contributes just `Options`),
  the weak literal is used — blanking a comment *can* manufacture whitespace, so `\s`-carrying
  parts are deliberately not relied on. Files that pass still run the full, comment-aware gate.
* **`Handle` gate on `extract_net_http_routes`.** `decode_net_http_registration` accepts a
  registration only when the selector field is the identifier `Handle` or `HandleFunc`. An
  identifier is a single contiguous token, so a file without the substring `Handle` cannot produce
  a route. 15,800 of kubernetes' 17,874 `.go` files don't contain it. The same necessary condition
  bounds `route_dirs`, whose only consumers — the request-param pre-passes — are read exclusively
  by `params_for_routes`, which returns immediately when the file produced no route.
* **`next if ts_routes.empty?` in `go/http.cr`.** With no routes, `routes_by_line` is empty, so no
  endpoint is created and `last_endpoint` stays `Endpoint.new("", "")`; both
  `add_param_to_endpoint` and the body-param branch require a non-empty URL. The per-line loop is a
  no-op by construction.
* **`Dir.exists?` short-circuit in `import_graph.cr`.** `File.exists?(dir/Name.ext)` implies
  `Dir.exists?(dir)`, so testing the directory first can only skip probes that would have failed.
* Every other change is a boolean-identical rewrite: `A.includes?(x) || A.includes?(y)` becomes
  `Regex.union(x, y).matches?(A)`, which is the same predicate in one pass. `Regex.union` escapes
  its arguments, so the literals stay literal.

The new caches in `ImportGraph` are FIFO-capped and registered with
`ExtractionResultCache.register_clearer`, so a second scan in the same process (`--diff`, library
use) cannot serve entries from the previous tree. The existing, previously unregistered
`sibling_source_roots` cache was folded into the same clearer.

## Verification

```
noir_ab.sh ./bin/noir spec/functional_test/fixtures /tmp/ab-w5/{before,after}
diff -ru /tmp/ab-w5/before /tmp/ab-w5/after     # empty (664 files)

corpus_ab.sh <binary> /tmp/corpusab-w5/{before,after}
diff -r /tmp/corpusab-w5/before /tmp/corpusab-w5/after   # empty (6,809 lines, 8 repos)

crystal spec spec/unit_test          # 4365 examples, 0 failures
crystal spec spec/functional_test    # 22536 examples, 0 failures
crystal tool format                  # clean
crystal run lib/ameba/bin/ameba.cr   # 1834 inspected, 0 failures
```

Each gate was run in its own command. Both A/B snapshots and both spec suites were re-run against
the final binary, not an intermediate one.

## Found but not fixed

**Out of this PR's scope (`src/analyzer/`), reported for whoever owns the detector.** After the
changes above, the top two hotspots of the largest corpus repo are both in `src/detector/`:

1. **`Detector::Go::Pocketbase#detect` — ~4 % of the whole kubernetes scan.** It runs
   `file_contents.includes?("pocketbase/tools/router")` on every `.go` file: 104 samples in
   `String#index`, the single largest non-I/O entry in the profile, and 31 samples on grafana. It
   is a one-line `Regex.union` away from free. The same shape appears in
   `Detector::Java::Play#detect` (101 samples), `Detector::Java::Spark#detect` (82) and
   `Detector::Java::Struts2#detect` (75) on spring-boot — together ~7 % of that scan.
2. **Detectors JSON-parse the same large document repeatedly.** kubernetes ships a 4.5 MB
   `api/openapi-spec/swagger.json` and 12 MB of `v3/*.json`; `JSON::Parser#parse_value` reached
   207 samples under `detector.cr:602` alone. A parsed-document cache shared across detectors (and
   ideally handed on to the spec analyzers) looks like the right fix, but it is a design change to
   the detector layer, not a local one.

**In scope, deliberately not done:**

3. **`oas2` / `oas3` / `caddy` each `JSON.parse` the same file.** On kubernetes, `swagger.json` is
   registered under `swagger-json`, `oas3-json` *and* `caddy-spec`, so three analyzers parse the
   same multi-MB buffer (62 + 57 samples for oas3 and caddy in one 3-second sample). A memoized
   `parse_json_document(path)` on `SpecificationEngine` would fix it, but it would hand the same
   mutable `JSON::Any` to several analyzers; I did not want to ship shared mutable parse state on
   the strength of an empty A/B diff alone, and auditing all ~40 spec analyzers for mutation was
   more than this PR's budget. Worth ~2–3 % on kubernetes.
4. **`gitlabhq` and `django` are detector-I/O bound.** 670 samples in `Noir::TextFile::read` and
   504 in `__open` on gitlab (917 MB). No analyzer change moves those; they are already 1.06×,
   which is all the analyzer-side headroom there was.
5. **`GoEngine.strip_comments` and `Java::Cli#strip_comments` are still character-array based.**
   Now that both are gated they run on a few hundred files instead of tens of thousands, so the
   remaining win is small. A byte-level rewrite that memcpy's the non-comment runs and counts
   non-continuation bytes for the comment runs would be exactly equivalent (the delimiters are all
   ASCII), but it is fiddly and no longer shows in any profile.
6. **`go_restful`, `oas3` and `go_cli` are now dominated by the shared `.go` / spec read path**, not
   by their own work — e.g. `go_restful` at 0.59 s against a 0.18 s floor is almost entirely the
   detector reading 17,874 Go files. Their `String#index` and tree-sitter costs are gone from the
   profile.

**No accuracy problems (FP or FN) were found while profiling.** That is a statement about what the
profiles surfaced, not an audit — this PR did not go looking for them, and the empty output diff
across eight repos means it neither fixed nor introduced any.
