### PR TITLE
refactor(dart): consolidate the duplicated line/paren scanning helpers

### DIFF
--- a/spec/unit_test/analyzer/dart_helper_spec.cr
+++ b/spec/unit_test/analyzer/dart_helper_spec.cr
@@ -47,4 +47,38 @@ describe Analyzer::Dart::Helper do
       Analyzer::Dart::Helper.extract_string_literal("RouteRoot()").should be_nil
     end
   end
+
+  describe ".find_matching_paren" do
+    it "returns the index of the balancing paren" do
+      text = "get('/a', handler)"
+      Analyzer::Dart::Helper.find_matching_paren(text, 3).should eq(text.size - 1)
+    end
+
+    it "skips nested calls" do
+      text = "get(join('/a', '/b'), handler)"
+      Analyzer::Dart::Helper.find_matching_paren(text, 3).should eq(text.size - 1)
+    end
+
+    it "ignores parens inside string literals" do
+      # The `)` in the path literal must not close the call.
+      text = "get('/a)b', handler)"
+      Analyzer::Dart::Helper.find_matching_paren(text, 3).should eq(text.size - 1)
+    end
+
+    it "honours backslash escapes inside literals" do
+      # Dart source: get('it\'s )', h) — the escaped quote must not end the
+      # literal, so the `)` inside it must not close the call either.
+      text = "get('it\\'s )', h)"
+      Analyzer::Dart::Helper.find_matching_paren(text, 3).should eq(text.size - 1)
+    end
+
+    it "returns char indices on multi-byte sources" do
+      text = "get('한글', handler)"
+      Analyzer::Dart::Helper.find_matching_paren(text, 3).should eq(text.size - 1)
+    end
+
+    it "returns nil when the expression never balances" do
+      Analyzer::Dart::Helper.find_matching_paren("get('/a', handler", 3).should be_nil
+    end
+  end
 end

--- a/src/analyzer/analyzers/dart/alfred.cr
+++ b/src/analyzer/analyzers/dart/alfred.cr
@@ -148,7 +148,7 @@ module Analyzer::Dart
           base = prefixes[recv]?
           next unless base
           open_paren = (m.end(0) || 0) - 1
-          close_paren = find_matching_paren(cleaned, open_paren)
+          close_paren = Helper.find_matching_paren(cleaned, open_paren)
           next unless close_paren
           args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
           next if args.empty?
@@ -180,7 +180,7 @@ module Analyzer::Dart
         match_end = m.end(0)
         next unless match_end
         open_paren = match_end - 1
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
         handle_call(method, cleaned, open_paren, close_paren, prefix, content, path, include_callee, endpoints, seen)
       end
@@ -202,7 +202,7 @@ module Analyzer::Dart
         base = prefixes[rvar]?
         next unless base
         open_paren = (m.end(0) || 0) - 1
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
         args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
         next if args.empty?
@@ -261,7 +261,7 @@ module Analyzer::Dart
         break unless i < stmt_end && chars[i] == '('
 
         open_paren = i
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         break unless close_paren && close_paren <= stmt_end
 
         if relevant_method?(name)
@@ -302,7 +302,7 @@ module Analyzer::Dart
       return unless literal
 
       url = prefix.empty? ? normalize_path(literal) : normalize_path(alfred_compose(prefix, literal))
-      line = line_for_offset(content, open_paren)
+      line = line_number_for_index(content, open_paren)
 
       callees = [] of Noir::DartCalleeExtractor::Entry
       if include_callee
@@ -388,49 +388,6 @@ module Analyzer::Dart
     end
 
     # ---------- Source-string utilities ----------
-
-    # Char-based matching `)` for the `(` at `open_idx`, so the returned
-    # offset stays in CHAR space (consistent with `line_for_offset` and the
-    # `char_index_to_byte_index` conversions used for callee extraction).
-    private def find_matching_paren(text : String, open_idx : Int32) : Int32?
-      # `String#[]` re-walks from byte 0 on every call once the source
-      # contains any multi-byte char, turning this scan O(n^2); index a
-      # materialized Array(Char) instead (O(1) per access).
-      chars = text.chars
-      depth = 0
-      i = open_idx
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth += 1
-        when ')'
-          depth -= 1
-          return i if depth == 0
-        else
-          # ignore
-        end
-        i += 1
-      end
-
-      nil
-    end
 
     # Char index just past the end of the statement beginning at `start`:
     # the first `;` at bracket depth zero (or end of source). Used to bound
