### PR TITLE
fix(analyzer): scan results must not depend on where the project sits on disk

### DIFF
--- a/spec/unit_test/analyzer/go_engine_spec.cr
+++ b/spec/unit_test/analyzer/go_engine_spec.cr
@@ -25,6 +25,14 @@ describe Analyzer::Go::GoEngine do
       Analyzer::Go::GoEngine.go_test_file?("_testdata/fixture.go").should be_true
     end
 
+    # Callers hand it `Analyzer#base_relative_path`, which is rooted with a
+    # leading `/` so the check never sees the absolute path.
+    it "accepts the `/`-rooted scan-base-relative form" do
+      Analyzer::Go::GoEngine.go_test_file?("/path/_examples/main.go").should be_true
+      Analyzer::Go::GoEngine.go_test_file?("/_testdata/fixture.go").should be_true
+      Analyzer::Go::GoEngine.go_test_file?("/path/to/server.go").should be_false
+    end
+
     it "returns false for standard production files" do
       Analyzer::Go::GoEngine.go_test_file?("main.go").should be_false
       Analyzer::Go::GoEngine.go_test_file?("path/to/server.go").should be_false

--- a/spec/unit_test/analyzer/scan_base_path_spec.cr
+++ b/spec/unit_test/analyzer/scan_base_path_spec.cr
@@ -1,0 +1,139 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+require "file_utils"
+
+# A scan's answer must not depend on where the project sits on disk.
+#
+# Analyzers, engines and the shared parser layer decide which files to skip
+# ("this is a test fixture", "this is vendored", "this is build output") and
+# which URL a file-routed handler serves, by matching path substrings. Those
+# checks used to run on the ABSOLUTE path, so a directory *above* the scan
+# base — one the user never asked noir to reason about — decided the result:
+# a clone into `~/work/tests/myapp`, or a CI job that checks out under a
+# `test/` step directory, silently reported nothing at all.
+#
+# Every case below copies a real fixture tree to two locations, scans both,
+# and asserts the endpoint sets are identical. `spec/unit_test/analyzer/
+# legacy_scan_base_path_spec.cr` covers the same contract for the legacy
+# stacks (Classic ASP, CFML) with hand-written sources.
+private def scan_endpoints(root : String) : Array(String)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints.map { |endpoint| "#{endpoint.method} #{endpoint.url}" }.sort!.uniq!
+ensure
+  CodeLocator.instance.clear_all
+end
+
+# Copy `fixture` to `<tmp>/<segment>/<name>` and scan that copy. `segment`
+# is the hostile ancestor: it never appears inside the fixture itself, so a
+# correct scan cannot see it at all.
+private def scan_under_segment(fixture : String, segment : String) : Array(String)
+  root = File.tempname("noir-scan-base")
+  target = File.join(root, segment, File.basename(fixture))
+
+  begin
+    FileUtils.mkdir_p(File.dirname(target))
+    FileUtils.cp_r(fixture, target)
+    scan_endpoints(target)
+  ensure
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+# The path segments each stack's convention filters key off. Picking a
+# segment the fixture itself never contains means a correct answer is
+# unchanged from the neutral scan, whatever the filter decides.
+HOSTILE_ANCESTORS = [
+  {"php/laravel", "tests"},
+  {"php/laravel", "Tests"},
+  {"rust/axum", "tests"},
+  {"rust/axum", "benches"},
+  {"kotlin/spring", "src/test"},
+  {"kotlin/spring", "testData"},
+  {"kotlin/spring", "build"},
+  {"java/spring", "src/test"},
+  {"java/spring", "src/it"},
+  {"scala/play", "src/test"},
+  {"csharp/aspnet_core_mvc", "test"},
+  {"csharp/aspnet_core_mvc", "testassets"},
+  {"go/gin", "vendor"},
+  {"go/gin", "_work"},
+  {"swift/vapor", "Tests"},
+  {"swift/vapor", ".build"},
+  {"fsharp/giraffe", "tests"},
+  {"python/django", "site-packages"},
+  {"javascript/express", "node_modules"},
+  {"javascript/express", "__tests__"},
+  {"javascript/express", "dist"},
+  {"javascript/nextjs", "app"},
+  {"javascript/nuxtjs", "server"},
+  {"javascript/sveltekit", "src"},
+  {"javascript/remix", "app"},
+  {"javascript/astro", "src"},
+  {"javascript/nitro", "routes"},
+  {"javascript/fresh", "routes"},
+  {"typescript/trpc", "__tests__"},
+  {"typescript/trpc", "vendor"},
+  {"dart/dart_frog", "routes"},
+  {"perl/mojolicious", "t"},
+  {"perl/mojolicious", "test"},
+  {"crystal/kemal", "test"},
+  {"crystal/kemal", "lib"},
+  {"clojure/compojure", "test"},
+  {"elixir/phoenix", "test"},
+  {"lua/lapis", "test"},
+  {"cpp/crow", "test"},
+  {"haskell/scotty", "test"},
+  {"groovy/grails", "src/test"},
+  {"zig/httpz", "test"},
+  {"mobile/ios", "Tests"},
+  {"specification/strapi", "api"},
+]
+
+describe "scan results and the scan base path" do
+  fixtures_root = "spec/functional_test/fixtures"
+
+  HOSTILE_ANCESTORS.each do |(fixture, segment)|
+    it "reports the same #{fixture} endpoints from a base path under `#{segment}/`" do
+      fixture_path = File.join(fixtures_root, fixture)
+      neutral = scan_under_segment(fixture_path, "neutral-parent")
+      hostile = scan_under_segment(fixture_path, segment)
+
+      neutral.should_not be_empty
+      hostile.should eq(neutral)
+    end
+  end
+
+  # `/test/` must match a whole path segment. Before the fix these were
+  # substring tests on the absolute path, so a directory merely *starting*
+  # with a filtered name matched too.
+  it "does not treat a `latest/` or `vendored_libs/` ancestor as a filtered segment" do
+    fixture_path = File.join(fixtures_root, "php/laravel")
+    neutral = scan_under_segment(fixture_path, "neutral-parent")
+
+    scan_under_segment(fixture_path, "latest").should eq(neutral)
+    scan_under_segment(fixture_path, "vendored_libs").should eq(neutral)
+  end
+
+  # Pointing noir *at* a directory named `tests` is an explicit request for
+  # what is inside it. Relativising handles this naturally — the base's own
+  # relative path is empty — but it is the case most likely to regress.
+  it "analyzes a project whose scan base is itself named `tests`" do
+    fixture_path = File.join(fixtures_root, "php/laravel")
+    neutral = scan_under_segment(fixture_path, "neutral-parent")
+
+    root = File.tempname("noir-scan-base-is-tests")
+    target = File.join(root, "tests")
+
+    begin
+      FileUtils.mkdir_p(root)
+      FileUtils.cp_r(fixture_path, target)
+      scan_endpoints(target).should eq(neutral)
+    ensure
+      FileUtils.rm_rf(root) if Dir.exists?(root)
+    end
+  end
+end

--- a/src/analyzer/analyzers/clojure/cli.cr
+++ b/src/analyzer/analyzers/clojure/cli.cr
@@ -103,7 +103,9 @@ module Analyzer::Clojure
     end
 
     private def cli_test_path?(path : String) : Bool
-      lower = path.downcase
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      lower = base_relative_path(path).downcase
       lower.includes?("/test/") || lower.includes?("_test.")
     end
 

--- a/src/analyzer/analyzers/cpp/cli.cr
+++ b/src/analyzer/analyzers/cpp/cli.cr
@@ -106,7 +106,9 @@ module Analyzer::Cpp
     end
 
     private def cpp_test_path?(path : String) : Bool
-      path.matches?(CPP_TEST_PATH_RE)
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      base_relative_path(path).matches?(CPP_TEST_PATH_RE)
     end
 
     private def cpp_binary_name(path : String) : String

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -276,7 +276,10 @@ module Analyzer::Crystal
         next if @static_disabled_bases.includes?(base)
         get_public_files(base).each do |file|
           # Extract the path after "/public/" regardless of depth
-          if file =~ /\/public\/(.*)/
+          # Scan-base-relative, never absolute: the leftmost `/public/`
+          # wins, so a `public/` directory above the scan base put the
+          # whole intervening path into the served URL.
+          if base_relative_path(file) =~ /\/public\/(.*)/
             relative_path = $1
             @result << Endpoint.new("/#{relative_path}", "GET")
           end

--- a/src/analyzer/analyzers/crystal/cli.cr
+++ b/src/analyzer/analyzers/crystal/cli.cr
@@ -98,7 +98,9 @@ module Analyzer::Crystal
     end
 
     private def cli_test_path?(path : String) : Bool
-      lower = path.downcase
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      lower = base_relative_path(path).downcase
       lower.includes?("_spec.") || lower.includes?("/test/")
     end
 

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -202,7 +202,10 @@ module Analyzer::Crystal
       base_paths.each do |base|
         next if @static_disabled_bases.includes?(base)
         get_public_files(base).each do |file|
-          if file =~ /\/public\/(.*)/
+          # Scan-base-relative, never absolute: the leftmost `/public/`
+          # wins, so a `public/` directory above the scan base put the
+          # whole intervening path into the served URL.
+          if base_relative_path(file) =~ /\/public\/(.*)/
             relative_path = $1
             @result << Endpoint.new("/#{relative_path}", "GET")
           end

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -175,7 +175,10 @@ module Analyzer::Crystal
       # longer leak in as fake Lucky endpoints.
       each_public_file do |file|
         # Extract the path after "/public/" regardless of depth
-        if file =~ /\/public\/(.*)/
+        # Scan-base-relative, never absolute: the leftmost `/public/`
+        # wins, so a `public/` directory above the scan base put the
+        # whole intervening path into the served URL.
+        if base_relative_path(file) =~ /\/public\/(.*)/
           relative_path = $1
           @result << Endpoint.new("/#{relative_path}", "GET")
         end

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -207,7 +207,10 @@ module Analyzer::Crystal
     private def collect_public_dir_endpoints
       each_public_file do |file|
         # Extract the path after "/public/" regardless of depth
-        if file =~ /\/public\/(.*)/
+        # Scan-base-relative, never absolute: the leftmost `/public/`
+        # wins, so a `public/` directory above the scan base put the
+        # whole intervening path into the served URL.
+        if base_relative_path(file) =~ /\/public\/(.*)/
           relative_path = $1
           @result << Endpoint.new("/#{relative_path}", "GET")
         end

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -170,7 +170,7 @@ module Analyzer::CSharp
                                     project_roots : Array(String), include_callee : Bool)
       controller_files = get_files_by_extension(".cs").select do |file|
         base = File.basename(file)
-        next false if Common.csharp_test_path?(file)
+        next false if Common.csharp_test_path?(base_relative_path(file))
         base.includes?("Controller") && !base.ends_with?("RouteConfig.cs") && base != "Program.cs" && base != "Startup.cs"
       end
 

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -63,7 +63,7 @@ module Analyzer::CSharp
 
     private def analyze_controllers(include_callee : Bool)
       controller_files = get_files_by_extension(".cs").select do |file|
-        next false if Common.csharp_test_path?(file)
+        next false if Common.csharp_test_path?(base_relative_path(file))
         file.includes?("Controller") && !file.includes?("RouteConfig")
       end
 

--- a/src/analyzer/analyzers/csharp/carter.cr
+++ b/src/analyzer/analyzers/csharp/carter.cr
@@ -46,7 +46,7 @@ module Analyzer::CSharp
 
       get_files_by_extension(".cs").each do |file|
         next unless File.exists?(file)
-        next if Common.csharp_test_path?(file)
+        next if Common.csharp_test_path?(base_relative_path(file))
 
         content = read_file_content(file)
         next unless Common.carter_module_source?(content)

--- a/src/analyzer/analyzers/csharp/cli.cr
+++ b/src/analyzer/analyzers/csharp/cli.cr
@@ -74,7 +74,7 @@ module Analyzer::CSharp
 
       get_files_by_extension(".cs").each do |path|
         next if File.directory?(path)
-        next if Common.csharp_test_path?(path)
+        next if Common.csharp_test_path?(base_relative_path(path))
         next unless File.exists?(path)
 
         begin

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -16,11 +16,15 @@ module Analyzer::CSharp::Common
   # dotnet/aspnetcore alone parks ~3,600 phantom endpoints under
   # `src/Mvc/test/...` and similar trees. Production code never
   # adopts any of these.
-  def self.csharp_test_path?(path : String) : Bool
-    return true if path.includes?("/test/")
-    return true if path.includes?("/tests/")
-    return true if path.includes?("/testassets/")
-    base = File.basename(path)
+  # Takes the scan-base-relative path (`Analyzer#base_relative_path`),
+  # never the absolute one. The conventions describe a location inside
+  # the solution, so on an absolute path a `test/` directory above the
+  # scan base suppressed the whole project.
+  def self.csharp_test_path?(relative_path : String) : Bool
+    return true if relative_path.includes?("/test/")
+    return true if relative_path.includes?("/tests/")
+    return true if relative_path.includes?("/testassets/")
+    base = File.basename(relative_path)
     return true if base.ends_with?("Tests.cs")
     base.ends_with?("Test.cs")
   end

--- a/src/analyzer/analyzers/csharp/fastendpoints.cr
+++ b/src/analyzer/analyzers/csharp/fastendpoints.cr
@@ -33,7 +33,7 @@ module Analyzer::CSharp
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      cs_files = get_files_by_extension(".cs").reject { |f| Common.csharp_test_path?(f) }
+      cs_files = get_files_by_extension(".cs").reject { |f| Common.csharp_test_path?(base_relative_path(f)) }
       # One pass picks the FastEndpoints sources and, from the same content,
       # the request-DTO names their `Endpoint<TRequest>` bases refer to. Only
       # those DTOs are worth indexing: the old code extracted the property

