### PR TITLE
refactor(analyzer): hoist the nine copied engine scan skeletons into a shared FileScanEngine

### DIFF
--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -1,17 +1,9 @@
 require "../../models/analyzer"
+require "./file_scan_engine"
 require "../../miniparsers/crystal_callee_extractor"
 
 module Analyzer::Crystal
-  abstract class CrystalEngine < Analyzer
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
-    end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
-
+  abstract class CrystalEngine < FileScanEngine
     # The shard that identifies this analyzer's framework. An analyzer that
     # declares one is only shown files inside a project whose `shard.yml`
     # depends on it. Without that, every Crystal analyzer sees every `.cr`
@@ -28,6 +20,12 @@ module Analyzer::Crystal
     # `path_under_shard_roots?` waves everything through, so a source tree
     # checked out without its manifest keeps working exactly as before.
     private def shard_roots : Array(String)
+      @shard_roots ||= compute_shard_roots
+    end
+
+    @shard_roots : Array(String)?
+
+    private def compute_shard_roots : Array(String)
       dependencies = shard_dependencies
       return [] of String if dependencies.empty?
 
@@ -62,37 +60,25 @@ module Analyzer::Crystal
       roots.any? { |root| Noir::PathScope.under_normalized_root?(expanded, root) }
     end
 
-    # `.cr` sources from the extension index, plus `lib/` exclusion
-    # (shards puts dependencies under `lib/` and we don't want to
-    # analyze them). Subclasses that need a custom scan shape can
-    # override `analyze` (e.g. Amber/Kemal run a public-dir post-pass
-    # after the file walk). Paths are detector-registered regular
-    # files — no per-path `File.exists?` / `File.directory?`.
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      begin
-        roots = shard_roots
-        parallel_analyze(get_files_by_extension(".cr")) do |path|
-          next if crystal_dependency_path?(path)
-          next unless path_under_shard_roots?(path, roots)
-          # Crystal's standard test directory is `spec/`, and test
-          # files always end in `_spec.cr`. Crystal framework repos
-          # (lucky, marten, amber, kemal) park hundreds of route
-          # declarations there to exercise the framework. Production
-          # code never adopts either convention. The `spec/` dir
-          # is checked relative to the project root so nested
-          # fixtures under noir's own `spec/functional_test/...`
-          # tree don't accidentally trip the filter.
-          next if crystal_spec_path?(path)
+    # `.cr` sources from the extension index; `lib/` exclusion (shards
+    # puts dependencies there) and the spec filter live in
+    # `scan_accepts?`.
+    protected def scan_target_files : Array(String)
+      get_files_by_extension(".cr")
+    end
 
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    protected def scan_accepts?(path : String) : Bool
+      return false if crystal_dependency_path?(path)
+      return false unless path_under_shard_roots?(path, shard_roots)
+      # Crystal's standard test directory is `spec/`, and test
+      # files always end in `_spec.cr`. Crystal framework repos
+      # (lucky, marten, amber, kemal) park hundreds of route
+      # declarations there to exercise the framework. Production
+      # code never adopts either convention. The `spec/` dir
+      # is checked relative to the project root so nested
+      # fixtures under noir's own `spec/functional_test/...`
+      # tree don't accidentally trip the filter.
+      !crystal_spec_path?(path)
     end
 
     # `*_spec.cr` is Crystal's official spec filename — unambiguous

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -1,17 +1,9 @@
 require "../../models/analyzer"
+require "./file_scan_engine"
 require "../../miniparsers/elixir_callee_extractor"
 
 module Analyzer::Elixir
-  abstract class ElixirEngine < Analyzer
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
-    end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
-
+  abstract class ElixirEngine < FileScanEngine
     protected def attach_elixir_callees(endpoint : Endpoint, callees : Array(Noir::ElixirCalleeExtractor::Entry))
       Noir::ElixirCalleeExtractor.attach_to(endpoint, callees)
     end
@@ -134,23 +126,15 @@ module Analyzer::Elixir
     # Walk only Elixir sources concurrently. Extension + ExUnit-test
     # filtering lives here so framework adapters don't re-check every
     # path the monorepo file map yields.
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      begin
-        # CodeLocator already registered these paths during detection;
-        # skip the per-file `File.exists?` syscall. Missing files surface
-        # as read errors inside the analyzer and are logged there.
-        parallel_analyze(elixir_source_files) do |path|
-          next if elixir_test_path?(path)
+    # CodeLocator already registered these paths during detection; skip
+    # the per-file `File.exists?` syscall. Missing files surface as read
+    # errors inside the analyzer and are logged there.
+    protected def scan_target_files : Array(String)
+      elixir_source_files
+    end
 
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    protected def scan_accepts?(path : String) : Bool
+      !elixir_test_path?(path)
     end
   end
 end

