### PR TITLE
fix(output_builder): four data-loss bugs across only-param, postman, httpie and markdown-table

### DIFF
--- a/spec/unit_test/output_builder/diff_spec.cr
+++ b/spec/unit_test/output_builder/diff_spec.cr
@@ -165,5 +165,24 @@ describe "OutputBuilderDiff" do
       output.should contain("[removed]")
       output.should_not contain("[changed]")
     end
+
+    it "quotes a metadata key that is not a bare TOML key" do
+      builder = OutputBuilderDiff.new(create_test_options)
+      builder.io = IO::Memory.new
+
+      # This builder used to emit keys raw, so a key containing a dot would be
+      # read as a dotted table path (`path.permissions` -> [path].permissions)
+      # and corrupt the document. Endpoint field names are all bare-safe, but
+      # `metadata` keys come from analyzers, so the quoting has to be here.
+      endpoint = Endpoint.new("content://com.example/items", "GET")
+      endpoint.protocol = "android-provider"
+      endpoint.metadata = {"path.permissions" => "read"}
+
+      builder.print_toml([endpoint], NoirRunner.new(create_test_options))
+      output = builder.io.to_s
+
+      output.should contain(%("path.permissions" = "read"))
+      output.should_not contain(%(path.permissions = "read"))
+    end
   end
 end

--- a/spec/unit_test/output_builder/html_spec.cr
+++ b/spec/unit_test/output_builder/html_spec.cr
@@ -729,4 +729,82 @@ describe "OutputBuilderHtml" do
     output.should contain("severity-high")
     output.should contain("severity-info")
   end
+
+  # Only the *failure* path of the custom-template feature was covered (an
+  # unreadable template falling back to the built-in report). A bare `rescue`
+  # in `apply_template` swallows every exception, so a regression in the
+  # substitution itself would have silently degraded to the default report with
+  # nothing to notice it — the documented `report-template.html` feature had no
+  # test that it works at all.
+  it "substitutes every placeholder in a custom report template" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    temp_dir = File.join(Dir.tempdir, "noir_tpl_#{Process.pid}_#{Time.utc.to_unix_ms}")
+    Dir.mkdir_p(temp_dir)
+    ENV["NOIR_HOME"] = temp_dir
+
+    begin
+      File.write(File.join(temp_dir, "report-template.html"), <<-TPL)
+        <!DOCTYPE html><html><head><%= noir_head %></head><body>
+        MARK-HEADER<%= noir_header %>
+        MARK-SUMMARY<%= noir_summary %>
+        MARK-ENDPOINTS<%= noir_endpoints %>
+        MARK-PASSIVE<%= noir_passive_scans %>
+        MARK-FOOTER<%= noir_footer %>
+        <%= noir_scripts %></body></html>
+        TPL
+
+      endpoint = Endpoint.new("/api/users", "GET")
+      endpoint.push_param(Param.new("page", "1", "query"))
+      scan_yaml = YAML.parse <<-YAML
+        id: tpl-rule
+        info:
+          name: "Test finding"
+          author: ["a"]
+          severity: "high"
+          description: "A finding rendered through the custom template"
+          reference: ["https://example.com"]
+        matchers-condition: "or"
+        matchers:
+          - type: "regex"
+            patterns: ["x"]
+            condition: "or"
+        category: "secret"
+        techs: ["*"]
+        YAML
+      finding = PassiveScanResult.new(PassiveScan.new(scan_yaml), "app/config.rb", 4, "SECRET=abc")
+
+      builder.print([endpoint], [finding])
+      output = builder.io.to_s
+
+      # The template's own markup survives — this is the custom layout, not the
+      # built-in one silently substituted for it.
+      output.should contain("MARK-HEADER")
+      output.should contain("MARK-SUMMARY")
+      output.should contain("MARK-ENDPOINTS")
+      output.should contain("MARK-PASSIVE")
+      output.should contain("MARK-FOOTER")
+
+      # Every placeholder is consumed; a leftover tag would ship to the browser.
+      output.should_not match(/<%=\s*noir_\w+\s*%>/)
+
+      # And each section actually rendered its content.
+      output.should contain("data-endpoint")
+      output.should contain("/api/users")
+      output.should contain("page")
+      output.should contain("Test finding")
+      output.should contain("noir-theme")
+    ensure
+      FileUtils.rm_rf(temp_dir)
+      ENV.delete("NOIR_HOME")
+    end
+  end
 end

--- a/spec/unit_test/output_builder/httpie_spec.cr
+++ b/spec/unit_test/output_builder/httpie_spec.cr
@@ -78,4 +78,51 @@ describe "OutputBuilderHttpie" do
     lines.map { |line| line.split("'")[1] }.should eq(WILDCARD_HTTP_METHODS)
     lines.any?(&.includes?("'ANY'")).should be_false
   end
+
+  it "keeps a form value containing & in one request item" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHttpie.new(options)
+    builder.io = IO::Memory.new
+
+    # Re-splitting the joined `k=v&k=v` body on `&` cannot tell a separator
+    # from a `&` inside a value: this came out as `'note=a' 'b=c'`, truncating
+    # the real value and inventing a `b` field the endpoint never had.
+    endpoint = Endpoint.new("/submit", "POST")
+    endpoint.push_param(Param.new("note", "a&b=c", "form"))
+
+    builder.print([endpoint])
+    line = builder.io.to_s.strip
+
+    line.should eq("http --form 'POST' '/submit' 'note=a&b=c'")
+    line.should_not contain("'b=c'")
+  end
+
+  it "emits form params whose param_type is the body alias" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHttpie.new(options)
+    builder.io = IO::Memory.new
+
+    # `body` aliases onto the `json` bucket, so these take the JSON branch —
+    # the form branch must not pick them up and must not lose them either.
+    endpoint = Endpoint.new("/upload", "POST")
+    endpoint.push_param(Param.new("avatar", "", "body"))
+
+    builder.print([endpoint])
+    line = builder.io.to_s.strip
+
+    line.should contain("'avatar='")
+    line.should_not contain("--form")
+  end
 end