--- a/src/analyzer/analyzers/csharp/httplistener.cr
+++ b/src/analyzer/analyzers/csharp/httplistener.cr
@@ -63,7 +63,7 @@ module Analyzer::CSharp
 
       get_files_by_extension(".cs").each do |file|
         next unless File.exists?(file)
-        next if Common.csharp_test_path?(file)
+        next if Common.csharp_test_path?(base_relative_path(file))
 
         content = read_file_content(file)
         next unless httplistener_related_source?(content)

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -24,7 +24,7 @@ module Analyzer::CSharp::MinimalApiSupport
   private def analyze_minimal_api_files(include_callee : Bool)
     get_files_by_extension(".cs").each do |file|
       next unless File.exists?(file)
-      next if Common.csharp_test_path?(file)
+      next if Common.csharp_test_path?(base_relative_path(file))
 
       content = read_file_content(file)
       # Carter modules register minimal-API routes too, but under a module

--- a/src/analyzer/analyzers/csharp/signalr.cr
+++ b/src/analyzer/analyzers/csharp/signalr.cr
@@ -64,7 +64,7 @@ module Analyzer::CSharp
       map_hub_types = Set(String).new # types named in MapHub<T>
 
       files = get_files_by_extension(".cs").reject do |path|
-        File.directory?(path) || Common.csharp_test_path?(path) || !File.exists?(path)
+        File.directory?(path) || Common.csharp_test_path?(base_relative_path(path)) || !File.exists?(path)
       end
 
       # Pass 1 — routes + mounted types across every file. A hub class and

--- a/src/analyzer/analyzers/dart/cli.cr
+++ b/src/analyzer/analyzers/dart/cli.cr
@@ -95,7 +95,9 @@ module Analyzer::Dart
     end
 
     private def cli_test_path?(path : String) : Bool
-      lower = path.downcase
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      lower = base_relative_path(path).downcase
       lower.matches?(TEST_PATH_RE)
     end
 

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -67,10 +67,14 @@ module Analyzer::Dart
           # are mock handlers exercised by `dart test`, never live routes.
           next if Helper.test_path?(path, base_paths)
 
-          idx = path.index("/routes/")
+          # Scan-base-relative, never absolute: `String#index` takes the
+          # FIRST occurrence, so a same-named directory above the scan base
+          # won outright and the derived URL changed with the checkout path.
+          scoped = base_relative_path(path)
+          idx = scoped.index("/routes/")
           next if idx.nil?
 
-          relative = path[(idx + "/routes/".size)..-1]
+          relative = scoped[(idx + "/routes/".size)..-1]
           leaf = File.basename(relative)
           next if leaf.starts_with?("_") # `_middleware.dart` and other plumbing
 

--- a/src/analyzer/analyzers/elixir/cli.cr
+++ b/src/analyzer/analyzers/elixir/cli.cr
@@ -70,7 +70,9 @@ module Analyzer::Elixir
     end
 
     private def cli_test_path?(path : String) : Bool
-      lower = path.downcase
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      lower = base_relative_path(path).downcase
       lower.includes?("/test/") || lower.includes?("_test.")
     end
 

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -96,9 +96,13 @@ module Analyzer::Fsharp
       @result
     end
 
+    # Scan-base-relative, never absolute: a `tests/` directory ABOVE the
+    # scan base is not this project's test tree — the fixture tree
+    # dropped all 61 of its endpoints when scanned from one.
     private def fsharp_test_path?(path : String) : Bool
-      return true if path.includes?("/tests/")
-      return true if path.includes?("/test/")
+      relative = base_relative_path(path)
+      return true if relative.includes?("/tests/")
+      return true if relative.includes?("/test/")
       base = File.basename(path)
       return true if base.ends_with?("Tests.fs")
       base.ends_with?("Test.fs")

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -50,7 +50,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -134,7 +134,7 @@ module Analyzer::Go
                 path = channel.receive?
                 break if path.nil?
                 next if File.directory?(path)
-                next if GoEngine.go_test_file?(path)
+                next if GoEngine.go_test_file?(base_relative_path(path))
                 if File.exists?(path)
                   content = file_contents_cache[path]? || read_file_content(path)
                   next unless content_matches?(content, IMPORT_MARKER_RE)

--- a/src/analyzer/analyzers/go/cli.cr
+++ b/src/analyzer/analyzers/go/cli.cr
@@ -133,7 +133,7 @@ module Analyzer::Go
 
       get_files_by_extension(".go").each do |path|
         next if File.directory?(path)
-        next if GoEngine.go_test_file?(path)
+        next if GoEngine.go_test_file?(base_relative_path(path))
         next unless File.exists?(path)
 
         begin

--- a/src/analyzer/analyzers/go/connect_rpc.cr
+++ b/src/analyzer/analyzers/go/connect_rpc.cr
@@ -75,7 +75,7 @@ module Analyzer::Go
     private def discover_connect_go_endpoints(seen_urls : Set(String))
       get_files_by_extension(".go").each do |path|
         next if File.directory?(path)
-        next if GoEngine.go_test_file?(path)
+        next if GoEngine.go_test_file?(base_relative_path(path))
         begin
           content = read_file_content(path)
           next unless content_matches?(content, IMPORT_MARKER_RE)
@@ -128,7 +128,7 @@ module Analyzer::Go
       begin
         get_files_by_extension(".go").each do |path|
           next if File.directory?(path)
-          next if GoEngine.go_test_file?(path)
+          next if GoEngine.go_test_file?(base_relative_path(path))
           base_path = configured_base_for(path)
           content = read_file_content(path)
           next unless content_matches?(content, IMPORT_OR_HANDLER_RE)

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -34,7 +34,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -23,7 +23,7 @@ module Analyzer::Go
         file_contents = Hash(String, String).new
         go_files.each do |fp|
           next if File.directory?(fp)
-          next if GoEngine.go_test_file?(fp)
+          next if GoEngine.go_test_file?(base_relative_path(fp))
           begin
             file_contents[fp] = read_file_content(fp)
           rescue File::NotFoundError
@@ -38,7 +38,7 @@ module Analyzer::Go
         base_paths.each do |current_base_path|
           go_files.each do |path|
             next unless path_under_root?(path, current_base_path)
-            next if GoEngine.go_test_file?(path)
+            next if GoEngine.go_test_file?(base_relative_path(path))
             if File.exists?(path)
               content = read_file_content(path)
               next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -33,7 +33,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -32,7 +32,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -44,7 +44,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)

--- a/src/analyzer/analyzers/go/go_restful.cr
+++ b/src/analyzer/analyzers/go/go_restful.cr
@@ -40,7 +40,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   next unless File.exists?(path)
 
                   content = file_contents[path]? || read_file_content(path)

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -37,7 +37,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -44,7 +44,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
 
                   # Handle both .go files and .api files
                   if File.exists?(path) && (File.extname(path) == ".go" || File.extname(path) == ".api")

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -38,7 +38,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)

--- a/src/analyzer/analyzers/go/http.cr
+++ b/src/analyzer/analyzers/go/http.cr
@@ -40,7 +40,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -49,7 +49,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -61,7 +61,7 @@ module Analyzer::Go
 
       get_files_by_extension(".go").each do |scan_path|
         next if File.directory?(scan_path)
-        next if GoEngine.go_test_file?(scan_path)
+        next if GoEngine.go_test_file?(base_relative_path(scan_path))
         begin
           dir = File.dirname(scan_path)
           package_files[dir] ||= [] of String
@@ -99,7 +99,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   next unless File.exists?(path)
 
                   content = file_contents_cache[path]? || read_file_content(path)

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -30,7 +30,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -40,7 +40,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)

--- a/src/analyzer/analyzers/go/pocketbase.cr
+++ b/src/analyzer/analyzers/go/pocketbase.cr
@@ -33,7 +33,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if GoEngine.go_test_file?(path)
+                  next if GoEngine.go_test_file?(base_relative_path(path))
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)

--- a/src/analyzer/analyzers/groovy/cli.cr
+++ b/src/analyzer/analyzers/groovy/cli.cr
@@ -237,7 +237,9 @@ module Analyzer::Groovy
     end
 
     private def cli_test_path?(path : String) : Bool
-      path.downcase.matches?(CLI_TEST_PATH_RE)
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      base_relative_path(path).downcase.matches?(CLI_TEST_PATH_RE)
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/haskell/cli.cr
+++ b/src/analyzer/analyzers/haskell/cli.cr
@@ -149,7 +149,9 @@ module Analyzer::Haskell
     end
 
     private def cli_test_path?(path : String) : Bool
-      path.downcase.matches?(TEST_PATH_RE)
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      base_relative_path(path).downcase.matches?(TEST_PATH_RE)
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -46,7 +46,7 @@ module Analyzer::Java
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if JavaEngine.test_path?(path)
+                  next if JavaEngine.test_path?(base_relative_path(path))
 
                   if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))
                     content = read_file_content(path)
@@ -461,7 +461,7 @@ module Analyzer::Java
       registrations = Hash(ScopedClassKey, Array(String)).new { |hash, key| hash[key] = [] of String }
 
       get_files_by_extension(".java").each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
 
         content = read_file_content(path)
         next unless content.includes?(".annotatedService")
@@ -486,7 +486,7 @@ module Analyzer::Java
       index = Hash(ScopedClassKey, Array(RouteEntry)).new
 
       get_files_by_extension(".java").each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
 
         content = read_file_content(path)
         next unless content.includes?("HttpServiceWithRoutes") || content.includes?("ServiceWithRoutes")

--- a/src/analyzer/analyzers/java/cli.cr
+++ b/src/analyzer/analyzers/java/cli.cr
@@ -58,7 +58,7 @@ module Analyzer::Java
 
       get_files_by_extension(".java").each do |path|
         next if File.directory?(path)
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
 
         begin

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -49,7 +49,7 @@ module Analyzer::Java
       path_configs = path_configs_for(file_list)
       dropwizard_roots = dropwizard_project_roots_for(file_list)
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
         project_root = project_root_for(path)
@@ -109,7 +109,7 @@ module Analyzer::Java
       project_roots = Set(String).new
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
         project_roots << project_root_for(path)
@@ -126,7 +126,7 @@ module Analyzer::Java
       roots = Set(String).new
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/httpserver.cr
+++ b/src/analyzer/analyzers/java/httpserver.cr
@@ -61,7 +61,7 @@ module Analyzer::Java
       include_callee = callees_needed?
 
       all_files.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
         next unless File.exists?(path)
 

--- a/src/analyzer/analyzers/java/javalin.cr
+++ b/src/analyzer/analyzers/java/javalin.cr
@@ -48,7 +48,7 @@ module Analyzer::Java
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -29,7 +29,7 @@ module Analyzer::Java
       application_base_paths = application_base_paths_for(file_list)
       derivative_project_roots = derivative_project_roots_for(file_list)
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
         next if derivative_project_roots.includes?(project_root_for(path))
@@ -81,7 +81,7 @@ module Analyzer::Java
       application_packages = Hash(String, Array(ApplicationBaseKey)).new { |hash, key| hash[key] = [] of ApplicationBaseKey }
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
@@ -118,7 +118,7 @@ module Analyzer::Java
       roots = Set(String).new
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
@@ -170,7 +170,7 @@ module Analyzer::Java
       global_candidates = Hash(String, Array(String)).new { |hash, key| hash[key] = [] of String }
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.basename(path) == "web.xml"
         next unless File.exists?(path)
 

--- a/src/analyzer/analyzers/java/micronaut.cr
+++ b/src/analyzer/analyzers/java/micronaut.cr
@@ -66,7 +66,7 @@ module Analyzer::Java
       end
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
@@ -120,7 +120,7 @@ module Analyzer::Java
       index = MicronautInterfaceRouteIndex.new
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
@@ -190,7 +190,7 @@ module Analyzer::Java
       project_roots = Set(String).new
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
         project_roots << project_root_for(path)

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -32,7 +32,10 @@ module Analyzer::Java
         # resources/`. Both `/src/test/` (Maven/Gradle convention) and
         # `/src/sbt-test/` (sbt-plugin's per-fixture test trees) are
         # unambiguous — production code never adopts either.
-        next if path.includes?("/src/test/") || path.includes?("/src/sbt-test/")
+        # Scan-base-relative, never absolute: a `src/test/` directory
+        # ABOVE the scan base is not this project's test tree.
+        relative = base_relative_path(path)
+        next if relative.includes?("/src/test/") || relative.includes?("/src/sbt-test/")
 
         if path.ends_with?("routes") || path.ends_with?("routes.conf") || path.includes?("/conf/routes")
           routes_files << path

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -50,7 +50,7 @@ module Analyzer::Java
       end
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
         next unless quarkus_roots.includes?(project_root_for(path))
@@ -96,7 +96,7 @@ module Analyzer::Java
       roots = Set(String).new
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
@@ -111,7 +111,7 @@ module Analyzer::Java
       base_paths = Hash(ApplicationBaseKey, String).new
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
         next unless quarkus_roots.includes?(project_root_for(path))
@@ -172,7 +172,7 @@ module Analyzer::Java
       project_roots = Set(String).new
 
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
         project_roots << project_root_for(path)

--- a/src/analyzer/analyzers/java/spark.cr
+++ b/src/analyzer/analyzers/java/spark.cr
@@ -49,7 +49,7 @@ module Analyzer::Java
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       file_list.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -4,6 +4,7 @@ require "../../../miniparsers/java_parameter_extractor_ts"
 require "../../../miniparsers/java_callee_extractor"
 require "../../../utils/spring_property_path"
 require "../../engines/java_engine"
+require "../../../utils/path_scope"
 require "yaml"
 
 module Analyzer::Java
@@ -92,7 +93,7 @@ module Analyzer::Java
       # content walks over the Java source set only; webflux /
       # servlet context paths come from `path_config_for` (application.yml
       # / .properties under each project root).