--- a/src/analyzer/engines/file_scan_engine.cr
+++ b/src/analyzer/engines/file_scan_engine.cr
@@ -1,0 +1,34 @@
+require "../../models/analyzer"
+
+# Base for engines whose scan is "walk the language's source files and
+# extract endpoints from each independently". The `analyze` here replaces
+# the byte-identical copy each such engine used to carry: a subclass
+# supplies the candidate list (`scan_target_files`), an optional per-path
+# veto (`scan_accepts?`, inherited from `Analyzer`), and the per-file
+# extraction (`analyze_file`).
+#
+# Engines whose concrete analyzers write their own `analyze` instead of
+# implementing `analyze_file` (Ruby, JavaScript) don't inherit from this;
+# they keep their `parallel_file_scan` signature and delegate to
+# `Analyzer#scan_files` for the shared skeleton.
+abstract class FileScanEngine < Analyzer
+  def analyze
+    parallel_file_scan do |path|
+      result.concat(analyze_file(path))
+    end
+    result
+  end
+
+  abstract def analyze_file(path : String) : Array(Endpoint)
+
+  # Candidate files for this engine's scan. Paths are detector-registered
+  # regular files — no per-path `File.exists?` / `File.directory?` needed.
+  protected abstract def scan_target_files : Array(String)
+
+  # Subclasses that need a custom scan shape override `analyze` and call
+  # this directly (e.g. Amber/Kemal run a public-dir post-pass after the
+  # file walk).
+  protected def parallel_file_scan(&block : String -> Nil) : Nil
+    scan_files(scan_target_files, &block)
+  end
+end

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -21,17 +21,7 @@ module Analyzer::Javascript
     #
     # Name-consistent with the other engines' `parallel_file_scan` helpers.
     protected def parallel_file_scan(extensions : Array(String) = DEFAULT_EXTENSIONS, &block : String -> Nil) : Nil
-      begin
-        parallel_analyze(get_files_by_extensions(extensions)) do |path|
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+      scan_files(get_files_by_extensions(extensions), &block)
     end
 
     # Crystal recompiles an interpolated regex literal (/...#{x}.../) on

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -1,16 +1,9 @@
 require "../../models/analyzer"
 
+require "./file_scan_engine"
+
 module Analyzer::Perl
-  abstract class PerlEngine < Analyzer
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
-    end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
-
+  abstract class PerlEngine < FileScanEngine
     # Perl ships in `.pl`, `.pm`, `.psgi`, and `.t`. Pull those from the
     # extension index instead of walking the whole monorepo `file_map`.
     # Adapters still re-filter inside `analyze_file` for framework-specific
@@ -18,18 +11,8 @@ module Analyzer::Perl
     # regular files — no per-path `File.exists?` / `File.directory?`.
     PERL_SOURCE_EXTENSIONS = [".pl", ".pm", ".psgi", ".t"]
 
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      begin
-        parallel_analyze(get_files_by_extensions(PERL_SOURCE_EXTENSIONS)) do |path|
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    protected def scan_target_files : Array(String)
+      get_files_by_extensions(PERL_SOURCE_EXTENSIONS)
     end
 
     # Perl test files live in `.t` scripts or under a `/t/` directory.

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -2,20 +2,13 @@ require "../../models/analyzer"
 require "../../miniparsers/php_callee_extractor"
 require "../../utils/utils.cr"
 
+require "./file_scan_engine"
+
 module Analyzer::Php
-  abstract class PhpEngine < Analyzer
+  abstract class PhpEngine < FileScanEngine
     # See AGENTS.md §"Two engine shapes" (and
     # docs/content/development/analyzer_architecture/) for when to override
     # `analyze_file` vs. `analyze` + `parallel_file_scan`.
-
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
-    end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
 
     # Default source set for PHP framework adapters: every registered
     # `.php` file. Symfony overrides this to also include YAML route
@@ -25,24 +18,15 @@ module Analyzer::Php
       get_files_by_extension(".php")
     end
 
