### PR TITLE
refactor(techs): derive the capability lists from per-tech :context flags

### DIFF
--- a/src/techs/catalog/clojure.cr
+++ b/src/techs/catalog/clojure.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :clojure_reitit => {
       :framework => "Reitit",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :clojure_pedestal => {
       :framework => "Pedestal",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :clojure_ring => {
       :framework => "Ring",

--- a/src/techs/catalog/cpp.cr
+++ b/src/techs/catalog/cpp.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :cpp_httplib => {
       :framework => "cpp-httplib",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :cpp_oatpp => {
       :framework => "oat++",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :cpp_crow => {
       :framework => "Crow",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/crystal.cr
+++ b/src/techs/catalog/crystal.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => true,
       },
+      :context => {:callee => true, :guards => true},
     },
     :crystal_kemal => {
       :framework => "Kemal",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :crystal_lucky => {
       :framework => "Lucky",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :crystal_marten => {
       :framework => "Marten",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :crystal_grip => {
       :framework => "Grip",
@@ -110,6 +114,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true, :guards => true},
     },
     :crystal_http => {
       :framework => "HTTP::Server",

--- a/src/techs/catalog/csharp.cr
+++ b/src/techs/catalog/csharp.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :cs_aspnet_core_mvc => {
       :framework => "ASP.NET Core MVC",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :cs_aspnet_core_minimal_api => {
       :framework => "ASP.NET Core Minimal API",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :cs_carter => {
       :framework => "Carter",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :cs_fastendpoints => {
       :framework => "FastEndpoints",
@@ -110,6 +114,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :cs_httplistener => {
       :framework => "System.Net.HttpListener",
@@ -128,6 +133,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :cs_signalr => {
       :framework => "ASP.NET Core SignalR",

--- a/src/techs/catalog/dart.cr
+++ b/src/techs/catalog/dart.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :dart_angel3 => {
       :framework => "Angel3",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :dart_get_server => {
       :framework => "GetServer",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :dart_frog => {
       :framework => "Dart Frog",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true},
     },
     :dart_http => {
       :framework => "dart:io HttpServer",
@@ -128,6 +132,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :dart_shelf => {
       :framework => "Shelf",
@@ -146,6 +151,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/elixir.cr
+++ b/src/techs/catalog/elixir.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :elixir_phoenix => {
       :framework => "Phoenix",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true, :guards => true},
     },
     :elixir_phoenix_channel => {
       :framework => "Phoenix Channels",
@@ -92,6 +94,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
   }
 end

--- a/src/techs/catalog/fsharp.cr
+++ b/src/techs/catalog/fsharp.cr
@@ -20,6 +20,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/go.cr
+++ b/src/techs/catalog/go.cr
@@ -20,6 +20,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_beego => {
       :framework => "Beego",
@@ -38,6 +39,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_cli => {
       :framework => "CLI (flag / cobra / urfave / pflag / go-arg / go-flags / kong / kingpin / mitchellh)",
@@ -78,6 +80,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_fasthttp => {
       :framework => "fasthttp",
@@ -96,6 +99,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_fiber => {
       :framework => "Fiber",
@@ -114,6 +118,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_gin => {
       :framework => "Gin",
@@ -132,6 +137,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_hertz => {
       :framework => "Hertz",
@@ -150,6 +156,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_iris => {
       :framework => "Iris",
@@ -168,6 +175,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_restful => {
       :framework => "go-restful",
@@ -186,6 +194,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_chi => {
       :framework => "Chi",
@@ -204,6 +213,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_gozero => {
       :framework => "go-zero",
@@ -222,6 +232,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_goyave => {
       :framework => "Goyave",
@@ -240,6 +251,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_http => {
       :framework => "net/http",
@@ -258,6 +270,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_mux => {
       :framework => "Gorilla Mux",
@@ -276,6 +289,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :go_connect_rpc => {
       :framework => "Connect-RPC",
@@ -312,6 +326,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :go_httprouter => {
       :framework => "httprouter",
@@ -330,6 +345,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :go_huma => {
       :framework => "Huma",
@@ -348,6 +364,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/groovy.cr
+++ b/src/techs/catalog/groovy.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/haskell.cr
+++ b/src/techs/catalog/haskell.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :haskell_servant => {
       :framework => "Servant",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :haskell_yesod => {
       :framework => "Yesod",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/java.cr
+++ b/src/techs/catalog/java.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :java_dropwizard => {
       :framework => "Dropwizard",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_httpserver => {
       :framework => "JDK HttpServer",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_jaxrs => {
       :framework => "JAX-RS",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_quarkus => {
       :framework => "Quarkus",
@@ -110,6 +114,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_javalin => {
       :framework => "Javalin",
@@ -128,6 +133,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_spark => {
       :framework => "Spark Java",
@@ -146,6 +152,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_micronaut => {
       :framework => "Micronaut",
@@ -164,6 +171,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_jsp => {
       :framework => "JSP",
@@ -182,6 +190,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:guards => true},
     },
     :java_spring => {
       :framework => "Spring",
@@ -200,6 +209,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :java_struts2 => {
       :framework => "Apache Struts 2",
@@ -218,6 +228,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_vertx => {
       :framework => "Vert.x",
@@ -236,6 +247,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :java_wicket => {
       :framework => "Apache Wicket",
@@ -254,6 +266,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :java_play => {
       :framework => "Play Framework",
@@ -272,6 +285,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
   }
 end

--- a/src/techs/catalog/javascript.cr
+++ b/src/techs/catalog/javascript.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_astro => {
       :framework => "Astro",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_elysia => {
       :framework => "Elysia",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_express => {
       :framework => "Express",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :js_socketio => {
       :framework => "Socket.IO",
@@ -128,6 +132,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :js_remix => {
       :framework => "Remix",
@@ -146,6 +151,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_sveltekit => {
       :framework => "SvelteKit",
@@ -164,6 +170,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_fastify => {
       :framework => "Fastify",
@@ -182,6 +189,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :js_fresh => {
       :framework => "Fresh",
@@ -200,6 +208,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_hapi => {
       :framework => "Hapi",
@@ -218,6 +227,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_apollo => {
       :framework => "Apollo Server",
@@ -236,6 +246,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true},
     },
     :js_graphql_yoga => {
       :framework => "GraphQL Yoga",
@@ -272,6 +283,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :js_http => {
       :framework => "Node.js http/https",
@@ -308,6 +320,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :js_nestjs => {
       :framework => "NestJS",
@@ -326,6 +339,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :js_nextjs => {
       :framework => "Next.js",
@@ -344,6 +358,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_nitro => {
       :framework => "Nitro",
@@ -362,6 +377,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :js_nuxtjs => {
       :framework => "NuxtJS",
@@ -380,6 +396,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
   }
 end

--- a/src/techs/catalog/kotlin.cr
+++ b/src/techs/catalog/kotlin.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :kotlin_spring => {
       :framework => "Spring",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :kotlin_ktor => {
       :framework => "Ktor",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
   }
 end

--- a/src/techs/catalog/lua.cr
+++ b/src/techs/catalog/lua.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :lua_lor => {
       :framework => "lor",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/mobile.cr
+++ b/src/techs/catalog/mobile.cr
@@ -17,6 +17,7 @@ module NoirTechs::Catalog
           :cookie => false,
         },
       },
+      :context => {:callee => true, :guards => true},
     },
     :ios => {
       :format    => ["PLIST"],
@@ -32,6 +33,7 @@ module NoirTechs::Catalog
           :cookie => false,
         },
       },
+      :context => {:callee => true, :guards => true},
     },
     :well_known_applinks => {
       :format    => ["JSON"],

--- a/src/techs/catalog/perl.cr
+++ b/src/techs/catalog/perl.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :perl_dancer2 => {
       :framework => "Dancer2",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :perl_mojolicious => {
       :framework => "Mojolicious",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true, :guards => true},
     },
   }
 end

--- a/src/techs/catalog/php.cr
+++ b/src/techs/catalog/php.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_laravel => {
       :framework => "Laravel",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_lumen => {
       :framework => "Lumen",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :php_mautic => {
       :framework => "Mautic",
@@ -110,6 +113,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_slim => {
       :framework => "Slim",
@@ -128,6 +132,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_symfony => {
       :framework => "Symfony",
@@ -146,6 +151,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_yii => {
       :framework => "Yii2",
@@ -164,6 +170,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_thinkphp => {
       :framework => "ThinkPHP",
@@ -182,6 +189,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_cakephp => {
       :framework => "CakePHP",
@@ -200,6 +208,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_codeigniter => {
       :framework => "CodeIgniter",
@@ -218,6 +227,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :php_hyperf => {
       :framework => "Hyperf",
@@ -236,6 +246,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :php_wordpress => {
       :framework => "WordPress",

--- a/src/techs/catalog/python.cr
+++ b/src/techs/catalog/python.cr
@@ -20,6 +20,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :python_django_ninja => {
       :framework => "Django Ninja",
@@ -38,6 +39,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :python_fastapi => {
       :framework => "FastAPI",
@@ -56,6 +58,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :python_aiohttp => {
       :framework => "aiohttp",
@@ -74,6 +77,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true},
     },
     :python_bottle => {
       :framework => "Bottle",
@@ -92,6 +96,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :python_cli => {
       :framework => "CLI (argparse / click / typer / fire / docopt / getopt / absl / cleo)",
@@ -131,6 +136,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :python_flask => {
       :framework => "Flask",
@@ -149,6 +155,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :python_litestar => {
       :framework => "Litestar",
@@ -167,6 +174,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true},
     },
     :python_pyramid => {
       :framework => "Pyramid",
@@ -185,6 +193,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :python_quart => {
       :framework => "Quart",
@@ -203,6 +212,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true, :guards => true},
     },
     :python_robyn => {
       :framework => "Robyn",
@@ -221,6 +231,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true},
     },
     :python_sanic => {
       :framework => "Sanic",
@@ -239,6 +250,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true, :guards => true},
     },
     :python_starlette => {
       :framework => "Starlette",
@@ -257,6 +269,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :python_tornado => {
       :framework => "Tornado",
@@ -275,6 +288,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => true,
       },
+      :context => {:callee => true, :guards => true},
     },
     :python_http_server => {
       :framework => "http.server",
@@ -293,6 +307,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/r.cr
+++ b/src/techs/catalog/r.cr
@@ -20,6 +20,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
   }
 end

--- a/src/techs/catalog/ruby.cr
+++ b/src/techs/catalog/ruby.cr
@@ -56,6 +56,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :ruby_hanami => {
       :framework => "Hanami",
@@ -74,6 +75,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :ruby_rails => {
       :framework => "Rails",
@@ -92,6 +94,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :ruby_roda => {
       :framework => "Roda",
@@ -110,6 +113,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :ruby_sinatra => {
       :framework => "Sinatra",
@@ -128,6 +132,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :ruby_webrick => {
       :framework => "WEBrick",
@@ -146,6 +151,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
   }
 end

--- a/src/techs/catalog/rust.cr
+++ b/src/techs/catalog/rust.cr
@@ -20,6 +20,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :rust_rocket => {
       :framework => "Rocket",
@@ -38,6 +39,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :rust_cli => {
       :framework => "CLI (std::env / clap / structopt / argh / getopts)",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :rust_loco => {
       :framework => "Loco",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :rust_rwf => {
       :framework => "RWF",
@@ -110,6 +114,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :rust_tide => {
       :framework => "Tide",
@@ -128,6 +133,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :rust_warp => {
       :framework => "Warp",
@@ -146,6 +152,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :rust_gotham => {
       :framework => "Gotham",
@@ -164,6 +171,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :rust_salvo => {
       :framework => "Salvo",
@@ -182,6 +190,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :rust_poem => {
       :framework => "Poem",
@@ -200,6 +209,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/scala.cr
+++ b/src/techs/catalog/scala.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :scala_http4s => {
       :framework => "http4s",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :scala_scalatra => {
       :framework => "Scalatra",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :scala_play => {
       :framework => "Play Framework",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :scala_tapir => {
       :framework => "Tapir",
@@ -110,6 +114,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :scala_zio_http => {
       :framework => "ZIO HTTP",
@@ -128,6 +133,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/swift.cr
+++ b/src/techs/catalog/swift.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :swift_kitura => {
       :framework => "Kitura",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :swift_hummingbird => {
       :framework => "Hummingbird",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
   }
 end

--- a/src/techs/catalog/typescript.cr
+++ b/src/techs/catalog/typescript.cr
@@ -20,6 +20,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true, :guards => true},
     },
     :ts_tanstack_router => {
       :framework => "TanStack Router",
@@ -38,6 +39,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :ts_trpc => {
       :framework => "tRPC",
@@ -56,6 +58,7 @@ module NoirTechs::Catalog
         :static_path => true,
         :websocket   => true,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/catalog/zig.cr
+++ b/src/techs/catalog/zig.cr
@@ -38,6 +38,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :zig_zap => {
       :framework => "Zap",
@@ -56,6 +57,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :zig_http => {
       :framework => "std.http.Server",
@@ -74,6 +76,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :zig_httpz => {
       :framework => "httpz",
@@ -92,6 +95,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
     :zig_tokamak => {
       :framework => "Tokamak",
@@ -110,6 +114,7 @@ module NoirTechs::Catalog
         :static_path => false,
         :websocket   => false,
       },
+      :context => {:callee => true},
     },
   }
 end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -2,60 +2,6 @@ require "json"
 require "./catalog/*"
 
 module NoirTechs
-  CALLEE_SUPPORTED_TECHS = [
-    "android", "ios",
-    "cpp_crow", "cpp_drogon", "cpp_httplib", "cpp_oatpp",
-    "clojure_compojure", "clojure_pedestal", "clojure_reitit",
-    "crystal_amber", "crystal_grip", "crystal_kemal", "crystal_lucky", "crystal_marten",
-    "cs_aspnet_core_mvc", "cs_aspnet_core_minimal_api", "cs_aspnet_mvc", "cs_carter", "cs_fastendpoints", "cs_httplistener",
-    "dart_alfred", "dart_angel3", "dart_get_server", "dart_frog", "dart_serverpod", "dart_shelf",
-    "elixir_bandit", "elixir_phoenix", "elixir_plug",
-    "fs_giraffe",
-    "go_beego", "go_chi", "go_echo", "go_fasthttp", "go_fiber", "go_gf", "go_gin", "go_http",
-    "go_gozero", "go_goyave", "go_hertz", "go_httprouter", "go_huma", "go_iris", "go_mux", "go_pocketbase", "go_restful",
-    "groovy_grails",
-    "haskell_scotty", "haskell_servant", "haskell_yesod",
-    "java_armeria", "java_dropwizard", "java_httpserver", "java_jaxrs", "java_javalin", "java_micronaut",
-    "java_play", "java_quarkus", "java_spark", "java_spring", "java_struts2", "java_vertx", "java_wicket",
-    "js_adonisjs", "js_apollo", "js_astro", "js_elysia", "js_express", "js_fastify",
-    "js_fresh", "js_hapi", "js_hono", "js_koa", "js_nestjs", "js_nextjs",
-    "js_nitro", "js_nuxtjs", "js_remix", "js_restify", "js_sveltekit",
-    "kotlin_http4k", "kotlin_ktor", "kotlin_spring",
-    "lua_lapis", "lua_lor",
-    "perl_catalyst", "perl_dancer2", "perl_mojolicious",
-    "php_cakephp", "php_codeigniter", "php_hyperf", "php_laminas", "php_laravel", "php_lumen", "php_pure", "php_slim", "php_symfony", "php_thinkphp", "php_yii",
-    "python_aiohttp", "python_bottle", "python_django", "python_django_ninja", "python_falcon", "python_fastapi",
-    "python_flask", "python_litestar", "python_pyramid", "python_quart", "python_robyn", "python_sanic", "python_starlette", "python_tornado", "python_http_server",
-    "ruby_grape", "ruby_hanami", "ruby_rails", "ruby_roda", "ruby_sinatra", "ruby_webrick",
-    "rust_actix_web", "rust_axum", "rust_gotham", "rust_loco", "rust_poem",
-    "rust_rocket", "rust_rwf", "rust_salvo", "rust_tide", "rust_warp",
-    "scala_akka", "scala_http4s", "scala_play", "scala_scalatra", "scala_tapir", "scala_zio_http",
-    "swift_hummingbird", "swift_kitura", "swift_vapor",
-    "ts_nestjs", "ts_tanstack_router", "ts_trpc",
-    "zig_jetzig", "zig_zap", "zig_http", "zig_httpz", "zig_tokamak",
-    "r_plumber",
-  ]
-
-  AI_CONTEXT_GUARD_SUPPORTED_TECHS = [
-    "android", "ios",
-    "crystal_amber", "crystal_grip", "crystal_kemal", "crystal_lucky", "crystal_marten",
-    "cs_aspnet_core_mvc", "cs_aspnet_core_minimal_api", "cs_aspnet_mvc", "cs_carter", "cs_fastendpoints",
-    "elixir_bandit", "elixir_phoenix", "elixir_plug",
-    "go_beego", "go_chi", "go_echo", "go_fasthttp", "go_fiber", "go_gf", "go_gin", "go_http", "go_gozero", "go_goyave", "go_hertz", "go_iris", "go_mux", "go_restful",
-    "java_armeria", "java_jsp", "java_play", "java_spring", "java_vertx",
-    "js_express", "js_fastify", "js_hono", "js_koa", "js_nestjs", "js_nuxtjs", "js_restify",
-    "kotlin_ktor", "kotlin_spring",
-    "perl_catalyst", "perl_dancer2", "perl_mojolicious",
-    "php_cakephp", "php_codeigniter", "php_laminas", "php_laravel", "php_pure", "php_slim", "php_symfony", "php_thinkphp", "php_yii",
-    "python_django", "python_fastapi", "python_flask", "python_quart", "python_sanic", "python_tornado",
-    "ruby_grape", "ruby_hanami", "ruby_rails", "ruby_roda", "ruby_sinatra", "ruby_webrick",
-    "rust_actix_web", "rust_axum", "rust_gotham", "rust_loco", "rust_rocket", "rust_rwf", "rust_tide", "rust_warp",
-    "scala_akka", "scala_http4s", "scala_play", "scala_scalatra", "scala_tapir",
-    "swift_hummingbird", "swift_kitura", "swift_vapor",
-    "ts_nestjs",
-    "r_plumber",
-  ]
-
   TECHS = Catalog::ASP
     .merge(Catalog::ASPNET)
     .merge(Catalog::CFML)
@@ -87,6 +33,21 @@ module NoirTechs
     .merge(Catalog::SWIFT)
     .merge(Catalog::TYPESCRIPT)
     .merge(Catalog::ZIG)
+
+  # Derived from the per-tech :context flags in the catalog files, so a
+  # capability can only be declared on an entry that exists — the drift
+  # class the tech-registry integrity spec (#2384) exists to catch.
+  CALLEE_SUPPORTED_TECHS = TECHS.compact_map do |key, value|
+    context = value[:context]?
+    next unless context.is_a?(Hash)
+    key.to_s if context[:callee]?
+  end
+
+  AI_CONTEXT_GUARD_SUPPORTED_TECHS = TECHS.compact_map do |key, value|
+    context = value[:context]?
+    next unless context.is_a?(Hash)
+    key.to_s if context[:guards]?
+  end
 
   def self.techs
     TECHS


### PR DESCRIPTION
## What

`CALLEE_SUPPORTED_TECHS` and `AI_CONTEXT_GUARD_SUPPORTED_TECHS` were hand-maintained arrays living apart from the catalog — the same parallel-registry drift class #2384's integrity spec exists to catch: a tech could gain an analyzer but never be registered as callee-capable, and nothing would fail or even warn.

Each catalog entry now carries its own `:context => {:callee => true, :guards => true}` flags (150 entries), and the two lists are derived from `TECHS` in `techs.cr`, so a capability can only be declared on an entry that exists — the list and the catalog can no longer disagree.

## Proof

- Both derived lists are set-identical to the old hand arrays (sorted diff, no changes: 149 callee / 85 guards).
- `just dsup` docs generator output unchanged.
- Unit 4,619 + functional 22,647 examples, 0 failures; format + ameba clean.