--- a/spec/unit_test/output_builder/markdown_table_spec.cr
+++ b/spec/unit_test/output_builder/markdown_table_spec.cr
@@ -84,4 +84,67 @@ describe "OutputBuilderMarkdownTable" do
     expected_line_2 = "| GET\\\\POST /&lt;script&gt;alert(1)&lt;/script&gt; | http | `&lt;i&gt;html&lt;/i&gt; (query)`  |"
     lines[3].should eq(expected_line_2)
   end
+
+  it "keeps the code span intact when a param name contains a backtick" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderMarkdownTable.new(options)
+    builder.io = IO::Memory.new
+
+    # A single backtick closed the span early and the remainder of the row ran
+    # on as loose text.
+    endpoint = Endpoint.new("/search", "POST")
+    endpoint.push_param(Param.new("md`tick", "v", "query"))
+    # Two adjacent backticks need a three-backtick fence.
+    endpoint.push_param(Param.new("run``two", "v", "query"))
+    # Leading/trailing backticks need the space pad CommonMark strips.
+    endpoint.push_param(Param.new("`edge", "v", "query"))
+
+    builder.print([endpoint])
+    cell = builder.io.to_s.split("\n")[2]
+
+    cell.should contain("``md`tick (query)``")
+    cell.should contain("```run``two (query)```")
+    cell.should contain("`` `edge (query) ``")
+  end
+
+  it "escapes a backtick in a text cell so it cannot open a span" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderMarkdownTable.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/a`b`c", "GET")])
+    cell = builder.io.to_s.split("\n")[2]
+
+    cell.should eq("| GET /a\\`b\\`c | http | - |")
+  end
+
+  it "renders a placeholder for an endpoint with no params" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderMarkdownTable.new(options)
+    builder.io = IO::Memory.new
+
+    # The `-` placeholder sat behind a `params.nil?` check that could never be
+    # true, so this rendered as an empty cell.
+    builder.print([Endpoint.new("/no-params", "GET")])
+
+    builder.io.to_s.split("\n")[2].should eq("| GET /no-params | http | - |")
+  end
 end

--- a/spec/unit_test/output_builder/only_param_spec.cr
+++ b/spec/unit_test/output_builder/only_param_spec.cr
@@ -37,4 +37,35 @@ describe "OutputBuilderOnlyParam" do
     lines.should contain("id")
     lines.should contain("username")
   end
+
+  it "includes body-typed params, which alias onto the json bucket" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderOnlyParam.new(options)
+    builder.io = IO::Memory.new
+
+    # NestJS/Nuxt/Nitro/Rocket/Servant/Scotty/Cowboy/Elli/Wisp/Drogon/oatpp all
+    # record a request-body field as `param_type == "body"`, which resolves to
+    # the `json` bucket via `Param#request_type`. Matching on the raw
+    # `param_type` dropped them from this format entirely.
+    endpoint = Endpoint.new("/admin/upload", "POST")
+    endpoint.push_param(Param.new("avatar", "", "body"))
+    endpoint.push_param(Param.new("file", "", "body"))
+    endpoint.push_param(Param.new("include", "", "query"))
+    endpoint.push_param(Param.new("authorization", "", "header"))
+
+    builder.print([endpoint])
+    lines = builder.io.to_s.split("\n").reject(&.empty?)
+
+    lines.should contain("avatar")
+    lines.should contain("file")
+    lines.should contain("include")
+    # Headers are not a fuzzable body/query bucket, so they stay out.
+    lines.should_not contain("authorization")
+  end
 end

--- a/spec/unit_test/output_builder/partial_options_spec.cr
+++ b/spec/unit_test/output_builder/partial_options_spec.cr
@@ -1,0 +1,58 @@
+require "../../spec_helper"
+require "../../../src/models/passive_scan"
+require "../../../src/output_builder/common"
+require "../../../src/output_builder/oas3"
+require "../../../src/output_builder/postman"
+require "../../../src/models/endpoint"
+require "../../../src/utils/utils"
+
+# `config_initializer` seeds every option key for CLI runs, so the builders got
+# away with reading `@options["url"]` / `@options["status_codes"]` by hard
+# index. Anything constructing a builder with only the keys it cares about —
+# specs here, library consumers — hit a KeyError instead, and inconsistently:
+# oas2 and only-url already read the same options through `[]?` while oas3,
+# postman and common did not.
+describe "Output builders with a partial options hash" do
+  minimal = {
+    "debug"   => YAML::Any.new(false),
+    "verbose" => YAML::Any.new(false),
+    "color"   => YAML::Any.new(false),
+    "nolog"   => YAML::Any.new(true),
+    "output"  => YAML::Any.new(""),
+  }
+
+  endpoint = Endpoint.new("/api/users/{id}", "GET")
+  endpoint.push_param(Param.new("id", "", "path"))
+  endpoint.push_param(Param.new("q", "noir", "query"))
+
+  it "renders plain output without the display-toggle keys" do
+    builder = OutputBuilderCommon.new(minimal)
+    builder.io = IO::Memory.new
+
+    builder.print([endpoint])
+
+    builder.io.to_s.should contain("/api/users/{id}?q=noir")
+    # No `url` option means no probing ran, so no status code is shown.
+    builder.io.to_s.should_not contain("[error]")
+  end
+
+  it "falls back to the default server url in oas3" do
+    builder = OutputBuilderOas3.new(minimal)
+    builder.io = IO::Memory.new
+
+    builder.print([endpoint])
+
+    JSON.parse(builder.io.to_s)["servers"][0]["url"].as_s.should eq("http://localhost")
+  end
+
+  it "falls back to the default baseUrl in postman" do
+    builder = OutputBuilderPostman.new(minimal)
+    builder.io = IO::Memory.new
+
+    builder.print([endpoint])
+    variables = JSON.parse(builder.io.to_s)["variable"].as_a
+
+    variables[0]["key"].as_s.should eq("baseUrl")
+    variables[0]["value"].as_s.should eq("http://localhost")
+  end
+end

