### PR TITLE
fix(ai): confine the AI agent's file tools to the scan base past symlinks

### DIFF
--- a/spec/unit_test/analyzer/analyzers/llm_analyzers/general_spec.cr
+++ b/spec/unit_test/analyzer/analyzers/llm_analyzers/general_spec.cr
@@ -1,5 +1,6 @@
 require "../../../../spec_helper"
 require "../../../../../src/analyzer/analyzers/llm_analyzers/unified_ai"
+require "file_utils"
 
 module LLM
   # Mocking get_max_tokens for testing purposes
@@ -71,6 +72,56 @@ describe Analyzer::AI::Unified do
       }
       analyzer = Analyzer::AI::Unified.new(options)
       analyzer.max_tokens.should eq(1024)
+    end
+  end
+
+  # The agent's file tools (read_file, list_directory, grep) take paths the
+  # LLM picked, and the LLM is steered by the source tree being scanned.
+  # Anything that escapes the scan base gets read and shipped to the provider.
+  describe "#path_within_base?" do
+    it "confines agent file tools to the scan base, symlinks included" do
+      root = File.tempname("noir-agent-base")
+      outside = File.tempname("noir-agent-outside")
+      begin
+        Dir.mkdir_p(File.join(root, "src", "nested"))
+        Dir.mkdir_p(outside)
+        File.write(File.join(root, "src", "app.rb"), "get '/' do; end\n")
+        File.write(File.join(outside, "id_rsa"), "PRIVATE KEY\n")
+
+        # What a hostile checkout can plant: a link to a file, and a link to
+        # a whole directory, both sitting innocently inside the repo.
+        File.symlink(File.join(outside, "id_rsa"), File.join(root, "src", "notes.rb"))
+        File.symlink(outside, File.join(root, "vendor"))
+
+        options = Hash{
+          "url"         => YAML::Any.new(""),
+          "debug"       => YAML::Any.new(false),
+          "verbose"     => YAML::Any.new(false),
+          "color"       => YAML::Any.new(false),
+          "nolog"       => YAML::Any.new(false),
+          "ai_provider" => YAML::Any.new("http://localhost:8000"),
+          "ai_model"    => YAML::Any.new("test-model"),
+          "ai_key"      => YAML::Any.new(""),
+          "base"        => YAML::Any.new([YAML::Any.new(root)]),
+        }
+        analyzer = Analyzer::AI::Unified.new(options)
+
+        analyzer.path_within_base?(File.join(root, "src", "app.rb")).should be_true
+        analyzer.path_within_base?(File.join(root, "src", "nested")).should be_true
+        analyzer.path_within_base?(root).should be_true
+
+        # Lexical escape.
+        analyzer.path_within_base?(File.join(root, "..", "etc", "passwd")).should be_false
+        analyzer.path_within_base?(File.join(outside, "id_rsa")).should be_false
+        # Symlinked file: passes a purely lexical prefix check, must not pass.
+        analyzer.path_within_base?(File.join(root, "src", "notes.rb")).should be_false
+        # Symlinked directory, and a path reached through one.
+        analyzer.path_within_base?(File.join(root, "vendor")).should be_false
+        analyzer.path_within_base?(File.join(root, "vendor", "id_rsa")).should be_false
+      ensure
+        FileUtils.rm_rf(root)
+        FileUtils.rm_rf(outside)
+      end
     end
   end
 end

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -52,11 +52,13 @@ module Analyzer::AI
     @api_key : String?
     @max_tokens : Int32
     @expanded_base_paths : Array(String)
+    @real_base_paths : Array(String)
     @use_agentic : Bool
     @agent_max_steps : Int32
     @native_tool_calling_allowlist : Array(String)?
     @agent_tool_cache : Hash(String, String)
     @agent_tool_cache_order : Array(String)
+    @symlinked_dir_cache = {} of String => Bool
 
     def initialize(options : Hash(String, YAML::Any))
       super(options)
@@ -88,6 +90,10 @@ module Analyzer::AI
       @expanded_base_paths.uniq!
       @expanded_base_paths.sort_by!(&.size)
       @expanded_base_paths.reverse!
+      # Symlink-resolved twins of the bases, for the containment check in
+      # `path_within_base?`. Resolved once here: `realpath` hits the
+      # filesystem, and the agent runs the check on every tool call.
+      @real_base_paths = @expanded_base_paths.map { |path| resolved_real_path(path) || path }.uniq!
       @use_agentic = options["ai_agent"]?.try { |val| any_to_bool(val) } || false
       @agent_max_steps = options["ai_agent_max_steps"]?.try(&.as_i) || 20
       @native_tool_calling_allowlist = parse_native_tool_allowlist(options["ai_native_tools_allowlist"]?.try(&.as_s))
@@ -762,11 +768,65 @@ module Analyzer::AI
       resolve_agent_roots(path).first?
     end
 
