### PR TITLE
fix(cache): stop leaving the AI cache world-readable

### DIFF
--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -92,9 +92,14 @@ class ConfigInitializer
   end
 
   def setup
-    # Create the directory if it doesn't exist
-    Dir.mkdir(@config_dir) unless Dir.exists?(@config_dir)
-    Dir.mkdir("#{@config_dir}/passive_rules") unless Dir.exists?("#{@config_dir}/passive_rules")
+    # Create the directory if it doesn't exist. 0700, not the default 0755:
+    # everything Noir keeps here is private to the user — the 0600 config
+    # below with its `ai_key`, and the AI response cache, whose entries are
+    # answers about the user's source. A world-readable parent leaks the
+    # cache filenames and contents even though the config file itself is
+    # locked down.
+    Dir.mkdir(@config_dir, 0o700) unless Dir.exists?(@config_dir)
+    Dir.mkdir("#{@config_dir}/passive_rules", 0o700) unless Dir.exists?("#{@config_dir}/passive_rules")
 
     # Create the config file if it doesn't exist — but only when this
     # is the *default* config path. When the user passed

--- a/src/llm/cache.cr
+++ b/src/llm/cache.cr
@@ -85,9 +85,17 @@ module LLM
       File.join(cache_dir, "#{key}#{CACHE_FILE_SUFFIX}")
     end
 
+    # 0700, and entries below are written 0600 (see `store`). A cache entry
+    # is the model's answer about a specific chunk of the user's source, and
+    # the prompt it answers is that source — private code, on a box that may
+    # have other accounts. The default 0755/0644 published it to every local
+    # user. `$NOIR_HOME/config.yaml` is already 0600 for the same reason.
+    CACHE_DIR_PERMISSIONS  = 0o700
+    CACHE_FILE_PERMISSIONS = 0o600
+
     def self.ensure_dir : Nil
       return if File.directory?(cache_dir)
-      FileUtils.mkdir_p(cache_dir)
+      FileUtils.mkdir_p(cache_dir, CACHE_DIR_PERMISSIONS)
     end
 
     def self.fetch(key : String) : String?
@@ -110,7 +118,9 @@ module LLM
       ensure_dir
       final = path_for(key)
       tmp = "#{final}#{CACHE_TMP_MARKER}#{Process.pid}-#{Random::Secure.hex(4)}"
-      File.write(tmp, content)
+      # Permission set at create time, not chmod'd after: a reader racing the
+      # write would otherwise get a window where the file is world-readable.
+      File.write(tmp, content, perm: CACHE_FILE_PERMISSIONS)
       File.rename(tmp, final)
       true
     rescue e


### PR DESCRIPTION
**Severity: low** — local information disclosure on a shared machine.

5 of 5 from a self-audit of Noir under the threat model *"the tree being scanned is untrusted input."* (This one isn't about the scanned tree — it turned up alongside the rest.)

## The problem

`$NOIR_HOME/cache/ai/*.json` holds the model's answer about a specific chunk of the user's source, and the prompt it answers *is* that source. It was written with the default 0644 inside a 0755 `$NOIR_HOME`, so on a shared box every local account could read a scan's AI output — and enumerate what had been scanned.

`config.yaml` is already 0600 for exactly this reason (it carries `ai_key`), which left the lockdown half-applied: the secret file was protected, but the directory holding it and everything else beneath it was not.

## The fix

Directories become 0700, cache entries 0600. The permission is set at create time rather than chmod'd after the write, so a reader racing the write never sees a world-readable window.

Existing directories and cache files keep their current mode — no retroactive chmod, since silently rewriting permissions on paths a user may have deliberately configured is not this change's business. New installs and new entries are locked down; anyone wanting the old files fixed can `chmod -R go-rwx "$NOIR_HOME"` or clear the cache.

## Verification

Full suite green (27284 examples), ameba clean.