--- a/spec/unit_test/output_builder/postman_spec.cr
+++ b/spec/unit_test/output_builder/postman_spec.cr
@@ -221,4 +221,73 @@ describe "OutputBuilderPostman URLs" do
     url["raw"].as_s.should eq("{{baseUrl}}/search?q=noir&page=2")
     url["query"].as_a.map(&.["key"].as_s).should eq(["q", "page"])
   end
+
+  it "keeps a query string the route itself carries, with no declared param" do
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    # How WordPress addresses an AJAX handler. This builder rebuilds the URL
+    # from `uri.path`, so the query used to be dropped outright and the
+    # imported request addressed a different handler.
+    builder.print([Endpoint.new("/wp-admin/admin-ajax.php?action=get_user_data", "GET")])
+    item = JSON.parse(builder.io.to_s)["item"][0]
+    url = item["request"]["url"]
+
+    url["raw"].as_s.should eq("{{baseUrl}}/wp-admin/admin-ajax.php?action=get_user_data")
+    url["query"].as_a.map(&.["key"].as_s).should eq(["action"])
+    url["query"].as_a.map(&.["value"].as_s).should eq(["get_user_data"])
+    item["name"].as_s.should eq("GET /wp-admin/admin-ajax.php?action=get_user_data")
+  end
+
+  it "does not repeat a pair the route and a declared param both spell out" do
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    # The WordPress analyzer records `action` as a query param on top of the
+    # URL that already carries it. Emitting both would produce
+    # `?action=get_user_data&action=get_user_data`.
+    endpoint = Endpoint.new("/wp-admin/admin-ajax.php?action=get_user_data", "GET")
+    endpoint.push_param(Param.new("action", "get_user_data", "query"))
+
+    builder.print([endpoint])
+    url = JSON.parse(builder.io.to_s)["item"][0]["request"]["url"]
+
+    url["raw"].as_s.should eq("{{baseUrl}}/wp-admin/admin-ajax.php?action=get_user_data")
+    url["query"].as_a.size.should eq(1)
+  end
+
+  it "appends a declared param that overrides the route's own value" do
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    # `--pvalue query=…` style override: the later pair is the one servers
+    # read, so it survives alongside the route's own.
+    endpoint = Endpoint.new("/search?q=old", "GET")
+    endpoint.push_param(Param.new("q", "new", "query"))
+
+    builder.print([endpoint])
+    url = JSON.parse(builder.io.to_s)["item"][0]["request"]["url"]
+
+    url["raw"].as_s.should eq("{{baseUrl}}/search?q=old&q=new")
+    url["query"].as_a.map(&.["value"].as_s).should eq(["old", "new"])
+  end
+
+  it "gives endpoints that differ only by query string distinct names" do
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    # `action` is the only discriminator for WordPress AJAX, so a path-only
+    # name renders these two identically in the Postman sidebar.
+    builder.print([
+      Endpoint.new("/wp-admin/admin-ajax.php?action=get_user_data", "GET"),
+      Endpoint.new("/wp-admin/admin-ajax.php?action=save_settings", "GET"),
+    ])
+    names = JSON.parse(builder.io.to_s)["item"].as_a.map(&.["name"].as_s)
+
+    names.uniq.size.should eq(2)
+    names.should eq([
+      "GET /wp-admin/admin-ajax.php?action=get_user_data",
+      "GET /wp-admin/admin-ajax.php?action=save_settings",
+    ])
+  end
 end

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -57,7 +57,11 @@ class OutputBuilderCommon < OutputBuilder
         r_buffer << "\n#{r_method} #{r_kind} #{r_name}"
       end
 
-      if any_to_bool(@options["status_codes"]) || !@options["exclude_codes"].to_s.empty?
+      # `[]?` throughout: `config_initializer` seeds every key for CLI runs,
+      # but a builder constructed with a partial options hash (specs, library
+      # use) raised KeyError on the first endpoint. `any_to_bool` is untyped
+      # and reads `nil` as false, matching each option's default.
+      if any_to_bool(@options["status_codes"]?) || !@options["exclude_codes"]?.to_s.empty?
         status_color = :light_green
         status_code = endpoint.details.status_code
         if status_code
@@ -175,12 +179,12 @@ class OutputBuilderCommon < OutputBuilder
       end
 
       # Show technology only if include_techs flag is set
-      if any_to_bool(@options["include_techs"]) && endpoint.details.technology
+      if any_to_bool(@options["include_techs"]?) && endpoint.details.technology
         r_tech = endpoint.details.technology.to_s.colorize(:light_blue).toggle(@is_color)
         r_buffer << "\n  ○ tech: #{r_tech}"
       end
 
-      if any_to_bool(@options["include_path"])
+      if any_to_bool(@options["include_path"]?)
         details = endpoint.details
         if details.code_paths && !details.code_paths.empty?
           details.code_paths.each do |code_path|
