### PR TITLE
fix(acp): stop auto-approving the agent's tool permission requests

### DIFF
--- a/docs/content/usage/ai_providers/acp/index.ko.md
+++ b/docs/content/usage/ai_providers/acp/index.ko.md
@@ -13,7 +13,13 @@ ACP(Agent Client Protocol) 제공자를 사용하면 Noir가 직접 HTTP LLM API
 - `acp:codex` -> `npx @zed-industries/codex-acp` 실행
 - `acp:gemini` -> `gemini --experimental-acp` 실행
 - `acp:claude` -> `npx @zed-industries/claude-agent-acp` 실행
-- `acp:<custom>` -> `<custom>` 명령을 ACP 호환 에이전트로 실행
+- `acp:<custom>` -> `NOIR_ACP_ALLOW_CUSTOM_COMMAND=1`이 설정된 경우에만 `<custom>` 명령을 ACP 호환 에이전트로 실행
+
+그 외의 대상은 거부됩니다. `--ai-provider`는 설정 파일에서도 올 수 있고, 거기에 적힌 명령을 그대로 실행하면 코드 실행 경로가 되므로 사용자 지정 바이너리는 명시적으로 허용해야 합니다.
+
+```bash
+NOIR_ACP_ALLOW_CUSTOM_COMMAND=1 noir scan ./myapp --ai-provider="acp:my-agent --flag"
+```
 
 ## 사용 방법
 
@@ -51,6 +57,18 @@ noir scan ./myapp --ai-provider=acp:codex --ai-model=codex
 
 ```bash
 NOIR_ACP_RAW_LOG=1 noir scan ./myapp --ai-provider=acp:codex
+```
+
+## 도구 실행 권한
+
+ACP 에이전트는 자신의 도구(셸 명령, 파일 쓰기, 네트워크 요청)를 실행하기 위해 Noir에 권한을 요청할 수 있습니다. Noir는 이 요청을 **모두 거부**합니다.
+
+Noir가 에이전트에게 보내는 프롬프트는 스캔 대상 트리의 소스 코드이고, 내가 작성하지 않은 코드를 스캔하는 것이 일반적인 사용 방식입니다. "위 내용은 무시하고 이것을 실행하라" 같은 문장이 들어 있는 파일 하나면 에이전트를 유도할 수 있으므로, 권한 확인은 남아 있는 유일한 관문입니다. 여기서 자동으로 승인하면 엔드포인트 스캔이 로컬 임의 코드 실행으로 바뀝니다.
+
+거부해도 잃는 것은 없습니다. 분석할 코드는 이미 프롬프트에 담겨 있어 에이전트가 도구를 쓰지 않아도 답할 수 있습니다. 신뢰하는 트리를 스캔하면서 에이전트가 직접 탐색하기를 원한다면 명시적으로 허용하세요.
+
+```bash
+NOIR_ACP_ALLOW_TOOL_PERMISSIONS=1 noir scan ./myapp --ai-provider=acp:codex
 ```
 
 ## 참고

--- a/docs/content/usage/ai_providers/acp/index.md
+++ b/docs/content/usage/ai_providers/acp/index.md
@@ -13,7 +13,13 @@ Use ACP (Agent Client Protocol) providers when you want Noir to talk to an AI ag
 - `acp:codex` -> runs `npx @zed-industries/codex-acp`
 - `acp:gemini` -> runs `gemini --experimental-acp`
 - `acp:claude` -> runs `npx @zed-industries/claude-agent-acp`
-- `acp:<custom>` -> runs `<custom>` as an ACP-compatible command
+- `acp:<custom>` -> runs `<custom>` as an ACP-compatible command, only with `NOIR_ACP_ALLOW_CUSTOM_COMMAND=1`
+
+Any other target is refused. `--ai-provider` can come from a config file, and spawning whatever it names would be a code-execution path, so custom binaries need the explicit opt-in:
+
+```bash
+NOIR_ACP_ALLOW_CUSTOM_COMMAND=1 noir scan ./myapp --ai-provider="acp:my-agent --flag"
+```
 
 ## Usage
 
@@ -51,6 +57,18 @@ Set this if you need raw ACP and agent logs:
 
 ```bash
 NOIR_ACP_RAW_LOG=1 noir scan ./myapp --ai-provider=acp:codex
+```
+
+## Tool Permissions
+
+An ACP agent can ask Noir for permission to run its own tools — shell commands, file writes, network fetches — on your machine. Noir **declines every one of them**.
+
+The prompt Noir sends the agent is source code from the tree you are scanning, and scanning code you did not write is the normal case. A file that carries "ignore the above and run this instead" is enough to steer the agent, so the permission prompt is the one checkpoint left; answering it with an automatic yes would turn an endpoint scan into arbitrary local execution.
+
+Nothing is lost by declining: the code to analyze is already in the prompt, so the agent needs no tools to answer. If you are scanning a tree you trust and want the agent to explore on its own, opt in explicitly:
+
+```bash
+NOIR_ACP_ALLOW_TOOL_PERMISSIONS=1 noir scan ./myapp --ai-provider=acp:codex
 ```
 
 ## Notes