-      java_files = get_files_by_extension(".java").reject { |path| JavaEngine.test_path?(path) }
+      java_files = get_files_by_extension(".java").reject { |path| JavaEngine.test_path?(base_relative_path(path)) }
       path_configs, spring_property_maps, stomp_prefixes, meta_annotation_index, interface_route_index =
         build_spring_indexes(java_files)
 
@@ -1277,14 +1278,26 @@ module Analyzer::Java
       end
     end
 
+    # The Maven/Gradle module root: everything above the source root that
+    # holds this file.
+    #
+    # The marker is searched inside the scan-base-relative path, never the
+    # absolute one. `String#index` returns the FIRST occurrence, so on an
+    # absolute path a `src/` directory anywhere above the scan base won
+    # outright and the module root resolved to a directory outside the
+    # scan — `application.properties` was then never found and every
+    # `server.servlet.context-path` prefix silently vanished.
     private def project_root_for(path : String) : String
+      base = configured_base_for(path)
+      relative = Noir::PathScope.base_relative(path, base)
+
       ["/src/main/java/", "/src/"].each do |marker|
-        if index = path.index(marker)
-          return path[...index]
+        if index = relative.index(marker)
+          return base.rstrip('/') + relative[...index]
         end
       end
 
-      configured_base_for(path)
+      base
     end
 
     private def normalize_optional_path(path : String?) : String

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -96,7 +96,7 @@ module Analyzer::Java
       seen = Set(String).new
 
       java_files = file_list.select do |path|
-        File.exists?(path) && path.ends_with?(".java") && !JavaEngine.test_path?(path)
+        File.exists?(path) && path.ends_with?(".java") && !JavaEngine.test_path?(base_relative_path(path))
       end
 
       # Build a FQCN → source-path index up front so XML `<action
@@ -172,7 +172,7 @@ module Analyzer::Java
         # deployed action — gate it the same way the `.java` selection at
         # the top of `analyze` does via the shared `JavaEngine.test_path?`
         # convention.
-        next false if JavaEngine.test_path?(path)
+        next false if JavaEngine.test_path?(base_relative_path(path))
         basename = File.basename(path)
         STRUTS_CONFIG_BASENAMES.includes?(basename) || basename.ends_with?("-struts.xml")
       end

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -71,7 +71,7 @@ module Analyzer::Java
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
-                  next if JavaEngine.test_path?(path)
+                  next if JavaEngine.test_path?(base_relative_path(path))
 
                   if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))
                     details = Details.new(PathInfo.new(path))

--- a/src/analyzer/analyzers/java/wicket.cr
+++ b/src/analyzer/analyzers/java/wicket.cr
@@ -85,7 +85,7 @@ module Analyzer::Java
       files = [] of FileInfo
 
       all_files.each do |path|
-        next if JavaEngine.test_path?(path)
+        next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/javascript/astro.cr
+++ b/src/analyzer/analyzers/javascript/astro.cr
@@ -44,10 +44,14 @@ module Analyzer::Javascript
       mutex = Mutex.new
 
       parallel_file_scan(EXTENSIONS) do |path|
-        idx = path.index("/src/pages/")
+        # Scan-base-relative, never absolute: `String#index` takes the
+        # FIRST occurrence, so a same-named directory above the scan base
+        # won outright and the derived URL changed with the checkout path.
+        scoped = base_relative_path(path)
+        idx = scoped.index("/src/pages/")
         next if idx.nil?
 
-        relative = path[(idx + "/src/pages/".size)..-1]
+        relative = scoped[(idx + "/src/pages/".size)..-1]
         # Skip private files / dirs (`_` prefix) and Astro components
         # nested under non-pages directories like `src/pages/_partials`.
         next if relative.split("/").any?(&.starts_with?("_"))

--- a/src/analyzer/analyzers/javascript/cli.cr
+++ b/src/analyzer/analyzers/javascript/cli.cr
@@ -155,8 +155,11 @@ module Analyzer::Javascript
     end
 
     private def js_test_or_vendor?(path : String) : Bool