@@ -194,7 +198,7 @@ class OutputBuilderCommon < OutputBuilder
       end
 
       context = endpoint.ai_context
-      if any_to_bool(@options["ai_context"]) && !context.nil?
+      if any_to_bool(@options["ai_context"]?) && !context.nil?
         unless context.empty?
           features = ai_context_feature_filter
           visible = (features.includes?("guards") && !context.guards.empty?) ||
@@ -214,7 +218,7 @@ class OutputBuilderCommon < OutputBuilder
             append_ai_context_block(r_buffer, "signals", context.signals) if features.includes?("signals")
           end
         end
-      elsif any_to_bool(@options["include_callee"]) && !endpoint.callees.empty?
+      elsif any_to_bool(@options["include_callee"]?) && !endpoint.callees.empty?
         r_buffer << "\n  ○ callees: "
         endpoint.callees.each_with_index do |callee, index|
           prefix = index == endpoint.callees.size - 1 ? "└── " : "├── "

--- a/src/output_builder/diff.cr
+++ b/src/output_builder/diff.cr
@@ -1,11 +1,14 @@
 require "../models/output_builder"
 require "../models/endpoint"
+require "./toml_serializer"
 
 require "json"
 require "yaml"
 require "colorize"
 
 class OutputBuilderDiff < OutputBuilder
+  include OutputBuilderTomlSerializer
+
   def diff(new_endpoints : Array(Endpoint), old_endpoints : Array(Endpoint))
     added = [] of Endpoint
     changed = [] of Endpoint
@@ -93,44 +96,5 @@ class OutputBuilderDiff < OutputBuilder
       end
     end
     result
-  end
-
-  private def generate_table_content(data : Hash(String, JSON::Any)) : String
-    String.build do |io|
-      data.each do |key, value|
-        case value.raw
-        when String, Int64, Float64, Bool
-          io << "#{key} = #{toml_value(value)}\n"
-        when Array
-          io << "#{key} = ["
-          io << value.as_a.map { |item| toml_value(item) }.join(", ")
-          io << "]\n"
-        when Hash
-          io << "#{key} = { "
-          io << value.as_h.map { |k, v| "#{k} = #{toml_value(v)}" }.join(", ")
-          io << " }\n"
-        end
-      end
-    end
-  end
-
-  private def toml_value(value : JSON::Any) : String
-    case raw = value.raw
-    when String
-      # Escape control chars so a multi-line value can't break the TOML document.
-      %("#{raw.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("\b", "\\b").gsub("\t", "\\t").gsub("\n", "\\n").gsub("\f", "\\f").gsub("\r", "\\r")}")
-    when Int64, Float64
-      raw.to_s
-    when Bool
-      raw.to_s
-    when Nil
-      %("")
-    when Array
-      "[#{raw.map { |item| toml_value(item) }.join(", ")}]"
-    when Hash
-      "{ #{raw.map { |k, v| "#{k} = #{toml_value(v)}" }.join(", ")} }"
-    else
-      %("#{raw}")
-    end
   end
 end

--- a/src/output_builder/httpie.cr
+++ b/src/output_builder/httpie.cr
@@ -36,11 +36,16 @@ class OutputBuilderHttpie < OutputBuilder
           end
         else
           option_parts << "--form"
-          form_parts = baked[:body].split('&')
-          form_parts.each do |part|
-            if part.includes?('=')
-              request_items << shell_quote(part)
-            end
+          # Read the params directly instead of re-splitting the `k=v&k=v`
+          # body `bake_endpoint` joined them into. That round trip has no way
+          # to tell a separator from a `&` inside a value, so a form param
+          # `note=a&b=c` came out as `'note=a' 'b=c'` — the real value
+          # truncated and a field named `b` that the endpoint never had.
+          # httpie takes everything after the first `=` as the value, so one
+          # shell-quoted item per param is exact.
+          endpoint.params.each do |param|
+            next unless param.request_type == "form"
+            request_items << shell_quote("#{param.name}=#{param.value}")
           end
         end
       end

--- a/src/output_builder/markdown_table.cr
+++ b/src/output_builder/markdown_table.cr
@@ -7,18 +7,46 @@ class OutputBuilderMarkdownTable < OutputBuilder
     ob_puts "| -------- | -------- | ------ |"
 
     endpoints.each do |endpoint|
-      if !endpoint.params.nil?
-        params_text = String.build do |cell|
-          endpoint.params.each do |param|
-            cell << '`' << sanitize_markdown_cell(param.name)
-            cell << " (" << sanitize_markdown_cell(param.param_type) << ")` "
-          end
-        end
-        ob_puts "| #{sanitize_markdown_cell(endpoint.method)} #{sanitize_markdown_cell(endpoint.url)} | #{sanitize_markdown_cell(endpoint.protocol)} | #{params_text} |"
-      else
-        ob_puts "| #{sanitize_markdown_cell(endpoint.method)} #{sanitize_markdown_cell(endpoint.url)} | #{sanitize_markdown_cell(endpoint.protocol)} | - |"
-      end
+      # `params` is a non-nilable Array, so the `-` placeholder used to sit
+      # behind an `unless params.nil?` that could never be false: a param-less
+      # endpoint rendered an empty cell instead. Branch on `empty?`, which is
+      # the condition that was meant.
+      params_text = if endpoint.params.empty?
+                      "-"
+                    else
+                      String.build do |cell|
+                        endpoint.params.each do |param|
+                          content = "#{sanitize_markdown_cell(param.name)} (#{sanitize_markdown_cell(param.param_type)})"
+                          cell << markdown_code_span(content) << ' '
+                        end
+                      end
+                    end
+
+      ob_puts "| #{sanitize_text_cell(endpoint.method)} #{sanitize_text_cell(endpoint.url)} | #{sanitize_text_cell(endpoint.protocol)} | #{params_text} |"
     end
