### PR TITLE
ci: run build, test and lint on Crystal 1.21.0 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.19.0, 1.20.0, 1.21.0]
+        crystal-version: [1.21.0]
     steps:
       - uses: actions/checkout@v7
       - uses: crystal-lang/install-crystal@v1
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.20.0
+          crystal: 1.21.0
       - name: Install dependencies
         run: shards install
       - name: Run Ameba linter
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.19.0, 1.20.0, 1.21.0]
+        crystal-version: [1.21.0]
     steps:
       - uses: actions/checkout@v7
       - uses: crystal-lang/install-crystal@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Crystal-based attack surface detector that identifies endpoints by static analys
 
 ```bash
 # Docker build (for CI or consistent environments)
-docker run --rm -v $(pwd):/app -w /app crystallang/crystal:1.19.0-alpine sh -c "apk add --no-cache yaml-dev zstd-dev && shards install && shards build"
+docker run --rm -v $(pwd):/app -w /app crystallang/crystal:1.21.0-alpine sh -c "apk add --no-cache yaml-dev zstd-dev && shards install && shards build"
 
 # Local install (Ubuntu/Debian)
 curl -fsSL https://crystal-lang.org/install.sh | sudo bash
@@ -161,6 +161,6 @@ Key design notes:
 4. Verify basic functionality: `./bin/noir -b spec/functional_test/fixtures/crystal`
 
 ## Environment
-- Crystal ~> 1.19 (CI: 1.19.0)
-- Docker image: `crystallang/crystal:1.19.0-alpine`
+- Crystal ~> 1.19 (CI: 1.21.0)
+- Docker image: `crystallang/crystal:1.21.0-alpine`
 - Dependencies: `libyaml-dev`, `libzstd-dev`, `zlib1g-dev`, `pkg-config`


### PR DESCRIPTION
## Summary

CI fanned `build-crystal` and `tests` out over Crystal 1.19.0, 1.20.0 and 1.21.0, and pinned `lint` to 1.20.0 — six jobs per run for versions we no longer target. Meanwhile the `Dockerfile` has already moved to `crystallang/crystal:1.21.0-alpine`, so the version CI exercised did not match what ships.

- `build-crystal` matrix: `[1.19.0, 1.20.0, 1.21.0]` → `[1.21.0]`
- `tests` matrix: `[1.19.0, 1.20.0, 1.21.0]` → `[1.21.0]`
- `lint`: `1.20.0` → `1.21.0`

The matrix form is kept rather than inlined, so extra versions can be restored by editing a single list.

`AGENTS.md` still documented 1.19.0 as both the CI and Docker version; updated to match the tree.

## Out of scope

- `shard.yml` keeps `crystal: ~> 1.19`. The declared support range for consumers is unchanged — only what CI verifies narrows.
- `release-binaries.yml` (1.20.0) and `snap/snapcraft.yaml` (1.20.0) are release-build paths, not the build/test lanes this change targets, so they are left alone.