-      path.includes?("/node_modules/") || path.includes?("/__tests__/") ||
-        path.includes?(".test.") || path.includes?(".spec.") || path.includes?(".d.ts")
+      # Scan-base-relative, never absolute: a `node_modules/` or
+      # `__tests__/` directory ABOVE the scan base is not this project's.
+      relative = base_relative_path(path)
+      relative.includes?("/node_modules/") || relative.includes?("/__tests__/") ||
+        relative.includes?(".test.") || relative.includes?(".spec.") || relative.includes?(".d.ts")
     end
 
     private def scan(lines : Array(String), path : String, root_url : String,

--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -111,10 +111,14 @@ module Analyzer::Javascript
 
       parallel_file_scan(EXTENSIONS) do |path|
         next unless path_under_project_roots?(path, project_roots)
-        idx = path.index("/routes/")
+        # Scan-base-relative, never absolute: `String#index` takes the
+        # FIRST occurrence, so a same-named directory above the scan base
+        # won outright and the derived URL changed with the checkout path.
+        scoped = base_relative_path(path)
+        idx = scoped.index("/routes/")
         next if idx.nil?
 
-        relative = path[(idx + "/routes/".size)..-1]
+        relative = scoped[(idx + "/routes/".size)..-1]
         leaf = strip_extension(File.basename(relative))
         next if SKIPPED_LEAVES.includes?(leaf)
         next if leaf.starts_with?("_") # other underscore-prefixed plumbing

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -91,9 +91,12 @@ module Analyzer::Javascript
     end
 
     private def ignored_nest_path?(path : String) : Bool
-      path.includes?(".test.") || path.includes?(".spec.") ||
-        path.includes?("/__tests__/") || path.includes?("/__mocks__/") ||
-        path.includes?("/test/fixtures/") || path.includes?("/tests/fixtures/")
+      # Scan-base-relative, never absolute: a `__tests__/` or `test/`
+      # directory ABOVE the scan base is not this project's test tree.
+      relative = base_relative_path(path)
+      relative.includes?(".test.") || relative.includes?(".spec.") ||
+        relative.includes?("/__tests__/") || relative.includes?("/__mocks__/") ||
+        relative.includes?("/test/fixtures/") || relative.includes?("/tests/fixtures/")
     end
 
     # Prepend the discovered `app.setGlobalPrefix('api')` value to

--- a/src/analyzer/analyzers/javascript/nextjs.cr
+++ b/src/analyzer/analyzers/javascript/nextjs.cr
@@ -48,25 +48,35 @@ module Analyzer::Javascript
     end
 
     private def ignored_next_path?(path : String) : Bool
-      path.includes?(".test.") || path.includes?(".spec.") ||
-        path.includes?("/__tests__/") || path.includes?("/__mocks__/") ||
-        path.includes?("/test/fixtures/") || path.includes?("/tests/fixtures/")
+      # Scan-base-relative, never absolute: a `__tests__/` or `test/`
+      # directory ABOVE the scan base is not this project's test tree.
+      relative = base_relative_path(path)
+      relative.includes?(".test.") || relative.includes?(".spec.") ||
+        relative.includes?("/__tests__/") || relative.includes?("/__mocks__/") ||
+        relative.includes?("/test/fixtures/") || relative.includes?("/tests/fixtures/")
     end
 
+    # The router-directory markers below name directories *inside* the
+    # Next.js project, so they are matched on the scan-base-relative
+    # path. On the absolute path a checkout that merely lived under an
+    # `app/` directory turned every `route.ts` in the tree into an
+    # app-router handler, and `String#index` (first occurrence) then
+    # derived the URL from that outside directory.
     private def app_router_file?(path : String) : Bool
-      return false unless path.includes?("/app/")
+      return false unless base_relative_path(path).includes?("/app/")
       EXTENSIONS.any? { |ext| path.ends_with?("/route#{ext}") }
     end
 
     private def pages_router_file?(path : String) : Bool
-      path.includes?("/pages/api/")
+      base_relative_path(path).includes?("/pages/api/")
     end
 
     private def analyze_pages_router_file(path : String, result : Array(Endpoint), mutex : Mutex, include_callee : Bool)
-      idx = path.index("/pages/api/")
+      scoped = base_relative_path(path)
+      idx = scoped.index("/pages/api/")
       return if idx.nil?
 
-      relative = path[(idx + "/pages/api/".size)..-1]
+      relative = scoped[(idx + "/pages/api/".size)..-1]
       relative = strip_extension(relative)
 
       # Skip private folders/files (leading underscore)
@@ -103,10 +113,11 @@ module Analyzer::Javascript
     end
 
     private def analyze_app_router_file(path : String, result : Array(Endpoint), mutex : Mutex, include_callee : Bool)
-      idx = path.index("/app/")
+      scoped = base_relative_path(path)
+      idx = scoped.index("/app/")
       return if idx.nil?
 
-      relative = path[(idx + "/app/".size)..-1]
+      relative = scoped[(idx + "/app/".size)..-1]
       # Drop /route.ext
       EXTENSIONS.each do |ext|
         if relative.ends_with?("/route#{ext}")

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -40,11 +40,15 @@ module Analyzer::Javascript
       # routes/users.get.ts -> /users (GET only)
       # routes/api/items.ts -> /api/items
 
-      base_path_idx = path.index("/routes/")
+      # Scan-base-relative, never absolute: `String#index` takes the
+      # FIRST occurrence, so a same-named directory above the scan base
+      # won outright and the derived URL changed with the checkout path.
+      scoped = base_relative_path(path)
+      base_path_idx = scoped.index("/routes/")
       return if base_path_idx.nil?
 
       # Get the path after /routes/
-      relative_path = path[(base_path_idx + "/routes/".size)..-1]
+      relative_path = scoped[(base_path_idx + "/routes/".size)..-1]
 
       # Remove file extension
       relative_path = relative_path.gsub(/\.(js|ts|mjs|mts)$/, "")

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -15,16 +15,19 @@ module Analyzer::Javascript
       parallel_file_scan(EXTENSIONS) do |path|
         # Focus on server/api and server/routes directories for Nuxt 3
         next unless path.includes?("/server/api/") || path.includes?("/server/routes/")
+        # Scan-base-relative, never absolute: a `test/` or `__tests__/`
+        # directory ABOVE the scan base is not this project's test tree.
+        relative = base_relative_path(path)
         # Skip `*.test.ts` / `*.spec.ts` siblings — they don't
         # define Nuxt event handlers, just exercise neighbors.
-        next if path.includes?(".test.") || path.includes?(".spec.")
+        next if relative.includes?(".test.") || relative.includes?(".spec.")
         # Skip mini-Nuxt fixtures used to test the framework itself.
         # nuxt/nuxt parks 18 phantom endpoints under
         # `test/fixtures/<scenario>/server/api/` — each fixture is a
         # full Nuxt project the test suite spins up, but none of the
         # routes serve real traffic.
-        next if path.includes?("/test/fixtures/") || path.includes?("/tests/fixtures/")
-        next if path.includes?("/__tests__/") || path.includes?("/__mocks__/")
+        next if relative.includes?("/test/fixtures/") || relative.includes?("/tests/fixtures/")
+        next if relative.includes?("/__tests__/") || relative.includes?("/__mocks__/")
         analyze_nuxt_file(path, result, mutex, include_callee)
       end
 
@@ -38,12 +41,16 @@ module Analyzer::Javascript
       # server/api/users.get.ts -> /api/users (GET only)
       # server/routes/custom.ts -> /custom
 
-      relative_path = path
-      base_path_idx = path.index("/server/api/")
+      # Scan-base-relative, never absolute: `String#index` takes the
+      # FIRST occurrence, so a same-named directory above the scan base
+      # won outright and the derived URL changed with the checkout path.
+      scoped = base_relative_path(path)
+      relative_path = scoped
+      base_path_idx = scoped.index("/server/api/")
       is_api_route = true
 
       if base_path_idx.nil?
-        base_path_idx = path.index("/server/routes/")
+        base_path_idx = scoped.index("/server/routes/")
         is_api_route = false
       end
 
@@ -51,9 +58,9 @@ module Analyzer::Javascript
 
       # Get the path after /server/api/ or /server/routes/
       if is_api_route
-        relative_path = path[(base_path_idx + "/server/api/".size)..-1]
+        relative_path = scoped[(base_path_idx + "/server/api/".size)..-1]
       else
-        relative_path = path[(base_path_idx + "/server/routes/".size)..-1]
+        relative_path = scoped[(base_path_idx + "/server/routes/".size)..-1]
       end
 
       # Remove file extension

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -54,10 +54,14 @@ module Analyzer::Javascript
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       parallel_file_scan(EXTENSIONS) do |path|
-        idx = path.index("/app/routes/")
+        # Scan-base-relative, never absolute: `String#index` takes the
+        # FIRST occurrence, so a same-named directory above the scan base
+        # won outright and the derived URL changed with the checkout path.
+        scoped = base_relative_path(path)
+        idx = scoped.index("/app/routes/")
         next if idx.nil?
 
-        relative = path[(idx + "/app/routes/".size)..-1]
+        relative = scoped[(idx + "/app/routes/".size)..-1]
         # Remix only looks at the directly-named route file. Files
         # nested deeper inside a route's directory (`route.tsx` /
         # subcomponents) are component wiring, not route hosts.

--- a/src/analyzer/analyzers/javascript/sveltekit.cr
+++ b/src/analyzer/analyzers/javascript/sveltekit.cr
@@ -51,10 +51,14 @@ module Analyzer::Javascript
 
       parallel_file_scan(EXTENSIONS) do |path|
         next unless path_under_project_roots?(path, project_roots)
-        idx = path.index("/src/routes/")
+        # Scan-base-relative, never absolute: `String#index` takes the
+        # FIRST occurrence, so a same-named directory above the scan base
+        # won outright and the derived URL changed with the checkout path.
+        scoped = base_relative_path(path)
+        idx = scoped.index("/src/routes/")
         next if idx.nil?
 
-        relative = path[(idx + "/src/routes/".size)..-1]
+        relative = scoped[(idx + "/src/routes/".size)..-1]
         leaf = File.basename(relative)
         next if private_segment_in?(relative)
 

--- a/src/analyzer/analyzers/kotlin/cli.cr
+++ b/src/analyzer/analyzers/kotlin/cli.cr
@@ -57,7 +57,7 @@ module Analyzer::Kotlin
 
       get_files_by_extension(".kt").each do |path|
         next if File.directory?(path)
-        next if KotlinEngine.test_path?(path)
+        next if KotlinEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
 
         begin

--- a/src/analyzer/analyzers/kotlin/http4k.cr
+++ b/src/analyzer/analyzers/kotlin/http4k.cr
@@ -15,7 +15,7 @@ module Analyzer::Kotlin
       kotlin_files = file_list.select do |path|
         File.exists?(path) &&
           path.ends_with?(".#{KOTLIN_EXTENSION}") &&
-          !KotlinEngine.test_path?(path)
+          !KotlinEngine.test_path?(base_relative_path(path))
       end
       file_contents = Hash(String, String).new
       string_constants_by_base = Hash(String, Hash(String, String)).new do |hash, key|

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -14,7 +14,7 @@ module Analyzer::Kotlin
       kotlin_files = file_list.select do |path|
         File.exists?(path) &&
           path.ends_with?(".#{KOTLIN_EXTENSION}") &&
-          !KotlinEngine.test_path?(path)
+          !KotlinEngine.test_path?(base_relative_path(path))
       end
       file_contents = Hash(String, String).new
       string_constants_by_base = Hash(String, Hash(String, String)).new do |hash, key|

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -4,6 +4,7 @@ require "../../../miniparsers/kotlin_parameter_extractor_ts"
 require "../../../miniparsers/kotlin_callee_extractor"
 require "../../engines/kotlin_engine"
 require "../../../utils/utils.cr"
+require "../../../utils/path_scope"
 
 module Analyzer::Kotlin
   class Spring < Analyzer
@@ -234,7 +235,7 @@ module Analyzer::Kotlin
       files.select do |path|
         File.exists?(path) &&
           path.ends_with?(".#{KOTLIN_EXTENSION}") &&
-          !KotlinEngine.test_path?(path) &&
+          !KotlinEngine.test_path?(base_relative_path(path)) &&
           !spring_ignored_path?(path)
       end
     end
@@ -243,9 +244,14 @@ module Analyzer::Kotlin
       dirs = Set(String).new
       files.each do |path|
         next if spring_ignored_path?(path)
-        index = path.index("/src/")
+        # Scan-base-relative, never absolute: `String#index` takes the
+        # FIRST occurrence, so a `src/` directory above the scan base
+        # made every module resolve to a source root outside the scan.
+        base = configured_base_for(path)
+        relative = Noir::PathScope.base_relative(path, base)
+        index = relative.index("/src/")
         next unless index
-        dirs << path[0, index + 4]
+        dirs << base.rstrip('/') + relative[0, index + 4]
       end
       dirs.to_a
     end
@@ -257,8 +263,10 @@ module Analyzer::Kotlin
     # each in spring_kotlin_files and spring_src_dirs.
     IGNORED_PATH_SEGMENT_RE = Regex.union("/.git/", "/.gradle/", "/build/", "/out/", "/target/", "/node_modules/")
 
+    # Scan-base-relative, never absolute: a `build/` or `target/`
+    # directory ABOVE the scan base is not this project's build output.
     private def spring_ignored_path?(path : String) : Bool
-      path.matches?(IGNORED_PATH_SEGMENT_RE)
+      base_relative_path(path).matches?(IGNORED_PATH_SEGMENT_RE)
     end
 
     # Read Spring Webflux base-path + static-locations from
@@ -357,7 +365,7 @@ module Analyzer::Kotlin
 
       file_list.each do |path|
         next unless File.exists?(path) && path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
+        next if KotlinEngine.test_path?(base_relative_path(path))
 
         content = read_file_content(path)
         next unless content.includes?("interface")
@@ -385,7 +393,7 @@ module Analyzer::Kotlin
 
       file_list.each do |path|
         next unless File.exists?(path) && path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
+        next if KotlinEngine.test_path?(base_relative_path(path))
 
         content = read_file_content(path)
         next unless content.includes?("fun") && content.matches?(CLASS_OR_OBJECT_RE)
@@ -597,7 +605,7 @@ module Analyzer::Kotlin
 
       file_list.each do |path|
         next unless File.exists?(path) && path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
+        next if KotlinEngine.test_path?(base_relative_path(path))
 
         content = read_file_content(path)
         next unless content.includes?("setApplicationDestinationPrefixes")
@@ -622,7 +630,7 @@ module Analyzer::Kotlin
 
       file_list.each do |path|
         next unless File.exists?(path) && path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
+        next if KotlinEngine.test_path?(base_relative_path(path))
         project_roots << project_root_for(path)
       end
 
@@ -710,7 +718,7 @@ module Analyzer::Kotlin
       roots = Set(String).new
       file_list.each do |path|
         next unless File.exists?(path) && path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
+        next if KotlinEngine.test_path?(base_relative_path(path))
         roots << project_root_for(path)
       end
 

--- a/src/analyzer/analyzers/lua/cli.cr
+++ b/src/analyzer/analyzers/lua/cli.cr
@@ -144,7 +144,9 @@ module Analyzer::Lua
     end
 
     private def cli_test_path?(path : String) : Bool
-      path.downcase.matches?(TEST_PATH_RE)
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      base_relative_path(path).downcase.matches?(TEST_PATH_RE)
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/mobile/ios.cr
+++ b/src/analyzer/analyzers/mobile/ios.cr
@@ -382,8 +382,12 @@ module Analyzer::Mobile
     # test targets. Mirrors `NoirMobileLinker::IosHandlers.skip_ios_source?`
     # in `src/mobile/linker.cr` (private to that module, so not reusable
     # directly from here).
+    #
+    # Matched on the scan-base-relative path, never the absolute one: a
+    # `Tests/` or `Pods/` directory ABOVE the scan base belongs to
+    # whatever the checkout happens to sit in, not to this app.
     private def ios_source_excluded?(path : String) : Bool
-      normalized = path.gsub('\\', '/')
+      normalized = base_relative_path(path).gsub('\\', '/')
       basename = File.basename(normalized)
       normalized.includes?("/.build/") || normalized.includes?("/.swiftpm/") ||
         normalized.includes?("/Pods/") || normalized.includes?("/Carthage/") ||

--- a/src/analyzer/analyzers/perl/cli.cr
+++ b/src/analyzer/analyzers/perl/cli.cr
@@ -116,7 +116,9 @@ module Analyzer::Perl
     end
 
     private def cli_test_path?(path : String) : Bool
-      path.downcase.matches?(CLI_TEST_PATH_RE)
+      # Scan-base-relative, never absolute: a `t/` or `test/` directory
+      # ABOVE the scan base is not this project's test tree.
+      base_relative_path(path).downcase.matches?(CLI_TEST_PATH_RE)
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/php/cli.cr
+++ b/src/analyzer/analyzers/php/cli.cr
@@ -78,7 +78,7 @@ module Analyzer::Php
 
       get_files_by_extension(".php").each do |path|
         next if File.directory?(path)
-        next if PhpEngine.test_path?(path)
+        next if PhpEngine.test_path?(base_relative_path(path))
 
         begin
           content = read_file_content(path)

--- a/src/analyzer/analyzers/php/magento.cr
+++ b/src/analyzer/analyzers/php/magento.cr
@@ -67,7 +67,7 @@ module Analyzer::Php
 
       get_files_by_extension(".xml").each do |path|
         next unless File.basename(path) == "routes.xml"
-        next if PhpEngine.test_path?(path)
+        next if PhpEngine.test_path?(base_relative_path(path))
 
         area = area_for_routes_path(path)
         begin

--- a/src/analyzer/analyzers/php/thinkphp.cr
+++ b/src/analyzer/analyzers/php/thinkphp.cr
@@ -19,8 +19,15 @@ module Analyzer::Php
       endpoints = [] of Endpoint
       return endpoints unless path.ends_with?(".php")
 
-      is_route = path.includes?("route/") || File.basename(path) == "route.php"
-      is_controller = path.includes?("controller/")
+      # ThinkPHP's `route/`, `controller/` and multi-app `app/<name>/`
+      # conventions describe a location inside the project, so they are
+      # matched on the scan-base-relative path. On the absolute path a
+      # checkout that merely sat under an `app/` directory picked up a
+      # phantom module prefix on every route it declared
+      # (`/blog/{id}` became `/thinkphp/blog/{id}`).
+      relative = base_relative_path(path)
+      is_route = relative.includes?("route/") || File.basename(path) == "route.php"
+      is_controller = relative.includes?("controller/")
 
       # PERFORMANCE OPTIMIZATION: Skip opening, reading, and parsing files that are
       # neither explicit route definitions nor implicit controller classes.
@@ -34,8 +41,8 @@ module Analyzer::Php
       if is_route
         # Determine base prefix from multi-app route files (e.g. app/shop/route/app.php -> prefix is "/shop")
         base_prefix = ""
-        if path.includes?("app/") || path.includes?("application/")
-          segments = path.split('/')
+        if relative.includes?("app/") || relative.includes?("application/")
+          segments = relative.split('/')
           route_idx = segments.index("route")
           if route_idx && route_idx > 1
             parent = segments[route_idx - 1]

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -134,7 +134,7 @@ module Analyzer::Python
 
       candidates = all_files.select do |file|
         next false unless file.ends_with?(".py")
-        next false if file.includes?("/site-packages/")
+        next false if base_relative_path(file).includes?("/site-packages/")
         next false if PythonEngine.python_test_path?(file, base_path_for(file))
         File.basename(file) == "urls.py" || file.includes?("/urls/")
       end
@@ -198,7 +198,7 @@ module Analyzer::Python
                 break if file.nil?
                 # No `File.directory?` — `all_files` is `file_map`, which
                 # holds regular files only.
-                next if file.includes?("/site-packages/")
+                next if base_relative_path(file).includes?("/site-packages/")
                 # `django_settings_path?` is pure string work and rejects
                 # all but a handful of files, so it runs before
                 # `base_path_for` / `python_test_path?`. Every gate here
@@ -606,7 +606,7 @@ module Analyzer::Python
 
       candidates = all_files.select do |file|
         next false unless file.ends_with?(".py")
-        next false if file.includes?("/site-packages/")
+        next false if base_relative_path(file).includes?("/site-packages/")
         next false if PythonEngine.python_test_path?(file, base_path_for(file))
         base = File.basename(file)
         base == "apps.py" || base == "config.py"

--- a/src/analyzer/analyzers/python/django_ninja.cr
+++ b/src/analyzer/analyzers/python/django_ninja.cr
@@ -66,7 +66,7 @@ module Analyzer::Python
       # Phase 1 — collect NinjaAPI/Router instances, their operations and
       # `add_router(...)` edges.
       python_files.each do |path|
-        next if path.includes?("/site-packages/")
+        next if base_relative_path(path).includes?("/site-packages/")
         next if python_test_path?(path)
         begin
           source = read_file_content(path)
@@ -371,7 +371,7 @@ module Analyzer::Python
 
     private def resolve_mount_prefixes(python_files : Array(::String), instances : Hash(::String, NinjaInstance)) : Nil
       python_files.each do |path|
-        next if path.includes?("/site-packages/")
+        next if base_relative_path(path).includes?("/site-packages/")
         next if python_test_path?(path)
         begin
           source = read_file_content(path)

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -76,7 +76,7 @@ module Analyzer::Python
       base_paths.each do |current_base_path|
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
+          next if base_relative_path(path).includes?("/site-packages/")
           next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -123,7 +123,10 @@ module Analyzer::Ruby
       framework_roots.each do |framework_root|
         begin
           get_public_files(files, framework_root).each do |file|
-            if file =~ /\/public\/(.*)/
+            # Scan-base-relative, never absolute: the leftmost `/public/`
+            # wins, so a `public/` directory above the scan base put the
+            # whole intervening path into the served URL.
+            if base_relative_path(file) =~ /\/public\/(.*)/
               relative_path = $1
               details = Details.new(PathInfo.new(file))
               @result << Endpoint.new("/#{relative_path}", "GET", details)

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -275,7 +275,7 @@ module Analyzer::Rust
       all_files.each do |path|
         next if File.directory?(path)
         next unless File.exists?(path) && File.extname(path) == ".rs"
-        next if RustEngine.test_path?(path)
+        next if RustEngine.test_path?(base_relative_path(path))
         base = configured_base_for(path)
         src = read_file_content(path)
         next unless src.includes?("scope(") && src.includes?(".service(")
@@ -400,7 +400,7 @@ module Analyzer::Rust
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
-        next if RustEngine.test_path?(fpath)
+        next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)
         src = read_file_content(fpath)
         next unless src.includes?(".configure(") && src.includes?("scope(")
@@ -504,7 +504,7 @@ module Analyzer::Rust
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
-        next if RustEngine.test_path?(fpath)
+        next if RustEngine.test_path?(base_relative_path(fpath))
         read_file_content(fpath).scan(/\bpub\s+use\s+([^;{}]+?)\s+as\s+([A-Za-z_]\w*)\s*;/) do |m|
           aliases[m[2]] = m[1].strip
         end
