### PR TITLE
fix(output_builder): the URL parts a `paths` key can't hold were being dropped

### DIFF
--- a/spec/unit_test/output_builder/oas2_spec.cr
+++ b/spec/unit_test/output_builder/oas2_spec.cr
@@ -148,9 +148,12 @@ describe "OutputBuilderOas2" do
 
     paths.as_h.has_key?("/users/{user_id}").should be_true
     paths["/users/{user_id}"].as_h.has_key?("any").should be_false
-    %w[get post put patch delete options head trace].each do |method|
+    %w[get post put patch delete options head].each do |method|
       paths["/users/{user_id}"].as_h.has_key?(method).should be_true
     end
+    # `trace` is an OpenAPI 3.0 addition; Swagger 2.0's Path Item Object has
+    # no such field and rejects the whole document over it.
+    paths["/users/{user_id}"].as_h.has_key?("trace").should be_false
 
     get_params = paths["/users/{user_id}"]["get"]["parameters"].as_a
     get_params.any? { |p| p["in"].as_s == "path" && p["name"].as_s == "user_id" }.should be_true

--- a/spec/unit_test/output_builder/route_url_parts_spec.cr
+++ b/spec/unit_test/output_builder/route_url_parts_spec.cr
@@ -1,0 +1,180 @@
+require "../../spec_helper"
+require "../../../src/output_builder/oas2"
+require "../../../src/output_builder/oas3"
+require "../../../src/output_builder/postman"
+require "../../../src/models/endpoint"
+require "../../../src/utils/utils"
+require "json"
+
+# The parts of an endpoint URL that a `paths` key or a Postman URL cannot
+# hold: the route's own query string, the `#fragment` Noir uses to address
+# many operations on one path, and the authority of an absolute URL. Every
+# builder that reconstructs a URL used to drop them.
+private def builder_options
+  {
+    "debug"   => YAML::Any.new(false),
+    "verbose" => YAML::Any.new(false),
+    "color"   => YAML::Any.new(false),
+    "nolog"   => YAML::Any.new(false),
+    "output"  => YAML::Any.new(""),
+    "url"     => YAML::Any.new(""),
+  }
+end
+
+private def render(builder, endpoints)
+  builder.io = IO::Memory.new
+  builder.print(endpoints)
+  JSON.parse(builder.io.to_s)
+end
+
+describe "route URL parts in reconstructing builders" do
+  describe "inline query string" do
+    it "keeps the values that address each handler as an oas3 enum" do
+      # Two WordPress AJAX handlers behind one PHP file.
+      first = Endpoint.new("/wp-admin/admin-ajax.php?action=get_user_data", "POST")
+      first.push_param(Param.new("action", "", "query"))
+      second = Endpoint.new("/wp-admin/admin-ajax.php?action=save_settings", "POST")
+      second.push_param(Param.new("action", "", "query"))
+
+      doc = render(OutputBuilderOas3.new(builder_options), [first, second])
+      parameters = doc["paths"]["/wp-admin/admin-ajax.php"]["post"]["parameters"].as_a
+      parameters.size.should eq(1)
+      parameters[0]["name"].as_s.should eq("action")
+      parameters[0]["in"].as_s.should eq("query")
+      parameters[0]["schema"]["enum"].as_a.map(&.as_s).should eq(["get_user_data", "save_settings"])
+    end
+
+    it "keeps them as an oas2 enum" do
+      endpoint = Endpoint.new("/index.cfm?method=ping", "GET")
+
+      doc = render(OutputBuilderOas2.new(builder_options), [endpoint])
+      parameters = doc["paths"]["/index.cfm"]["get"]["parameters"].as_a
+      parameters[0]["enum"].as_a.map(&.as_s).should eq(["ping"])
+    end
+
+    it "records a declared override alongside the route's own value" do
+      endpoint = Endpoint.new("/admin.php?action=list", "GET")
+      endpoint.push_param(Param.new("action", "delete", "query"))
+
+      doc = render(OutputBuilderOas3.new(builder_options), [endpoint])
+      parameters = doc["paths"]["/admin.php"]["get"]["parameters"].as_a
+      parameters.size.should eq(1)
+      parameters[0]["schema"]["enum"].as_a.map(&.as_s).should eq(["list", "delete"])
+    end
+
+    it "leaves a plain query param unconstrained" do
+      endpoint = Endpoint.new("/search", "GET")
+      endpoint.push_param(Param.new("q", "", "query"))
+
+      doc = render(OutputBuilderOas3.new(builder_options), [endpoint])
+      parameters = doc["paths"]["/search"]["get"]["parameters"].as_a
+      parameters[0]["schema"].as_h.has_key?("enum").should be_false
+    end
+
+    it "gives postman one query list built from the route" do
+      endpoint = Endpoint.new("/wp-admin/admin-ajax.php?action=save_settings", "POST")
+      endpoint.push_param(Param.new("action", "", "query"))
+
+      doc = render(OutputBuilderPostman.new(builder_options), [endpoint])
+      url = doc["item"][0]["request"]["url"]
+      url["query"].as_a.size.should eq(1)
+      url["query"][0]["key"].as_s.should eq("action")
+      url["query"][0]["value"].as_s.should eq("save_settings")
+      url["raw"].as_s.should eq("{{baseUrl}}/wp-admin/admin-ajax.php?action=save_settings")
+    end
+  end
+
+  describe "many-operations-one-path fragment" do
+    it "lists every GraphQL operation the merged oas3 operation covers" do
+      endpoints = ["Query.users", "Mutation.createUser", "Subscription.userAdded"].map do |name|
+        Endpoint.new("/graphql##{name}", "POST")
+      end
+
+      doc = render(OutputBuilderOas3.new(builder_options), endpoints)
+      operation = doc["paths"]["/graphql"]["post"]
+      operation["x-noir-operations"].as_a.map(&.as_s).should eq(
+        ["Query.users", "Mutation.createUser", "Subscription.userAdded"])
+    end
+
+    it "lists them for oas2 too" do
+      endpoints = ["eth_blockNumber", "eth_getBalance"].map { |name| Endpoint.new("/rpc##{name}", "POST") }
+
+      doc = render(OutputBuilderOas2.new(builder_options), endpoints)
+      doc["paths"]["/rpc"]["post"]["x-noir-operations"].as_a.map(&.as_s).should eq(
+        ["eth_blockNumber", "eth_getBalance"])
+    end
+
+    it "gives every postman item a distinct name without putting it in the request URL" do
+      endpoints = ["Query.users", "Mutation.createUser"].map { |name| Endpoint.new("/graphql##{name}", "POST") }
+
+      doc = render(OutputBuilderPostman.new(builder_options), endpoints)
+      doc["item"].as_a.map(&.["name"].as_s).should eq(
+        ["POST /graphql#Query.users", "POST /graphql#Mutation.createUser"])
+      doc["item"][0]["request"]["url"]["raw"].as_s.should eq("{{baseUrl}}/graphql")
+    end
+  end
+
+  describe "absolute URL authority" do
+    it "keeps both hosts when two absolute endpoints collapse onto one oas3 operation" do
+      endpoints = [
+        Endpoint.new("https://demo.example.com/api/users", "GET"),
+        Endpoint.new("https://demo.example.com.evil/api/users", "GET"),
+      ]
+
+      doc = render(OutputBuilderOas3.new(builder_options), endpoints)
+      doc["paths"]["/api/users"]["get"]["servers"].as_a.map(&.["url"].as_s).should eq(
+        ["https://demo.example.com", "https://demo.example.com.evil"])
+    end
+
+    it "records them on the oas2 operation, which has no per-operation host" do
+      endpoints = [
+        Endpoint.new("https://a.example.com/api/users", "GET"),
+        Endpoint.new("https://b.example.com/api/users", "GET"),
+      ]
+
+      doc = render(OutputBuilderOas2.new(builder_options), endpoints)
+      doc["paths"]["/api/users"]["get"]["x-noir-hosts"].as_a.map(&.as_s).should eq(
+        ["https://a.example.com", "https://b.example.com"])
+    end
+
+    it "leaves a relative endpoint with no server override" do
+      doc = render(OutputBuilderOas3.new(builder_options), [Endpoint.new("/api/users", "GET")])
+      doc["paths"]["/api/users"]["get"].as_h.has_key?("servers").should be_false
+    end
+  end
+
+  describe "route syntax that is not a query" do
+    it "does not truncate a regex route at its `?`" do
+      # Drogon `/grp/(?:a|b)/(.*)?` used to emit the path `/grp/(` and a query
+      # parameter named `:a|b)/(.*)?`.
+      doc = render(OutputBuilderOas3.new(builder_options), [Endpoint.new("/grp/(?:a|b)/(.*)?", "GET")])
+      doc["paths"].as_h.keys.should eq(["/grp/({a}|b)/(.{wildcard})"])
+    end
+
+    it "keeps an optional trailing segment in the postman path" do
+      # Giraffe `/legacy(/?)` used to import as `{{baseUrl}}/legacy(?)=`.
+      doc = render(OutputBuilderPostman.new(builder_options), [Endpoint.new("/legacy(/?)", "GET")])
+      url = doc["item"][0]["request"]["url"]
+      url["raw"].as_s.should eq("{{baseUrl}}/legacy(/?)")
+      url.as_h.has_key?("query").should be_false
+    end
+
+    it "still treats a real key=value pair as a query" do
+      doc = render(OutputBuilderPostman.new(builder_options), [Endpoint.new("/geo/:ip?", "GET")])
+      doc["item"][0]["request"]["url"]["raw"].as_s.should eq("{{baseUrl}}/geo/:ip?")
+    end
+  end
+end
+
+describe "operation methods the emitted version supports" do
+  it "reports an explicit TRACE endpoint as unsupported in oas2" do
+    doc = render(OutputBuilderOas2.new(builder_options), [Endpoint.new("/debug", "TRACE")])
+    doc["paths"]["/debug"].as_h.has_key?("trace").should be_false
+    doc["paths"]["/debug"]["x-noir-unsupported-methods"].as_a.map(&.as_s).should eq(["TRACE"])
+  end
+
+  it "keeps trace in oas3, where the Path Item Object has the field" do
+    doc = render(OutputBuilderOas3.new(builder_options), [Endpoint.new("/debug", "TRACE")])
+    doc["paths"]["/debug"].as_h.has_key?("trace").should be_true
+  end
+end

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -70,6 +70,17 @@ class OutputBuilder
   # introducers aren't consumed as a bare two-character escape.
   ANSI_ESCAPE = /\e\[[0-?]*[ -\/]*[@-~]|\e\][^\a\e]*(?:\a|\e\\)|\e[ -\/]*[0-~]/
 