+  end
+
+  # A code span's opening delimiter must be longer than the longest backtick
+  # run inside it (CommonMark), or a backtick in a param name closes the span
+  # early: ``md`tick (query)`` rendered as the code "md", then loose text, then
+  # a stray backtick that ran on into the rest of the row. Content that starts
+  # or ends with a backtick is padded with a space, which CommonMark strips
+  # exactly one of, so the backtick survives as content.
+  private def markdown_code_span(content : String) : String
+    longest = content.scan(/`+/).max_of?(&.[0].size) || 0
+    return "`#{content}`" if longest.zero?
+
+    fence = "`" * (longest + 1)
+    pad = content.starts_with?('`') || content.ends_with?('`') ? " " : ""
+    "#{fence}#{pad}#{content}#{pad}#{fence}"
+  end
+
+  # Cells rendered as inline text rather than inside a code span. A backtick
+  # here would open a span of its own and swallow part of a URL, so it is
+  # backslash-escaped — which only works outside a code span, hence the split
+  # from `sanitize_markdown_cell`.
+  private def sanitize_text_cell(content : String) : String
+    sanitize_markdown_cell(content).gsub('`', "\\`")
   end
 
   private def sanitize_markdown_cell(content : String) : String

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -129,12 +129,20 @@ class OutputBuilderOas3 < OutputBuilder
       } of String => JSON::Any),
       "servers" => JSON::Any.new([
         JSON::Any.new({
-          "url" => JSON::Any.new(@options["url"].to_s.empty? ? "http://localhost" : @options["url"].to_s),
+          "url" => JSON::Any.new(target_url),
         } of String => JSON::Any),
       ]),
       "paths" => JSON::Any.new(paths.transform_values { |v| JSON::Any.new(v) }),
     } of String => JSON::Any
 
     ob_puts JSON::Any.new(oas3_hash).to_pretty_json
+  end
+
+  # `[]?`, not `[]`: `config_initializer` seeds every key for CLI runs, but a
+  # builder constructed with a partial options hash (specs, library use) hit a
+  # KeyError here while the sibling oas2 builder read the same option safely.
+  private def target_url : String
+    url = @options["url"]?.to_s
+    url.empty? ? "http://localhost" : url
   end
 end

--- a/src/output_builder/only-param.cr
+++ b/src/output_builder/only-param.cr
@@ -10,7 +10,13 @@ class OutputBuilderOnlyParam < OutputBuilder
 
     endpoints.each do |endpoint|
       endpoint.params.each do |param|
-        if targets.includes? param.param_type
+        # `request_type`, not `param_type`: the canonical bucket is what every
+        # consumer dispatches on (see `Param#request_type`). Fourteen analyzers
+        # spell a body field `body` rather than `json`, and matching on the raw
+        # `param_type` dropped every one of them — 82 params across the fixture
+        # tree were invisible here while `-f plain` and `-f curl` (which bake
+        # through `request_type`) showed them.
+        if targets.includes? param.request_type
           common_params << param.name
         end
       end

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -32,28 +32,8 @@ class OutputBuilderPostman < OutputBuilder
         end
       end
 
-      url_obj = build_url_object(uri, path_with_vars)
-
-      # Add query parameters
-      query_params = [] of JSON::Any
-      endpoint.params.each do |param|
-        if param.request_type == "query"
-          query_params << JSON::Any.new({
-            "key"   => JSON::Any.new(param.name),
-            "value" => JSON::Any.new(param.value),
-          } of String => JSON::Any)
-        end
-      end
-
-      if !query_params.empty?
-        url_obj["query"] = JSON::Any.new(query_params)
-        # `raw` is the field a human reads in the URL bar and the one most
-        # non-Postman importers key off, so it has to agree with the
-        # structured `query` list. It was built from the path alone, which
-        # also dropped a query string the route itself carried
-        # (`admin-ajax.php?action=…`).
-        url_obj["raw"] = JSON::Any.new(raw_with_query(url_obj["raw"].as_s, query_params))
-      end
+      query_pairs = merged_query_pairs(uri, endpoint)
+      url_obj = build_url_object(uri, path_with_vars, query_pairs)
 
       # Add path variables
       path_vars = [] of JSON::Any
@@ -206,14 +186,52 @@ class OutputBuilderPostman < OutputBuilder
   # throwing away the host Noir had actually found: `demo.example.com` and
   # `demo.example.com.evil` imported as the same request. curl, httpie and
   # only-url all keep the host on the same scan; this now does too.
-  private def build_url_object(uri : URI, path_with_vars : Array(String)) : Hash(String, JSON::Any)
+  # The query string the emitted request actually carries: the one the route
+  # itself spells out, plus the query params the analyzer recorded.
+  #
+  # This builder is the only one that *reconstructs* the URL (`URI.parse` then
+  # `uri.path`) instead of passing `endpoint.url` through, so `uri.query` was
+  # dropped on the floor. `raw` was rebuilt from the path alone and the
+  # structured `query` list only ever came from declared params, so a route
+  # addressed through its query — `admin-ajax.php?action=get_user_data`, which
+  # is how WordPress reaches an AJAX handler — imported as a request that hits
+  # a different handler entirely. curl, httpie, powershell and only-url all
+  # keep it because they never take the URL apart.
+  #
+  # Merge order mirrors `bake_endpoint`: a pair the route already spells
+  # verbatim is not repeated, while a *different* value for the same name is
+  # appended as an override (the later pair is the one servers read).
+  private def merged_query_pairs(uri : URI, endpoint : Endpoint) : Array(Tuple(String, String))
+    pairs = [] of Tuple(String, String)
+
+    if query = uri.query
+      query.split('&').each do |pair|
+        next if pair.empty?
+        name, _, value = pair.partition('=')
+        pairs << {name, value}
+      end
+    end
+
+    endpoint.params.each do |param|
+      next unless param.request_type == "query"
+      next if pairs.includes?({param.name, param.value})
+      pairs << {param.name, param.value}
+    end
+
+    pairs
+  end
+
+  private def build_url_object(uri : URI, path_with_vars : Array(String),
+                               query_pairs : Array(Tuple(String, String))) : Hash(String, JSON::Any)
     host = uri.host
     if host.nil? || host.empty?
