### PR TITLE
refactor: consolidate Python string extraction helper

### DIFF
--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -159,7 +159,7 @@ module Analyzer::Python
       route_path = extract_keyword_string(args, "path") ||
                    extract_keyword_string(args, "rule") ||
                    extract_keyword_string(args, "uri") ||
-                   args[0]?.try { |arg| extract_python_string(arg) }
+                   args[0]?.try { |arg| Helper.extract_python_string(arg) }
       return unless route_path
 
       callback_name = extract_callback_name(args)
@@ -414,15 +414,10 @@ module Analyzer::Python
         keyword_match = arg.match(keyword_re)
         next unless keyword_match
 
-        return extract_python_string(keyword_match[1])
+        return Helper.extract_python_string(keyword_match[1])
       end
 
       nil
-    end
-
-    private def extract_python_string(expression : String) : String?
-      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
-      string_match ? string_match[1] : nil
     end
 
     private def extract_callback_name(args : Array(String)) : String?

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -803,7 +803,7 @@ module Analyzer::Python
         args = split_python_arguments(call_match[1])
         next if args.size < 2
 
-        route = extract_python_string(args[0])
+        route = Helper.extract_python_string(args[0])
         route ||= extract_python_keyword_string(args, "route")
         route ||= extract_python_keyword_string(args, "regex")
         next unless route
@@ -937,7 +937,7 @@ module Analyzer::Python
         args = split_python_arguments(register_match[2])
         next if args.empty?
 
-        prefix = extract_python_string(args[0]) || extract_python_keyword_string(args, "prefix")
+        prefix = Helper.extract_python_string(args[0]) || extract_python_keyword_string(args, "prefix")
         next unless prefix
 
         view_ref = extract_python_keyword_expression(args, "viewset") || args[1]?.try(&.strip)
@@ -1174,11 +1174,6 @@ module Analyzer::Python
       view
     end
 
-    private def extract_python_string(expression : ::String) : ::String?
-      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
-      string_match ? string_match[1] : nil
-    end
-
     private def keyword_expression_regex(keyword : ::String) : Regex
       @keyword_regex_cache[keyword] ||= /^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m
     end
@@ -1195,7 +1190,7 @@ module Analyzer::Python
 
     private def extract_python_keyword_string(args : Array(::String), keyword : ::String) : ::String?
       if expression = extract_python_keyword_expression(args, keyword)
-        return extract_python_string(expression)
+        return Helper.extract_python_string(expression)
       end
 
       nil

--- a/src/analyzer/analyzers/python/django_ninja.cr
+++ b/src/analyzer/analyzers/python/django_ninja.cr
@@ -155,13 +155,13 @@ module Analyzer::Python
       args = split_python_arguments(match[2])
       return if args.size < 2
 
-      prefix = extract_python_string(args[0]) || extract_python_keyword_string(args, "prefix")
+      prefix = Helper.extract_python_string(args[0]) || extract_python_keyword_string(args, "prefix")
       return unless prefix
 
       target_expr = extract_python_keyword_expression(args, "router") || args[1]?.try(&.strip)
       return unless target_expr
 
-      if literal = extract_python_string(target_expr)
+      if literal = Helper.extract_python_string(target_expr)
         return {var, RouterEdge.new(prefix, literal, true, path, base)}
       end
 
@@ -190,7 +190,7 @@ module Analyzer::Python
         arg_list = split_python_arguments(args)
         return if arg_list.size < 2
         methods = extract_methods_list(arg_list[0])
-        op_path = extract_python_string(arg_list[1]) || extract_route_path(args)
+        op_path = Helper.extract_python_string(arg_list[1]) || extract_route_path(args)
       elsif HTTP_DECORATOR_METHODS.includes?(attr)
         methods = [attr.upcase]
         op_path = extract_route_path(args)
@@ -239,11 +239,11 @@ module Analyzer::Python
         stripped = arg.strip
         next if stripped.empty?
         break if top_level_keyword_argument?(stripped)
-        return extract_python_string(stripped)
+        return Helper.extract_python_string(stripped)
       end
 
       if kw = extract_python_keyword_expression(args, "path")
-        return extract_python_string(kw)
+        return Helper.extract_python_string(kw)
       end
       nil
     end
@@ -628,15 +628,10 @@ module Analyzer::Python
       ""
     end
 
-    private def extract_python_string(expression : ::String) : ::String?
-      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
-      string_match ? string_match[1] : nil
-    end
-
     private def extract_python_keyword_string(args : Array(::String), keyword : ::String) : ::String?
       args.each do |arg|
         if match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
-          return extract_python_string(match[1].strip)
+          return Helper.extract_python_string(match[1].strip)
         end
       end
       nil

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -287,7 +287,7 @@ module Analyzer::Python
       return unless call_match
 
       args = split_python_arguments(call_match[1])
