### PR TITLE
test: cover three modules that had no unit spec at all

### DIFF
--- a/spec/unit_test/ai_context/source_reader_spec.cr
+++ b/spec/unit_test/ai_context/source_reader_spec.cr
@@ -1,0 +1,513 @@
+require "../../spec_helper"
+require "../../../src/ai_context/source_reader"
+
+# Writes `content` to a uniquely-named temp file, yields the path, and
+# removes it afterwards. Paths are unique per example so the process-wide
+# `CodeLocator` cache cannot leak between them.
+private def with_source_file(content : String, ext = ".txt", &)
+  path = File.join(Dir.tempdir, "noir-source-reader-#{Process.pid}-#{Random.rand(1_000_000)}#{ext}")
+  File.write(path, content)
+  begin
+    yield path
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+describe NoirAIContext::SourceReader do
+  describe "#snippet_for" do
+    it "returns nil without a path" do
+      NoirAIContext::SourceReader.new.snippet_for(nil, 3, 2).should be_nil
+    end
+
+    it "returns nil without a line" do
+      with_source_file("a\nb\nc\n") do |path|
+        NoirAIContext::SourceReader.new.snippet_for(path, nil, 2).should be_nil
+      end
+    end
+
+    it "returns nil for a line number below 1" do
+      with_source_file("a\nb\nc\n") do |path|
+        NoirAIContext::SourceReader.new.snippet_for(path, 0, 2).should be_nil
+      end
+    end
+
+    it "returns nil for a line past the end of the file" do
+      with_source_file("a\nb\nc\n") do |path|
+        NoirAIContext::SourceReader.new.snippet_for(path, 99, 2).should be_nil
+      end
+    end
+
+    it "returns nil for a file that does not exist" do
+      NoirAIContext::SourceReader.new.snippet_for("/no/such/noir/file.rb", 1, 2).should be_nil
+    end
+
+    it "captures a radius-sized window around the line, 1-based and joined" do
+      with_source_file("one\ntwo\nthree\nfour\nfive\n") do |path|
+        NoirAIContext::SourceReader.new
+          .snippet_for(path, 3, 1)
+          .should eq("2: two | 3: three | 4: four")
+      end
+    end
+
+    it "clamps the window at the start of the file" do
+      with_source_file("one\ntwo\nthree\n") do |path|
+        NoirAIContext::SourceReader.new
+          .snippet_for(path, 1, 3)
+          .should eq("1: one | 2: two | 3: three")
+      end
+    end
+
+    it "clamps the window at the end of the file" do
+      with_source_file("one\ntwo\nthree") do |path|
+        NoirAIContext::SourceReader.new
+          .snippet_for(path, 3, 3)
+          .should eq("1: one | 2: two | 3: three")
+      end
+    end
+
+    it "returns only the line itself at radius 0" do
+      with_source_file("one\ntwo\nthree\n") do |path|
+        NoirAIContext::SourceReader.new.snippet_for(path, 2, 0).should eq("2: two")
+      end
+    end
+
+    # Blank lines used to emit bare `N: ` placeholders that spent the
+    # character budget the surrounding code needs.
+    it "drops blank lines instead of emitting bare line-number placeholders" do
+      with_source_file("one\n\n\nfour\n") do |path|
+        NoirAIContext::SourceReader.new
+          .snippet_for(path, 1, 3)
+          .should eq("1: one | 4: four")
+      end
+    end
+
+    it "strips indentation and collapses interior whitespace runs" do
+      with_source_file("    def    foo(a,   b)\n") do |path|
+        NoirAIContext::SourceReader.new.snippet_for(path, 1, 0).should eq("1: def foo(a, b)")
+      end
+    end
+
+    it "collapses a tab-indented line the same way" do
+      with_source_file("\t\tres.json(x)\n") do |path|
+        NoirAIContext::SourceReader.new.snippet_for(path, 1, 0).should eq("1: res.json(x)")
+      end
+    end
+
+    it "returns nil when every line in the window is blank" do
+      with_source_file("\n\n\n\n\n") do |path|
+        NoirAIContext::SourceReader.new.snippet_for(path, 3, 1).should be_nil
+      end
+    end
+
+    it "truncates the snippet at MAX_SNIPPET_CHARS" do
+      long = ("x" * 300) + "\n"
+      with_source_file(long) do |path|
+        snippet = NoirAIContext::SourceReader.new.snippet_for(path, 1, 0)
+        snippet.should_not be_nil
+        snippet.not_nil!.size.should eq(NoirAIContext::SourceReader::MAX_SNIPPET_CHARS)
+      end
+    end
+
+    it "leaves a snippet at exactly the budget untruncated" do
+      body = "y" * (NoirAIContext::SourceReader::MAX_SNIPPET_CHARS - 3)
+      with_source_file("#{body}\n") do |path|
+        # "1: " + body == exactly MAX_SNIPPET_CHARS
+        NoirAIContext::SourceReader.new.snippet_for(path, 1, 0).should eq("1: #{body}")
+      end
+    end
+
+    it "serves a repeat request from the snippet cache" do
+      with_source_file("one\ntwo\nthree\n") do |path|
+        reader = NoirAIContext::SourceReader.new
+        first = reader.snippet_for(path, 2, 0)
+        File.write(path, "CHANGED\nCHANGED\nCHANGED\n")
+        reader.snippet_for(path, 2, 0).should eq(first)
+      end
+    end
+
+    it "keeps snippets for different radii separate in the cache" do
+      with_source_file("one\ntwo\nthree\n") do |path|
+        reader = NoirAIContext::SourceReader.new
+        reader.snippet_for(path, 2, 0).should eq("2: two")
+        reader.snippet_for(path, 2, 1).should eq("1: one | 2: two | 3: three")
+      end
+    end
+  end
+
+  describe "#route_scope_snippet_for" do
+    it "returns nil without a path" do
+      NoirAIContext::SourceReader.new.route_scope_snippet_for(nil, 1).should be_nil
+    end
+
+    it "returns nil for a line number below 1" do
+      with_source_file("a\n") do |path|
+        NoirAIContext::SourceReader.new.route_scope_snippet_for(path, 0).should be_nil
+      end
+    end
+
+    it "returns nil for a line past the end of the file" do
+      with_source_file("a\n") do |path|
+        NoirAIContext::SourceReader.new.route_scope_snippet_for(path, 42).should be_nil
+      end
+    end
+
+    it "returns nil for a file that does not exist" do
+      NoirAIContext::SourceReader.new.route_scope_snippet_for("/no/such/noir/file.js", 1).should be_nil
+    end
+
+    context "brace-delimited handlers" do
+      it "captures the handler body until the braces close" do
+        source = <<-JS
+          app.get('/users', (req, res) => {
+            res.json(users)
+          })
+          app.get('/other', otherHandler)
+          JS
+
+        with_source_file(source, ".js") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .should eq("1: app.get('/users', (req, res) => { | 2: res.json(users) | 3: })")
+        end
+      end
+
+      # Braces inside string literals are masked before the depth count,
+      # so a `'}'` in the body must not close the block early.
+      it "ignores braces inside string literals when tracking depth" do
+        source = <<-JS
+          app.get('/a', (req, res) => {
+            res.send('}')
+            res.end()
+          })
+          JS
+
+        with_source_file(source, ".js") do |path|
+          snippet = NoirAIContext::SourceReader.new.route_scope_snippet_for(path, 1)
+          snippet.not_nil!.should contain("3: res.end()")
+          snippet.not_nil!.should contain("4: })")
+        end
+      end
+
+      it "does not bleed into the next handler" do
+        source = <<-JS
+          app.get('/a', (req, res) => {
+            res.json(a)
+          })
+          app.post('/b', (req, res) => {
+            res.json(b)
+          })
+          JS
+
+        with_source_file(source, ".js") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .not_nil!.should_not contain("app.post")
+        end
+      end
+
+      it "skips blank lines inside the body without ending the block" do
+        source = <<-JS
+          app.get('/a', (req, res) => {
+
+            res.json(a)
+          })
+          JS
+
+        with_source_file(source, ".js") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .should eq("1: app.get('/a', (req, res) => { | 3: res.json(a) | 4: })")
+        end
+      end
+    end
+
+    context "python-style handlers" do
+      it "stops when indentation returns to the def column" do
+        source = <<-PY
+          @app.route("/x")
+          def handler():
+              return "ok"
+
+          def other():
+              return "no"
+          PY
+
+        with_source_file(source, ".py") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 2)
+            .should eq(%(1: @app.route("/x") | 2: def handler(): | 3: return "ok"))
+        end
+      end
+
+      # The django `/public/` false positive: the *next* handler's
+      # `@login_required` was captured into the previous handler's scope.
+      it "does not capture the next function's decorator" do
+        source = <<-PY
+          def public_view(request):
+              return render(request)
+
+          @login_required
+          def private_view(request):
+              return render(request)
+          PY
+
+        with_source_file(source, ".py") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .not_nil!.should_not contain("login_required")
+        end
+      end
+
+      it "captures decorator lines above the def" do
+        source = <<-PY
+          @csrf_exempt
+          @app.route("/x")
+          def handler():
+              pass
+          PY
+
+        with_source_file(source, ".py") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 3)
+            .not_nil!.should contain("1: @csrf_exempt")
+        end
+      end
+
+      it "looks back at most MAX_LEAD_DECORATOR_LINES decorator lines" do
+        source = <<-PY
+          @a
+          @b
+          @c
+          @d
+          @e
+          def handler():
+              pass
+          PY
+
+        with_source_file(source, ".py") do |path|
+          snippet = NoirAIContext::SourceReader.new.route_scope_snippet_for(path, 6).not_nil!
+          snippet.should contain("2: @b")
+          snippet.should_not contain("1: @a")
+        end
+      end
+
+      it "continues the lead-in scan past a blank line without emitting it" do
+        source = <<-PY
+          @app.route("/x")
+
+          def handler():
+              pass
+          PY
+
+        with_source_file(source, ".py") do |path|
+          snippet = NoirAIContext::SourceReader.new.route_scope_snippet_for(path, 3).not_nil!
+          snippet.should contain(%(1: @app.route("/x")))
+          snippet.should_not contain("2: ")
+        end
+      end
+
+      it "stops the lead-in scan at the first non-decorator line" do
+        source = <<-PY
+          CONSTANT = 1
+          def handler():
+              pass
+          PY
+
+        with_source_file(source, ".py") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 2)
+            .not_nil!.should_not contain("CONSTANT")
+        end
+      end
+    end
+
+    context "ruby-style handlers" do
+      it "stops after the matching end at the def's indent" do
+        source = <<-RB
+          def index
+            render json: @users
+          end
+
+          def show
+            render json: @user
+          end
+          RB
+
+        with_source_file(source, ".rb") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .should eq("1: def index | 2: render json: @users | 3: end")
+        end
+      end
+
+      it "keeps a nested end without ending the block early" do
+        source = <<-RB
+          def index
+            if admin?
+              render json: @users
+            end
+            head :ok
+          end
+          RB
+
+        with_source_file(source, ".rb") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .not_nil!.should contain("5: head :ok")
+        end
+      end
+    end
+
+    context "single-statement routes" do
+      it "stops at the end of a one-line statement" do
+        source = <<-JS
+          app.get('/users', listUsers);
+          app.get('/other', otherHandler);
+          JS
+
+        with_source_file(source, ".js") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .should eq("1: app.get('/users', listUsers);")
+        end
+      end
+
+      it "keeps reading while parentheses are still open" do
+        source = <<-GO
+          r.HandleFunc("/users",
+              listUsers)
+          r.HandleFunc("/other", otherHandler)
+          GO
+
+        with_source_file(source, ".go") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .should eq(%(1: r.HandleFunc("/users", | 2: listUsers)))
+        end
+      end
+    end
+
+    context "budgets" do
+      it "honours a caller-supplied max_lines" do
+        source = <<-JS
+          app.get('/a', (req, res) => {
+            one()
+            two()
+            three()
+            four()
+          })
+          JS
+
+        with_source_file(source, ".js") do |path|
+          snippet = NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1, max_lines: 3).not_nil!
+          snippet.should contain("3: two()")
+          snippet.should_not contain("4: three()")
+        end
+      end
+
+      it "caps the capture at MAX_ROUTE_SCOPE_LINES by default" do
+        body = (1..40).map { |i| "  call#{i}()" }.join("\n")
+        source = "app.get('/a', (req, res) => {\n#{body}\n})"
+
+        with_source_file(source, ".js") do |path|
+          snippet = NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1, max_chars: 100_000).not_nil!
+          snippet.should contain("call11()")
+          snippet.should_not contain("call12()")
+        end
+      end
+
+      it "honours a caller-supplied max_chars" do
+        source = <<-JS
+          app.get('/a', (req, res) => {
+            res.json(payload)
+          })
+          JS
+
+        with_source_file(source, ".js") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1, max_chars: 12)
+            .not_nil!.size.should eq(12)
+        end
+      end
+
+      it "truncates at MAX_SNIPPET_CHARS by default" do
+        body = (1..20).map { |i| "  someCall#{i}(withArguments, andMore)" }.join("\n")
+        source = "app.get('/a', (req, res) => {\n#{body}\n})"
+
+        with_source_file(source, ".js") do |path|
+          NoirAIContext::SourceReader.new
+            .route_scope_snippet_for(path, 1)
+            .not_nil!.size.should eq(NoirAIContext::SourceReader::MAX_SNIPPET_CHARS)
+        end
+      end
+    end
+
+    it "serves a repeat request from the route-scope cache" do
+      with_source_file("app.get('/a', h);\n", ".js") do |path|
+        reader = NoirAIContext::SourceReader.new
+        first = reader.route_scope_snippet_for(path, 1)
+        File.write(path, "app.get('/CHANGED', h);\n")
+        reader.route_scope_snippet_for(path, 1).should eq(first)
+      end
+    end
+
+    it "keeps entries for different budgets separate in the cache" do
+      source = <<-JS
+        app.get('/a', (req, res) => {
+          res.json(payload)
+        })
+        JS
+
+      with_source_file(source, ".js") do |path|
+        reader = NoirAIContext::SourceReader.new
+        wide = reader.route_scope_snippet_for(path, 1, max_chars: 1000)
+        narrow = reader.route_scope_snippet_for(path, 1, max_chars: 10)
+        narrow.not_nil!.size.should eq(10)
+        wide.not_nil!.size.should be > 10
+      end
+    end
+  end
+
+  describe "#lines_for" do
+    it "returns an empty array without a path" do
+      NoirAIContext::SourceReader.new.lines_for(nil).should eq([] of String)
+    end
+
+    it "returns an empty array for a file that does not exist" do
+      NoirAIContext::SourceReader.new.lines_for("/no/such/noir/file.rb").should eq([] of String)
+    end
+
+    it "splits the file into lines" do
+      with_source_file("one\ntwo\nthree") do |path|
+        NoirAIContext::SourceReader.new.lines_for(path).should eq(["one", "two", "three"])
+      end
+    end
+
+    it "keeps the trailing empty element for a file ending in a newline" do
+      with_source_file("one\ntwo\n") do |path|
+        NoirAIContext::SourceReader.new.lines_for(path).should eq(["one", "two", ""])
+      end
+    end
+
+    it "serves a repeat read from the file cache" do
+      with_source_file("one\ntwo\n") do |path|
+        reader = NoirAIContext::SourceReader.new
+        first = reader.lines_for(path)
+        File.write(path, "CHANGED\n")
+        reader.lines_for(path).should eq(first)
+      end
+    end
+
+    # `lines_for` hands back the cached array itself rather than a copy —
+    # a documented contract the augmentor's hot path depends on.
+    it "returns the same array instance on a cache hit" do
+      with_source_file("one\ntwo\n") do |path|
+        reader = NoirAIContext::SourceReader.new
+        reader.lines_for(path).same?(reader.lines_for(path)).should be_true
+      end
+    end
+  end
+end