-      return {
-        "raw"  => JSON::Any.new("{{baseUrl}}/#{path_with_vars.join("/")}"),
+      url_obj = {
+        "raw"  => JSON::Any.new(with_query("{{baseUrl}}/#{path_with_vars.join("/")}", query_pairs)),
         "host" => JSON::Any.new([JSON::Any.new("{{baseUrl}}")]),
         "path" => JSON::Any.new(path_with_vars.map { |p| JSON::Any.new(p) }),
       } of String => JSON::Any
+      add_query_list(url_obj, query_pairs)
+      return url_obj
     end
 
     authority = String.build do |io|
@@ -224,7 +242,7 @@ class OutputBuilderPostman < OutputBuilder
 
     url_obj = {
       # Postman splits a real host into its domain labels.
-      "raw"  => JSON::Any.new("#{authority}/#{path_with_vars.join("/")}"),
+      "raw"  => JSON::Any.new(with_query("#{authority}/#{path_with_vars.join("/")}", query_pairs)),
       "host" => JSON::Any.new(host.split('.').map { |label| JSON::Any.new(label) }),
       "path" => JSON::Any.new(path_with_vars.map { |p| JSON::Any.new(p) }),
     } of String => JSON::Any
@@ -236,22 +254,48 @@ class OutputBuilderPostman < OutputBuilder
       url_obj["port"] = JSON::Any.new(port.to_s)
     end
 
+    add_query_list(url_obj, query_pairs)
     url_obj
   end
 
-  private def raw_with_query(raw : String, query_params : Array(JSON::Any)) : String
-    pairs = query_params.map do |param|
-      entry = param.as_h
-      "#{entry["key"].as_s}=#{entry["value"].as_s}"
-    end
+  # `raw` is the field a human reads in the URL bar and the one most
+  # non-Postman importers key off, so it has to agree with the structured
+  # `query` list built from the same pairs.
+  private def with_query(raw : String, query_pairs : Array(Tuple(String, String))) : String
+    return raw if query_pairs.empty?
 
-    "#{raw}#{raw.includes?('?') ? '&' : '?'}#{pairs.join("&")}"
+    "#{raw}?#{query_pairs.map { |name, value| "#{name}=#{value}" }.join("&")}"
   end
 
+  private def add_query_list(url_obj : Hash(String, JSON::Any), query_pairs : Array(Tuple(String, String)))
+    return if query_pairs.empty?
+
+    url_obj["query"] = JSON::Any.new(query_pairs.map do |name, value|
+      JSON::Any.new({
+        "key"   => JSON::Any.new(name),
+        "value" => JSON::Any.new(value),
+      } of String => JSON::Any)
+    end)
+  end
+
+  # The sidebar shows this name alone, so it has to carry every part of the URL
+  # that distinguishes one entry from another: the host (an absolute
+  # `demo.example.com/api/users/{id}` and `demo.example.com.evil/api/users/{id}`
+  # otherwise read identically) and the route's own query string — the only
+  # thing telling `admin-ajax.php?action=get_user_data` from
+  # `?action=save_settings`, which is 8 endpoints under 4 names on the
+  # WordPress fixture.
+  #
+  # Deliberately `uri.query` and not the merged pairs `build_url_object` uses:
+  # an inline query is part of how the route is addressed, while a declared
+  # query param is an input *to* a route and doesn't change its identity.
+  # Folding declared params in here would rename every parameterised endpoint.
   private def item_label(uri : URI) : String
     host = uri.host
-    return uri.path if host.nil? || host.empty?
+    label = host.nil? || host.empty? ? uri.path : "#{host}#{uri.path}"
+    query = uri.query
+    return label if query.nil? || query.empty?
 
-    "#{host}#{uri.path}"
+    "#{label}?#{query}"
   end
 end

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -170,7 +170,7 @@ class OutputBuilderPostman < OutputBuilder
       "variable" => JSON::Any.new([
         JSON::Any.new({
           "key"   => JSON::Any.new("baseUrl"),
-          "value" => JSON::Any.new(@options["url"].to_s.empty? ? "http://localhost" : @options["url"].to_s),
+          "value" => JSON::Any.new(base_url),
         } of String => JSON::Any),
       ]),
     } of String => JSON::Any
@@ -186,6 +186,14 @@ class OutputBuilderPostman < OutputBuilder
   # throwing away the host Noir had actually found: `demo.example.com` and
   # `demo.example.com.evil` imported as the same request. curl, httpie and
   # only-url all keep the host on the same scan; this now does too.
+  # `[]?`, not `[]`: `config_initializer` seeds every key for CLI runs, but a
+  # builder constructed with a partial options hash (specs, library use) hit a
+  # KeyError here while the oas2 builder read the same option safely.
+  private def base_url : String
+    url = @options["url"]?.to_s
+    url.empty? ? "http://localhost" : url
+  end
+
   # The query string the emitted request actually carries: the one the route
   # itself spells out, plus the query params the analyzer recorded.
   #