-      extract_keyword_string(args, "prefix") || args[0]?.try { |arg| extract_python_string(arg) }
+      extract_keyword_string(args, "prefix") || args[0]?.try { |arg| Helper.extract_python_string(arg) }
     end
 
     private def split_python_arguments(args : ::String) : Array(::String)
@@ -349,15 +349,10 @@ module Analyzer::Python
         keyword_match = arg.match(keyword_re)
         next unless keyword_match
 
-        return extract_python_string(keyword_match[1])
+        return Helper.extract_python_string(keyword_match[1])
       end
 
       nil
-    end
-
-    private def extract_python_string(expression : ::String) : ::String?
-      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
-      string_match ? string_match[1] : nil
     end
 
     private def static_route_path(route_path : ::String) : ::String

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -156,7 +156,7 @@ module Analyzer::Python
         next unless call_match
 
         args = split_python_arguments(call_match[1])
-        name = extract_python_keyword_string(args, "name") || args[0]?.try { |arg| extract_python_string(arg) }
+        name = extract_python_keyword_string(args, "name") || args[0]?.try { |arg| Helper.extract_python_string(arg) }
         next if name.nil? || name.empty?
 
         result << Endpoint.new(static_view_route_path(name), "GET", Details.new(PathInfo.new(path, line_index + 1)))
@@ -381,15 +381,10 @@ module Analyzer::Python
         keyword_match = arg.match(keyword_re)
         next unless keyword_match
 
-        return extract_python_string(keyword_match[1])
+        return Helper.extract_python_string(keyword_match[1])
       end
 
       nil
-    end
-
-    private def extract_python_string(expression : String) : String?
-      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
-      string_match ? string_match[1] : nil
     end
 
     private def static_view_route_path(name : String) : String

--- a/src/analyzer/analyzers/python/python_helper.cr
+++ b/src/analyzer/analyzers/python/python_helper.cr
@@ -18,5 +18,10 @@ module Analyzer::Python
 
       normalize_path("#{prefix}/#{path}")
     end
+
+    def extract_python_string(expression : ::String) : ::String?
+      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
+      string_match ? string_match[1] : nil
+    end
   end
 end

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -433,7 +433,7 @@ module Analyzer::Python
       args = split_python_arguments(call_match[2])
       static_path = extract_keyword_string(args, "uri") ||
                     extract_keyword_string(args, "path") ||
-                    args[0]?.try { |arg| extract_python_string(arg) } || ""
+                    args[0]?.try { |arg| Helper.extract_python_string(arg) } || ""
       return if static_path.empty?
 
       {router_name, static_path}
@@ -515,7 +515,7 @@ module Analyzer::Python
       end
 
       return "" if args.size < 2
-      extract_python_string(args[1]) || ""
+      Helper.extract_python_string(args[1]) || ""
     end
 
     private def extract_programmatic_methods(args : Array(::String)) : Array(::String)
@@ -548,15 +548,10 @@ module Analyzer::Python
 
     private def extract_keyword_string(args : Array(::String), keyword : ::String) : ::String?
       if expression = extract_keyword_expression(args, keyword)
-        return extract_python_string(expression)
+        return Helper.extract_python_string(expression)
       end
 
       nil
-    end
-
-    private def extract_python_string(expression : ::String) : ::String?
-      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
-      string_match ? string_match[1] : nil
     end
 
     private def clean_reference(expression : ::String) : ::String

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -109,7 +109,7 @@ module Analyzer::Python
             receiver = normalize_receiver(programmatic_match[1])
             websocket_route = !(programmatic_match[2]?).to_s.empty?
             args = split_python_arguments(programmatic_match[3])
-            route_path = extract_python_keyword_string(args, "path") || args[0]?.try { |arg| extract_python_string(arg) }
+            route_path = extract_python_keyword_string(args, "path") || args[0]?.try { |arg| Helper.extract_python_string(arg) }
             next unless route_path
 
             handler_expr = extract_python_keyword_expression(args, "endpoint") || args[1]?.try(&.strip)
@@ -620,15 +620,10 @@ module Analyzer::Python
 
     private def extract_python_keyword_string(args : Array(::String), keyword : ::String) : ::String?
       if expression = extract_python_keyword_expression(args, keyword)
-        return extract_python_string(expression)
+        return Helper.extract_python_string(expression)
       end
 
       nil
-    end
-
-    private def extract_python_string(expression : ::String) : ::String?
-      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
-      string_match ? string_match[1] : nil
     end
 
     private def clean_reference(expression : ::String) : ::String


### PR DESCRIPTION
## Summary

- move `extract_python_string` into `Analyzer::Python::Helper`
- update Bottle, Django, Django Ninja, Falcon, Pyramid, Sanic, and Starlette analyzers to use the shared helper
- remove the seven duplicated private implementations without changing extraction behavior

## Testing

- `crystal tool format --check`
- `lib/ameba/bin/ameba.cr` (1837 files, 0 failures)
- `crystal spec spec/unit_test` (4424 examples, 0 failures)
- `crystal spec spec/functional_test`

Validated with Crystal 1.19.0.

Closes #2445
