### PR TITLE
fix(deliver): keep --probe-header secrets on the --url target

### DIFF
--- a/docs/content/usage/more_features/deliver/index.ko.md
+++ b/docs/content/usage/more_features/deliver/index.ko.md
@@ -63,6 +63,14 @@ noir scan ./source -u http://localhost:3000 \
 
 <img src="./deliver-header.png" alt="인터셉트 프록시에 잡힌 요청. Noir가 추가하도록 지정한 Abcd 와 X-API-Key 헤더가 함께 실려 있다." width="1136" height="460" loading="lazy" decoding="async">
 
+이 헤더는 `-u` 타깃에만 붙습니다. 대부분의 endpoint는 noir가 `-u`에 이어붙인 경로지만, 소스에 이미 scheme과 host가 적혀 있던 endpoint(OAS `servers:` 항목, HAR 캡처, 호스팅 백엔드 URL)는 그 host를 그대로 유지하며, 그 host는 지금 스캔 중인 코드에서 온 값입니다. 이런 endpoint도 probe는 그대로 나가지만 사용자의 헤더는 실리지 않고, 어떤 host에서 빠졌는지 한 번 알려줍니다.
+
+```
+▲ Probe: --probe-header values withheld from https://collector.example.com — it is not the --url target.
+```
+
+export 대상(`--export-es`, `--export-webhook`)은 영향을 받지 않습니다. 그 host는 사용자가 직접 지정한 것이므로 `--probe-header`가 그대로 인증에 쓰입니다.
+
 ### Match / skip
 
 proxy로 흘려보낼 endpoint를 좁힐 수 있습니다. 패턴은 URL 부분 문자열, HTTP 메서드(대소문자 무시), 또는 `method:URL` 조합을 받습니다.

--- a/docs/content/usage/more_features/deliver/index.md
+++ b/docs/content/usage/more_features/deliver/index.md
@@ -63,6 +63,14 @@ noir scan ./source -u http://localhost:3000 \
 
 <img src="./deliver-header.png" alt="A proxied request in the intercepting proxy, carrying the custom Abcd and X-API-Key headers Noir was told to add." width="1136" height="460" loading="lazy" decoding="async">
 
+These headers go to the `-u` target and nowhere else. Most endpoints are paths that noir joined onto `-u`, but an endpoint that already carried its own scheme and host in the source — an OAS `servers:` entry, a HAR capture, a hosted-backend URL — keeps that host, and the host came from the code you are scanning. Those endpoints are still probed; your headers are not attached, and noir names the host once so you can see what was withheld:
+
+```
+▲ Probe: --probe-header values withheld from https://collector.example.com — it is not the --url target.
+```
+
+Export destinations (`--export-es`, `--export-webhook`) are unaffected — you named those hosts yourself, so `--probe-header` still authenticates them.
+
 ### Match / skip
 
 Narrow the set of endpoints sent through the proxy. Patterns accept a URL substring, an HTTP method (case-insensitive), or `method:URL` combined.

--- a/spec/unit_test/deliver/send_req_spec.cr
+++ b/spec/unit_test/deliver/send_req_spec.cr
@@ -555,6 +555,50 @@ describe SendReq do
       end
     end
 