--- a/src/output_builder/toml.cr
+++ b/src/output_builder/toml.cr
@@ -1,7 +1,10 @@
 require "../models/output_builder"
 require "../models/endpoint"
+require "./toml_serializer"
 
 class OutputBuilderToml < OutputBuilder
+  include OutputBuilderTomlSerializer
+
   def print(endpoints : Array(Endpoint))
     message = {"endpoints" => endpoints, "passive_results" => [] of PassiveScanResult}.to_json
     json_obj = JSON.parse(message)
@@ -50,59 +53,5 @@ class OutputBuilderToml < OutputBuilder
       end
     end
     result
-  end
-
-  private def generate_table_content(data : Hash(String, JSON::Any)) : String
-    result = String.build do |io|
-      data.each do |key, value|
-        case value.raw
-        when String, Int64, Float64, Bool
-          io << "#{toml_key(key)} = #{toml_value(value)}\n"
-        when Array
-          io << "#{toml_key(key)} = ["
-          items = value.as_a.map { |item| toml_value(item) }
-          io << items.join(", ")
-          io << "]\n"
-        when Hash
-          # Nested inline table
-          io << "#{toml_key(key)} = { "
-          pairs = value.as_h.map { |k, v| "#{toml_key(k)} = #{toml_value(v)}" }
-          io << pairs.join(", ")
-          io << " }\n"
-        end
-      end
-    end
-    result
-  end
-
-  # TOML bare keys allow only [A-Za-z0-9_-]. A key with a dot, space, or
-  # quote would otherwise be read as a dotted table path (config.file →
-  # [config].file) and corrupt the document, so quote anything non-bare.
-  private def toml_key(key : String) : String
-    return key if key.matches?(/\A[A-Za-z0-9_-]+\z/)
-    %("#{key.gsub("\\", "\\\\").gsub("\"", "\\\"")}")
-  end
-
-  private def toml_value(value : JSON::Any) : String
-    case raw = value.raw
-    when String
-      # TOML basic strings can't contain raw newlines/control chars — escape
-      # them so a multi-line snippet/description doesn't break the document.
-      %("#{raw.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("\b", "\\b").gsub("\t", "\\t").gsub("\n", "\\n").gsub("\f", "\\f").gsub("\r", "\\r")}")
-    when Int64, Float64
-      raw.to_s
-    when Bool
-      raw.to_s
-    when Nil
-      %("")
-    when Array
-      items = raw.map { |item| toml_value(item) }
-      "[#{items.join(", ")}]"
-    when Hash
-      pairs = raw.map { |k, v| "#{toml_key(k)} = #{toml_value(v)}" }
-      "{ #{pairs.join(", ")} }"
-    else
-      %("#{raw}")
-    end
   end
 end

--- a/src/output_builder/toml_serializer.cr
+++ b/src/output_builder/toml_serializer.cr
@@ -1,0 +1,62 @@
+require "json"
+
+# TOML emission shared by the `-f toml` builder and diff mode's `print_toml`.
+#
+# Both hand-roll TOML from the same `Endpoint#to_json` shape, and both had
+# their own copy of these three methods. The copies had already drifted: only
+# the `toml.cr` one quoted non-bare keys, so `diff.cr` would have emitted a key
+# containing a dot as a dotted table path and corrupted the document. That is
+# latent rather than live — every key in the endpoint JSON is bare-safe today —
+# but it is exactly the kind of divergence a shared module prevents, and a
+# change to one copy silently left the other behind.
+module OutputBuilderTomlSerializer
+  # Renders the scalar/array/inline-table body of one TOML table.
+  private def generate_table_content(data : Hash(String, JSON::Any)) : String
+    String.build do |io|
+      data.each do |key, value|
+        case value.raw
+        when String, Int64, Float64, Bool
+          io << "#{toml_key(key)} = #{toml_value(value)}\n"
+        when Array
+          io << "#{toml_key(key)} = ["
+          io << value.as_a.map { |item| toml_value(item) }.join(", ")
+          io << "]\n"
+        when Hash
+          # Nested inline table
+          io << "#{toml_key(key)} = { "
+          io << value.as_h.map { |k, v| "#{toml_key(k)} = #{toml_value(v)}" }.join(", ")
+          io << " }\n"
+        end
+      end
+    end
+  end
+
+  # TOML bare keys allow only [A-Za-z0-9_-]. A key with a dot, space, or
+  # quote would otherwise be read as a dotted table path (config.file →
+  # [config].file) and corrupt the document, so quote anything non-bare.
+  private def toml_key(key : String) : String
+    return key if key.matches?(/\A[A-Za-z0-9_-]+\z/)
+    %("#{key.gsub("\\", "\\\\").gsub("\"", "\\\"")}")
+  end
+
+  private def toml_value(value : JSON::Any) : String
+    case raw = value.raw
+    when String
+      # TOML basic strings can't contain raw newlines/control chars — escape
+      # them so a multi-line snippet/description doesn't break the document.
+      %("#{raw.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("\b", "\\b").gsub("\t", "\\t").gsub("\n", "\\n").gsub("\f", "\\f").gsub("\r", "\\r")}")
+    when Int64, Float64
+      raw.to_s
+    when Bool
+      raw.to_s
+    when Nil
+      %("")
+    when Array
+      "[#{raw.map { |item| toml_value(item) }.join(", ")}]"
+    when Hash
+      "{ #{raw.map { |k, v| "#{toml_key(k)} = #{toml_value(v)}" }.join(", ")} }"
+    else
+      %("#{raw}")
+    end
+  end
+end