-    private def path_within_base?(path : String) : Bool
+    # Containment gate for every agent file tool. The agent picks these
+    # paths from LLM output, and the LLM is steered by the source tree being
+    # scanned, so "stay inside the scan base" is a boundary an untrusted repo
+    # gets to push on.
+    #
+    # `File.expand_path` is purely lexical — it folds `..` and makes the path
+    # absolute but never follows a link. A checked-out repo containing
+    # `notes -> /home/user/.ssh/id_rsa` therefore passed as an in-base path,
+    # and `read_file` shipped the target's contents to the LLM provider.
+    # (The tree walk, the grep and the bundling path all skip symlinks
+    # already; these two entry points were the gap.)
+    #
+    # So resolve both sides and require containment of the *real* path. A
+    # base that is itself reached through a link (`/tmp` -> `/private/tmp` on
+    # macOS) still matches, because `@real_base_paths` went through the same
+    # resolution. The lexical check stays as the first gate: it rejects the
+    # plain `../../etc/passwd` case without touching the filesystem.
+    #
+    # Public rather than private so the rule can be asserted directly:
+    # reaching it through a live LLM round trip is not a test.
+    def path_within_base?(path : String) : Bool
       expanded = File.expand_path(path)
-      @expanded_base_paths.any? do |base|
-        expanded == base || expanded.starts_with?(base == File::SEPARATOR ? base : "#{base}/")
+      return false unless contained_in?(expanded, @expanded_base_paths)
+      return true unless File.symlink?(expanded) || symlinked_ancestor?(expanded)
+
+      real = resolved_real_path(expanded)
+      return false if real.nil?
+      contained_in?(real, @real_base_paths)
+    end
+
+    private def contained_in?(path : String, bases : Array(String)) : Bool
+      bases.any? do |base|
+        path == base || path.starts_with?(base == File::SEPARATOR ? base : "#{base}/")
       end
+    end
+
+    # Only the part of the path below the base can be a planted link, so the
+    # walk stops at the base rather than at `/` — that keeps the stat count
+    # proportional to the repo-relative depth and leaves a symlinked base
+    # (already accounted for in `@real_base_paths`) out of it. Per-directory
+    # answers are memoized because grep runs this once per candidate file and
+    # the ancestors repeat for every file in a directory.
+    private def symlinked_ancestor?(path : String) : Bool
+      current = File.dirname(path)
+      while current != "/" && current != "." && !current.empty?
+        return false if @expanded_base_paths.includes?(current)
+        return true if @symlinked_dir_cache.fetch(current) { |dir| @symlinked_dir_cache[dir] = File.symlink?(dir) }
+        parent = File.dirname(current)
+        break if parent == current
+        current = parent
+      end
+      false
+    end
+
+    private def resolved_real_path(path : String) : String?
+      File.realpath(path)
+    rescue ex : Exception
+      logger.debug "Failed to resolve real path for '#{path}': #{ex.message}"
+      nil
     end
 
     private def agent_relative_path(path : String) : String


### PR DESCRIPTION
**Severity: high** — arbitrary local file read, exfiltrated to the configured LLM provider.

2 of 5 from a self-audit of Noir under the threat model *"the tree being scanned is untrusted input."*

## The problem

`path_within_base?` is the containment gate for every agent file tool (`read_file`, `list_directory`, `grep`), and the paths it checks come out of LLM output that is steered by the source tree being scanned. It was:

```crystal
expanded = File.expand_path(path)
@expanded_base_paths.any? { |base| expanded == base || expanded.starts_with?("#{base}/") }
```

`File.expand_path` is purely lexical — it folds `..` and makes the path absolute, but never follows a link. So a checked-out repo containing

```
notes -> /home/user/.ssh/id_rsa
```

passed as an in-base path, and `read_file` shipped the target's contents to the LLM provider. A symlinked *directory* did the same for everything beneath it. Git tracks symlinks with their target verbatim, absolute paths included, so the hostile checkout brings its own — no pre-existing links on the scanner's disk required.

The tree walk (`walk_directory_tree`), the grep loop and the bundling path all skip symlinks already. These two entry points were the gap.

## The fix

Resolve both sides and require containment of the *real* path. A base that is itself reached through a link (`/tmp` -> `/private/tmp` on macOS) still matches, because `@real_base_paths` went through the same resolution.

The lexical check stays as the first gate — it rejects plain `../../etc/passwd` without touching the filesystem — and the ancestor scan memoizes per directory, so grep's per-candidate-file call doesn't re-stat the same parents.

## Verification

New spec plants both shapes (symlinked file, symlinked directory) in a temp base and asserts each is refused while real in-base paths still pass. Confirmed it fails against the old lexical check:

```
Failure/Error: analyzer.path_within_base?(File.join(root, "src", "notes.rb")).should be_false
  Expected: false
       got: true
```

Full suite green (27284 examples), ameba clean.