### PR TITLE
refactor: use idiomatic zero-size predicates

### DIFF
--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -1847,11 +1847,11 @@ module Analyzer::Python
         REQUEST_PARAM_FIELD_PATTERNS.each do |field_pattern|
           field_name, field_methods, param_type, bracket_re, get_re = field_pattern
           matches = line.scan(bracket_re)
-          if matches.size == 0
+          if matches.empty?
             matches = line.scan(get_re)
           end
 
-          if matches.size != 0
+          unless matches.empty?
             matches.each do |match|
               next if match.size != 2
               param_name = match[1]
@@ -1878,11 +1878,11 @@ module Analyzer::Python
 
       if line.includes? "form.cleaned_data"
         matches = line.scan(/form\.cleaned_data\[[rf]?['"]([^'"]*)['"]\]/)
-        if matches.size == 0
+        if matches.empty?
           matches = line.scan(/form\.cleaned_data\.get\([rf]?['"]([^'"]*)['"]/)
         end
 
-        if matches.size != 0
+        unless matches.empty?
           matches.each do |match|
             next if match.size != 2
             suspicious_params << Param.new(match[1], "", "form")

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -413,7 +413,7 @@ module Analyzer::Python
               # reuse it instead of allocating a new gsub copy per line.
               effective_add_url_rule_stripped = has_add_url_rule ? effective_add_url_rule.gsub(" ", "") : line
               effective_add_url_rule_stripped.scan(ADD_URL_RULE_RE) do |_match|
-                next if _match.size == 0
+                next if _match.size.zero?
                 router_name = _match[1]
                 args_str = _match[2]
 
@@ -1477,7 +1477,7 @@ module Analyzer::Python
         REQUEST_PARAM_FIELD_PATTERNS.each do |field_pattern|
           noir_param_type, bracket_re, get_re = field_pattern
           matches = codeblock_line.scan(bracket_re)
-          if matches.size == 0
+          if matches.empty?
             matches = codeblock_line.scan(get_re)
           end
 
@@ -1497,10 +1497,10 @@ module Analyzer::Python
         json_variable_names.each do |json_variable_name|
           bracket_json_re, get_json_re = json_param_regexes(json_variable_name)
           matches = codeblock_line.scan(bracket_json_re)
-          if matches.size == 0
+          if matches.empty?
             matches = codeblock_line.scan(get_json_re)
           end
-          next if matches.size == 0
+          next if matches.empty?
 
           matches.each do |parameter_match|
             next if parameter_match.size != 2

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -791,7 +791,7 @@ module Analyzer::Python
         REQUEST_PARAM_FIELD_PATTERNS.each do |field_pattern|
           noir_param_type, bracket_re, get_re = field_pattern
           matches = codeblock_line.scan(bracket_re)
-          if matches.size == 0
+          if matches.empty?
             matches = codeblock_line.scan(get_re)
           end
 
@@ -810,10 +810,10 @@ module Analyzer::Python
         json_variable_names.each do |json_variable_name|
           bracket_json_re, get_json_re = json_param_regexes(json_variable_name)
           matches = codeblock_line.scan(bracket_json_re)
-          if matches.size == 0
+          if matches.empty?
             matches = codeblock_line.scan(get_json_re)
           end
-          next if matches.size == 0
+          next if matches.empty?
 
           matches.each do |parameter_match|
             next if parameter_match.size != 2

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -468,7 +468,7 @@ module Analyzer::Go
 
     def resolve_public_dirs_with_glob(public_dirs : Array(Hash(String, String)))
       public_dirs.each do |p_dir|
-        next if p_dir["file_path"].size == 0
+        next if p_dir["file_path"].empty?
         full_path = resolve_public_dir_path(p_dir)
 
         next unless File.directory?(full_path)

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -635,14 +635,12 @@ module Analyzer::Python
       end
 
       def to_s : ::String
-        unless @type.empty?
-          unless @default.empty?
-            "Name(#{@name}): Type(#{@type}) = Default(#{@default})"
-          else
-            "Name(#{@name}): Type(#{@type})"
-          end
-        else
+        if @type.empty?
           "Name(#{@name})"
+        elsif @default.empty?
+          "Name(#{@name}): Type(#{@type})"
+        else
+          "Name(#{@name}): Type(#{@type}) = Default(#{@default})"
         end
       end
 

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -227,7 +227,7 @@ module Analyzer::Python
         var_patterns.each do |json_var_name, subscript_regex, get_regex|
           next unless codeblock_line.includes?(json_var_name)
           matches = codeblock_line.scan(subscript_regex)
-          if matches.size == 0
+          if matches.empty?
             matches = codeblock_line.scan(get_regex)
           end
 
@@ -390,7 +390,7 @@ module Analyzer::Python
       return data if data.numeric?
 
       # Check if the data is a string
-      if data.size != 0
+      unless data.empty?
         if data[0] == data[-1] && data[0].in?('"', '\'')
           return data[1..-2]
         end
@@ -635,8 +635,8 @@ module Analyzer::Python
       end
 
       def to_s : ::String
-        if @type.size != 0
-          if @default.size != 0
+        unless @type.empty?
+          unless @default.empty?
             "Name(#{@name}): Type(#{@type}) = Default(#{@default})"
           else
             "Name(#{@name}): Type(#{@type})"

--- a/src/utils/tnetstring.cr
+++ b/src/utils/tnetstring.cr
@@ -86,7 +86,7 @@ module Tnetstring
       else              raise ParseError.new("invalid boolean payload: #{s}")
       end
     when NULL_TYPE
-      raise ParseError.new("null payload must be empty") unless payload.size == 0
+      raise ParseError.new("null payload must be empty") unless payload.empty?
       nil
     when LIST_TYPE
       list = [] of Value


### PR DESCRIPTION
## Summary

- replace the 16 String/Array zero-size comparisons with `empty?` and readable `unless` forms
- use `size.zero?` for the remaining `_match` receiver, which is `Regex::MatchData` and does not implement `empty?`
- preserve every branch polarity and remove all `.size == 0` / `.size != 0` forms from `src/`

The `Regex::MatchData` distinction corrects one premise in the issue while keeping its intended behavior and idiomatic zero check. Applying `empty?` at that site fails Crystal compilation.

Closes #2450

## Validation

- `docker build --target builder -t noir-pr2450-check .` — full Crystal 1.21 static build passed
- `docker run --rm noir-pr2450-check crystal tool format --check`
- `docker run --rm noir-pr2450-check crystal spec spec/unit_test`
- `docker run --rm noir-pr2450-check crystal spec spec/functional_test`
- confirmed no `.size == 0` or `.size != 0` remains under `src/`

AI-assisted contribution; I reviewed every changed branch and used the compiler to validate receiver-specific APIs.