### PR DESCRIPTION
A focused bug hunt across `src/output_builder/` (27 files), `html_assets/{js,css}.cr`, `models/output_builder.cr` and the dispatch in `models/noir.cr`. Every finding below was reproduced with a CLI run or a temporary spec before being fixed — nothing here is reasoning-only.

## Data loss

**`-f only-param` dropped every `body`-typed param.** The builder filtered on `param.param_type` while every other consumer dispatches on `param.request_type`, the canonical bucket documented on `Param#request_type`. Fourteen analyzers (NestJS, Nuxt, Nitro, Rocket, Servant, Scotty, Cowboy, Elli, Wisp, Drogon, oatpp) spell a request-body field `body`, which `BODY_TYPE_ALIASES` resolves to `json` — so none matched the `targets` list.

Measured on the fixture tree: **82 body-typed params across 82 endpoints were invisible.** On the nestjs fixture the format emitted 3 of 6 params while `-f plain` and `-f curl` showed all six. This format feeds fuzzers and param miners, so the loss is silent and consequential.

**`-f postman` discarded a query string the route itself carried.** This is the only builder that *reconstructs* the URL (`URI.parse` then `uri.path`) rather than passing `endpoint.url` through, so `uri.query` was dropped. `raw` was rebuilt from the path alone and the structured `query` list came only from declared params. `/wp-admin/admin-ajax.php?action=get_user_data` imported as `{{baseUrl}}/wp-admin/admin-ajax.php` with no query at all — **a request that hits a different handler.** curl, httpie, powershell and only-url all keep it, because none of them take the URL apart.

Query pairs now merge route + declared params in the same order `bake_endpoint` uses: a pair the route already spells verbatim is not repeated, a different value for the same name is appended as an override. Both `raw` and `query` derive from that one list so they cannot disagree.

**`-f httpie` invented form fields.** `bake_endpoint` joins form params into `k=v&k=v`; the builder split that back apart on `&`, which cannot tell a separator from a `&` inside a value. A lone form param `note=a&b=c` came out as `'note=a' 'b=c'` — the real value truncated and a field named `b` the endpoint never had. Now reads `endpoint.params` directly.

## Correctness

**postman item names collided.** The naming code already included the host to stop two sidebar entries reading identically, but `action` is the only discriminator for WordPress AJAX — the fixture produced 8 admin-ajax/admin-post endpoints under 4 names, now 19 of 19 distinct. Declared query params stay out of the name deliberately: an inline query is part of how a route is addressed, a declared param is an input to it.

**markdown-table cells broke around backticks.** A backtick in a param name closed its code span early and the rest of the row ran on as loose text; pipes and angle brackets were already escaped, backticks were not. Delimiters are now sized to the longest backtick run per CommonMark, with the space pad for content starting/ending in one. Text cells get the backslash escape instead (only valid outside a code span). Also: the `-` placeholder for a param-less endpoint sat behind an `unless params.nil?` check that could never be false, since `params` is a non-nilable Array — such rows rendered an empty cell.

## Hardening

**Options read through `[]?` consistently.** `config_initializer` seeds every key, so hard-indexing worked for CLI runs, but a builder built with a partial options hash hit KeyError — inconsistently, since oas2 and only-url already used `[]?` while oas3, postman and common did not. CLI behaviour is unchanged: `-u` is still honoured, its absence still yields `http://localhost`.

**One shared TOML serializer.** `toml.cr` and `diff.cr` each had their own copy of `generate_table_content`/`toml_value`, and they had drifted — only `toml.cr` routed keys through `toml_key`, so `diff.cr` would emit a dotted key as a table path and corrupt the document. Latent (endpoint field names are bare-safe) but `metadata` keys come from analyzers. Output verified byte-for-byte unchanged for both paths.

## Verification

- Unit specs **148 → 163** in `spec/unit_test/output_builder`. Full suite: **4447 unit, 22647 functional, 0 failures.** `crystal tool format --check` clean, ameba clean (1840 files).
- markdown-table output checked through a real CommonMark renderer, not just string comparison.
- The new HTML custom-template spec was confirmed to actually guard: renaming a placeholder trips the leftover-tag assertion, forcing the fallback trips the custom-markup assertion.
- TOML refactor verified byte-identical via diff on the wordpress and nestjs fixtures; both still parse under `tomllib`.
- All 22 formats re-run end to end; json/jsonl/sarif/oas2/oas3/postman parse under `jq`, toml under `tomllib`.

## Checked and deliberately not changed

- **SARIF's positional result→endpoint index mapping** is sound — verified with duplicate endpoints sharing message text and with mixed `code_paths` presence (which splits the emit path). The shard preserves insertion order and does not dedupe.
- **HTML report escaping is complete** — `<script>`/`onerror` payloads in URLs and param names escape correctly; every non-escaped interpolation is an integer or a fixed `case` return.
- **Diff mode's leading newline** on `-f json`/`yaml`/`toml`: cosmetic, no bug behind it, and `-f json` is what CI pipelines diff byte-for-byte. Not worth a breaking output change.
- **`metadata["extras"]` double-printing** in `common.cr` reproduces, but no producer sets that key, so it is unreachable. Same for mermaid's unsanitized `method == "*"`. No commits for dead code.

## Known gaps

`css.cr` (670 lines) was only examined for the `display`/`[hidden]` interaction that the JS filter depends on. `html.cr`'s bare `rescue` in `apply_template` still swallows every exception and degrades silently to the default report — the new spec catches regressions now, but narrowing that rescue is follow-up work.