+    it "withholds --probe-header secrets from a host that isn't the --url target" do
+      target = CapturingServer.new
+      third_party = CapturingServer.new
+      begin
+        # A path endpoint, already joined to `-u` by the optimizer.
+        own = Endpoint.new(target.url_for("/api/orders"), "GET")
+        # An endpoint that carried its own scheme+host in the scanned source
+        # (OAS `servers:`, a HAR capture, a hosted-backend client). Those are
+        # passed through un-rewritten, so the host comes from the repo.
+        offhost = Endpoint.new(third_party.url_for("/collect"), "GET")
+
+        options = base_deliver_options
+        options["url"] = YAML::Any.new(target.url_for(""))
+        options["probe_header"] = YAML::Any.new([YAML::Any.new("Authorization: Bearer s3cret")])
+        SendReq.new(options).run([own, offhost])
+
+        target.requests.first[:headers]["Authorization"]?.should eq("Bearer s3cret")
+        # Still probed — just not with the user's credential attached.
+        third_party.requests.size.should eq(1)
+        third_party.requests.first[:headers]["Authorization"]?.should be_nil
+      ensure
+        target.close
+        third_party.close
+      end
+    end
+
+    it "keeps sending --probe-header when the endpoint host matches the target" do
+      server = CapturingServer.new
+      begin
+        ep = Endpoint.new(server.url_for("/api/items"), "GET")
+
+        options = base_deliver_options
+        # Same origin, different path and a trailing slash — the comparison is
+        # on scheme/host/port, so this must not be read as a different host.
+        options["url"] = YAML::Any.new(server.url_for("/api/"))
+        options["probe_header"] = YAML::Any.new([YAML::Any.new("Authorization: Bearer s3cret")])
+        SendReq.new(options).run([ep])
+
+        server.requests.first[:headers]["Authorization"]?.should eq("Bearer s3cret")
+      ensure
+        server.close
+      end
+    end
+
     it "does not leak one endpoint's discovered headers onto another's request" do
       server = CapturingServer.new
       begin

--- a/spec/unit_test/utils/url_origin_spec.cr
+++ b/spec/unit_test/utils/url_origin_spec.cr
@@ -1,0 +1,41 @@
+require "spec"
+require "../../../src/utils/url_origin"
+
+describe Noir::UrlOrigin do
+  it "extracts scheme, host and port" do
+    Noir::UrlOrigin.of("https://api.example.com/v1/users").should eq("https://api.example.com")
+    Noir::UrlOrigin.of("http://127.0.0.1:8080/health").should eq("http://127.0.0.1:8080")
+  end
+
+  it "treats the scheme's default port as absent" do
+    Noir::UrlOrigin.of("https://api.example.com:443/x").should eq(Noir::UrlOrigin.of("https://api.example.com/x"))
+    Noir::UrlOrigin.of("http://api.example.com:80/x").should eq(Noir::UrlOrigin.of("http://api.example.com/x"))
+  end
+
+  it "compares case-insensitively on scheme and host" do
+    Noir::UrlOrigin.of("HTTPS://API.Example.COM/x").should eq(Noir::UrlOrigin.of("https://api.example.com/y"))
+  end
+
+  it "distinguishes host, port and scheme" do
+    target = Noir::UrlOrigin.of("https://api.example.com")
+    target.should_not eq(Noir::UrlOrigin.of("https://evil.example.com"))
+    target.should_not eq(Noir::UrlOrigin.of("https://api.example.com:8443"))
+    target.should_not eq(Noir::UrlOrigin.of("http://api.example.com"))
+    # A lookalike that only shares a prefix — a plain `starts_with?` check
+    # would call this the same host.
+    target.should_not eq(Noir::UrlOrigin.of("https://api.example.com.evil.test"))
+  end
+
+  it "accepts the scheme-less authority form -u allows" do
+    Noir::UrlOrigin.of("example.com/api").should eq("http://example.com")
+    Noir::UrlOrigin.of("example.com:8080").should eq("http://example.com:8080")
+  end
+
+  it "returns nil when there is no host to compare" do
+    Noir::UrlOrigin.of(nil).should be_nil
+    Noir::UrlOrigin.of("").should be_nil
+    Noir::UrlOrigin.of("   ").should be_nil
+    Noir::UrlOrigin.of("/api/users").should be_nil
+    Noir::UrlOrigin.of("/{tenant}/users").should be_nil
+  end
+end

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -3,6 +3,7 @@ require "openssl"
 require "./logger"
 require "../utils/utils"
 require "../utils/http_symbols"
+require "../utils/url_origin"
 
 class Deliver
   @logger : NoirLogger
@@ -15,6 +16,13 @@ class Deliver
   @headers : Hash(String, String) = {} of String => String
   @matchers : Array(String) = [] of String
   @filters : Array(String) = [] of String