@@ -569,21 +526,6 @@ module Analyzer::Dart
       end
       result << chars[start..].join if start <= chars.size
       result
-    end
-
-    private def line_for_offset(content : String, offset : Int32) : Int32
-      return 1 if offset <= 0
-      limit = offset > content.size ? content.size : offset
-      count = 1
-      i = 0
-      # `each_char` walks the UTF-8 buffer once with a reader instead of
-      # re-scanning from byte 0 on every indexed `content[i]` access.
-      content.each_char do |c|
-        break if i >= limit
-        count += 1 if c == '\n'
-        i += 1
-      end
-      count
     end
   end
 end

--- a/src/analyzer/analyzers/dart/angel3.cr
+++ b/src/analyzer/analyzers/dart/angel3.cr
@@ -118,7 +118,7 @@ module Analyzer::Dart
         next if prefix.nil?
 
         open_paren = (m.end(0) || 0) - 1
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
 
         handle_call(method, cleaned, open_paren, close_paren, prefix, content, path, include_callee, endpoints, seen)
@@ -179,7 +179,7 @@ module Analyzer::Dart
         call = m.begin(0)
         open_paren = (m.end(0) || 0) - 1
         next unless call
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
         args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
         next if args.size < 2
@@ -261,7 +261,7 @@ module Analyzer::Dart
       return unless literal
 
       url = join_path(prefix, normalize_path(literal))
-      line = line_for_offset(content, open_paren)
+      line = line_number_for_index(content, open_paren)
 
       callees = [] of Noir::DartCalleeExtractor::Entry
       if include_callee
@@ -330,46 +330,6 @@ module Analyzer::Dart
     end
 
     # ---------- source-string utilities ----------
-
-    private def find_matching_paren(text : String, open_idx : Int32) : Int32?
-      # `String#[]` re-walks from byte 0 on every call once the source
-      # contains any multi-byte char, turning this scan O(n^2); index a
-      # materialized Array(Char) instead (O(1) per access).
-      chars = text.chars
-      depth = 0
-      i = open_idx
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth += 1
-        when ')'
-          depth -= 1
-          return i if depth == 0
-        else
-          # ignore
-        end
-        i += 1
-      end
-
-      nil
-    end
 
     private def first_top_level_comma(text : String, start : Int32, limit : Int32) : Int32?
       chars = text.chars
@@ -465,21 +425,6 @@ module Analyzer::Dart
       end
       result << chars[start..].join if start <= chars.size
       result
-    end
-
-    private def line_for_offset(content : String, offset : Int32) : Int32
-      return 1 if offset <= 0
-      limit = offset > content.size ? content.size : offset
-      count = 1
-      i = 0
-      # `each_char` walks the UTF-8 buffer once with a reader instead of
-      # re-scanning from byte 0 on every indexed `content[i]` access.
-      content.each_char do |c|
-        break if i >= limit
-        count += 1 if c == '\n'
-        i += 1
-      end
-      count
     end
   end
 end

--- a/src/analyzer/analyzers/dart/dart_helper.cr
+++ b/src/analyzer/analyzers/dart/dart_helper.cr
@@ -113,6 +113,55 @@ module Analyzer::Dart
       nil
     end
 
+    # Index of the `)` closing the `(` at `open_idx`, or nil when the
+    # expression never balances. String literals are skipped so a paren
+    # inside `'a)b'` doesn't close the call, and backslash escapes inside
+    # them are honoured.
+    #
+    # Both the argument and the result stay in CHAR space, consistent with
+    # `Regex::MatchData#begin`, `Analyzer#line_number_for_index` and the
+    # `char_index_to_byte_index` conversions the analyzers use for callee
+    # extraction.
+    def find_matching_paren(text : String, open_idx : Int32) : Int32?
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = text.chars
+      depth = 0
+      i = open_idx
+      in_string = false
+      string_quote = '\0'
+
+      while i < chars.size
+        c = chars[i]
+        if in_string
+          if c == '\\' && i + 1 < chars.size
+            i += 2
+            next
+          end
+          in_string = false if c == string_quote
+          i += 1
+          next
+        end
+
+        case c
+        when '"', '\''
+          in_string = true
+          string_quote = c
+        when '('
+          depth += 1
+        when ')'
+          depth -= 1
+          return i if depth == 0
+        else
+          # ignore
+        end
+        i += 1
+      end
+
+      nil
+    end
+
     private def relative_for_match(path : String, base_path : String?) : String
       Noir::PathScope.relative_under(path, base_path)
     end