@@ -945,7 +945,7 @@ module Analyzer::Rust
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
-        next if RustEngine.test_path?(fpath)
+        next if RustEngine.test_path?(base_relative_path(fpath))
         src = read_file_content(fpath)
         begin
           Noir::TreeSitter.parse_rust(src) do |root|

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -1179,7 +1179,7 @@ module Analyzer::Rust
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
-        next if RustEngine.test_path?(fpath)
+        next if RustEngine.test_path?(base_relative_path(fpath))
         src = read_file_content(fpath)
         next unless src.matches?(CROSS_NEST_EVIDENCE_RE)
         base = configured_base_for(fpath)
@@ -1442,7 +1442,7 @@ module Analyzer::Rust
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
-        next if RustEngine.test_path?(fpath)
+        next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)
         src = read_file_content(fpath)
         next unless src.matches?(UTOIPA_INDEX_EVIDENCE_RE)

--- a/src/analyzer/analyzers/rust/cli.cr
+++ b/src/analyzer/analyzers/rust/cli.cr
@@ -60,7 +60,7 @@ module Analyzer::Rust
 
       get_files_by_extension(".rs").each do |path|
         next if File.directory?(path)
-        next if RustEngine.test_path?(path)
+        next if RustEngine.test_path?(base_relative_path(path))
 
         begin
           content = read_file_content(path)

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -115,7 +115,7 @@ module Analyzer::Rust
       all_files.each do |path|
         next if File.directory?(path)
         next unless File.exists?(path) && File.extname(path) == ".rs"
-        next if RustEngine.test_path?(path)
+        next if RustEngine.test_path?(base_relative_path(path))
         base = configured_base_for(path)
         src = read_file_content(path)
         next unless src.matches?(MOUNT_INDEX_EVIDENCE_RE)

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -86,7 +86,7 @@ module Analyzer::Rust
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
-        next if RustEngine.test_path?(fpath)
+        next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)
         src = read_file_content(fpath)
         next unless src.includes?("#[handler]")
@@ -679,7 +679,7 @@ module Analyzer::Rust
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
-        next if RustEngine.test_path?(fpath)
+        next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)
         src = read_file_content(fpath)
         next unless src.matches?(FN_EDGE_EVIDENCE_RE)
@@ -854,7 +854,7 @@ module Analyzer::Rust
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
-        next if RustEngine.test_path?(fpath)
+        next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)
         src = read_file_content(fpath)
         next unless src.includes?(": &") && src.includes?("str")

--- a/src/analyzer/analyzers/scala/cli.cr
+++ b/src/analyzer/analyzers/scala/cli.cr
@@ -184,7 +184,9 @@ module Analyzer::Scala
     end
 
     private def cli_test_path?(path : String) : Bool
-      path.downcase.matches?(CLI_TEST_PATH_RE)
+      # Scan-base-relative, never absolute: a `test/` or `it/` directory
+      # ABOVE the scan base is not this project's test tree.
+      base_relative_path(path).downcase.matches?(CLI_TEST_PATH_RE)
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -33,7 +33,10 @@ module Analyzer::Scala
         # convention) and `/src/sbt-test/` (sbt-plugin's per-fixture
         # test trees) are unambiguous — production code never adopts
         # either.
-        next if path.includes?("/src/test/") || path.includes?("/src/sbt-test/")
+        # Scan-base-relative, never absolute: a `src/test/` directory
+        # ABOVE the scan base is not this project's test tree.
+        relative = base_relative_path(path)
+        next if relative.includes?("/src/test/") || relative.includes?("/src/sbt-test/")
 
         if path.ends_with?("routes") || path.ends_with?("routes.conf") || path.includes?("/conf/routes")
           routes_files << path

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -73,8 +73,10 @@ module Analyzer::Scala
       prefix.rstrip("/*")
     end
 
+    # Scan-base-relative, never absolute: a `src/test/` directory ABOVE
+    # the scan base is not this project's test tree.
     private def scalatra_test_path?(path : String) : Bool
-      path.matches?(TEST_PATH_RE)
+      base_relative_path(path).matches?(TEST_PATH_RE)
     end
 
     # Extract routes from Scalatra DSL

--- a/src/analyzer/analyzers/specification/strapi.cr
+++ b/src/analyzer/analyzers/specification/strapi.cr
@@ -167,8 +167,13 @@ module Analyzer::Specification
     end
 
     # `src/api/<name>/content-types/<name>/schema.json` -> `<name>`.
+    #
+    # Scan-base-relative, never absolute: `String#index` takes the FIRST
+    # occurrence, so an `api/` directory above the scan base named the
+    # content type instead of the project's own.
     private def api_directory_name(source : String) : String?
-      path = source.includes?('\\') ? source.gsub('\\', '/') : source
+      scoped = base_relative_path(source)
+      path = scoped.includes?('\\') ? scoped.gsub('\\', '/') : scoped
       marker = path.index("/api/")
       return unless marker
       rest = path[(marker + 5)..]

--- a/src/analyzer/analyzers/swift/cli.cr
+++ b/src/analyzer/analyzers/swift/cli.cr
@@ -33,7 +33,7 @@ module Analyzer::Swift
 
       get_files_by_extension(".swift").each do |path|
         next if File.directory?(path)
-        next if SwiftEngine.swift_test_path?(path)
+        next if SwiftEngine.swift_test_path?(base_relative_path(path))
         next unless File.exists?(path)
 
         begin

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -92,10 +92,13 @@ module Analyzer::Typescript
       "/test-files/",
     ]
 
+    # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+    # scan base is not this project's test tree.
     private def tanstack_test_fixture_path?(path : String) : Bool
-      TEST_FIXTURE_PATH_MARKERS.any? { |marker| path.includes?(marker) } ||
-        path.includes?(".test.") ||
-        path.includes?(".spec.")
+      relative = base_relative_path(path)
+      TEST_FIXTURE_PATH_MARKERS.any? { |marker| relative.includes?(marker) } ||
+        relative.includes?(".test.") ||
+        relative.includes?(".spec.")
     end
 
     private def analyze_file_routes(content : String, path : String, result : Array(Endpoint), literal_mask : Array(Bool))

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -195,10 +195,13 @@ module Analyzer::Typescript
       "/test-files/",
     ]
 
+    # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+    # scan base is not this project's test tree.
     private def trpc_test_fixture_path?(path : String) : Bool
-      TEST_FIXTURE_PATH_MARKERS.any? { |marker| path.includes?(marker) } ||
-        path.includes?(".test.") ||
-        path.includes?(".spec.")
+      relative = base_relative_path(path)
+      TEST_FIXTURE_PATH_MARKERS.any? { |marker| relative.includes?(marker) } ||
+        relative.includes?(".test.") ||
+        relative.includes?(".spec.")
     end
 
     private def string_literal_mask(content : String) : Array(Bool)

--- a/src/analyzer/analyzers/zig/cli.cr
+++ b/src/analyzer/analyzers/zig/cli.cr
@@ -232,7 +232,10 @@ module Analyzer::Zig
     end
 
     private def cli_test_path?(path : String) : Bool
-      path.downcase.includes?("/test") || path.includes?("_test.")
+      # Scan-base-relative, never absolute: a `test/` directory ABOVE the
+      # scan base is not this project's test tree.
+      relative = base_relative_path(path)
+      relative.downcase.includes?("/test") || relative.includes?("_test.")
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/zig/http.cr
+++ b/src/analyzer/analyzers/zig/http.cr
@@ -41,7 +41,7 @@ module Analyzer::Zig
 
       all_files.each do |path|
         next unless path.ends_with?(".zig")
-        next if Noir::ZigCalleeExtractor.vendored_framework_path?(path)
+        next if Noir::ZigCalleeExtractor.vendored_framework_path?(base_relative_path(path))
         content = read_file_content(path)
         next unless std_http_server_file?(content)
         process_file(path, content, include_callee)

--- a/src/analyzer/analyzers/zig/httpz.cr
+++ b/src/analyzer/analyzers/zig/httpz.cr
@@ -40,7 +40,7 @@ module Analyzer::Zig
 
       all_files.each do |path|
         next unless path.ends_with?(".zig")
-        next if Noir::ZigCalleeExtractor.vendored_framework_path?(path)
+        next if Noir::ZigCalleeExtractor.vendored_framework_path?(base_relative_path(path))
         content = read_file_content(path)
         # Route-bearing files don't always reference `httpz` literally — a
         # common layout registers routes in a helper `fn group(router: *Foo)`

--- a/src/analyzer/analyzers/zig/jetzig.cr
+++ b/src/analyzer/analyzers/zig/jetzig.cr
@@ -50,7 +50,7 @@ module Analyzer::Zig
 
       all_files.each do |path|
         next unless path.ends_with?(".zig")
-        next if Noir::ZigCalleeExtractor.vendored_framework_path?(path)
+        next if Noir::ZigCalleeExtractor.vendored_framework_path?(base_relative_path(path))
 
         content = read_file_content(path)
 

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -79,7 +79,7 @@ module Analyzer::Zig
     def analyze
       include_callee = callees_needed?
       zig_files = all_files.select do |f|
-        f.ends_with?(".zig") && !Noir::ZigCalleeExtractor.vendored_framework_path?(f)
+        f.ends_with?(".zig") && !Noir::ZigCalleeExtractor.vendored_framework_path?(base_relative_path(f))
       end
 
       alias_to_file = build_alias_map(zig_files)

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -61,7 +61,7 @@ module Analyzer::Zig
     def analyze
       include_callee = callees_needed?
       zig_files = all_files.select do |f|
-        f.ends_with?(".zig") && !Noir::ZigCalleeExtractor.vendored_framework_path?(f)
+        f.ends_with?(".zig") && !Noir::ZigCalleeExtractor.vendored_framework_path?(base_relative_path(f))
       end
 
       bindings = build_path_bindings(zig_files)

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -119,8 +119,13 @@ module Analyzer::Crystal
     # application directories like `library/`, `glib/`, or a project
     # literally named `amber-library` aren't silently dropped (that bug
     # made a real Amber app surface 0 routes — only public files).
+    #
+    # Scan-base-relative, never absolute: `lib` is common enough as a
+    # directory name that matching the absolute path let an ancestor of
+    # the checkout (`/usr/lib/...`, `~/lib/work/...`) suppress every
+    # source file in the project.
     protected def crystal_dependency_path?(path : String) : Bool
-      path.includes?("/lib/") || path.starts_with?("lib/")
+      base_relative_path(path).includes?("/lib/")
     end
 
     # Crystal `"…"` strings interpolate `#{expr}`. The Kemal/Lucky/

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -18,9 +18,20 @@ module Analyzer::Go
     # `kataras/iris` alone parks 392 phantom endpoints under
     # `_examples/...`; they're documented apps, not production
     # routes the framework ships.
-    def self.go_test_file?(path : String) : Bool
-      return true if path.ends_with?("_test.go")
-      path.split("/").any?(&.starts_with?("_"))
+    #
+    # Takes the scan-base-relative path (`Analyzer#base_relative_path`),
+    # never the absolute one. Go's toolchain rule is relative to the
+    # module, so on an absolute path a single `_`-prefixed directory
+    # anywhere above the scan base — `~/_work/repo` on a self-hosted CI
+    # runner — excluded every `.go` file in the project.
+    #
+    # `relative_path` from `base_relative_path` is `/`-rooted, so `"/_"`
+    # is exactly "a path segment starts with `_`" without the per-call
+    # `split` allocation. The leading-`_` check covers a caller that
+    # passes an unrooted relative path.
+    def self.go_test_file?(relative_path : String) : Bool
+      return true if relative_path.ends_with?("_test.go")
+      relative_path.starts_with?('_') || relative_path.includes?("/_")
     end
 
     # Blanks out `//` line comments and `/* */` block comments, replacing
@@ -126,7 +137,7 @@ module Analyzer::Go
       file_contents = Hash(String, String).new
 
       get_files_by_extension(".go").each do |path|
-        next if GoEngine.go_test_file?(path)
+        next if GoEngine.go_test_file?(base_relative_path(path))
         dir = File.dirname(path)
         files_by_dir[dir] ||= [] of String
         files_by_dir[dir] << path
@@ -417,7 +428,7 @@ module Analyzer::Go
     def read_package_file_contents : Hash(String, String)
       file_contents = Hash(String, String).new
       get_files_by_extension(".go").each do |path|
-        next if GoEngine.go_test_file?(path)
+        next if GoEngine.go_test_file?(base_relative_path(path))
         begin
           file_contents[path] = read_file_content(path)
         rescue File::NotFoundError
@@ -543,7 +554,11 @@ module Analyzer::Go
       # handful of entries out of tens of thousands. No `File.directory?`
       # either — the detector only registers regular files.
       get_files_by_basename("go.mod").each do |path|
-        next if path.split("/").includes?("vendor")
+        # Scan-base-relative: a `vendor` directory *above* the base is
+        # not this project's vendor tree, and matching it dropped the
+        # module map (and with it 13 of the fixture tree's 276
+        # endpoints) for any checkout that lived under one.
+        next if base_relative_path(path).includes?("/vendor/")
 
         begin
           content = read_file_content(path)

--- a/src/analyzer/engines/java_engine.cr
+++ b/src/analyzer/engines/java_engine.cr
@@ -19,9 +19,16 @@ module Analyzer::Java
     # Also covers Maven's archetype source-roots
     # (`src/it/`, integration-test convention used by some Quarkus
     # extensions and Apache projects) which sit alongside `src/test/`.
-    def self.test_path?(path : String) : Bool
-      return true if path.includes?("/src/test/")
-      return true if path.includes?("/src/it/")
+    #
+    # Takes the scan-base-relative path (`Analyzer#base_relative_path`),
+    # never the absolute one. The layout is a contract between the build
+    # tool and the *project*, so matching the absolute path let a
+    # directory above the scan base decide the answer — a CI job that
+    # checks out under a `src/test/` step directory silently lost 375 of
+    # the fixture tree's 396 endpoints.
+    def self.test_path?(relative_path : String) : Bool
+      return true if relative_path.includes?("/src/test/")
+      return true if relative_path.includes?("/src/it/")
       false
     end
   end