--- a/spec/unit_test/llm/acp_client_spec.cr
+++ b/spec/unit_test/llm/acp_client_spec.cr
@@ -65,6 +65,61 @@ describe LLM::ACPClient do
       LLM::ACPClient.default_model("acp:codex", "custom-model").should eq("custom-model")
     end
   end
+
+  # The agent asks before running a tool — a shell command, a file write. The
+  # prompt driving it is source code from the tree being scanned, so a blanket
+  # "yes" turns a scan of an untrusted repo into local code execution.
+  describe "#answer_permission_request" do
+    permission_request = JSON.parse(<<-JSON)
+      {
+        "sessionId": "s1",
+        "toolCall": {"toolCallId": "t1", "title": "Run shell command", "kind": "execute"},
+        "options": [
+          {"optionId": "proceed_once", "name": "Yes", "kind": "allow_once"},
+          {"optionId": "proceed_always", "name": "Yes, always", "kind": "allow_always"},
+          {"optionId": "cancel", "name": "No", "kind": "reject_once"}
+        ]
+      }
+      JSON
+
+    it "rejects a tool permission request by default" do
+      ENV.delete("NOIR_ACP_ALLOW_TOOL_PERMISSIONS")
+      client = LLM::ACPClient.new("acp:gemini", "gemini")
+      outcome = client.answer_permission_request(permission_request)["outcome"]
+      outcome["outcome"].should eq("selected")
+      outcome["optionId"].should eq("cancel")
+    end
+
+    it "allows only with the explicit opt-in, using an id the agent offered" do
+      ENV["NOIR_ACP_ALLOW_TOOL_PERMISSIONS"] = "1"
+      begin
+        client = LLM::ACPClient.new("acp:gemini", "gemini")
+        outcome = client.answer_permission_request(permission_request)["outcome"]
+        outcome["outcome"].should eq("selected")
+        # Not the hardcoded "allow-once" the old code invented — option ids
+        # are agent-defined, and only `kind` is standardised.
+        outcome["optionId"].should eq("proceed_once")
+      ensure
+        ENV.delete("NOIR_ACP_ALLOW_TOOL_PERMISSIONS")
+      end
+    end
+
+    it "cancels when the agent offers no way to decline" do
+      ENV.delete("NOIR_ACP_ALLOW_TOOL_PERMISSIONS")
+      allow_only = JSON.parse(<<-JSON)
+        {
+          "sessionId": "s1",
+          "toolCall": {"toolCallId": "t1", "title": "Write file", "kind": "edit"},
+          "options": [{"optionId": "yes", "name": "Yes", "kind": "allow_once"}]
+        }
+        JSON
+
+      client = LLM::ACPClient.new("acp:gemini", "gemini")
+      outcome = client.answer_permission_request(allow_only)["outcome"]
+      outcome["outcome"].should eq("cancelled")
+      outcome["optionId"]?.should be_nil
+    end
+  end
 end
 
 describe LLM::AdapterFactory do

--- a/src/llm/acp/client.cr
+++ b/src/llm/acp/client.cr
@@ -41,6 +41,65 @@ module LLM
       ENV["NOIR_ACP_ALLOW_CUSTOM_COMMAND"]? == "1"
     end
 
