### PR TITLE
refactor: consolidate the byte-identical join_paths copies

### DIFF
--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -1098,19 +1098,6 @@ module Analyzer::Swift
       ""
     end
 
-    private def join_paths(prefix : String, path : String) : String
-      return normalize_path(path) if prefix.empty? || prefix == "/"
-      return normalize_path(prefix) if path.empty? || path == "/"
-
-      "#{normalize_path(prefix).rstrip("/")}/#{path.lstrip("/")}"
-    end
-
-    private def normalize_path(path : String) : String
-      normalized = path.empty? ? "/" : path
-      normalized = "/#{normalized}" unless normalized.starts_with?("/")
-      normalized.gsub(%r{/+}, "/")
-    end
-
     private def strip_code_line(line : String) : String
       stripped, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, 0, false)
       stripped

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -389,19 +389,6 @@ module Analyzer::Swift
       ""
     end
 
-    private def join_paths(prefix : String, path : String) : String
-      return normalize_path(path) if prefix.empty? || prefix == "/"
-      return normalize_path(prefix) if path.empty? || path == "/"
-
-      "#{normalize_path(prefix).rstrip("/")}/#{path.lstrip("/")}"
-    end
-
-    private def normalize_path(path : String) : String
-      normalized = path.empty? ? "/" : path
-      normalized = "/#{normalized}" unless normalized.starts_with?("/")
-      normalized.gsub(%r{/+}, "/")
-    end
-
     private def code_line(line : String) : String
       # String-aware: only truncate at a `//` OUTSIDE a string literal, so a path
       # like "api//v2" or a "https://..." redirect arg isn't cut (which made

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -39,6 +39,23 @@ module Analyzer::Swift
       get_files_by_extension(".swift")
     end
 
+    # Route-path composition shared by the Vapor and Hummingbird
+    # analyzers (which carried byte-identical copies): prefix and path
+    # join with exactly one `/`, a bare or root side yields the other
+    # side normalized, and repeated slashes collapse.
+    protected def join_paths(prefix : String, path : String) : String
+      return normalize_path(path) if prefix.empty? || prefix == "/"
+      return normalize_path(prefix) if path.empty? || path == "/"
+
+      "#{normalize_path(prefix).rstrip("/")}/#{path.lstrip("/")}"
+    end
+
+    protected def normalize_path(path : String) : String
+      normalized = path.empty? ? "/" : path
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized.gsub(%r{/+}, "/")
+    end
+
     protected def scan_accepts?(path : String) : Bool
       # Swift Package Manager convention parks tests under
       # `Tests/<TargetName>Tests/`. Real route handlers never

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -1,3 +1,4 @@
+require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 require "./extraction_result_cache"
 require "../models/endpoint"
@@ -1291,30 +1292,10 @@ module Noir
       nil
     end
 
-    # Join a class prefix and a method path with exactly one `/`. Also
-    # handles the leading-slash ambiguity Spring is famously relaxed
-    # about: `@RequestMapping("items")` + `@GetMapping("{id}")` maps to
-    # `/items/{id}` even though neither segment has a leading slash.
-    #
-    # Empty method path (`@PostMapping` with no argument, or
-    # `@GetMapping("")`) collapses onto the class prefix — Spring absorbs
-    # the empty segment, so `@RequestMapping("/api")` + `@GetMapping`
-    # maps to `/api`, not `/api/` (see the empty-path branch below).
+    # Join a class prefix and a method path under Spring's
+    # mapping-composition rule — see `Noir::URLPath.join_absorbing`.
     private def join_paths(prefix : String, path : String) : String
-      return path if prefix.empty?
-      # A bare method mapping (`@GetMapping` / `@GetMapping("")`) on a
-      # class mapped to `/api/polls` resolves to `/api/polls` in Spring,
-      # NOT `/api/polls/` — the empty segment is absorbed into the class
-      # prefix. Mirror the jaxrs/quarkus/micronaut extractors and drop
-      # the trailing slash here; only a class prefix that is itself all
-      # slashes (`@RequestMapping("/")`) keeps the root `/`.
-      if path.empty?
-        trimmed = prefix.rstrip('/')
-        return trimmed.empty? ? "/" : trimmed
-      end
-      trimmed_prefix = prefix.rstrip('/')
-      trimmed_path = path.lstrip('/')
-      "#{trimmed_prefix}/#{trimmed_path}"
+      Noir::URLPath.join_absorbing(prefix, path)
     end
   end
 end

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -1,3 +1,4 @@
+require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 
 module Noir
@@ -1970,18 +1971,7 @@ module Noir
     # + `@GetMapping` (no path) maps to `/api`, not `/api/` (see the
     # empty-path branch below).
     private def join_paths(prefix : String, path : String) : String
-      return path if prefix.empty?
-      # A bare method mapping (`@GetMapping` with no path arg) on a class
-      # mapped to `/api/article` resolves to `/api/article` in Spring —
-      # the empty segment is absorbed, not turned into `/api/article/`.
-      # An explicit `@GetMapping("/")` still carries its own `/` segment
-      # and falls through to the last branch. Only an all-slash class
-      # prefix (`@RequestMapping("/")`) keeps the root `/`.
-      if path.empty?
-        trimmed = prefix.rstrip('/')
-        return trimmed.empty? ? "/" : trimmed
-      end
-      "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
+      Noir::URLPath.join_absorbing(prefix, path)
     end
   end
 end

--- a/src/utils/url_path.cr
+++ b/src/utils/url_path.cr
@@ -59,5 +59,26 @@ module Noir
       return prefix.rstrip('/') if suffix.empty?
       "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
+
+    # Spring's mapping-composition rule, shared by the Java and Kotlin
+    # tree-sitter route extractors (which carried byte-identical copies):
+    # a bare method mapping (`@GetMapping` with no path arg) on a class
+    # mapped to `/api/article` resolves to `/api/article` — the empty
+    # segment is absorbed, not turned into `/api/article/`. An explicit
+    # `@GetMapping("/")` still carries its own `/` segment and falls
+    # through to the seam join. Only an all-slash class prefix
+    # (`@RequestMapping("/")`) keeps the root `/`.
+    #
+    # Not `join_trimmed`: that keeps an empty-prefix suffix untouched but
+    # trims a trailing slash when the *suffix* is empty without the
+    # root-`/` restore this rule needs.
+    def self.join_absorbing(prefix : String, path : String) : String
+      return path if prefix.empty?
+      if path.empty?
+        trimmed = prefix.rstrip('/')
+        return trimmed.empty? ? "/" : trimmed
+      end
+      "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
+    end
   end
 end


### PR DESCRIPTION
## What

Round-3 backlog item (#2392 consolidated the first seven copies; this finishes the identical remainder):

- The Java and Kotlin tree-sitter route extractors carried the same Spring mapping-composition join (empty method path absorbed into the class prefix, root `/` preserved). It is now `Noir::URLPath.join_absorbing`, documented next to `join`/`join_trimmed` with the semantic differences spelled out; both extractors delegate.
- Vapor and Hummingbird carried byte-identical `join_paths` + `normalize_path` pairs; both now live on `SwiftEngine`.

The remaining `join_paths` definitions differ semantically per framework (gotham/loco root handling, warp passthrough, hanami/akka array forms, and the guard-free one-liners in the Go extractor and axum whose empty-side behavior differs from `join_trimmed`) and stay put deliberately.

## Proof

- A/B fixture sweep: main vs branch `--release` binaries over all 664 fixture dirs — normalized (method, url, params, tags) output identical, 5,158 endpoints, 0 failures.
- Unit 4,619 + functional 22,647 examples, 0 failures; format + ameba clean.