--- a/src/analyzer/engines/kotlin_engine.cr
+++ b/src/analyzer/engines/kotlin_engine.cr
@@ -22,15 +22,21 @@ module Analyzer::Kotlin
     # ktor's own repo registers ~370 phantom endpoints from
     # `ktor-client/...-tests/` modules and `*/jvm/test/...` directories
     # that exercise the routing DSL under inline test servers.
-    def self.test_path?(path : String) : Bool
-      return true if path.includes?("/src/test/")
-      return true if path.includes?("/jvmTest/")
-      return true if path.includes?("/commonTest/")
-      return true if path.includes?("/jsTest/")
-      return true if path.includes?("/nativeTest/")
-      return true if path.includes?("/test/")
-      return true if path.includes?("/testData/")
-      base = File.basename(path)
+    #
+    # Takes the scan-base-relative path (`Analyzer#base_relative_path`),
+    # never the absolute one. `/test/` is generic enough that matching the
+    # absolute path made the answer depend on where the checkout lived:
+    # the same tree under `~/work/test/` reported 0 endpoints instead of
+    # 93.
+    def self.test_path?(relative_path : String) : Bool
+      return true if relative_path.includes?("/src/test/")
+      return true if relative_path.includes?("/jvmTest/")
+      return true if relative_path.includes?("/commonTest/")
+      return true if relative_path.includes?("/jsTest/")
+      return true if relative_path.includes?("/nativeTest/")
+      return true if relative_path.includes?("/test/")
+      return true if relative_path.includes?("/testData/")
+      base = File.basename(relative_path)
       return true if base.ends_with?("Test.kt")
       base.ends_with?("Tests.kt")
     end

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -33,9 +33,14 @@ module Analyzer::Perl
     end
 
     # Perl test files live in `.t` scripts or under a `/t/` directory.
+    # Scan-base-relative, never absolute. `t` is a single character, so
+    # matching the absolute path was catastrophic in practice: any
+    # ancestor directory literally named `t` — and every checkout under
+    # one — lost its whole endpoint set (the Perl fixture tree went from
+    # 109 endpoints to 0).
     protected def perl_test_path?(path : String, ext : String) : Bool
       return true if ext == ".t"
-      return true if path.includes?("/t/")
+      return true if base_relative_path(path).includes?("/t/")
       false
     end
 

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -32,7 +32,7 @@ module Analyzer::Php
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
         parallel_analyze(php_source_files) do |path|
-          next if PhpEngine.test_path?(path)
+          next if PhpEngine.test_path?(base_relative_path(path))
 
           begin
             block.call(path)
@@ -57,10 +57,17 @@ module Analyzer::Php
     # under `src/Symfony/Bundle/FrameworkBundle/Tests/...`. The
     # conventions are unambiguous — production routing never adopts
     # any of them.
-    def self.test_path?(path : String) : Bool
-      return true if path.includes?("/Tests/")
-      return true if path.includes?("/tests/")
-      base = File.basename(path)
+    #
+    # Takes the scan-base-relative path (`Analyzer#base_relative_path`),
+    # never the absolute one. The conventions describe a location inside
+    # the project, so matching the absolute path handed the decision to
+    # whatever directory the checkout happened to live in: the same tree
+    # scanned from `~/work/tests/myapp` reported 0 endpoints instead of
+    # 235.
+    def self.test_path?(relative_path : String) : Bool
+      return true if relative_path.includes?("/Tests/")
+      return true if relative_path.includes?("/tests/")
+      base = File.basename(relative_path)
       return true if base.ends_with?("Test.php")
       base.ends_with?("Tests.php")
     end

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -59,7 +59,7 @@ module Analyzer::Python
     # `get_files_by_extension(".py")` + nested `base_paths.each`.
     protected def python_source_files : Array(String)
       get_files_by_extension(".py").reject do |path|
-        path.includes?("/site-packages/") || python_test_path?(path)
+        base_relative_path(path).includes?("/site-packages/") || python_test_path?(path)
       end
     end
 

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -39,7 +39,7 @@ module Analyzer::Rust
       begin
         roots = crate_roots
         parallel_analyze(get_files_by_extension(".rs")) do |path|
-          next if RustEngine.test_path?(path)
+          next if RustEngine.test_path?(base_relative_path(path))
           next unless path_under_crate_roots?(path, roots)
 
           begin
@@ -113,14 +113,20 @@ module Analyzer::Rust
     # all park hundreds of route registrations under one of these
     # patterns. Promoted from `axum.cr#test_only_path?` (#1569) to
     # the shared engine so the rest of the Rust family benefits.
-    def self.test_path?(path : String) : Bool
-      return true if path.includes?("/tests/")
+    #
+    # Takes the scan-base-relative path (`Analyzer#base_relative_path`),
+    # never the absolute one. Cargo's conventions are relative to the
+    # crate, so matching the absolute path let a directory *above* the
+    # scan base decide the answer: the same tree cloned into
+    # `~/work/tests/myapp` reported 0 endpoints instead of 220.
+    def self.test_path?(relative_path : String) : Bool
+      return true if relative_path.includes?("/tests/")
       # Cargo's `benches/` directory holds `cargo bench` harnesses
       # (`Router::new().route(...)` scaffolding for throughput tests),
       # never production endpoints — axum/tide park route-building
       # benchmarks here. Exclude it like `tests/`.
-      return true if path.includes?("/benches/")
-      base = File.basename(path)
+      return true if relative_path.includes?("/benches/")
+      base = File.basename(relative_path)
       base == "tests.rs" || base.ends_with?("_test.rs") || base.ends_with?("_tests.rs")
     end
 

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -13,25 +13,29 @@ module Analyzer::Swift
 
     # `Tests/...` directory + `*Tests.swift` filename: the rigid Swift
     # Package Manager / XCTest conventions for test sources.
-    def self.swift_test_path?(path : String) : Bool
-      return true if path.includes?("/Tests/")
-      File.basename(path).ends_with?("Tests.swift")
+    #
+    # Both take the scan-base-relative path (`Analyzer#base_relative_path`),
+    # never the absolute one — SwiftPM's layout is relative to the package,
+    # and matching the absolute path made the scan's answer depend on where
+    # the package happened to be checked out.
+    def self.swift_test_path?(relative_path : String) : Bool
+      return true if relative_path.includes?("/Tests/")
+      File.basename(relative_path).ends_with?("Tests.swift")
     end
 
     private def swift_test_path?(path : String) : Bool
-      SwiftEngine.swift_test_path?(path)
+      SwiftEngine.swift_test_path?(base_relative_path(path))
     end
 
     # SwiftPM parks resolved dependency sources under `.build/` (and Xcode
     # under `.swiftpm/`). Scanning them pulls every transitive package's
     # routes into the report — pure noise against the project under test.
-    def self.swift_vendor_path?(path : String) : Bool
-      path.includes?("/.build/") || path.starts_with?(".build/") ||
-        path.includes?("/.swiftpm/") || path.starts_with?(".swiftpm/")
+    def self.swift_vendor_path?(relative_path : String) : Bool
+      relative_path.includes?("/.build/") || relative_path.includes?("/.swiftpm/")
     end
 
     private def swift_vendor_path?(path : String) : Bool
-      SwiftEngine.swift_vendor_path?(path)
+      SwiftEngine.swift_vendor_path?(base_relative_path(path))
     end
 
     # `.swift` sources from the extension index. Subclasses that need a

--- a/src/detector/detectors/dart/dart_frog.cr
+++ b/src/detector/detectors/dart/dart_frog.cr
@@ -22,7 +22,9 @@ module Detector::Dart
         return true
       end
 
-      if filename.includes?("/routes/") &&
+      # Scan-base-relative: `routes/` is Dart Frog's project-root
+      # convention, not a directory the checkout happens to sit under.
+      if base_relative_path(filename).includes?("/routes/") &&
          file_contents.match(/\b(?:Response|Future<Response>)\s+onRequest\s*\(/)
         return true
       end

--- a/src/detector/detectors/php/magento.cr
+++ b/src/detector/detectors/php/magento.cr
@@ -27,7 +27,7 @@ module Detector::Php
         return true
       end
       if base == "module.xml" && file_contents.includes?("<module") &&
-         (file_contents.includes?("Magento_") || filename.includes?("/Magento/"))
+         (file_contents.includes?("Magento_") || base_relative_path(filename).includes?("/Magento/"))
         return true
       end
 

--- a/src/detector/detectors/php/wordpress.cr
+++ b/src/detector/detectors/php/wordpress.cr
@@ -51,13 +51,17 @@ module Detector::Php
         return true
       end
 
-      # Core directory layout. Accept both absolute scan paths
-      # (`/repo/wp-content/...`) and repo-relative ones (`wp-content/...`).
-      if filename.ends_with?(".php") &&
-         (filename.includes?("/wp-content/") || filename.starts_with?("wp-content/") ||
-         filename.includes?("/wp-includes/") || filename.starts_with?("wp-includes/") ||
-         filename.includes?("/wp-admin/") || filename.starts_with?("wp-admin/"))
-        return true
+      # Core directory layout, matched on the scan-base-relative path so
+      # the leading `/` covers a repo-root `wp-content/` too. On the
+      # absolute path a checkout that merely lived under a `wp-content/`
+      # directory made every `.php` file in it look like WordPress.
+      if filename.ends_with?(".php")
+        relative = base_relative_path(filename)
+        if relative.includes?("/wp-content/") ||
+           relative.includes?("/wp-includes/") ||
+           relative.includes?("/wp-admin/")
+          return true
+        end
       end
 
       # Plugin / theme file headers (`Plugin Name:` / `Theme Name:` in the

--- a/src/detector/detectors/php/yii.cr
+++ b/src/detector/detectors/php/yii.cr
@@ -10,8 +10,9 @@ module Detector::Php
         return true
       end
 
-      # Check for Yii2 vendor path
-      if filename.includes?("vendor/yiisoft/")
+      # Check for Yii2 vendor path. Scan-base-relative: a `vendor/yiisoft/`
+      # directory above the base belongs to some other checkout.
+      if base_relative_path(filename).includes?("vendor/yiisoft/")
         return true
       end
 

--- a/src/detector/detectors/specification/strapi.cr
+++ b/src/detector/detectors/specification/strapi.cr
@@ -83,7 +83,7 @@ module Detector::Specification
 
     private def schema_file?(filename : String) : Bool
       return false unless File.basename(filename) == SCHEMA_FILENAME
-      normalize(filename).includes?("/content-types/")
+      normalize(base_relative_path(filename)).includes?("/content-types/")
     end
 
     # A Strapi route module lives at `src/api/<name>/routes/<file>` (or
@@ -94,7 +94,12 @@ module Detector::Specification
     # +server.ts`, which contains both segments the other way round, and
     # any framework that merely keeps route modules in a `routes/`
     # directory.
+    # Scan-base-relative, never absolute: the layout below describes a
+    # location inside the Strapi project, and `String#index` takes the
+    # first occurrence, so an `api/` or `server/` directory above the scan
+    # base decided the ordering.
     private def routes_module?(path : String) : Bool
+      path = base_relative_path(path)
       routes_at = path.rindex("/routes/")
       return false unless routes_at
 

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -690,13 +690,21 @@ module Noir
     CLIENT_SIDE_FRAMEWORK_MARKER = Regex.union(CLIENT_SIDE_FRAMEWORK_MARKERS)
     HTTP_SERVER_LIBRARY_MARKER   = Regex.union(HTTP_SERVER_LIBRARY_MARKERS)
 
+    # Every marker below names a directory *inside the project*
+    # (`__tests__/`, `dist/`, `vendor/`, `public/`, ...), so they are
+    # matched on the scan-base-relative path. Matched on the absolute
+    # path they also fired on directories ABOVE the base: a checkout
+    # under `~/build/` or `~/vendor/` looked like bundled output and
+    # every route in it disappeared (the JS fixture tree dropped from
+    # 430 endpoints to 394, and to 191 under `__tests__/`).
     def self.test_stub_only?(file_path : String, content : String,
                              include_client_frameworks : Bool = true) : Bool
-      return true if file_path.matches?(TEST_STUB_FILENAME_MARKER)
-      return true if file_path.matches?(STRICT_TEST_PATH_MARKER)
+      relative_path = CodeLocator.instance.base_relative(file_path)
+      return true if File.basename(file_path).matches?(TEST_STUB_FILENAME_MARKER)
+      return true if relative_path.matches?(STRICT_TEST_PATH_MARKER)
       has_library = content_matches?(content, TEST_STUB_LIBRARY_MARKER) ||
                     (include_client_frameworks && content_matches?(content, CLIENT_SIDE_FRAMEWORK_MARKER))
-      has_path_marker = file_path.matches?(TEST_STUB_PATH_MARKER)
+      has_path_marker = relative_path.matches?(TEST_STUB_PATH_MARKER)
       return false unless has_library || has_path_marker
       !content_matches?(content, HTTP_SERVER_LIBRARY_MARKER)
     end

--- a/src/miniparsers/zig_callee_extractor.cr
+++ b/src/miniparsers/zig_callee_extractor.cr
@@ -54,8 +54,11 @@ module Noir::ZigCalleeExtractor
   # a vendor directory immediately followed by a framework package directory.
   VENDORED_FRAMEWORK_RE = %r{/(?:deps|dep|lib|libs|vendor|vendored|pkg|pkgs|zig-pkg|packages|third_party|third-party|modules|subprojects|external|\.deps)/(?:zap|httpz|http\.zig|tokamak|jetzig|zmpl|zmd)/}
 
-  def vendored_framework_path?(path : String) : Bool
-    path.gsub('\\', '/').matches?(VENDORED_FRAMEWORK_RE)
+  # Takes the scan-base-relative path (`Analyzer#base_relative_path`),
+  # never the absolute one — the vendoring layout is a property of the
+  # project, not of the directory the checkout happens to sit in.
+  def vendored_framework_path?(relative_path : String) : Bool
+    relative_path.gsub('\\', '/').matches?(VENDORED_FRAMEWORK_RE)
   end
 
   # `test { … }` / `test "name" { … }` block opener. Route registrations inside

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -6,6 +6,7 @@ require "../miniparsers/java_callee_extractor"
 require "../miniparsers/swift_callee_extractor"
 require "../miniparsers/objc_callee_extractor"
 require "../utils/text_file"
+require "../utils/path_scope"
 
 # Post-analysis pass that links mobile deep-link endpoints (produced by the
 # config-file analyzers from AndroidManifest.xml) to the source code that
@@ -528,7 +529,7 @@ module NoirMobileLinker
 
       CodeLocator.instance.files_by_extension(".swift").each do |path|
         next unless in_scope?(path, expanded_scope)
-        next if skip_ios_source?(path)
+        next if skip_ios_source?(path, expanded_scope)
         content = NoirMobileLinker.read_content(path)
         next unless content
         next unless swift_handler_candidate?(content)
@@ -539,7 +540,7 @@ module NoirMobileLinker
       {".m", ".mm"}.each do |ext|
         CodeLocator.instance.files_by_extension(ext).each do |path|
           next unless in_scope?(path, expanded_scope)
-          next if skip_ios_source?(path)
+          next if skip_ios_source?(path, expanded_scope)
           content = NoirMobileLinker.read_content(path)
           next unless content
           next unless objc_handler_candidate?(content)
@@ -588,7 +589,7 @@ module NoirMobileLinker
 
       CodeLocator.instance.files_by_extension(".swift").each do |path|
         next unless in_scope?(path, expanded_root)
-        next if skip_ios_source?(path)
+        next if skip_ios_source?(path, expanded_root)
         content = NoirMobileLinker.read_content(path)
         return true if content && swift_handler_candidate?(content)
       end
@@ -596,7 +597,7 @@ module NoirMobileLinker
       {".m", ".mm"}.each do |ext|
         CodeLocator.instance.files_by_extension(ext).each do |path|
           next unless in_scope?(path, expanded_root)
-          next if skip_ios_source?(path)
+          next if skip_ios_source?(path, expanded_root)
           content = NoirMobileLinker.read_content(path)
           return true if content && objc_handler_candidate?(content)
         end
@@ -605,8 +606,17 @@ module NoirMobileLinker
       false
     end
 
-    private def self.skip_ios_source?(path : String) : Bool
-      normalized = path.gsub('\\', '/')
+    # `scope_root` is the Xcode project root the caller already resolved.
+    # The directory conventions below describe a location inside that
+    # project, so they are matched on the project-relative path — on the
+    # absolute path a `Tests/` directory anywhere above the checkout
+    # excluded every source file in it. With no scope root there is
+    # nothing to relativise against, and the whole path is matched as
+    # before.
+    private def self.skip_ios_source?(path : String, scope_root : String? = nil) : Bool
+      relative = scope_root ? Noir::PathScope.relative_under(path, scope_root) : path
+      normalized = relative.gsub('\\', '/')
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
       basename = File.basename(normalized)
       normalized.includes?("/.build/") || normalized.includes?("/.swiftpm/") ||
         normalized.includes?("/Pods/") || normalized.includes?("/Carthage/") ||
@@ -749,7 +759,7 @@ module NoirMobileLinker
       actions.each do |action|
         CodeLocator.instance.files_by_extension(".swift").each do |path|
           next unless in_scope?(path, expanded_scope)
-          next if skip_ios_source?(path)
+          next if skip_ios_source?(path, expanded_scope)
           content = NoirMobileLinker.read_content(path)
           next unless content
           next unless content.includes?("case .#{action.action}")
@@ -828,7 +838,7 @@ module NoirMobileLinker
                                                  expanded_scope : String?) : String?
       CodeLocator.instance.files_by_extension(".swift").each do |path|
         next unless in_scope?(path, expanded_scope)