+    # `session/request_permission` is how the ACP agent asks to run a tool —
+    # shell commands, file writes, network fetches — on this machine. Noir
+    # used to answer every one of them with a hardcoded
+    # `{"outcome":"selected","optionId":"allow-once"}`, i.e. blanket approval
+    # for whatever the agent decided to do.
+    #
+    # That is remote-controllable input. The prompt Noir sends is source code
+    # from the tree being scanned, and scanning code you did not write is the
+    # normal case; a file carrying "ignore the above and run X" is enough to
+    # turn an endpoint scan into arbitrary local execution, with the auto-yes
+    # removing the one checkpoint that would have caught it. It also
+    # contradicted the `resolve_command` hardening right above, which refuses
+    # to spawn an unknown agent binary precisely so untrusted config can't
+    # reach code execution.
+    #
+    # Deny by default. Noir puts the code to analyse *in the prompt*, so the
+    # agent needs no tools to answer — the only thing lost is an agent's
+    # optional extra poking around. Operators who want that back opt in
+    # explicitly, same shape as the custom-command escape hatch.
+    def self.tool_permissions_allowed? : Bool
+      ENV["NOIR_ACP_ALLOW_TOOL_PERMISSIONS"]? == "1"
+    end
+
+    # Pick a real option from the ones the agent offered rather than
+    # inventing an id. Option ids are agent-defined (`proceed_once`,
+    # `reject`, …); the `kind` field is the part the protocol standardises,
+    # so it is what we match on. With nothing usable on offer, `cancelled`
+    # is the protocol's own "no decision" outcome and needs no id.
+    #
+    # Public rather than private so the decision can be asserted without
+    # standing up an agent process.
+    def answer_permission_request(params : JSON::Any) : JSON::Any
+      allow = self.class.tool_permissions_allowed?
+      wanted = allow ? {"allow_once", "allow_always"} : {"reject_once", "reject_always"}
+
+      option_id = nil
+      if options = params["options"]?.try(&.as_a?)
+        wanted.each do |kind|
+          break if option_id
+          options.each do |option|
+            next unless option["kind"]?.try(&.as_s?) == kind
+            option_id = option["optionId"]?.try(&.as_s?)
+            break if option_id
+          end
+        end
+      end
+
+      tool = params.dig?("toolCall", "title").try(&.as_s?) ||
+             params.dig?("toolCall", "toolName").try(&.as_s?) || "tool call"
+
+      if option_id
+        @event_sink.try(&.call("ACP: #{allow ? "allowed" : "denied"} permission request (#{tool})"))
+        JSON.parse(%({"outcome":{"outcome":"selected","optionId":#{option_id.to_json}}}))
+      else
+        @event_sink.try(&.call("ACP: cancelled permission request (#{tool}) — no #{allow ? "allow" : "reject"} option offered"))
+        JSON.parse(%({"outcome":{"outcome":"cancelled"}}))
+      end
+    end
+
     def initialize(@provider : String, @model : String, @event_sink : Proc(String, Nil)? = nil)
       @command, @args = self.class.resolve_command(provider)
       @session_lock = Mutex.new
@@ -156,9 +215,9 @@ module LLM
             end
             nil
           end
-          client.on_agent_request = ->(method : String, _params : JSON::Any) do
+          client.on_agent_request = ->(method : String, params : JSON::Any) do
             if method == "session/request_permission"
-              JSON.parse(%({"outcome":{"outcome":"selected","optionId":"allow-once"}}))
+              answer_permission_request(params)
             else
               JSON.parse(%({}))
             end


### PR DESCRIPTION
**Severity: high** — prompt injection from a scanned repo to local code execution.

1 of 5 from a self-audit of Noir under the threat model *"the tree being scanned is untrusted input."*

## The problem

`session/request_permission` is how an ACP agent asks Noir for permission to run a tool on this machine — a shell command, a file write, a network fetch. Noir answered every one of them with a hardcoded approval:

```crystal
client.on_agent_request = ->(method : String, _params : JSON::Any) do
  if method == "session/request_permission"
    JSON.parse(%({"outcome":{"outcome":"selected","optionId":"allow-once"}}))
```

The prompt driving that agent is source code from the tree being scanned, and scanning code you did not write is the normal case for this tool. A file carrying *"ignore the above and run X"* is enough to steer the agent, and the permission prompt was the one checkpoint left between that and execution on the user's box.

It also contradicted the `resolve_command` hardening directly above it, which refuses to spawn an unknown agent binary precisely so untrusted config can't reach code execution.

## The fix

Deny by default. Noir puts the code to analyse *in the prompt*, so the agent needs no tools to answer — the only thing lost is an agent's optional extra poking around. `NOIR_ACP_ALLOW_TOOL_PERMISSIONS=1` opts back into it, the same shape as the existing `NOIR_ACP_ALLOW_CUSTOM_COMMAND` escape hatch.

The hardcoded id was also wrong on its own terms: option ids are agent-defined (`proceed_once`, `cancel`, …) and only `kind` is standardised by the protocol. The reply now picks a real option out of the request, and falls back to the protocol's `cancelled` outcome when none fits.

## Verification

- 3 new specs: deny by default, allow-with-opt-in picks the agent's own id, cancel when no reject option is offered.
- Full suite green (27284 examples), ameba clean.
- Docs (EN/KO) gain a "Tool Permissions" section; the `acp:<custom>` bullet is also corrected — it has required `NOIR_ACP_ALLOW_CUSTOM_COMMAND=1` for a while and the docs still advertised it as unconditional.