-    # Walk PHP sources concurrently. Extension + test-path filtering
-    # lives here so adapters don't re-check every monorepo path.
-    # Paths come from CodeLocator (regular files only); missing files
-    # error on read and are logged.
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      begin
-        parallel_analyze(php_source_files) do |path|
-          next if PhpEngine.test_path?(base_relative_path(path))
+    # Extension + test-path filtering lives here so adapters don't
+    # re-check every monorepo path. Paths come from CodeLocator (regular
+    # files only); missing files error on read and are logged.
+    protected def scan_target_files : Array(String)
+      php_source_files
+    end
 
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    protected def scan_accepts?(path : String) : Bool
+      !PhpEngine.test_path?(base_relative_path(path))
     end
 
     # Standard PHP test-source conventions:

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -207,17 +207,7 @@ module Analyzer::Ruby
     RUBY_SOURCE_EXTENSIONS = [".rb", ".ru"]
 
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      begin
-        parallel_analyze(get_files_by_extensions(RUBY_SOURCE_EXTENSIONS)) do |path|
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+      scan_files(get_files_by_extensions(RUBY_SOURCE_EXTENSIONS), &block)
     end
 
     protected def attach_ruby_callees(endpoint : Endpoint, callees : Array(Noir::RubyCalleeExtractor::Entry))

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -1,17 +1,9 @@
 require "../../models/analyzer"
+require "./file_scan_engine"
 require "../../miniparsers/rust_callee_extractor"
 
 module Analyzer::Rust
-  abstract class RustEngine < Analyzer
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
-    end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
-
+  abstract class RustEngine < FileScanEngine
     # Standard set of HTTP methods that `axum::routing::any(...)` /
     # actix `web::route()` / similar method-agnostic registrations
     # accept. Mirrors the Go `fan_out_verbs` set so output formats
@@ -30,27 +22,15 @@ module Analyzer::Rust
       end
     end
 
-    # `.rs` sources from the extension index. Subclasses that want a
-    # different scan shape (e.g. a post-pass after the file walk) can
-    # override `analyze` and call this helper directly; the default
-    # `analyze` above is the simpler path. Paths are detector-registered
-    # regular files — no per-path `File.exists?` / `File.directory?`.
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      begin
-        roots = crate_roots
-        parallel_analyze(get_files_by_extension(".rs")) do |path|
-          next if RustEngine.test_path?(base_relative_path(path))
-          next unless path_under_crate_roots?(path, roots)
+    # `.rs` sources from the extension index; test-path and crate-root
+    # gating lives in `scan_accepts?`.
+    protected def scan_target_files : Array(String)
+      get_files_by_extension(".rs")
+    end
 
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    protected def scan_accepts?(path : String) : Bool
+      return false if RustEngine.test_path?(base_relative_path(path))
+      path_under_crate_roots?(path, crate_roots)
     end
 
     # The Cargo dependencies that identify this analyzer's framework. An
@@ -70,6 +50,12 @@ module Analyzer::Rust
     # case `path_under_crate_roots?` waves everything through, so a source
     # tree checked out without its manifest keeps working exactly as before.
     private def crate_roots : Array(String)
+      @crate_roots ||= compute_crate_roots
+    end
+
+    @crate_roots : Array(String)?
+
+    private def compute_crate_roots : Array(String)
       dependencies = crate_dependencies
       return [] of String if dependencies.empty?
 

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -2,33 +2,16 @@ require "../../models/analyzer"
 require "../../miniparsers/scala_callee_extractor"
 require "../../minilexers/scala_lexer"
 
+require "./file_scan_engine"
+
 module Analyzer::Scala
-  abstract class ScalaEngine < Analyzer
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
-    end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
-
+  abstract class ScalaEngine < FileScanEngine
     # `.scala` sources from the extension index. Subclasses that need a
     # custom scan shape can override `analyze` and call this helper
     # directly. Paths are detector-registered regular files — no per-path
     # `File.exists?` / `File.directory?`.
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      begin
-        parallel_analyze(get_files_by_extension(".scala")) do |path|
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    protected def scan_target_files : Array(String)
+      get_files_by_extension(".scala")
     end
 
     protected def attach_scala_callees(endpoint : Endpoint, callees : Array(Noir::ScalaCalleeExtractor::Entry))

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -1,16 +1,9 @@
 require "../../models/analyzer"
 