+  # Origin of `--url`, resolved lazily (see `target_origin`) and the set of
+  # off-target origins already warned about, so the warning fires once per
+  # host instead of once per endpoint.
+  @target_origin : String? = nil
+  @target_origin_resolved = false
+  @offhost_origins = Set(String).new
+  @offhost_mutex = Mutex.new
 
   def initialize(options : Hash(String, YAML::Any))
     @options = options
@@ -235,10 +243,11 @@ class Deliver
   # fiber, so merging into it in place would race and leak one endpoint's
   # headers onto another's request.
   protected def probe_headers(endpoint : Endpoint) : Hash(String, String)
+    user_headers = user_headers_for(endpoint)
     params = endpoint.params_to_hash
     discovered = params["header"]
     cookies = params["cookie"]
-    return @headers if discovered.empty? && cookies.empty?
+    return user_headers if discovered.empty? && cookies.empty?
 
     result = {} of String => String
     discovered.each { |name, value| result[name] = value }
@@ -246,7 +255,64 @@ class Deliver
     unless cookies.empty?
       result["Cookie"] = cookies.map { |name, value| "#{name}=#{value}" }.join("; ")
     end
-    result.merge(@headers)
+    result.merge(user_headers)
+  end
+
+  # `--probe-header` values are the user's own secrets — a session cookie, a
+  # bearer token for the app they are testing. They are meant for the `-u`
+  # target and nowhere else.
+  #
+  # Most endpoints are paths that `combine_url_and_endpoints` prefixed with
+  # `-u`, so they carry the target's origin by construction. But an endpoint
+  # that already had a scheme and host in the source — an OAS `servers:`
+  # entry, a HAR capture, a hosted-backend URL in a schema-generated client —
+  # is passed through untouched by design, and the source is the tree being
+  # scanned. Attaching the token to those means a repo can name a host and
+  # have Noir hand the user's credential to it.
+  #
+  # `send_req` already refuses to follow redirects for exactly this reason
+  # ("Crest copies the request headers onto the redirected request, including
+  # a --probe-header Authorization token"); the same leak was reachable
+  # without any redirect at all. Off-origin endpoints are still probed — that
+  # part is intentional — just without the user's headers, and the dropped
+  # hosts are named once so the omission is visible rather than silent.
+  private def user_headers_for(endpoint : Endpoint) : Hash(String, String)
+    return @headers if @headers.empty?
+
+    target = target_origin
+    # No `-u` means no origin to trust or distrust: the user pointed the
+    # probe straight at whatever the catalog holds, so their headers ride
+    # along as before.
+    return @headers if target.nil?
+
+    origin = Noir::UrlOrigin.of(endpoint.url)
+    return @headers if origin.nil? || origin == target
+
+    note_offhost_header_drop(origin)
+    {} of String => String
+  end
+
+  private def target_origin : String?
+    origin = @target_origin
+    return origin unless origin.nil?
+    return if @target_origin_resolved
+
+    @target_origin_resolved = true
+    @target_origin = Noir::UrlOrigin.of(@options["url"]?.to_s)
+  end
+
+  private def note_offhost_header_drop(origin : String)
+    fresh = false
+    @offhost_mutex.synchronize do
+      unless @offhost_origins.includes?(origin)
+        @offhost_origins << origin
+        fresh = true
+      end
+    end
+    return unless fresh
+
+    @logger.warning "Probe: --probe-header values withheld from #{origin} — it is not the --url target. " \
+                    "Endpoints on that host are still probed, without your headers."
   end
 
   # True for endpoints that belong in the reported catalog but must not be