--- a/src/analyzer/analyzers/dart/get_server.cr
+++ b/src/analyzer/analyzers/dart/get_server.cr
@@ -152,14 +152,14 @@ module Analyzer::Dart
         match_begin = m.begin(0)
         open_paren = m.end(0).try &.- 1
         next unless match_begin && open_paren
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
 
         args = named_args(cleaned[(open_paren + 1)...close_paren])
         name_arg = args["name"]?
         next unless name_arg
 
-        line = line_for_offset(content, match_begin)
+        line = line_number_for_index(content, match_begin)
         pages << {
           name_arg:   name_arg,
           method_arg: args["method"]?,
@@ -307,43 +307,6 @@ module Analyzer::Dart
       nil
     end
 
-    private def find_matching_paren(text : String, open_idx : Int32) : Int32?
-      chars = text.chars
-      depth = 0
-      i = open_idx
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth += 1
-        when ')'
-          depth -= 1
-          return i if depth == 0
-        else
-          # ignore
-        end
-        i += 1
-      end
-
-      nil
-    end
-
     private def split_top_level_args(text : String) : Array(String)
       result = [] of String
       chars = text.chars
@@ -400,21 +363,6 @@ module Analyzer::Dart
       end
       result << chars[start..].join if start <= chars.size
       result
-    end
-
-    private def line_for_offset(content : String, offset : Int32) : Int32
-      return 1 if offset <= 0
-      limit = offset > content.size ? content.size : offset
-      count = 1
-      i = 0
-      # `each_char` walks the UTF-8 buffer once with a reader instead of
-      # re-scanning from byte 0 on every indexed `content[i]` access.
-      content.each_char do |c|
-        break if i >= limit
-        count += 1 if c == '\n'
-        i += 1
-      end
-      count
     end
   end
 end

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -82,7 +82,7 @@ module Analyzer::Dart
         next unless body_info
         body, body_start = body_info
 
-        line = line_for_offset(content, match_start)
+        line = line_number_for_index(content, match_start)
         methods = web_route_methods(body)
         callees = include_callee ? web_handler_callees(path, body, body_start, content) : [] of Noir::DartCalleeExtractor::Entry
         route_classes[{base_path, class_name}] = {methods: methods, file: path, line: line, callees: callees}
@@ -90,7 +90,7 @@ module Analyzer::Dart
 
       cleaned.scan(/\baddRoute\s*\(/) do |match|
         open_paren = (match.end(0) || 0) - 1
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
         args = split_top_level_commas(cleaned[(open_paren + 1)...close_paren])
         next if args.size < 2
@@ -137,19 +137,19 @@ module Analyzer::Dart
       m = class_body.match(/\b(?:handleCall|build)\s*\(/)
       return [] of Noir::DartCalleeExtractor::Entry unless m
       open_paren = (m.end(0) || 0) - 1
-      close_paren = find_matching_paren(class_body, open_paren)
+      close_paren = Helper.find_matching_paren(class_body, open_paren)
       return [] of Noir::DartCalleeExtractor::Entry unless close_paren
 
-      # close_paren is a CHAR index (find_matching_paren is char-based); the
+      # close_paren is a CHAR index (Helper.find_matching_paren is char-based); the
       # extractor scans/returns BYTE offsets. Convert at the boundary so the
-      # body slice is correct and line_for_offset (char-based) gets char offsets.
+      # body slice is correct and line_number_for_index (char-based) gets char offsets.
       start_byte = class_body.char_index_to_byte_index(close_paren + 1)
       return [] of Noir::DartCalleeExtractor::Entry unless start_byte
       body_info = Noir::DartCalleeExtractor.extract_body_after(class_body, start_byte)
       return [] of Noir::DartCalleeExtractor::Entry unless body_info
       body, body_start, _ = body_info
       body_start_char = class_body.byte_index_to_char_index(body_start) || 0
-      start_line = line_for_offset(file_content, class_body_start + body_start_char)
+      start_line = line_number_for_index(file_content, class_body_start + body_start_char)
       Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
     end
 
@@ -180,7 +180,7 @@ module Analyzer::Dart
         next unless body_info
 
         body, body_start = body_info
-        line_number = line_for_offset(content, match_start)
+        line_number = line_number_for_index(content, match_start)
         endpoint_name = endpoint_name_for(class_name)
         process_class_body(path, endpoint_name, body, body_start, content, line_number, include_callee)
       end
@@ -245,11 +245,11 @@ module Analyzer::Dart
           if rest.match(/\A\s*Session\s+[A-Za-z_][A-Za-z0-9_]*/)
             method_name = method_name_before(body, i)
             if method_name && !method_name.empty? && !method_name.starts_with?("_")
-              close_paren = find_matching_paren(body, i)
+              close_paren = Helper.find_matching_paren(body, i)
               if close_paren
                 params_text = body[(i + 1)...close_paren]
                 params = parse_method_params(params_text)
-                line = line_for_offset(file_content, body_start + i)
+                line = line_number_for_index(file_content, body_start + i)
                 line = fallback_line if line <= 0
                 callees = include_callee ? callees_for_method_body(path, body, body_start, close_paren, file_content) : [] of Noir::DartCalleeExtractor::Entry
                 emit_endpoint(path, endpoint_name, method_name, params, line, callees)
@@ -379,48 +379,8 @@ module Analyzer::Dart
 
       body, body_start, _ = body_info
       body_start_char = class_body.byte_index_to_char_index(body_start) || 0
-      start_line = line_for_offset(file_content, class_body_start + body_start_char)
+      start_line = line_number_for_index(file_content, class_body_start + body_start_char)
       Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
-    end
-
-    private def find_matching_paren(text : String, open_idx : Int32) : Int32?
-      # `String#[]` re-walks from byte 0 on every call once the source
-      # contains any multi-byte char, turning this scan O(n^2); index a
-      # materialized Array(Char) instead (O(1) per access).
-      chars = text.chars
-      depth = 0
-      i = open_idx
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth += 1
-        when ')'
-          depth -= 1
-          return i if depth == 0
-        else
-          # ignore
-        end
-        i += 1
-      end
-
-      nil
     end
 
     private def extract_braced_block(text : String, start : Int32) : Tuple(String, Int32)?
@@ -538,21 +498,6 @@ module Analyzer::Dart
       end
 
       result.to_s
-    end
-
-    private def line_for_offset(content : String, offset : Int32) : Int32
-      return 1 if offset <= 0
-      limit = offset > content.size ? content.size : offset
-      count = 1
-      i = 0
-      # `each_char` walks the UTF-8 buffer once with a reader instead of
-      # re-scanning from byte 0 on every indexed `content[i]` access.
-      content.each_char do |c|
-        break if i >= limit
-        count += 1 if c == '\n'
-        i += 1
-      end
-      count
     end
   end
 end

--- a/src/analyzer/analyzers/dart/shelf.cr
+++ b/src/analyzer/analyzers/dart/shelf.cr
@@ -197,7 +197,7 @@ module Analyzer::Dart
         match_begin = m.begin(0)
         open_paren = m.end(0).try &.- 1
         next unless match_begin && open_paren
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
 
         args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
@@ -213,7 +213,7 @@ module Analyzer::Dart
         prefix = owner ? prefixes[owner]? : nil
         route_path = normalize_path(prefix ? join_path(prefix, normalize_path(literal)) : literal)
 
-        line = line_for_offset(content, match_begin)
+        line = line_number_for_index(content, match_begin)
         callees = include_callee ? annotation_callees(content, close_paren, path) : [] of Noir::DartCalleeExtractor::Entry
 
         key = owner || "@route:#{path}"
@@ -234,7 +234,7 @@ module Analyzer::Dart
         match_begin = m.begin(0)
         open_paren = m.end(0).try &.- 1
         next unless match_begin && open_paren
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
         args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
         next if args.empty?
@@ -368,7 +368,7 @@ module Analyzer::Dart
             j += 1
           end
           if j < chars.size && chars[j] == '(' && relevant_method?(name)
-            close_paren = find_matching_paren(cleaned, j)
+            close_paren = Helper.find_matching_paren(cleaned, j)
             if close_paren && close_paren < end_idx
               handle_call(name, cleaned, j, close_paren, file_content, path, include_callee, routes, mounts)
               i = close_paren + 1
@@ -394,7 +394,7 @@ module Analyzer::Dart
         match_end = m.end(0)
         next unless match_end
         open_paren = match_end - 1
-        close_paren = find_matching_paren(cleaned, open_paren)
+        close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
         handle_call(method, cleaned, open_paren, close_paren, file_content, path, include_callee, routes, mounts)
       end
@@ -421,7 +421,7 @@ module Analyzer::Dart
       literal = extract_string_literal(args[0])
       return unless literal
 
-      line = line_for_offset(file_content, open_paren)
+      line = line_number_for_index(file_content, open_paren)
 
       case method
       when "mount"
@@ -623,43 +623,6 @@ module Analyzer::Dart
       chars.size
     end
 
-    private def find_matching_paren(text : String, open_idx : Int32) : Int32?
-      chars = text.chars
-      depth = 0
-      i = open_idx
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth += 1
-        when ')'
-          depth -= 1
-          return i if depth == 0
-        else
-          # ignore
-        end
-        i += 1
-      end
-
-      nil
-    end
-
     private def split_top_level_args(text : String) : Array(String)
       result = [] of String
       chars = text.chars
@@ -786,21 +749,6 @@ module Analyzer::Dart
       end
 
       result.to_s
-    end
-
-    private def line_for_offset(content : String, offset : Int32) : Int32
-      return 1 if offset <= 0
-      limit = offset > content.size ? content.size : offset
-      count = 1
-      i = 0
-      # `each_char` walks the UTF-8 buffer once with a reader instead of
-      # re-scanning from byte 0 on every indexed `content[i]` access.
-      content.each_char do |c|
-        break if i >= limit
-        count += 1 if c == '\n'
-        i += 1
-      end
-      count
     end
   end
 end


### PR DESCRIPTION
Closes #2443.

## What

**`find_matching_paren`** — five copies across alfred/angel3/get_server/serverpod/shelf, identical apart from a perf comment two of them were missing. One copy now lives in `Analyzer::Dart::Helper` (which the five analyzers already require and call into for `test_path?`/`strip_comments`/`extract_string_literal`), and the fourteen call sites route through it. The CHAR-space contract that only alfred documented is preserved on the helper.

**`line_for_offset`** — as noted [in the issue thread](https://github.com/owasp-noir/noir/issues/2443#issuecomment-5218991439), this one needed no new home: its five byte-identical copies duplicate `Analyzer#line_number_for_index` (`src/models/analyzer.cr:298`), which every Dart analyzer already inherits. Both are 1-based and count the newlines preceding a **char** offset. So the copies are deleted and their ten call sites renamed, rather than moved into the helper — one less thing for the next Dart analyzer to copy.

Net −298/+74 lines.

## Proof

Because this moves line-number computation, the usual method/url/params sweep is not sufficient on its own:

- **Differential over the two line implementations** — 140 cases (multi-byte sources, trailing/consecutive newlines, offsets past end, negative offsets): zero disagreements.
- **A/B fixture sweep including line numbers** — main vs branch `--release`, all 664 fixture dirs scanned with `--include-callee`, normalized on method/url/params/tags **plus `details.code_paths[].{path,line}` and `callees[].{name,path,line}`**: byte-identical (5,461 code_path lines compared), 0 scan failures.
- Unit 4,625 (six new `find_matching_paren` examples) + functional 22,647 examples, 0 failures; format + ameba clean.

## Note for #2444

The sibling Clojure issue is **not** the same shape: its `line_number_for` is `source.byte_slice(0, index)`, i.e. byte-indexed, so it is not interchangeable with the char-indexed base helper. That one wants the helper module exactly as the issue describes, and is left for a first-time contributor.