+require "./file_scan_engine"
+
 module Analyzer::Swift
-  abstract class SwiftEngine < Analyzer
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
-    end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
-
+  abstract class SwiftEngine < FileScanEngine
     # `Tests/...` directory + `*Tests.swift` filename: the rigid Swift
     # Package Manager / XCTest conventions for test sources.
     #
@@ -42,28 +35,20 @@ module Analyzer::Swift
     # custom scan shape can override `analyze` and call this helper
     # directly. Paths are detector-registered regular files — no per-path
     # `File.exists?` / `File.directory?`.
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      begin
-        parallel_analyze(get_files_by_extension(".swift")) do |path|
-          # Swift Package Manager convention parks tests under
-          # `Tests/<TargetName>Tests/`. Real route handlers never
-          # live there, but vapor's own repo accounts for ~58
-          # phantom endpoints from `Tests/VaporTests/*Tests.swift`
-          # files that register routes against an inline test app.
-          # XCTest-style `*Tests.swift` filenames carry the same
-          # signal — pick them both up.
-          next if swift_test_path?(path)
-          next if swift_vendor_path?(path)
+    protected def scan_target_files : Array(String)
+      get_files_by_extension(".swift")
+    end
 
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    protected def scan_accepts?(path : String) : Bool
+      # Swift Package Manager convention parks tests under
+      # `Tests/<TargetName>Tests/`. Real route handlers never
+      # live there, but vapor's own repo accounts for ~58
+      # phantom endpoints from `Tests/VaporTests/*Tests.swift`
+      # files that register routes against an inline test app.
+      # XCTest-style `*Tests.swift` filenames carry the same
+      # signal — pick them both up.
+      return false if swift_test_path?(path)
+      !swift_vendor_path?(path)
     end
   end
 end

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -199,6 +199,30 @@ class Analyzer
     end
   end
 
+  # Engine scan skeleton shared by the per-language engines: runs `block`
+  # over `files` in parallel, skipping paths `scan_accepts?` vetoes, and
+  # isolating failures so one unreadable or unparsable file costs only
+  # itself (logged at debug), never the whole scan. Before this existed,
+  # nine engines carried byte-identical copies of the double-rescue body.
+  protected def scan_files(files : Array(String), &block : String -> Nil) : Nil
+    parallel_analyze(files) do |path|
+      next unless scan_accepts?(path)
+      begin
+        block.call(path)
+      rescue e
+        logger.debug "Error analyzing #{path}: #{e}"
+      end
+    end
+  rescue e
+    logger.debug e
+  end
+
+  # Per-path veto consulted by `scan_files`. Engines override this with
+  # their language's test/vendor/dependency filters.
+  protected def scan_accepts?(path : String) : Bool
+    true
+  end
+
   # Order-preserving dedup of params by (name, param_type). Analyzers
   # that accumulate every reference they see (rather than every route)
   # collect the same key many times over.


### PR DESCRIPTION
## What

Every per-file engine (crystal / elixir / perl / php / rust / scala / swift, plus the ruby / javascript variants) carried a byte-identical `analyze` + double-rescue `parallel_file_scan` body — the only real differences were the candidate file list and the per-path veto.

- `Analyzer#scan_files` now holds the shared skeleton (parallel walk, per-file error isolation), consulting a new `scan_accepts?(path)` hook (default: accept).
- New `FileScanEngine < Analyzer` abstract base carries the shared `analyze` + `abstract analyze_file` + zero-arg `parallel_file_scan`; the seven per-file engines now inherit it and declare only `scan_target_files` / `scan_accepts?`.
- Ruby/JavaScript engines (whose concrete analyzers write their own `analyze`) keep their `parallel_file_scan` signatures and delegate to `scan_files` — no analyzer call sites changed.
- CrystalEngine/RustEngine shard/crate root computation is memoized per instance, preserving the old hoist-out-of-the-loop behavior.

Net −105 lines; the next engine gets the skeleton for free.

## Proof

- Unit 4,619 + functional 22,647 examples, 0 failures.
- A/B fixture sweep: base (`main`) vs branch `--release` binaries scanned all 664 `spec/functional_test/fixtures/*/*/` dirs; normalized (method, url, params, tags) output is byte-identical, 5,158 endpoints, 0 scan failures.
- `crystal tool format --check` + ameba clean.