-        next if skip_ios_source?(path)
+        next if skip_ios_source?(path, expanded_scope)
         content = NoirMobileLinker.read_content(path)
         next unless content
         next unless content.includes?(receiver_type) && content.includes?("func #{method}")
@@ -891,7 +901,7 @@ module NoirMobileLinker
 
       CodeLocator.instance.files_by_extension(".swift").each do |path|
         next unless in_scope?(path, expanded_scope)
-        next if skip_ios_source?(path)
+        next if skip_ios_source?(path, expanded_scope)
         content = NoirMobileLinker.read_content(path)
         next unless content
         next unless content.includes?("enum #{enum_name}") && content.includes?("case #{case_name}")

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -230,8 +230,7 @@ class Analyzer
   # from `/srv/inc/site` instead of `/srv/site` dropped 33 of its 35
   # endpoints, because every page looked like an `#include` fragment.
   def base_relative_path(path : String) : String
-    relative = get_relative_path(configured_base_for(path), path).gsub(File::SEPARATOR, "/")
-    relative.starts_with?("/") ? relative : "/#{relative}"
+    Noir::PathScope.base_relative(path, configured_base_for(path))
   end
 
   def web_root_path(path : String, markers : Array(String)) : String

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -1,3 +1,5 @@
+require "../utils/path_scope"
+
 class CodeLocator
   @@instance : CodeLocator? = nil
 
@@ -25,6 +27,7 @@ class CodeLocator
   @content_cache_skipped : Int32
   @expanded_file_map : Array(Tuple(String, String))?
   @expanded_path_index : Hash(String, String)?
+  @scan_base_paths : Array(String)
 
   @lock : Mutex
 
@@ -49,7 +52,35 @@ class CodeLocator
     @content_cache_skipped = 0
     @expanded_file_map = nil
     @expanded_path_index = nil
+    @scan_base_paths = [] of String
     @lock = Mutex.new
+  end
+
+  # The `-b` roots of the current scan, published once by `NoirRunner`.
+  #
+  # Convention filters ("is this file under `tests/`?", "is this bundled
+  # output?") must run on the path *relative to the scan base*, never on
+  # the absolute path — otherwise a directory above the base decides the
+  # result and the same source tree reports different endpoints depending
+  # on where it is checked out. Analyzers get that through
+  # `Analyzer#base_relative_path`; the shared parser layer
+  # (`Noir::JSRouteExtractor` and friends) has no analyzer instance, so it
+  # reads the roots from here.
+  def scan_base_paths=(paths : Array(String))
+    @scan_base_paths = paths.reject(&.empty?)
+  end
+
+  def scan_base_paths : Array(String)
+    @scan_base_paths
+  end
+
+  # `path` relative to the scan base that owns it, `/`-separated and
+  # rooted with a leading `/`. With no registered bases (library callers,
+  # unit specs that drive a parser directly) the path is returned
+  # unchanged, which is exactly the pre-registry behaviour.
+  def base_relative(path : String) : String
+    return path if @scan_base_paths.empty?
+    Noir::PathScope.base_relative(path, @scan_base_paths)
   end
 
   # Megabyte figures at or above this overflow `Int64` once scaled to bytes.

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -1,4 +1,5 @@
 require "./logger"
+require "./code_locator"
 require "../utils/text_file"
 require "../utils/utils"
 require "yaml"
@@ -37,6 +38,23 @@ class Detector
   def detect(filename : String, file_contents : String) : Bool
     # After inheriting the class, write an action code here.
     false
+  end
+
+  # `filename` relative to the scan base that owns it, `/`-separated and
+  # rooted with a leading `/`.
+  #
+  # A detector that keys off a DIRECTORY (`wp-content/`, `vendor/yiisoft/`,
+  # `routes/`) rather than a filename must match on this: on the absolute
+  # path, a checkout that merely sat under a same-named directory made
+  # every file in the project look like the framework's. Filename markers
+  # (`composer.json`, `Cargo.toml`) are unaffected either way — an
+  # ancestor directory contributes no filename.
+  #
+  # Reads the roots from `CodeLocator`, which `NoirRunner#detect` publishes
+  # before the walk; with none registered (detector unit specs) the path is
+  # returned unchanged.
+  def base_relative_path(filename : String) : String
+    CodeLocator.instance.base_relative(filename)
   end
 
   # Declares the detector's tech name and the cheap filename gate that lets

--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -3,6 +3,7 @@ require "./endpoint"
 require "./code_locator"
 require "./file_helper"
 require "../utils/text_file"
+require "../utils/path_scope"
 
 struct SourceContext
   property path : String
@@ -57,6 +58,13 @@ class FrameworkTagger < Tagger
     else
       [raw.to_s]
     end
+  end
+
+  # Convention filters ("is this a test file?", "is this vendored?") must
+  # match on this, never on the absolute path — see
+  # `Noir::PathScope.base_relative`.
+  def base_relative_path(path : String) : String
+    Noir::PathScope.base_relative(path, @base_paths)
   end
 
   # Collect files with the given extension across every configured base

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -113,6 +113,10 @@ class NoirRunner
 
   def detect
     base_paths = options["base"].as_a.map(&.to_s)
+    # Publish the scan roots before anything walks a file: the shared
+    # parser layer relativises convention filters against them (see
+    # `CodeLocator#base_relative`).
+    CodeLocator.instance.scan_base_paths = base_paths
     detected_techs = detect_techs base_paths, options, @passive_scans, @logger
     @techs = detected_techs[0]
     @passive_results = detected_techs[1]

--- a/src/tagger/framework_taggers/rust/rust_security.cr
+++ b/src/tagger/framework_taggers/rust/rust_security.cr
@@ -167,10 +167,15 @@ class RustSecurityTagger < FrameworkTagger
 
   # Integration tests / benches / examples define throwaway apps whose
   # middleware must not leak onto real endpoints.
+  #
+  # Scan-base-relative, never absolute: a `tests/` directory above the
+  # scan base belongs to whatever the checkout sits in, and matching it
+  # skipped the whole middleware pre-scan.
   private def test_path?(path : String) : Bool
-    path.includes?("/tests/") ||
-      path.includes?("/benches/") ||
-      path.includes?("/examples/")
+    relative = base_relative_path(path)
+    relative.includes?("/tests/") ||
+      relative.includes?("/benches/") ||
+      relative.includes?("/examples/")
   end
 
   private def scan_rust_source(content : String)

--- a/src/utils/path_scope.cr
+++ b/src/utils/path_scope.cr
@@ -1,3 +1,5 @@
+require "./utils"
+
 module Noir
   # Path-boundary helpers shared by the analyzers and engines. Monorepo
   # scans (multiple `-b` base paths) have to answer two questions
@@ -55,6 +57,42 @@ module Noir
         best_size = normalized.size
       end
       best_base
+    end
+
+    # The form every *convention filter* must match on: `path`'s location
+    # relative to the scan base that owns it, `/`-separated and rooted
+    # with a leading `/`.
+    #
+    # "Is this file under `tests/`?", "is this vendored?", "is this build
+    # output?" are all statements about a location inside the project. Ask
+    # them of the absolute path and the answer depends on where the
+    # checkout happens to sit: a clone into `~/work/tests/myapp`, or a CI
+    # job that checks out under a `test/` step directory, matches every
+    # file in the project and silently reports nothing. Rooting the result
+    # means one `includes?("/tests/")` also covers a `tests/` directory at
+    # the top of the project, and keeps every match on a whole path
+    # segment (`/test/` never matches `latest/`).
+    #
+    # A path outside `base_path` keeps its own (absolute) form, exactly as
+    # `get_relative_path` returns it — the filters then behave as they did
+    # before, which is the conservative choice for a file the scan base
+    # does not own.
+    def base_relative(path : String, base_path : String) : String
+      relative = get_relative_path(base_path, path)
+      relative = relative.gsub(File::SEPARATOR, "/") unless File::SEPARATOR == '/'
+      relative.starts_with?("/") ? relative : "/#{relative}"
+    end
+
+    # Multi-base overload: resolves the owning base first. Callers with a
+    # per-path base cache (`Analyzer#configured_base_for`) should use that
+    # and call the single-base form instead.
+    def base_relative(path : String, base_paths : Array(String)) : String
+      base = if base_paths.size <= 1
+               base_paths.first?
+             else
+               longest_base(path, base_paths)
+             end
+      base_relative(path, base || "")
     end
 
     # Remainder of `path` beneath `base_path`, or the bare basename when


### PR DESCRIPTION
Skip filters and path-marker checks across the analyzers, the shared JS parser and the detectors all
matched the file's **absolute** path. A directory *above* the scan base — one the user never asked
noir to reason about — therefore decided the answer, and **scanning the same source tree from two
different locations on disk gave different results**, with no error and no warning.

Found while reviewing #2439, which fixed exactly this for Classic ASP (`includes/`) and `CfmlEngine`
(`/test/`, `/tests/`). That PR's scope was the legacy stacks; this one is the rest of the codebase.

## Evidence — real repositories

Each repo scanned from a neutral path, and from a path with the named segment above the scan base.
Same binary, same tree, only the location differs.

| corpus repo | ancestor segment | neutral | before | after |
|---|---|---|---|---|
| laravel/framework | `tests/` | 118 | **0** | 118 |
| tokio-rs/axum | `tests/` | 91 | **0** | 91 |
| spring-projects/spring-petclinic | `src/test/` | 17 | **0** | 17 |
| django/django | `site-packages/` | 27 | **0** | 27 |
| dotnet/aspnetcore | `test/` | 448 | 74 | 448 |
| nestjs/nest | `__tests__/` | 171 | 33 | 171 |
| symfony/symfony | `tests/` | 79 | 3 | 79 |
| gin-gonic/gin | `vendor/`, `_work/` | 0 | 0 | 0 |

