### PR TITLE
fix(cli): render error messages in red

### DIFF
--- a/spec/unit_test/cli/error_color_spec.cr
+++ b/spec/unit_test/cli/error_color_spec.cr
@@ -1,0 +1,44 @@
+require "../../spec_helper"
+require "colorize"
+require "../../../src/cli/common"
+
+describe "early CLI error colors" do
+  source_files = [
+    "src/options.cr",
+    "src/cli_validation.cr",
+    "src/models/output_builder.cr",
+    "src/cli/common.cr",
+  ]
+  error_lines = source_files.flat_map do |path|
+    File.read_lines(path).select(&.includes?(%q(STDERR.puts "ERROR:)))
+  end
+
+  it "uses red for every error path" do
+    error_lines.size.should eq(14)
+    error_lines.each(&.should contain(".colorize(:red)"))
+  end
+
+  it "renders errors red when colors are enabled" do
+    Colorize.enabled = true
+
+    "ERROR: invalid option".colorize(:red).to_s.should contain("\e[31m")
+  ensure
+    Colorize.enabled = true
+  end
+
+  it "renders errors as plain text with NO_COLOR" do
+    previous_env = ENV["NO_COLOR"]?
+    ENV["NO_COLOR"] = "1"
+    Colorize.enabled = true
+    Noir::CLI.apply_global_color_flag!([] of String)
+
+    "ERROR: invalid option".colorize(:red).to_s.should eq("ERROR: invalid option")
+  ensure
+    Colorize.enabled = true
+    if value = previous_env
+      ENV["NO_COLOR"] = value
+    else
+      ENV.delete("NO_COLOR")
+    end
+  end
+end

--- a/src/cli/common.cr
+++ b/src/cli/common.cr
@@ -35,7 +35,7 @@ module Noir::CLI
   end
 
   def self.die(message : String, code : Int32 = 1) : NoReturn
-    STDERR.puts "ERROR: #{message}".colorize(:yellow)
+    STDERR.puts "ERROR: #{message}".colorize(:red)
     exit(code)
   end
 

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -310,7 +310,7 @@ module Noir::CliValidation
 
   def self.exit_with_error(message : String) : NoReturn
     lines = message.lines
-    STDERR.puts "ERROR: #{lines.first}".colorize(:yellow)
+    STDERR.puts "ERROR: #{lines.first}".colorize(:red)
     lines[1..]?.try do |rest|
       rest.each { |line| STDERR.puts line }
     end

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -144,7 +144,7 @@ class OutputBuilder
         # far cheaper than the open+write+close this replaced.
         file.flush
       rescue e : IO::Error
-        STDERR.puts "ERROR: Could not write output file '#{@output_file}': #{e.message}".colorize(:yellow)
+        STDERR.puts "ERROR: Could not write output file '#{@output_file}': #{e.message}".colorize(:red)
         exit(1)
       end
     end

--- a/src/options.cr
+++ b/src/options.cr
@@ -63,7 +63,7 @@ end
 private def positive_int_or_die!(flag : String, raw : String) : Int32
   value = raw.to_i?
   if value.nil? || value < 1
-    STDERR.puts "ERROR: Invalid #{flag} '#{raw}'. Must be a positive integer.".colorize(:yellow)
+    STDERR.puts "ERROR: Invalid #{flag} '#{raw}'. Must be a positive integer.".colorize(:red)
     exit(1)
   end
   value
@@ -78,7 +78,7 @@ private def process_override_flag(
     noir_options[option_key] = YAML::Any.new(args[i + 1])
     i + 2
   else
-    STDERR.puts "ERROR: #{flag} requires an argument.".colorize(:yellow)
+    STDERR.puts "ERROR: #{flag} requires an argument.".colorize(:red)
     exit(1)
   end
 end
@@ -138,7 +138,7 @@ def extract_legacy_aliases(args : Array(String), noir_options : Hash(String, YAM
       i += 1
     elsif pvalue_key = LEGACY_PVALUE_TARGETS[arg]?
       if i + 1 >= args.size
-        STDERR.puts "ERROR: #{arg} requires an argument.".colorize(:yellow)
+        STDERR.puts "ERROR: #{arg} requires an argument.".colorize(:red)
         exit(1)
       end
       append_to_yaml_array(noir_options, pvalue_key, args[i + 1])
@@ -362,7 +362,7 @@ def run_options_parser
       if lvl.in?(%w[critical high medium low])
         noir_options["passive_scan_severity"] = YAML::Any.new(lvl)
       else
-        STDERR.puts "ERROR: Invalid severity '#{v}'. Valid: critical, high, medium, low".colorize(:yellow)
+        STDERR.puts "ERROR: Invalid severity '#{v}'. Valid: critical, high, medium, low".colorize(:red)
         exit(1)
       end
     end
@@ -527,7 +527,7 @@ def run_options_parser
     parser.on "--concurrency N", "Concurrency level" do |v|
       value = v.to_i?
       if value.nil? || value < 1
-        STDERR.puts "ERROR: Invalid concurrency '#{v}'. Concurrency must be an integer greater than or equal to 1.".colorize(:yellow)
+        STDERR.puts "ERROR: Invalid concurrency '#{v}'. Concurrency must be an integer greater than or equal to 1.".colorize(:red)
         exit(1)
       end
 
@@ -559,19 +559,19 @@ def run_options_parser
     parser.invalid_option do |flag|
       case flag
       when "--ollama", "--ollama-model"
-        STDERR.puts "ERROR: #{flag} was removed in v1.0.".colorize(:yellow)
+        STDERR.puts "ERROR: #{flag} was removed in v1.0.".colorize(:red)
         STDERR.puts "       Use --ai-provider ollama [--ai-model NAME] instead."
         STDERR.puts "       Example: noir scan ./app --ai-provider ollama --ai-model llama3"
         exit(1)
       else
-        STDERR.puts "ERROR: #{flag} is not a valid option.".colorize(:yellow)
+        STDERR.puts "ERROR: #{flag} is not a valid option.".colorize(:red)
         STDERR.puts parser
         exit(1)
       end
     end
 
     parser.missing_option do |flag|
-      STDERR.puts "ERROR: #{flag} requires an argument.".colorize(:yellow)
+      STDERR.puts "ERROR: #{flag} requires an argument.".colorize(:red)
       exit(1)
     end
   end
@@ -629,7 +629,7 @@ def handle_pvalue(noir_options : Hash(String, YAML::Any), spec : String)
 
   key = PVALUE_TYPE_KEYS[type]?
   if key.nil?
-    STDERR.puts "ERROR: --pvalue: unknown type '#{type}'. Valid: #{PVALUE_TYPE_KEYS.keys.join(", ")}.".colorize(:yellow)
+    STDERR.puts "ERROR: --pvalue: unknown type '#{type}'. Valid: #{PVALUE_TYPE_KEYS.keys.join(", ")}.".colorize(:red)
     exit(1)
   end
 
@@ -647,7 +647,7 @@ def apply_include_list(noir_options : Hash(String, YAML::Any), spec : String)
     target = raw.strip.downcase
     key = INCLUDE_TARGETS[target]?
     if key.nil?
-      STDERR.puts "ERROR: --include: unknown target '#{raw.strip}'. Valid: #{INCLUDE_TARGETS.keys.join(", ")}.".colorize(:yellow)
+      STDERR.puts "ERROR: --include: unknown target '#{raw.strip}'. Valid: #{INCLUDE_TARGETS.keys.join(", ")}.".colorize(:red)
       exit(1)
     end
     noir_options[key] = YAML::Any.new(true)
@@ -682,6 +682,6 @@ def validate_ai_context_features(spec : String, origin : String)
 
   # Echo the user's original spelling (not the lowercased form) so a typo
   # like `Sinkz` reads as it was written.
-  STDERR.puts "ERROR: #{origin}: unknown feature '#{unknown.first}'. Valid: #{NoirAIContext::FEATURES.join(", ")}.".colorize(:yellow)
+  STDERR.puts "ERROR: #{origin}: unknown feature '#{unknown.first}'. Valid: #{NoirAIContext::FEATURES.join(", ")}.".colorize(:red)
   exit(1)
 end


### PR DESCRIPTION
Closes #2451

Changes:
- render early CLI errors in red while keeping warnings yellow
- cover ANSI red output and NO_COLOR behavior

Tests:
- `crystal build --no-codegen src/noir.cr`
- `crystal build --no-codegen spec/unit_test/cli/error_color_spec.cr`
- `crystal tool format --check spec/unit_test/cli/error_color_spec.cr`