--- a/spec/unit_test/miniparser/js_object_config_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_object_config_extractor_spec.cr
@@ -1,0 +1,282 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/js_object_config_extractor"
+
+describe Noir::JSObjectConfigExtractor do
+  describe ".extract" do
+    it "returns nothing for empty source" do
+      Noir::JSObjectConfigExtractor.extract("", ["slug"]).should be_empty
+    end
+
+    it "returns nothing when no required keys are given" do
+      Noir::JSObjectConfigExtractor.extract("export const x = { slug: 'a' }", [] of String).should be_empty
+    end
+
+    it "returns nothing when the object is missing a required key" do
+      source = "export const Posts = { slug: 'posts' }"
+      Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"]).should be_empty
+    end
+
+    it "finds an object carrying every required key" do
+      source = "export const Posts = { slug: 'posts', fields: [] }"
+      configs = Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])
+      configs.size.should eq(1)
+      configs[0].string("slug").should eq("posts")
+    end
+
+    it "reports a 1-based line number for the matched object" do
+      source = <<-TS
+        // header comment
+        export const Posts = {
+          slug: 'posts',
+          fields: [],
+        }
+        TS
+
+      Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0].line.should eq(2)
+    end
+
+    context "declaration shapes" do
+      it "reads a TypeScript type-annotated declaration" do
+        source = "export const Posts: CollectionConfig = { slug: 'posts', fields: [] }"
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0]
+          .string("slug").should eq("posts")
+      end
+
+      it "reads a `satisfies` assertion" do
+        source = "export const Posts = { slug: 'posts', fields: [] } satisfies CollectionConfig"
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0]
+          .string("slug").should eq("posts")
+      end
+
+      it "reads a generic `satisfies` assertion" do
+        source = "export const Posts = { slug: 'posts', fields: [] } satisfies Config<Post>"
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0]
+          .string("slug").should eq("posts")
+      end
+
+      it "reads an object nested inside a call argument" do
+        source = "export default buildConfig({ collections: [{ slug: 'posts', fields: [] }] })"
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0]
+          .string("slug").should eq("posts")
+      end
+
+      it "reads a CommonJS module.exports assignment" do
+        source = "module.exports = { slug: 'posts', fields: [] }"
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0]
+          .string("slug").should eq("posts")
+      end
+
+      it "reads a let/var declaration" do
+        source = "let Posts = { slug: 'posts', fields: [] }; var Pages = { slug: 'pages', fields: [] }"
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])
+          .map(&.string("slug")).should eq(["posts", "pages"])
+      end
+
+      # The type-annotation strip is line-preserving so reported lines
+      # still line up with the original source.
+      it "keeps line numbers correct after stripping a type annotation" do
+        source = <<-TS
+          import type { CollectionConfig } from 'payload'
+
+          export const Posts: CollectionConfig = {
+            slug: 'posts',
+            fields: [],
+          }
+          TS
+
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0].line.should eq(3)
+      end
+    end
+
+    context "multiple and nested matches" do
+      it "finds every sibling object that matches" do
+        source = <<-TS
+          export const Posts = { slug: 'posts', fields: [] }
+          export const Pages = { slug: 'pages', fields: [] }
+          TS
+
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])
+          .map(&.string("slug")).should eq(["posts", "pages"])
+      end
+
+      # A matched object is terminal — descending into it would re-report
+      # the same config from an inner object repeating the required keys.
+      it "does not re-report a nested object that repeats the required keys" do
+        source = <<-TS
+          export const Posts = {
+            slug: 'posts',
+            fields: [],
+            admin: { slug: 'inner', fields: [] },
+          }
+          TS
+
+        configs = Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])
+        configs.size.should eq(1)
+        configs[0].string("slug").should eq("posts")
+      end
+    end
+
+    context "value decoding" do
+      it "decodes single-quoted, double-quoted and template strings" do
+        source = "const c = { a: 'one', b: \"two\", c: `three`, k: 1 }"
+        config = Noir::JSObjectConfigExtractor.extract(source, ["a", "b", "c"])[0]
+        config.string("a").should eq("one")
+        config.string("b").should eq("two")
+        config.string("c").should eq("three")
+      end
+
+      it "decodes numbers as floats" do
+        source = "const c = { method: 'GET', limit: 25 }"
+        Noir::JSObjectConfigExtractor.extract(source, ["method", "limit"])[0]["limit"]
+          .should eq(25.0)
+      end
+
+      it "decodes booleans" do
+        source = "const c = { auth: false, enabled: true }"
+        config = Noir::JSObjectConfigExtractor.extract(source, ["auth", "enabled"])[0]
+        config.bool("auth").should be_false
+        config.bool("enabled").should be_true
+      end
+
+      it "decodes null and undefined as nil while keeping the key" do
+        source = "const c = { auth: null, policy: undefined }"
+        config = Noir::JSObjectConfigExtractor.extract(source, ["auth", "policy"])[0]
+        config["auth"].should be_nil
+        config["policy"].should be_nil
+      end
+
+      it "decodes arrays of strings" do
+        source = "const c = { routes: ['a', 'b'], name: 'x' }"
+        Noir::JSObjectConfigExtractor.extract(source, ["routes", "name"])[0]
+          .array("routes").should eq(["a", "b"])
+      end
+
+      it "decodes an array of objects" do
+        source = <<-TS
+          export default {
+            routes: [
+              { method: 'GET', path: '/things', handler: 'thing.find' },
+              { method: 'POST', path: '/things', handler: 'thing.create' },
+            ],
+          }
+          TS
+
+        routes = Noir::JSObjectConfigExtractor.extract(source, ["routes"])[0].array("routes")
+        routes.should_not be_nil
+        routes.not_nil!.size.should eq(2)
+
+        first = routes.not_nil![0]
+        first.should be_a(Hash(String, Noir::JSObjectConfigExtractor::ConfigValue))
+        first.as(Hash(String, Noir::JSObjectConfigExtractor::ConfigValue))["path"].should eq("/things")
+      end
+
+      it "decodes a nested object value" do
+        source = "const c = { name: 'x', config: { auth: false } }"
+        nested = Noir::JSObjectConfigExtractor.extract(source, ["name", "config"])[0].hash("config")
+        nested.should_not be_nil
+        nested.not_nil!["auth"].should be_false
+      end
+
+      # Anything not statically resolvable decodes to nil, but the key is
+      # still recorded so `has_key?` — and therefore matching — still sees it.
+      it "records a key whose value is an arrow function as nil" do
+        source = "const c = { slug: 'posts', fields: [], hooks: () => {} }"
+        config = Noir::JSObjectConfigExtractor.extract(source, ["slug", "hooks"])[0]
+        config["hooks"].should be_nil
+        config.string("slug").should eq("posts")
+      end
+
+      it "records a key whose value is an identifier as nil but still matches" do
+        source = "const c = { slug: 'posts', fields: sharedFields }"
+        config = Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0]
+        config["fields"].should be_nil
+      end
+
+      it "decodes a quoted key" do
+        source = "const c = { 'slug': 'posts', \"fields\": [] }"
+        Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])[0]
+          .string("slug").should eq("posts")
+      end
+    end
+
+    context "ConfigObject accessors" do
+      config = Noir::JSObjectConfigExtractor.extract(
+        "const c = { s: 'str', b: false, t: true, n: 3, arr: [1], obj: { k: 'v' }, nul: null }",
+        ["s", "b", "n"]
+      )[0]
+
+      it "returns nil from #string for a non-string value" do
+        config.string("n").should be_nil
+      end
+
+      it "returns nil from #bool for a non-boolean value" do
+        config.bool("s").should be_nil
+      end
+
+      it "returns nil from #array for a non-array value" do
+        config.array("s").should be_nil
+      end
+
+      it "returns nil from #hash for a non-hash value" do
+        config.hash("s").should be_nil
+      end
+
+      it "returns nil from #[] for a key that is absent" do
+        config["missing"].should be_nil
+      end
+
+      it "reads an array value" do
+        config.array("arr").should eq([1.0])
+      end
+
+      it "reads a hash value" do
+        config.hash("obj").not_nil!["k"].should eq("v")
+      end
+
+      describe "#truthy?" do
+        it "is false for an absent key" do
+          config.truthy?("missing").should be_false
+        end
+
+        it "is false for an explicit false" do
+          config.truthy?("b").should be_false
+        end
+
+        it "is false for a null value" do
+          config.truthy?("nul").should be_false
+        end
+
+        it "is true for an explicit true" do
+          config.truthy?("t").should be_true
+        end
+
+        it "is true for any other present value" do
+          config.truthy?("s").should be_true
+        end
+      end
+    end
+
+    context "robustness" do
+      it "does not raise on syntactically broken source" do
+        Noir::JSObjectConfigExtractor.extract("export const Posts = { slug: 'posts',", ["slug"])
+          .should be_a(Array(Noir::JSObjectConfigExtractor::ConfigObject))
+      end
+
+      it "does not raise on source with no object literal at all" do
+        Noir::JSObjectConfigExtractor.extract("const a = 1; function f() { return a }", ["slug"])
+          .should be_empty
+      end
+
+      it "stops decoding beyond MAX_VALUE_DEPTH instead of recursing forever" do
+        depth = Noir::JSObjectConfigExtractor::MAX_VALUE_DEPTH + 8
+        inner = "'leaf'"
+        depth.times { inner = "{ n: #{inner} }" }
+        source = "const c = { slug: 'posts', fields: #{inner} }"
+
+        configs = Noir::JSObjectConfigExtractor.extract(source, ["slug", "fields"])
+        configs.size.should eq(1)
+        configs[0].string("slug").should eq("posts")
+      end
+    end
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/go_group_scope_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_group_scope_spec.cr
@@ -1,0 +1,390 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/framework_taggers/go/group_scope"
+
+# `GoRouteGroupScope` is a mixin with no `extend self`, so exercising it
+# needs a host. This mirrors how `go_auth` / `go_security` include it.
+private class GroupScopeHost
+  include GoRouteGroupScope
+
+  # Every `.Use(...)` in `content`, as {line, scope}. This is the exact
+  # shape both real taggers build their guarded-prefix list from.
+  def uses(content : String) : Array(Tuple(String, GoRouteGroupScope::Scope))
+    found = [] of Tuple(String, GoRouteGroupScope::Scope)
+    each_group_scoped_line(content) do |stripped, scopes|
+      if scope = resolve_use_scope(stripped, scopes)
+        found << {stripped, scope}
+      end
+    end
+    found
+  end
+
+  # Just the resolved prefixes, for the common assertion.
+  def use_prefixes(content : String) : Array(String)
+    uses(content).map { |(_, scope)| scope[:prefix] }
+  end
+
+  def use_kinds(content : String) : Array(GoRouteGroupScope::ScopeKind)
+    uses(content).map { |(_, scope)| scope[:kind] }
+  end
+
+  def covers?(prefix : String, url : String) : Bool
+    prefix_covers?(prefix, url)
+  end
+end
+
+describe GoRouteGroupScope do
+  host = GroupScopeHost.new
+
+  describe ".join_prefix" do
+    it "prefixes a bare segment with a slash" do
+      GoRouteGroupScope.join_prefix("", "/web").should eq("/web")
+    end
+
+    it "joins a base and a segment that has no leading slash" do
+      GoRouteGroupScope.join_prefix("/api", "v1").should eq("/api/v1")
+    end
+
+    it "collapses the duplicate slash between base and segment" do
+      GoRouteGroupScope.join_prefix("/api", "/v1").should eq("/api/v1")
+    end
+
+    it "collapses repeated inner slashes" do
+      GoRouteGroupScope.join_prefix("/api//", "//v1").should eq("/api/v1")
+    end
+
+    it "returns the root when both parts are empty" do
+      GoRouteGroupScope.join_prefix("", "").should eq("/")
+    end
+
+    it "returns the root when the base is already root and the segment is empty" do
+      GoRouteGroupScope.join_prefix("/", "").should eq("/")
+    end
+
+    it "drops a trailing slash on the segment" do
+      GoRouteGroupScope.join_prefix("/api", "v1/").should eq("/api/v1")
+    end
+  end
+
+  describe "#prefix_covers?" do
+    it "treats the root prefix as covering every url" do
+      host.covers?("/", "/anything/at/all").should be_true
+    end
+
+    it "covers a url equal to the prefix" do
+      host.covers?("/web", "/web").should be_true
+    end
+
+    it "covers a url nested under the prefix" do
+      host.covers?("/web", "/web/login").should be_true
+    end
+
+    it "respects segment boundaries so /web does not cover /website" do
+      host.covers?("/web", "/website").should be_false
+    end
+
+    it "does not cover an unrelated url" do
+      host.covers?("/api", "/admin/users").should be_false
+    end
+  end
+
+  describe GoRouteGroupScope::Scopes do
+    it "reports the global scope at file scope" do
+      scopes = GoRouteGroupScope::Scopes.new
+      scopes.current.should eq(GoRouteGroupScope::GLOBAL_SCOPE)
+    end
+
+    it "falls back to the current scope for an untracked receiver" do
+      scopes = GoRouteGroupScope::Scopes.new
+      scopes.receiver("someRandomVar").should eq(GoRouteGroupScope::GLOBAL_SCOPE)
+    end
+
+    it "falls back to the current scope for a nil receiver" do
+      scopes = GoRouteGroupScope::Scopes.new
+      scopes.receiver(nil).should eq(GoRouteGroupScope::GLOBAL_SCOPE)
+    end
+
+    it "extends a known scope with a literal segment" do
+      scopes = GoRouteGroupScope::Scopes.new
+      extended = scopes.extend({kind: GoRouteGroupScope::ScopeKind::Group, prefix: "/api"}, "v1")
+      extended[:kind].should eq(GoRouteGroupScope::ScopeKind::Group)
+      extended[:prefix].should eq("/api/v1")
+    end
+
+    it "extends the global scope into a group" do
+      scopes = GoRouteGroupScope::Scopes.new
+      extended = scopes.extend(GoRouteGroupScope::GLOBAL_SCOPE, "/api")
+      extended[:kind].should eq(GoRouteGroupScope::ScopeKind::Group)
+      extended[:prefix].should eq("/api")
+    end
+
+    it "keeps an unresolvable base unresolvable even under a literal segment" do
+      scopes = GoRouteGroupScope::Scopes.new
+      extended = scopes.extend(GoRouteGroupScope::UNKNOWN_SCOPE, "/v1")
+      extended[:kind].should eq(GoRouteGroupScope::ScopeKind::Unknown)
+    end
+  end
+
+  describe "#each_group_scoped_line / #resolve_use_scope" do
+    it "yields no use scope for a file that registers no middleware" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          r.GET("/ping", pong)
+        }
+        GO
+
+      host.uses(content).should be_empty
+    end
+
+    it "resolves an engine-level Use to the global scope" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          r.Use(authMiddleware())
+          r.GET("/ping", pong)
+        }
+        GO
+
+      scopes = host.uses(content)
+      scopes.size.should eq(1)
+      scopes[0][1][:kind].should eq(GoRouteGroupScope::ScopeKind::Global)
+      scopes[0][1][:prefix].should eq("/")
+    end
+
+    it "resolves a Use on an assignment group to that group's prefix" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          api := r.Group("/api")
+          api.Use(authMiddleware())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api"])
+    end
+
+    it "resolves a Use on a nested assignment group to the composed prefix" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          api := r.Group("/api")
+          v1 := api.Group("/v1")
+          v1.Use(authMiddleware())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api/v1"])
+    end
+
+    # The regression this module exists for: modelling assignment groups
+    # with a push/pop stack made siblings accumulate into "/api/admin".
+    it "keeps sibling assignment groups independent instead of accumulating" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          api := r.Group("/api")
+          admin := r.Group("/admin")
+          api.Use(apiAuth())
+          admin.Use(adminAuth())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api", "/admin"])
+    end
+
+    it "resolves a Use inside a closure group to the closure's prefix" do
+      content = <<-GO
+        func main() {
+          r := chi.NewRouter()
+          r.Route("/api", func(r chi.Router) {
+            r.Use(authMiddleware)
+            r.Get("/users", listUsers)
+          })
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api"])
+    end
+
+    it "retires a closure group once its braces unwind" do
+      content = <<-GO
+        func main() {
+          r := chi.NewRouter()
+          r.Route("/api", func(r chi.Router) {
+            r.Use(authMiddleware)
+          })
+          r.Use(globalMiddleware)
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api", "/"])
+      host.use_kinds(content).last.should eq(GoRouteGroupScope::ScopeKind::Global)
+    end
+
+    it "composes nested closure groups" do
+      content = <<-GO
+        func main() {
+          r := chi.NewRouter()
+          r.Route("/api", func(r chi.Router) {
+            r.Route("/v1", func(r chi.Router) {
+              r.Use(authMiddleware)
+            })
+          })
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api/v1"])
+    end
+
+    it "resolves a chained Group(...).Use(...) without an intermediate variable" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          r.Group("/api").Use(authMiddleware())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api"])
+    end
+
+    it "resolves a chained Use on a group variable to the composed prefix" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          api := r.Group("/api")
+          api.Group("/v1").Use(authMiddleware())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api/v1"])
+    end
+
+    it "resolves Party and PartyFunc groups (iris)" do
+      content = <<-GO
+        func main() {
+          app := iris.New()
+          admin := app.Party("/admin")
+          admin.Use(basicAuth)
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/admin"])
+    end
+
+    it "resolves Pre as a middleware registration (echo)" do
+      content = <<-GO
+        func main() {
+          e := echo.New()
+          g := e.Group("/api")
+          g.Pre(middleware.AddTrailingSlash())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api"])
+    end
+
+    # A group whose path is not a literal is genuinely unknowable to a
+    # line scanner. Collapsing it to Global would tag every endpoint —
+    # including the explicitly public ones — as guarded.
+    it "marks an assignment group with a non-literal path as Unknown, not Global" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          api := r.Group(cfg.APIBase + "/v1")
+          api.Use(authMiddleware())
+        }
+        GO
+
+      host.use_kinds(content).should eq([GoRouteGroupScope::ScopeKind::Unknown])
+    end
+
+    it "marks a closure group with a non-literal path as Unknown" do
+      content = <<-GO
+        func main() {
+          r := chi.NewRouter()
+          r.Route(basePath, func(r chi.Router) {
+            r.Use(authMiddleware)
+          })
+        }
+        GO
+
+      host.use_kinds(content).should eq([GoRouteGroupScope::ScopeKind::Unknown])
+    end
+
+    it "marks a chained Use on a non-literal group as Unknown" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          r.Group(cfg.Base).Use(authMiddleware())
+        }
+        GO
+
+      host.use_kinds(content).should eq([GoRouteGroupScope::ScopeKind::Unknown])
+    end
+
+    it "keeps a literal child of an unknown parent unknown" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          api := r.Group(cfg.Base)
+          v1 := api.Group("/v1")
+          v1.Use(authMiddleware())
+        }
+        GO
+
+      host.use_kinds(content).should eq([GoRouteGroupScope::ScopeKind::Unknown])
+    end
+
+    # `admin := r.Group("/admin", func(c *gin.Context) {...})` is both a
+    # closure group and an assignment. Resolving the assignment against
+    # the already-pushed closure frame would fold the prefix in twice.
+    it "does not double-count a line that is both a closure and an assignment group" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          admin := r.Group("/admin", func(c *gin.Context) {
+            c.Next()
+          })
+          admin.Use(adminAuth())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/admin"])
+    end
+
+    it "resolves a Use on a group declared with = rather than :=" do
+      content = <<-GO
+        func register(r *gin.Engine) {
+          var api *gin.RouterGroup
+          api = r.Group("/api")
+          api.Use(authMiddleware())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/api"])
+    end
+
+    it "handles an empty group path as the root prefix" do
+      content = <<-GO
+        func main() {
+          r := gin.Default()
+          root := r.Group("")
+          root.Use(authMiddleware())
+        }
+        GO
+
+      host.use_prefixes(content).should eq(["/"])
+    end
+
+    it "yields every line of the file, stripped" do
+      content = "package main\n\n  func main() {}\n"
+      seen = [] of String
+      host.each_group_scoped_line(content) { |stripped, _| seen << stripped }
+      seen.should eq(["package main", "", "func main() {}"])
+    end
+
+    it "handles empty content without raising" do
+      host.uses("").should be_empty
+    end
+  end
+end

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -1,4 +1,6 @@
 require "../utils/path_scope"
+require "../utils/utils"
+require "./logger"
 
 class CodeLocator
   @@instance : CodeLocator? = nil


### PR DESCRIPTION
## Motivation

Mapping spec coverage across the tree turned up three files with **no direct unit spec — not one reference anywhere under `spec/`**, despite being pure, deterministic logic sitting under decisions that matter:

| File | LOC | What it decides |
|---|---|---|
| `src/tagger/framework_taggers/go/group_scope.cr` | 172 | Which URL prefix a Go middleware registration guards |
| `src/miniparsers/js_object_config_extractor.cr` | 217 | Payload CMS / Strapi declarative config decoding |
| `src/ai_context/source_reader.cr` | 240 | The source snippets the AI context is built from |

Each was reachable only through functional tests of its callers, so a regression in the shared logic would surface (if at all) as a puzzling endpoint diff several layers away.

## What's covered

**`GoRouteGroupScope`** (39 examples) — `go_auth` and `go_security` both build their guarded-prefix list from this module, so a wrong answer here is a security-tag false positive. The specs pin the behaviours its header comment says it exists for:

- sibling assignment groups staying independent instead of accumulating (`api` then `admin` must not resolve to `/api/admin`)
- a non-literal group path (`r.Group(cfg.APIBase)`) resolving to `Unknown` rather than collapsing to `Global` — collapsing would tag every endpoint, including the explicitly public ones, as guarded
- a line that is both a closure and an assignment group not folding its own prefix in twice
- closure frames retiring on brace unwind, chained `Group(...).Use(...)`, and `Party`/`Pre` router dialects

**`NoirAIContext::SourceReader`** (47 examples) — its character budget is load-bearing: a snippet truncated before the suppressing evidence becomes a false positive downstream. Covers the budget (default, caller-supplied, and the exact-fit boundary), the three caches, and the block-boundary walk across all four styles — brace / python / ruby / bare statement — including the decorator lead-in and the indent guard behind the django `/public/` false positive.

**`Noir::JSObjectConfigExtractor`** (39 examples) — every declaration shape its header comment claims to handle (TS type annotation, `satisfies`, call argument, `module.exports`), the value decoder including the statically-unresolvable-but-key-still-recorded case, and both depth guards.

## Drive-by fix

`src/models/code_locator.cr` referenced `NoirLogger` and `any_to_bool` without requiring either. It compiled only because every real entry point happens to require `logger.cr` first — `require`-ing `source_reader.cr` on its own failed to compile. Requiring a file's own dependencies is what makes anything downstream of it unit-testable in isolation.

## Verification

- 125 new examples, all passing
- `crystal spec spec/unit_test` — 4619 examples, 0 failures
- `crystal spec spec/functional_test` — 22647 examples, 0 failures
- `just check` — 1842 files inspected, 0 failures

No production behaviour changes; the only `src/` edit is two `require` lines.