+  # A `?` in a Noir URL is not always a query separator — it is also route
+  # syntax (Express `/geo/:ip?`, F# `/legacy(/?)`, a regex route
+  # `/grp/(?:a|b)/(.*)?`). Only a `?` that introduces a `key=value` pair
+  # before the next path separator opens a query string. Shared by
+  # `bake_endpoint`, which appends to a URL, and the builders that take one
+  # apart, so the two can never disagree about where the route ends.
+  INLINE_QUERY = /\?([^?\/#]*=[^?#]*)/
+
+  # `scheme://authority` at the head of an absolute endpoint URL.
+  ROUTE_AUTHORITY = /\A[a-z][a-z0-9+.\-]*:\/\/[^\/]*/i
+
   @logger : NoirLogger
   @options : Hash(String, YAML::Any)
   @is_debug : Bool
@@ -196,20 +207,29 @@ class OutputBuilder
     # `?` here does not always open a query string — it is also route syntax
     # (Express `/geo/:ip?`, regex routes `/grp/(?:a|b)`). Only a `?` that
     # introduces a `key=value` pair before the next path separator does.
-    existing_query = final_url.match(/\?([^?\/#]*=[^?#]*)/).try(&.[1])
+    existing_query = final_url.match(INLINE_QUERY).try(&.[1])
     existing_pairs = existing_query.try(&.split('&')) || [] of String
+    existing_names = existing_pairs.map { |pair| pair.split('=', 2)[0] }
     first_query = existing_query.nil?
 
     unless params.nil?
       params.each do |param|
         if param.request_type == "query"
           pair = "#{param.name}=#{param.value}"
-          # A pair the route already spells out verbatim adds nothing. A
-          # *different* value for the same name is an override (`--pvalue
-          # query=…`) and is still appended — the later pair is the one
-          # servers read, so the override survives. Skipping with `next` would
-          # also skip this param's tag collection at the bottom of the block.
-          unless existing_pairs.includes?(pair)
+          # A pair the route already spells out verbatim adds nothing, and
+          # neither does a value-less declaration of a name the route already
+          # pins — the analyzer records `action` precisely *because* the route
+          # spells `action=save_settings`. Appending `&action=` there would
+          # blank the value out, since the later pair is the one servers read:
+          # the URL would stop addressing the handler it was found on.
+          #
+          # A *different, non-empty* value is a real override (`--pvalue
+          # query=…`) and is still appended, for that same last-pair-wins
+          # reason. Skipping with `next` would also skip this param's tag
+          # collection at the bottom of the block.
+          redundant = existing_pairs.includes?(pair) ||
+                      (param.value.empty? && existing_names.includes?(param.name))
+          unless redundant
             if first_query
               final_url += "?#{pair}"
               first_query = false
@@ -281,6 +301,57 @@ class OutputBuilder
       tags:       final_tags.uniq,
       body_type:  is_json ? "json" : "form",
     }
+  end
+
+  # Splits a Noir endpoint URL into the route itself and the two parts a
+  # `paths` key / Postman URL cannot hold: the query string the route spells
+  # out (`admin-ajax.php?action=save_settings`, how WordPress addresses an
+  # AJAX handler) and the `#fragment` Noir uses to address many operations on
+  # one path (`POST /graphql#Query.users`, `POST /rpc#eth_getBalance`).
+  #
+  # Deliberately not `URI.parse`: an endpoint URL is a route *pattern*, not a
+  # URI. `URI.parse` reads the `?` in `/grp/(?:a|b)/(.*)?` as a query
+  # separator, truncating the path to `/grp/(` and handing back a query
+  # parameter named `:a|b)/(.*)?` that nothing ever declared.
+  protected def split_route_url(url : String) : NamedTuple(route: String, query: Array(Tuple(String, String)), fragment: String?)
+    route = url
+    query = [] of Tuple(String, String)
+
+    if match = route.match(INLINE_QUERY)
+      query = match[1].split('&').compact_map do |pair|
+        next if pair.empty?
+        name, _, value = pair.partition('=')
+        {name, value}
+      end
+      route = route[0...match.begin] + route[match.end..]
+    end
+
+    fragment = nil
+    if index = route.index('#')
+      candidate = route[(index + 1)..]
+      fragment = candidate unless candidate.empty?
+      route = route[0...index]
+    end
+
+    {route: route, query: query, fragment: fragment}
+  end
+
+  # `scheme://host[:port]` when the route is absolute, nil when it is a bare
+  # path. Absolute endpoint URLs are real — an OpenAPI `servers` entry, a HAR
+  # capture spanning domains — and the host is the only thing telling
+  # `demo.example.com` from `demo.example.com.evil`.
+  protected def route_authority(route : String) : String?
+    route.match(ROUTE_AUTHORITY).try(&.[0])
+  end
+
+  # The path portion of a route, with any `scheme://authority` prefix removed.
+  # Textual rather than `URI#path` for the same reason as `split_route_url`.
+  protected def route_path(route : String) : String
+    authority = route_authority(route)
+    return route unless authority
+
+    tail = route[authority.size..]
+    tail.empty? ? "/" : tail
   end
 
   protected def noir_callee_json(callee : Callee) : JSON::Any

--- a/src/output_builder/mermaid.cr
+++ b/src/output_builder/mermaid.cr
@@ -3,6 +3,12 @@ require "../models/endpoint"
 require "../models/passive_scan"
 
 class OutputBuilderMermaid < OutputBuilder
+  # CLI inputs get a plural label; the bucket key is the singular param type.
+  CLI_PARAM_LABELS = {"flag" => "flags", "argument" => "arguments", "env" => "env"}
+
+  # Buckets `output_tree` renders explicitly, under a label of their own.
+  RENDERED_BUCKETS = Set{"header", "cookie", "query", "json", "form", "path"}
+
   def print(endpoints : Array(Endpoint))
     build_mindmap(endpoints)
   end
@@ -171,9 +177,20 @@ class OutputBuilderMermaid < OutputBuilder
       # CLI inputs (protocol "cli") live outside the six canonical HTTP
       # buckets — render flags / positional arguments / env reads as their
       # own groups so they aren't silently dropped from the mindmap.
-      {"flag" => "flags", "argument" => "arguments", "env" => "env"}.each do |param_type, label|
+      CLI_PARAM_LABELS.each do |param_type, label|
         bucket = params_hash[param_type]?
         render_param_group(bucket, label, indent) unless bucket.nil?
+      end
+
+      # Anything left is still a named input the endpoint reads: a multipart
+      # `file` field, an `xml` request body, an Android intent `extra`. The
+      # fixed list above covered nine of the fourteen param types analyzers
+      # actually emit, so the rest were dropped from the map while every
+      # other format showed them. Render the remaining buckets by name so a
+      # new param type is never silently lost here again.
+      params_hash.each do |param_type, bucket|
+        next if RENDERED_BUCKETS.includes?(param_type) || CLI_PARAM_LABELS.has_key?(param_type)
+        render_param_group(bucket, sanitize_label(param_type), indent)
       end
     end
 

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -6,6 +6,13 @@ require "json"
 class OutputBuilderOas2 < OutputBuilder
   include OutputBuilderOasCommon
 
+  # A TRACE endpoint — or any `ANY` route, which expands across every verb —
+  # is reported through `x-noir-unsupported-methods` instead, the same place
+  # every other verb Swagger 2.0 can't express already goes.
+  private def supported_operation_methods : Set(String)
+    OAS2_OPERATION_METHODS
+  end
+
   def print(endpoints : Array(Endpoint))
     paths = {} of String => Hash(String, JSON::Any)
 
@@ -17,7 +24,16 @@ class OutputBuilderOas2 < OutputBuilder
       json_properties = {} of String => JSON::Any
       has_form = false
 
+      url_parts = split_route_url(endpoint.url)
+      route_query = route_query_parameters(url_parts[:query], endpoint)
+      route_query.each do |name, values|
+        append_unique_parameter(parameters, swagger_parameter(name, "query", false, values))
+      end
+
       endpoint.params.each do |param|
+        # Already emitted above, with the value the route spells out.
+        next if param.request_type == "query" && route_query.has_key?(param.name)
+
         case param.request_type
         when "json"
           # JSON body parameters should be represented as a body parameter in OAS2
@@ -46,7 +62,7 @@ class OutputBuilderOas2 < OutputBuilder
       end
 
       declared_path_params = endpoint.params.compact_map { |p| p.name if p.request_type == "path" }
-      oas_path = normalize_oas_path(endpoint.url, declared_path_params)
+      oas_path = normalize_oas_path(route_path(url_parts[:route]), declared_path_params)
       template_names = path_template_names(oas_path)
       template_names.each do |name|
         # A path template variable wins over a same-named query/header
@@ -123,6 +139,16 @@ class OutputBuilderOas2 < OutputBuilder
         operation["consumes"] = JSON::Any.new(consumes.map { |c| JSON::Any.new(c) })
       end
 
+      # Swagger 2.0 has one document-level `host`, with no per-operation
+      # override to put an absolute endpoint's real host in (OAS3 has
+      # `servers`, which the oas3 builder uses). Recording it as an extension
+      # at least stops the host Noir found from disappearing when two
+      # different hosts collapse onto one path+method.
+      if authority = route_authority(url_parts[:route])
+        operation["x-noir-hosts"] = JSON::Any.new([JSON::Any.new(authority)])
+      end
+
+      add_operation_names_extension(operation, url_parts[:fragment])
       add_unmapped_path_params_extension(operation, unmapped_path_params)
       add_noir_callees_extension(operation, endpoint)
       add_noir_ai_context_extension(operation, endpoint)

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -15,7 +15,16 @@ class OutputBuilderOas3 < OutputBuilder
       json_properties = {} of String => JSON::Any
       form_properties = {} of String => JSON::Any
 
+      url_parts = split_route_url(endpoint.url)
+      route_query = route_query_parameters(url_parts[:query], endpoint)
+      route_query.each do |name, values|
+        append_unique_parameter(parameters, openapi_parameter(name, "query", false, values))
+      end
+
       endpoint.params.each do |param|
+        # Already emitted above, with the value the route spells out.
+        next if param.request_type == "query" && route_query.has_key?(param.name)
+
         case param.request_type
         when "json"
           # JSON body parameters go into requestBody
@@ -43,7 +52,7 @@ class OutputBuilderOas3 < OutputBuilder
       end
 
       declared_path_params = endpoint.params.compact_map { |p| p.name if p.request_type == "path" }
-      oas_path = normalize_oas_path(endpoint.url, declared_path_params)
+      oas_path = normalize_oas_path(route_path(url_parts[:route]), declared_path_params)
       template_names = path_template_names(oas_path)
       template_names.each do |name|
         # A path template variable must win over a same-named query/header/
@@ -101,6 +110,20 @@ class OutputBuilderOas3 < OutputBuilder
         } of String => JSON::Any)
       end
 
+      # An absolute endpoint URL names the host Noir actually found. Without
+      # this the document sent every operation to the single global server, so
+      # `https://demo.example.com/api/users/{id}` and
+      # `https://demo.example.com.evil/api/users/{id}` merged into one
+      # operation aimed at `http://localhost` — the same host loss the Postman
+      # builder was fixed for. `servers` is an Operation Object field in OAS3
+      # and overrides the document-level list.
+      if authority = route_authority(url_parts[:route])
+        operation["servers"] = JSON::Any.new([
+          JSON::Any.new({"url" => JSON::Any.new(authority)} of String => JSON::Any),
+        ])
+      end
+
+      add_operation_names_extension(operation, url_parts[:fragment])
       add_unmapped_path_params_extension(operation, unmapped_path_params)
       add_noir_callees_extension(operation, endpoint)
       add_noir_ai_context_extension(operation, endpoint)

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -6,17 +6,35 @@ module OutputBuilderOasCommon
   VALID_OPERATION_METHODS = Set{"get", "put", "post", "delete", "options", "head", "patch", "trace"}
   ANY_OPERATION_METHODS   = WILDCARD_HTTP_METHODS.map(&.downcase)
 
+  # Swagger 2.0's Path Item Object has no `trace` field — `trace` arrived with
+  # OpenAPI 3.0. Emitting one made the *whole document* invalid, not just that
+  # operation, and an `ANY` route expands across every verb, so this hit 25 of
+  # the fixture tree's OAS2 documents.
+  OAS2_OPERATION_METHODS = VALID_OPERATION_METHODS - Set{"trace"}
+
   # Converter names that can appear in a `<…>` path placeholder. Same list the
   # optimizer's `angle_bracket_param` uses, so the two resolve a placeholder
   # the same way.
   PATH_CONVERTER_TYPES = Set{"int", "str", "string", "slug", "uuid", "float", "bool", "path"}
 
+  # Operation keys whose value is a list of alternatives rather than a single
+  # answer. When two endpoints collapse onto one path+method, keeping the
+  # first one's value throws the rest away — `servers` would name one of two
+  # hosts, `x-noir-operations` one of fifteen GraphQL operations — so these
+  # are unioned instead.
+  UNIONED_OPERATION_KEYS = Set{"servers", "x-noir-operations", "x-noir-hosts"}
+
   # `declared_path_params` are the names the endpoint itself records as
   # `param_type == "path"`. They disambiguate `<a:b>` placeholders, whose two
   # halves are spelled in either order depending on the framework.
-  private def normalize_oas_path(raw_url : String, declared_path_params : Array(String) = [] of String) : String
-    uri = URI.parse(raw_url)
-    path = uri.path
+  #
+  # Takes the route's path (see `OutputBuilder#route_path`), not the raw URL:
+  # this used to run `URI.parse(raw_url).path`, which truncated a route at the
+  # first `?` even when the `?` was regex or optional-segment syntax rather
+  # than a query separator — Drogon's `/grp/(?:a|b)/(.*)?` emitted the path
+  # `/grp/(` and Giraffe's `/legacy(/?)` emitted `/legacy(/`.
+  private def normalize_oas_path(raw_path : String, declared_path_params : Array(String) = [] of String) : String
+    path = raw_path
     path = "/" if path.empty?
 
     # Google AIP / gRPC-transcoding resource patterns (`{name=projects/*}`)
@@ -70,6 +88,12 @@ module OutputBuilderOasCommon
       wildcards == 1 ? "{wildcard}" : "{wildcard#{wildcards}}"
     end
 
+    # A `?` that reaches here is route syntax a path template has no way to
+    # carry — an optional segment (`/geo/:ip?`) or a regex group
+    # (`/items(?:/(\d+))?`). Drop it: a literal `?` in a path key opens a
+    # query string the moment the key is appended to a server URL.
+    path = path.delete('?')
+
     path.starts_with?("/") ? path : "/#{path}"
   end
 
@@ -96,16 +120,54 @@ module OutputBuilderOasCommon
     tail
   end
 
+  # The route's own query string and any declared query param of the same
+  # name describe one parameter, and `bake_endpoint` already settled how they
+  # relate: a pair the route spells verbatim adds nothing, while a *different*
+  # value for the same name is an override worth keeping. Resolved up front,
+  # in route order, so a value-less declaration (the usual case — the analyzer
+  # records `action` because the route spells `action=get_user_data`) cannot
+  # erase the value the route carries.
+  #
+  # Returns name => concrete values, empty array meaning unconstrained.
+  private def route_query_parameters(route_query : Array(Tuple(String, String)), endpoint : Endpoint) : Hash(String, Array(String))
+    resolved = {} of String => Array(String)
+
+    route_query.each do |name, value|
+      values = resolved[name] ||= [] of String
+      values << value unless value.empty? || values.includes?(value)
+    end
+
+    endpoint.params.each do |param|
+      next unless param.request_type == "query"
+      values = resolved[param.name]?
+      next if values.nil? || param.value.empty?
+
+      values << param.value unless values.includes?(param.value)
+    end
+
+    resolved
+  end
+
   private def path_template_names(path : String) : Array(String)
     names = path.scan(/\{([^{}\/]+)\}/).map { |match| match[1] }
     names.uniq!
     names
   end
 
+  # The operation fields the emitted version's Path Item Object accepts.
+  # Overridden by the OAS2 builder, which has no `trace`.
+  private def supported_operation_methods : Set(String)
+    VALID_OPERATION_METHODS
+  end
+
   private def operation_methods(method : String) : Array(String)
+    supported = supported_operation_methods
     normalized = method.downcase
-    return [normalized] if VALID_OPERATION_METHODS.includes?(normalized)
-    return ANY_OPERATION_METHODS if {"any", "all", "forward", "use"}.includes?(normalized)
+    return [normalized] if supported.includes?(normalized)
+
+    if {"any", "all", "forward", "use"}.includes?(normalized)
+      return ANY_OPERATION_METHODS.select { |candidate| supported.includes?(candidate) }
+    end
 
     [] of String
   end
@@ -126,9 +188,77 @@ module OutputBuilderOasCommon
 
   private def append_unique_parameter(parameters : Array(Hash(String, JSON::Any)), parameter : Hash(String, JSON::Any))
     key = parameter_key(parameter)
-    return if parameters.any? { |existing| parameter_key(existing) == key }
+    if index = parameters.index { |existing| parameter_key(existing) == key }
+      parameters[index] = merge_parameter(parameters[index], parameter)
+      return
+    end
 
     parameters << parameter
+  end
+
+  # A repeated name+in is not always redundant. Two routes that differ only in
+  # a value their path key can't hold — `admin-ajax.php?action=get_user_data`
+  # and `?action=save_settings`, two different WordPress AJAX handlers —
+  # collapse onto one path+method, and keeping the first parameter dropped
+  # every other handler's address. Union the enumerated values instead.
+  #
+  # A parameter with no enum is unconstrained, and unconstrained wins: if one
+  # route pins `action` to a value and another accepts anything, the merged
+  # operation accepts anything.
+  private def merge_parameter(existing : Hash(String, JSON::Any), incoming : Hash(String, JSON::Any)) : Hash(String, JSON::Any)
+    existing_values = parameter_enum(existing)
+    incoming_values = parameter_enum(incoming)
+    return with_parameter_enum(existing, nil) unless existing_values && incoming_values
+
+    with_parameter_enum(existing, existing_values | incoming_values)
+  end
+
+  # OAS3 nests the constraint under `schema`, Swagger 2.0 puts it on the
+  # parameter itself. Both builders share the merge, so both shapes are read
+  # and written through here.
+  private def enum_container(parameter : Hash(String, JSON::Any)) : Hash(String, JSON::Any)?
+    parameter["schema"]?.try(&.as_h?)
+  end
+
+  private def parameter_enum(parameter : Hash(String, JSON::Any)) : Array(String)?
+    container = enum_container(parameter) || parameter
+    container["enum"]?.try(&.as_a?).try(&.map(&.as_s))
+  end
+
+  private def with_parameter_enum(parameter : Hash(String, JSON::Any), values : Array(String)?) : Hash(String, JSON::Any)
+    result = parameter.dup
+    encoded = values.try { |list| JSON::Any.new(list.map { |value| JSON::Any.new(value) }) }
+
+    if schema = enum_container(result)
+      schema = schema.dup
+      encoded ? (schema["enum"] = encoded) : schema.delete("enum")
+      result["schema"] = JSON::Any.new(schema)
+    else
+      encoded ? (result["enum"] = encoded) : result.delete("enum")
+    end
+
+    result
+  end
+
+  # The `#fragment` Noir uses to address many operations on one path. An OAS
+  # path key cannot hold it and the request really is a single
+  # `POST /graphql`, so the operations are correctly merged — but their names
+  # were merged away with them: 15 Hasura operations became one
+  # `POST /v1/graphql` with nothing left saying what could be called, and 41
+  # operations vanished from the fixture tree's documents altogether.
+  private def add_operation_names_extension(operation : Hash(String, JSON::Any), name : String?)
+    return unless name
+
+    operation["x-noir-operations"] = JSON::Any.new([JSON::Any.new(name)])
+  end
+
+  private def union_json_arrays(existing : JSON::Any, incoming : JSON::Any) : JSON::Any
+    merged = existing.as_a.dup
+    incoming.as_a.each do |item|
+      merged << item unless merged.any? { |seen| seen == item }
+    end
+
+    JSON::Any.new(merged)
   end
 
   # Both OAS2 and OAS3 require an `in: path` parameter to correspond to a
@@ -209,7 +339,12 @@ module OutputBuilderOasCommon
 
     incoming.each do |key, value|
       next if {"parameters", "requestBody"}.includes?(key)
-      merged[key] = value unless merged.has_key?(key)
+
+      if UNIONED_OPERATION_KEYS.includes?(key) && (existing_value = merged[key]?)
+        merged[key] = union_json_arrays(existing_value, value)
+      else
+        merged[key] = value unless merged.has_key?(key)
+      end
     end
 
     JSON::Any.new(merged)
@@ -229,22 +364,47 @@ module OutputBuilderOasCommon
     } of String => JSON::Any)
   end
 