--- a/src/utils/url_origin.cr
+++ b/src/utils/url_origin.cr
@@ -1,0 +1,46 @@
+require "uri"
+
+# The origin (scheme + host + port) of a URL, used to decide whether two URLs
+# address the same server. Delivery uses it to keep the user's
+# `--probe-header` secrets pinned to the `--url` target.
+module Noir::UrlOrigin
+  # Ports that are implied by the scheme, so `https://api.test` and
+  # `https://api.test:443` compare equal.
+  DEFAULT_PORTS = {"http" => 80, "https" => 443, "ws" => 80, "wss" => 443}
+
+  # `scheme://host[:port]`, downcased, or nil when the URL names no host —
+  # a bare path (`/users`), an empty string, junk that will not parse. A
+  # host-less URL has no origin to compare, and callers treat that as
+  # "unknown" rather than as a match.
+  #
+  # A scheme-less authority (`example.com/x`, which `-u` accepts) parses as
+  # a path with no host, so it gets one parse attempt with `http://`
+  # prepended — the same accommodation the OAS builder makes for `-u`.
+  def self.of(url : String?) : String?
+    return if url.nil?
+    raw = url.strip
+    return if raw.empty?
+
+    origin = parse_origin(raw)
+    return origin if origin
+
+    # Only worth a second attempt when the value looks like an authority
+    # rather than a path: `/users` must stay origin-less.
+    return if raw.starts_with?('/') || raw.includes?("://")
+    parse_origin("http://#{raw}")
+  end
+
+  private def self.parse_origin(raw : String) : String?
+    uri = URI.parse(raw)
+    host = uri.host
+    return if host.nil? || host.empty?
+
+    scheme = (uri.scheme || "http").downcase
+    port = uri.port
+    port = nil if port && DEFAULT_PORTS[scheme]? == port
+
+    port ? "#{scheme}://#{host.downcase}:#{port}" : "#{scheme}://#{host.downcase}"
+  rescue URI::Error
+    nil
+  end
+end


### PR DESCRIPTION
**Severity: medium** — a scanned repo can name a host and receive the user's probe credentials.

3 of 5 from a self-audit of Noir under the threat model *"the tree being scanned is untrusted input."*

## The problem

`--probe-header` values are the user's own credentials — a session cookie, a bearer token for the app they are testing. Every probe carried them, including probes to hosts the user never named.

Most endpoints are paths that `combine_url_and_endpoints` prefixed with `-u`, so they carry the target's origin by construction. But an endpoint that already had a scheme and host in the source is passed through untouched, by design ([`path_params.cr`](https://github.com/owasp-noir/noir/blob/main/src/optimizer/optimizer/path_params.cr#L18-L27)):

> An endpoint that already carries its own scheme + host (HAR / OAS absolute URLs) is self-contained. Prefixing the target or collapsing its scheme `//` would corrupt it, so pass it through untouched.

That host comes from the tree being scanned — an OAS `servers:` entry, a HAR capture, a hosted-backend URL in a schema-generated client. So:

```bash
noir scan ./untrusted-repo -u https://myapp.test \
  --probe --probe-header "Authorization: Bearer <token>"
```

sends that token wherever the repo's spec points.

`send_req` already refuses to follow redirects for precisely this reason:

> Redirects are off because Crest copies the request headers onto the redirected request, including a `--probe-header` Authorization token, and follows absolute Locations to other hosts.

The same leak was reachable with no redirect at all.

## The fix

User-supplied headers go to the `-u` origin and nowhere else. Off-origin endpoints are **still probed** — that part is intentional — just without the credentials, and each dropped host is named once:

```
▲ Probe: --probe-header values withheld from https://collector.example.com — it is not the --url target.
```

Deliberately unchanged:
- **Analyzer-discovered header/cookie params** still ride along. Those came from the app's own source, not the user's secret store.
- **Export destinations** (`--export-es`, `--export-webhook`) are untouched — the user named those hosts themselves, and `--probe-header` is the documented way to authenticate them.
- **No `-u`** means no origin to trust or distrust, so behaviour is unchanged there.

Origin comparison lands in a shared `Noir::UrlOrigin` helper: scheme + host + port, default ports folded (`https://h` == `https://h:443`), case-insensitive, and nil for a host-less URL so a bare path is never mistaken for a match. A prefix-based check would have called `api.example.com.evil.test` the same host; this doesn't.

## Verification

- 2 new end-to-end specs against real in-process servers: token reaches the target, off-host probe arrives with the header stripped; same-origin-different-path still gets it.
- 6 specs for `UrlOrigin` covering default ports, case, lookalike hosts, scheme-less `-u`, and host-less URLs.
- Full suite green (27284 examples), ameba clean. Docs (EN/KO) updated.