These are the shapes a real checkout takes: a clone into `~/work/tests/`, a CI job whose workspace is
a `test/` step directory, a self-hosted runner under `~/_work/`, an app installed inside a
virtualenv's `site-packages/`, a Rails app under `~/public/`.

## Evidence — fixture matrix (the full before/after table)

Every one of the 33 language fixture trees copied under each of **57 hostile ancestor segments** and
scanned. `clean` is the neutral-path count; each entry is the count when that segment sits above the
base. Segments not listed for a language were already correct.

| language | clean | before | after |
|---|---|---|---|
| clojure | 75 | `test/` → 68, `src/test/` → 68 | 75 (all) |
| cpp | 48 | `test/` → 42, `tests/` → 42, `src/test/` → 42, `Tests/` → 42 | 48 (all) |
| crystal | 78 | `lib/` → 7, `test/` → 77, `src/test/` → 77 | 78 (all) |
| csharp | 143 | `test/` → 2, `tests/` → 2, `src/test/` → 2 | 143 (all) |
| dart | 106 | `test/` → 104, `src/test/` → 104, `routes/` → 118 | 106 (all) |
| elixir | 77 | `test/` → 76, `src/test/` → 76 | 77 (all) |
| etc (Kubernetes/IaC) | 14 | `lib/` → 12 | 14 (all) |
| fsharp | 61 | `test/` → **0**, `tests/` → **0**, `src/test/` → **0** | 61 (all) |
| go | 276 | `_work/` → 6, `__tests__/` → 6, `vendor/` → 263 | 276 (all) |
| groovy | 60 | `test/` → 57, `src/test/` → 57 | 60 (all) |
| haskell | 42 | `test/` → 40, `src/test/` → 40 | 42 (all) |
| java | 396 | `src/test/` → 21, `src/it/` → 52, `src/` → 399 | 396 (all) |
| javascript | 430 | `__tests__/` → 94, `e2e/` → 191, `cypress/` → 191, `vendor/` `build/` `dist/` `public/` `coverage/` `.next/` `.nuxt/` → 394, `app/` → 396, `node_modules/` → 417, `routes/` → 465 | 430 (all) |
| kotlin | 93 | `test/` `src/test/` `testData/` `jvmTest/` → **0**, `node_modules/` `build/` `target/` `out/` → 30 | 93 (all) |
| lua | 108 | `test/` → 104, `src/test/` → 104 | 108 (all) |
| mobile (iOS) | 70 | `.build/` `Tests/` `Pods/` `Generated/` `DerivedData/` `Carthage/` `UITests/` → 58 | 70 (all) |
| perl | 109 | `t/` → **0**, `test/` → 107, `src/test/` → 107 | 109 (all) |
| php | 235 | `tests/` → **0**, `Tests/` → **0**, `app/` → 237 | 235 (all) |
| python | 365 | `site-packages/` → **0** | 365 (all) |
| ruby | 179 | `public/` → 181 | 179 (all) |
| rust | 220 | `tests/` → **0**, `benches/` → **0** | 220 (all) |
| scala | 88 | `src/test/` → 51, `test/` → 86, `src/it/` → 86 | 88 (all) |
| swift | 39 | `Tests/` → **0**, `.build/` → 2 | 39 (all) |
| typescript | 66 | `__tests__/` → **0**, `test/` `tests/` `src/test/` `vendor/` `build/` `dist/` `public/` `e2e/` `cypress/` `coverage/` `.next/` `.nuxt/` → 37 | 66 (all) |
| zig | 45 | `test/` `tests/` `src/test/` `testData/` `Tests/` → 42 | 45 (all) |

**25 of 33 languages, 94 (language, segment) pairs affected before. Zero after.**

### Checked and already correct

`asp`, `aspnet`, `cfml` (fixed by #2439); `erlang`, `gleam`, `r`, `specification` (no path-substring
conventions at all). Within the affected languages, these filters were **already** scan-relative and
were left alone: `PythonEngine.python_test_path?`, `Analyzer::Dart::Helper.test_path?`,
`RubyEngine`'s `RUBY_NON_PRODUCTION_DIRS`, `CrystalEngine#crystal_spec_path?`, `Lua::Lapis`/`Lua::Lor`
spec-directory checks, and `Gleam::Wisp#gleam_module_name` (uses `rindex`, so the project's own
`src/`/`test/` always wins). The detectors' filename markers (`composer.json`, `Cargo.toml`,
`shard.yml`, `go.mod`, `pom.xml`, …) need no change either way — an ancestor directory contributes no
filename, so they can only match a real file inside the scan.

## Changes

| area | FP/FN | what was wrong | evidence |
|---|---|---|---|
| `utils/path_scope.cr` | — | new shared `Noir::PathScope.base_relative` — `/`-rooted, `/`-separated, whole-segment safe. `Analyzer#base_relative_path` (from #2439) now delegates to it; `Detector` and `FrameworkTagger` gain the same helper | — |
| `models/code_locator.cr`, `models/noir.cr` | — | the shared parser layer has no analyzer instance, so the runner publishes the `-b` roots to `CodeLocator` before the walk; `CodeLocator#base_relative` returns the path unchanged when none are registered | — |
| engines `{php,rust,kotlin,java,go,swift,perl,crystal,python}_engine.cr` | FN | `test_path?` / `go_test_file?` / `swift_test_path?` / `swift_vendor_path?` / `perl_test_path?` / `crystal_dependency_path?` / site-packages matched the absolute path | php 235→0 under `tests/`; rust 220→0; kotlin 93→0; perl 109→0 under `t/` |
| `csharp/common.cr` | FN | `/test/`, `/tests/`, `/testassets/` absolute | aspnetcore 448→74 under `test/` |
| `javascript/{nestjs,nextjs,nuxtjs,cli}.cr`, `typescript/{trpc,tanstack_router}.cr` | FN | `__tests__/`, `__mocks__/`, `node_modules/`, `test/fixtures/` absolute | nest 171→33 under `__tests__/` |
| `miniparsers/js_route_extractor.cr` | FN | `TEST_STUB_PATH_MARKERS` / `STRICT_TEST_PATH_MARKERS` (`dist/`, `vendor/`, `public/`, `e2e/`, `cypress/`, …) absolute; the *filename* markers (`.test.`, `.spec.`) now match the basename, which is what they document | js fixtures 430→191 under `e2e/`, →394 under `vendor/` |
| `{java,scala}/play.cr`, `scala/scalatra.cr`, `fsharp/giraffe.cr`, `kotlin/spring.cr` | FN | `src/test/`, `src/sbt-test/`, `/tests/`, `build/`+`target/`+`out/`+`node_modules/` absolute | fsharp 61→0; kotlin 93→30 under `build/` |
| `*/cli.cr` (dart, perl, haskell, lua, scala, cpp, groovy, clojure, elixir, crystal, zig, javascript) | FN | the CLI-app analyzers' `cli_test_path?` matched the absolute path | cpp 48→42, groovy 60→57, haskell 42→40 |
| `python/{django,django_ninja,pyramid}.cr` | FN | `/site-packages/` absolute — an app *inside* a virtualenv lost everything | django fixtures 365→0 |
| `mobile/ios.cr`, `mobile/linker.cr` | FN | `Tests/`, `Pods/`, `Carthage/`, `DerivedData/`, `Generated/` absolute; the linker now relativises against the Xcode project root it already resolved | mobile 70→58 |
| `miniparsers/zig_callee_extractor.cr` | FN | `VENDORED_FRAMEWORK_RE` absolute | (no fixture drift; fixed for consistency) |
| `tagger/framework_taggers/rust/rust_security.cr` | FP | `tests/`/`benches/`/`examples/` absolute — skipped the whole middleware pre-scan, so real endpoints lost their security tags | — |
| `javascript/{nextjs,nuxtjs,nitro,fresh,remix,sveltekit,astro}.cr`, `dart/dart_frog.cr` | FP | file-routed URL derivation used `String#index` (leftmost match) on the absolute path, so an ancestor `routes/`/`app/`/`src/`/`server/` won and the intervening directories landed in the URL | js 430→465 under `routes/` (phantom URLs), dart 106→118 |
| `java/spring.cr`, `kotlin/spring.cr` | FN | `project_root_for` / `spring_src_dirs` resolved the module root from the leftmost `/src/`, landing outside the scan; `application.properties` was then never found and every `server.servlet.context-path` prefix vanished | java 396→399 under `src/` (`/configured-api/items` became `/api/items`) |
| `php/thinkphp.cr` | FP | `route/`, `controller/`, multi-app `app/` absolute — a checkout under `app/` gave every route a phantom module prefix | php 235→237 under `app/` (`/blog/{id}` → `/thinkphp/blog/{id}`) |
| `ruby/rails.cr`, `crystal/{kemal,amber,lucky,marten}.cr` | FP | static-file URLs built from the leftmost `/public/` | ruby 179→181 (`/secret.html` → `/ruby/rails/public/secret.html`) |
| `specification/strapi.cr` (analyzer + detector) | FP | `/api/`, `/content-types/`, `/routes/` ordering on the absolute path | — |
| `detector/detectors/php/{wordpress,magento,yii}.cr`, `detector/detectors/dart/dart_frog.cr` | FP | `wp-content/`, `/Magento/`, `vendor/yiisoft/`, `/routes/` absolute — a repo cloned into `~/wp-content/` was detected as WordPress | — |

## Regression contract

- **Fixture A/B**: `noir_ab.sh` over all **664** fixture projects, before vs after — **diff is empty**.
  Detection from a neutral path is byte-identical.
- **Corpus A/B**, neutral path, normalized `METHOD url [params]` sets:

  | repo | before | after | changed lines |
  |---|---|---|---|
  | dotnet/aspnetcore | 448 | 448 | 0 |
  | nestjs/nest | 171 | 171 | 0 |
  | laravel/framework | 118 | 118 | 0 |
  | tokio-rs/axum | 91 | 91 | 0 |
  | symfony/symfony | 79 | 79 | 0 |
  | django/django | 27 | 27 | 0 |
  | spring-petclinic | 17 | 17 | 0 |
  | gin-gonic/gin | 0 | 0 | 0 |

- `crystal spec spec/unit_test` — 4424 examples, 0 failures
- `crystal spec spec/functional_test` — 22647 examples, 0 failures
- `crystal tool format` clean, `ameba` 1837 inspected / 0 failures

## Performance

Not a perf change; measured to confirm it is not a regression. `--release` binary, page cache warm,
3 runs each, wall clock in seconds.

| repo | size | before | after |
|---|---|---|---|
| symfony/symfony | 149 MB | 6.24 / 6.00 / 6.35 | 6.22 / 6.21 / 6.12 |
| dotnet/aspnetcore | 262 MB | 2.41 / 2.41 / 2.40 | 2.38 / 2.31 / 2.32 |
| laravel/framework | 42 MB | 1.17 / 1.14 / 1.15 | 1.15 / 1.18 / 1.15 |
| nestjs/nest | 13 MB | 0.28 / 0.30 / 0.27 | 0.29 / 0.31 / 0.28 |

Within run-to-run noise. The relativisation is a prefix strip on a per-file path; the one place it
could have cost something — `GoEngine.go_test_file?`, called once per file per Go analyzer — got
*cheaper*, because `path.split("/").any?(&.starts_with?("_"))` (an array allocation per call) became
`includes?("/_")` on the rooted relative path.

## Specs

`spec/unit_test/analyzer/scan_base_path_spec.cr` (new, sibling to the `legacy_` file from #2439):
44 (fixture, segment) pairs, one or more per language touched. Each copies a real fixture tree to a
neutral temp path and to one under the hostile segment, scans both, and asserts the endpoint sets are
**equal** — asserting equality rather than a fixed URL list means the guard survives future analyzer
work. Reverting `src/` makes 20+ of them fail.

Three cases are called out separately because they are the ones most likely to regress:

- a `latest/` or `vendored_libs/` ancestor must **not** match the `/test/` and `vendor` conventions —
  segment, not substring;
- pointing noir *at* a directory named `tests` is an explicit request for what is inside it
  (relativising handles it because the base's own relative path is empty);
- the `/`-rooted form of Go's `_`-prefix rule, added to `go_engine_spec.cr`.

## Deliberately not fixed

- **`NoirMobileLinker::IosHandlers.skip_ios_source?` with no scope root.** It now relativises against
  the Xcode project root the caller already resolved; when that is `nil` there is nothing to
  relativise against and the whole path is matched as before. Narrowing further would need the linker
  to learn the scan base, which is a bigger change than the bug warrants.
- **`Lua::Lapis`, `Lua::Lor`, `Analyzer::Dart::Helper`, `PythonEngine`** each relativise by hand
  rather than through the shared helper. They are correct; converting them is churn with a real risk
  of changing which files are skipped, and this PR's contract is that the neutral-path diff stays
  empty.
- **`Zig::Cli`'s `/test` prefix match** (`/testing/` matches too) and **`Kemal`/`Amber`'s
  `public_folder` regex** (built from a configured value, not a path convention) are left as they
  are. Both are pre-existing looseness *inside* the project; changing them would alter which files
  are skipped for a neutral scan, which is exactly what the regression contract forbids.
- **`Gleam::Wisp#gleam_module_name`** uses `rindex`, so the project's own `src/`/`test/` already wins
  over any ancestor. Verified clean in the matrix; left alone.

## Honesty notes

- The matrix covers 57 segments chosen from the literals the filters actually use plus common
  checkout-directory names. It is not exhaustive over all possible directory names.
- The `gin` corpus row is 0 endpoints in every configuration — the framework's own repo parks
  everything under `_examples/`, which Go's toolchain ignores. It is included because it is the only
  repo that exercises the `_`-prefix and `vendor/` rules, and equality is the assertion being made.
- The `symfony` hostile row improved from 3 to 79, not from 0: three endpoints came from non-PHP
  files that the PHP test filter never saw.