-  private def openapi_parameter(name : String, location : String, required : Bool) : Hash(String, JSON::Any)
+  # `values` are the concrete values a route spells out for the parameter,
+  # recorded as an `enum` so they survive into the document — otherwise
+  # `/wp-admin/admin-ajax.php?action=get_user_data` documents an `action`
+  # parameter with no hint that `get_user_data` is what reaches the handler.
+  # No values means unconstrained.
+  private def enum_values(values : Array(String)?) : Array(JSON::Any)?
+    return if values.nil? || values.empty?
+
+    values.map { |value| JSON::Any.new(value) }
+  end
+
+  private def openapi_parameter(name : String, location : String, required : Bool, values : Array(String)? = nil) : Hash(String, JSON::Any)
+    schema = schema_string
+    if encoded = enum_values(values)
+      schema = JSON::Any.new({
+        "type" => JSON::Any.new("string"),
+        "enum" => JSON::Any.new(encoded),
+      } of String => JSON::Any)
+    end
+
     {
       "name"     => JSON::Any.new(name),
       "in"       => JSON::Any.new(location),
       "required" => JSON::Any.new(required),
-      "schema"   => schema_string,
+      "schema"   => schema,
     } of String => JSON::Any
   end
 
-  private def swagger_parameter(name : String, location : String, required : Bool) : Hash(String, JSON::Any)
-    {
+  private def swagger_parameter(name : String, location : String, required : Bool, values : Array(String)? = nil) : Hash(String, JSON::Any)
+    parameter = {
       "name"     => JSON::Any.new(name),
       "in"       => JSON::Any.new(location),
       "type"     => JSON::Any.new("string"),
       "required" => JSON::Any.new(required),
     } of String => JSON::Any
+
+    if encoded = enum_values(values)
+      parameter["enum"] = JSON::Any.new(encoded)
+    end
+
+    parameter
   end
 
   private def swagger_url_parts(raw_url : String) : NamedTuple(host: String?, base_path: String, schemes: Array(String))

--- a/src/output_builder/only-param.cr
+++ b/src/output_builder/only-param.cr
@@ -2,11 +2,20 @@ require "../models/output_builder"
 require "../models/endpoint"
 
 class OutputBuilderOnlyParam < OutputBuilder
+  # Excluded rather than an allow-list of what to print. This format exists to
+  # feed parameter fuzzers, so the question is which inputs *aren't* wanted:
+  # headers and cookies have their own `-f only-header` / `-f only-cookie`,
+  # and a path param is a URL segment rather than a parameter to submit.
+  #
+  # It used to be the other way round — an allow-list of six types — and every
+  # type outside it was silently dropped: multipart `file` fields, an `xml`
+  # request body, Android intent `extra`s. That is the same failure the `body`
+  # alias fix hit, one layer up, and a deny-list means a param type a new
+  # analyzer introduces shows up here by default instead of vanishing.
+  EXCLUDED_TYPES = Set{"header", "cookie", "path"}
+
   def print(endpoints : Array(Endpoint))
     common_params = [] of String
-    # CLI endpoints carry their fuzzable inputs as flag/argument/env params,
-    # so include them alongside the HTTP body-ish buckets.
-    targets = ["query", "json", "form", "flag", "argument", "env"]
 
     endpoints.each do |endpoint|
       endpoint.params.each do |param|
@@ -16,7 +25,7 @@ class OutputBuilderOnlyParam < OutputBuilder
         # `param_type` dropped every one of them — 82 params across the fixture
         # tree were invisible here while `-f plain` and `-f curl` (which bake
         # through `request_type`) showed them.
-        if targets.includes? param.request_type
+        unless EXCLUDED_TYPES.includes? param.request_type
           common_params << param.name
         end
       end

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -13,10 +13,18 @@ class OutputBuilderPostman < OutputBuilder
       # request item (URI.parse + {{baseUrl}} + HTTP verbs) is meaningless
       # for them — keep them out of the collection.
       next if endpoint.non_http?
+      # `URI.parse` is used for the authority only — scheme / host / port sit
+      # ahead of anything a route pattern can spell, so it reads those
+      # correctly. The path, query and fragment come from `split_route_url`,
+      # which knows a `?` in a route is as often regex or optional-segment
+      # syntax as it is a query separator. Taking them from `URI` truncated
+      # Giraffe's `/legacy(/?)` to `/legacy(` and emitted a query parameter
+      # named `:a|b)/(.*)?` for Drogon's `/grp/(?:a|b)/(.*)?`.
       uri = URI.parse(endpoint.url)
+      url_parts = split_route_url(endpoint.url)
 
       # Build URL parts
-      path_parts = uri.path.split("/").reject(&.empty?)
+      path_parts = route_path(url_parts[:route]).split("/").reject(&.empty?)
       path_with_vars = path_parts.map do |part|
         if part.starts_with?("<") && part.ends_with?(">") && part.includes?(":")
           # Handle <type:param> format - convert to :param
@@ -32,7 +40,7 @@ class OutputBuilderPostman < OutputBuilder
         end
       end
 
-      query_pairs = merged_query_pairs(uri, endpoint)
+      query_pairs = merged_query_pairs(url_parts[:query], endpoint)
       url_obj = build_url_object(uri, path_with_vars, query_pairs)
 
       # Add path variables
@@ -148,7 +156,7 @@ class OutputBuilderPostman < OutputBuilder
         # `demo.example.com.evil/api/users/{id}` are two entries in the
         # sidebar reading exactly the same.
         item = {
-          "name"    => JSON::Any.new("#{method} #{item_label(uri)}"),
+          "name"    => JSON::Any.new("#{method} #{item_label(uri, url_parts)}"),
           "request" => JSON::Any.new(request),
         } of String => JSON::Any
 
@@ -209,20 +217,17 @@ class OutputBuilderPostman < OutputBuilder
   # Merge order mirrors `bake_endpoint`: a pair the route already spells
   # verbatim is not repeated, while a *different* value for the same name is
   # appended as an override (the later pair is the one servers read).
-  private def merged_query_pairs(uri : URI, endpoint : Endpoint) : Array(Tuple(String, String))
-    pairs = [] of Tuple(String, String)
-
-    if query = uri.query
-      query.split('&').each do |pair|
-        next if pair.empty?
-        name, _, value = pair.partition('=')
-        pairs << {name, value}
-      end
-    end
+  private def merged_query_pairs(route_query : Array(Tuple(String, String)), endpoint : Endpoint) : Array(Tuple(String, String))
+    pairs = route_query.dup
 
     endpoint.params.each do |param|
       next unless param.request_type == "query"
       next if pairs.includes?({param.name, param.value})
+      # A value-less declaration of a name the route already pins is the same
+      # parameter, not an override: appending `action=` after
+      # `action=save_settings` blanks out the value that reaches the handler.
+      next if param.value.empty? && pairs.any? { |name, _| name == param.name }
+
       pairs << {param.name, param.value}
     end
 
@@ -294,16 +299,30 @@ class OutputBuilderPostman < OutputBuilder
   # `?action=save_settings`, which is 8 endpoints under 4 names on the
   # WordPress fixture.
   #
-  # Deliberately `uri.query` and not the merged pairs `build_url_object` uses:
-  # an inline query is part of how the route is addressed, while a declared
-  # query param is an input *to* a route and doesn't change its identity.
-  # Folding declared params in here would rename every parameterised endpoint.
-  private def item_label(uri : URI) : String
+  # It also has to carry the `#fragment` Noir uses to address many operations
+  # on one path: every GraphQL resolver and JSON-RPC method lives at the same
+  # `POST /graphql`, so without it Hasura's 15 operations were 15 sidebar
+  # entries all reading `POST /v1/graphql`, with nothing saying which was
+  # which. The fragment stays out of the request URL — it is Noir's
+  # discriminator, not something a server ever sees — so only the name
+  # carries it.
+  #
+  # Deliberately the route's own query and not the merged pairs
+  # `build_url_object` uses: an inline query is part of how the route is
+  # addressed, while a declared query param is an input *to* a route and
+  # doesn't change its identity. Folding declared params in here would rename
+  # every parameterised endpoint.
+  private def item_label(uri : URI, url_parts) : String
     host = uri.host
-    label = host.nil? || host.empty? ? uri.path : "#{host}#{uri.path}"
-    query = uri.query
-    return label if query.nil? || query.empty?
+    path = route_path(url_parts[:route])
+    label = host.nil? || host.empty? ? path : "#{host}#{path}"
 
-    "#{label}?#{query}"
+    query = url_parts[:query]
+    unless query.empty?
+      label = "#{label}?#{query.map { |name, value| "#{name}=#{value}" }.join("&")}"
+    end
+
+    fragment = url_parts[:fragment]
+    fragment ? "#{label}##{fragment}" : label
   end
 end


### PR DESCRIPTION
Three builders — oas2, oas3 and postman — take an endpoint URL apart with
`URI.parse` and rebuild it from `uri.path`. An endpoint URL is a route
*pattern*, not a URI, so that lost information in four ways. Every finding
below was reproduced on the fixture tree before being fixed.

Data loss:

* Many-operations-one-path fragments vanished. `POST /graphql#Query.users`
  is how Noir addresses one GraphQL resolver, JSON-RPC method or Hasura
  operation among many on a single route. `URI.parse` drops the fragment, so
  the endpoints collapsed onto one path+method and `add_operation` merged
  them: Hasura's 15 operations became a single `POST /v1/graphql`, and 41 of
  the 56 fragment endpoints across 9 fixtures disappeared from the emitted
  documents. The merge is right — the request really is one `POST /graphql` —
  but the names were merged away with it, so they are now kept in
  `x-noir-operations`. Postman kept all 16 items but named 15 of them
  `POST /v1/graphql`; the fragment now goes in the item name, and stays out
  of the request URL, which no server ever sees it on.

* A route's own query string vanished. `admin-ajax.php?action=get_user_data`
  is how WordPress reaches an AJAX handler, and four such routes collapsed
  onto two OAS paths with nothing left saying which `action` values worked.
  The values are now carried as a query-parameter `enum`, unioned when
  operations merge — 20 endpoints across 3 fixtures (WordPress, two CFML).

* An absolute URL's host vanished. `https://demo.example.com/api/users/{id}`
  and `https://demo.example.com.evil/api/users/{id}` merged into one
  operation aimed at the single global server. This is the host loss the
  Postman builder was fixed for in #2416, still live in both OAS builders.
  OAS3 now emits the real host as an operation-level `servers` entry; OAS2,
  which has no per-operation host, records `x-noir-hosts`.

* Routes were truncated at a `?` that was never a query separator.
  `bake_endpoint` already draws this line — a `?` is as often optional-segment
  or regex syntax — but the three reconstructing builders did not. Drogon's
  `/grp/(?:a|b)/(.*)?` emitted the OAS path `/grp/(` and a Postman query
  parameter named `:a|b)/(.*)?`; Giraffe's `/legacy(/?)` imported as
  `{{baseUrl}}/legacy(?)=`. The rule is now one shared `INLINE_QUERY`
  constant and one `split_route_url`.

Correctness:

* `-f oas2` emitted `trace` operations. Swagger 2.0's Path Item Object has no
  `trace` field — it arrived with OpenAPI 3.0 — and an `ANY` route expands
  across every verb, so 25 of the 33 fixture trees produced an OAS2 document
  that fails validation outright. Measured with `openapi-spec-validator`:
  25 invalid before, 0 after. TRACE now goes to `x-noir-unsupported-methods`.

* A value-less declared query param blanked out the route's own value.
  `?action=save_settings` plus a bare `action` appended `&action=`, and the
  later pair is the one servers read, so the baked URL stopped addressing the
  handler it was found on. Latent on the fixture tree; fixed in
  `bake_endpoint` and the Postman merge together.

* `-f mermaid` and `-f only-param` dispatched on fixed allow-lists that
  covered 9 of the 14 param types analyzers emit. Multipart `file` fields, an
  `xml` request body and Android intent `extra`s were silently dropped from
  both — the same shape as the `body`-alias bug in #2460, one layer up. The
  mermaid map now renders every remaining bucket by name, and `only-param`
  excludes header/cookie/path rather than allow-listing six types, so a param
  type a new analyzer introduces shows up by default.

Verification: unit specs 163 -> 179 in spec/unit_test/output_builder; full
suite 4492 unit / 22647 functional, 0 failures; format and ameba clean.
Every format run over every fixture directory and diffed against a `main`
binary: only oas2 (44), oas3 (19), postman (15), mermaid (6) and only-param
(5) changed, and no operation or parameter was lost anywhere that wasn't a
renamed truncated path.

Deliberately unchanged: `x-noir-callees` / `x-noir-ai-context` still take the
first collapsed endpoint's value rather than unioning; the `??` in
`/posts/:id??filter=` (Express optional segment plus a real query) stays
ambiguous, as it already does in curl and plain.