### PR TITLE
refactor(analyzer): extract Analyzer::Clojure::Helper for the shared s-expression scanners

### DIFF
--- a/src/analyzer/analyzers/clojure/cli.cr
+++ b/src/analyzer/analyzers/clojure/cli.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "./clojure_helper"
 
 module Analyzer::Clojure
   # Surfaces the command-line attack surface of Clojure programs as `cli://`
@@ -140,16 +141,16 @@ module Analyzer::Clojure
       # A dispatch entry surfaces its `cli://root/cmd` endpoint even if its
       # `:spec` map is empty/absent (e.g. a bare `help` subcommand).
       entries.each do |(o, _, segments)|
-        fetch_endpoint(endpoints, "#{root_url}/#{segments}", path, line_number_for(content, o))
+        fetch_endpoint(endpoints, "#{root_url}/#{segments}", path, Helper.line_number_for(content, o))
       end
 
       content.scan(/:spec\s*(\{)/) do |m|
         spec_open = m.byte_begin(1)
-        spec_close = find_matching_delimiter(content, spec_open, '{', '}', content.bytesize)
+        spec_close = Helper.find_matching_delimiter(content, spec_open, '{', '}', content.bytesize)
         owner = entries.find { |(o, c, _)| o <= spec_open && spec_close <= c }
         target_url = owner ? "#{root_url}/#{owner[2]}" : root_url
         spec_options(content, spec_open, spec_close).each do |(opt_name, key_pos)|
-          fetch_endpoint(endpoints, target_url, path, line_number_for(content, key_pos)).push_param(Param.new(opt_name, "", "flag"))
+          fetch_endpoint(endpoints, target_url, path, Helper.line_number_for(content, key_pos)).push_param(Param.new(opt_name, "", "flag"))
         end
       end
     end
@@ -167,9 +168,9 @@ module Analyzer::Clojure
         char = content.byte_at(i).unsafe_chr
         case char
         when ';'
-          i = skip_comment(content, i, spec_close)
+          i = Helper.skip_comment(content, i, spec_close)
         when '"'
-          i = skip_string(content, i, spec_close)
+          i = Helper.skip_string(content, i, spec_close)
         when '{'
           depth += 1
         when '}'
@@ -197,9 +198,9 @@ module Analyzer::Clojure
         char = content.byte_at(i).unsafe_chr
         case char
         when ';'
-          i = skip_comment(content, i, limit)
+          i = Helper.skip_comment(content, i, limit)
         when '"'
-          i = skip_string(content, i, limit)
+          i = Helper.skip_string(content, i, limit)
         when '{'
           stack.push(i)
         when '}'
@@ -210,60 +211,6 @@ module Analyzer::Clojure
         i += 1
       end
       pairs
-    end
-
-    private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
-      i = index
-      while i < limit && source.byte_at(i).unsafe_chr != '\n'
-        i += 1
-      end
-      i
-    end
-
-    private def skip_string(source : String, index : Int32, limit : Int32) : Int32
-      i = index + 1
-      escaping = false
-
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        if escaping
-          escaping = false
-        elsif char == '\\'
-          escaping = true
-        elsif char == '"'
-          return i
-        end
-        i += 1
-      end
-
-      limit - 1
-    end
-
-    private def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
-      depth = 0
-      i = index
-
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        case char
-        when ';'
-          i = skip_comment(source, i, limit)
-        when '"'
-          i = skip_string(source, i, limit)
-        when open_char
-          depth += 1
-        when close_char
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-
-      index
-    end
-
-    private def line_number_for(source : String, index : Int32) : Int32
-      source.byte_slice(0, index).count('\n') + 1
     end
   end
 end

--- a/src/analyzer/analyzers/clojure/clojure_helper.cr
+++ b/src/analyzer/analyzers/clojure/clojure_helper.cr
@@ -1,0 +1,75 @@
+module Analyzer::Clojure
+  # Shared helpers for the Clojure framework analyzers (CLI, Compojure,
+  # Pedestal, Reitit, Ring). Every one of them walks s-expressions the same
+  # way, so the scanning primitives live here instead of being copied per
+  # analyzer.
+  #
+  # All four operate on byte offsets into the raw source (`byte_at`), never on
+  # character indices, so the offsets they return stay usable with
+  # `String#byte_slice` on sources containing non-ASCII text.
+  module Helper
+    extend self
+
+    # Advance past a `;` line comment, stopping on the newline that ends it.
+    def skip_comment(source : String, index : Int32, limit : Int32) : Int32
+      i = index
+      while i < limit && source.byte_at(i).unsafe_chr != '\n'
+        i += 1
+      end
+      i
+    end
+
+    # Advance from the opening `"` of a string literal to its closing quote,
+    # honouring `\` escapes. Returns the last in-range offset when the literal
+    # is unterminated so callers still make progress.
+    def skip_string(source : String, index : Int32, limit : Int32) : Int32
+      i = index + 1
+      escaping = false
+
+      while i < limit
+        char = source.byte_at(i).unsafe_chr
+        if escaping
+          escaping = false
+        elsif char == '\\'
+          escaping = true
+        elsif char == '"'
+          return i
+        end
+        i += 1
+      end
+
+      limit - 1
+    end
+
+    # Find the offset of the delimiter closing the one at `index`, skipping
+    # over comments and string literals so a `)` inside `";)"` never closes a
+    # form. Returns `index` unchanged when no match is found.
+    def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
+      depth = 0
+      i = index
+
+      while i < limit
+        char = source.byte_at(i).unsafe_chr
+        case char
+        when ';'
+          i = skip_comment(source, i, limit)
+        when '"'
+          i = skip_string(source, i, limit)
+        when open_char
+          depth += 1
+        when close_char
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+
+      index
+    end
+
+    # 1-based line number of a byte offset.
+    def line_number_for(source : String, index : Int32) : Int32
+      source.byte_slice(0, index).count('\n') + 1
+    end
+  end
+end

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
+require "./clojure_helper"
 
 module Analyzer::Clojure
   class Compojure < Analyzer
@@ -71,11 +72,11 @@ module Analyzer::Clojure
       while i < end_index
         case source.byte_at(i).unsafe_chr
         when ';'
-          i = skip_comment(source, i, end_index)
+          i = Helper.skip_comment(source, i, end_index)
         when '"'
-          i = skip_string(source, i, end_index) + 1
+          i = Helper.skip_string(source, i, end_index) + 1
         when '('
-          form_end = find_matching_delimiter(source, i, '(', ')', end_index)
+          form_end = Helper.find_matching_delimiter(source, i, '(', ')', end_index)
           break if form_end <= i
 
           symbol_start = skip_ws_and_comments(source, i + 1, form_end)
@@ -121,7 +122,7 @@ module Analyzer::Clojure
       route_path = normalize_route_path(raw_route_path)
 
       full_path = join_path(prefix, route_path)
-      endpoint = Endpoint.new(full_path, method, Details.new(PathInfo.new(path, line_number_for(source, form_start))))
+      endpoint = Endpoint.new(full_path, method, Details.new(PathInfo.new(path, Helper.line_number_for(source, form_start))))
 
       path_param_names = extract_path_param_names(route_path)
       path_param_names.each do |name|
@@ -148,7 +149,7 @@ module Analyzer::Clojure
       return if body_start >= form_end
 
       body = source.byte_slice(body_start, form_end - body_start)
-      start_line = line_number_for(source, body_start)
+      start_line = Helper.line_number_for(source, body_start)
       callees = Noir::ClojureCalleeExtractor.callees_for_body(body, path, start_line)
       Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
     end
@@ -171,7 +172,7 @@ module Analyzer::Clojure
 
           if (ptype = RESTRUCTURING_PARAMS[keyword]?) &&
              value_start < value_end && source.byte_at(value_start).unsafe_chr == '['
-            bind_end = find_matching_delimiter(source, value_start, '[', ']', value_end)
+            bind_end = Helper.find_matching_delimiter(source, value_start, '[', ']', value_end)
             if bind_end > value_start
               binding_param_names(source, value_start + 1, bind_end).each do |name|
                 add_param_once(endpoint, name, ptype)
@@ -260,7 +261,7 @@ module Analyzer::Clojure
       return false if i >= form_end
       return false unless source.byte_at(i).unsafe_chr == '{'
 
-      map_end = find_matching_delimiter(source, i, '{', '}', form_end)
+      map_end = Helper.find_matching_delimiter(source, i, '{', '}', form_end)
       return false if map_end <= i
 
       route_path = prefix.empty? ? "/" : prefix
@@ -284,14 +285,14 @@ module Analyzer::Clojure
 
     private def emit_resource_endpoint(source : String, offset : Int32, route_path : String, method : String,
                                        path : String, include_callee : Bool, handler_range : Tuple(Int32, Int32)?)
-      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, line_number_for(source, offset))))
+      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, Helper.line_number_for(source, offset))))
       extract_path_param_names(route_path).each do |name|
         endpoint.push_param(Param.new(name, "", "path"))
       end
 
       if include_callee && handler_range
         body = source.byte_slice(handler_range[0], handler_range[1] - handler_range[0])
-        start_line = line_number_for(source, handler_range[0])
+        start_line = Helper.line_number_for(source, handler_range[0])
         Noir::ClojureCalleeExtractor.attach_to(endpoint,
           Noir::ClojureCalleeExtractor.callees_for_body(body, path, start_line))
       end
@@ -309,7 +310,7 @@ module Analyzer::Clojure
       inner_start = i
       inner_limit = limit
       if source.byte_at(i).unsafe_chr == '{'
-        map_end = find_matching_delimiter(source, i, '{', '}', limit)
+        map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         return if map_end <= i
         inner_start = i + 1
         inner_limit = map_end
@@ -348,16 +349,16 @@ module Analyzer::Clojure
 
       case source.byte_at(i).unsafe_chr
       when '"'
-        e = skip_string(source, i, limit)
+        e = Helper.skip_string(source, i, limit)
         e >= i ? e + 1 : limit
       when '('
-        e = find_matching_delimiter(source, i, '(', ')', limit)
+        e = Helper.find_matching_delimiter(source, i, '(', ')', limit)
         e > i ? e + 1 : limit
       when '['
-        e = find_matching_delimiter(source, i, '[', ']', limit)
+        e = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         e > i ? e + 1 : limit
       when '{'
-        e = find_matching_delimiter(source, i, '{', '}', limit)
+        e = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         e > i ? e + 1 : limit
       when '\'', '`'
         resource_end_of_value(source, i + 1, limit)
@@ -366,10 +367,10 @@ module Analyzer::Clojure
         case nxt
         when '{', '('
           inner_close = nxt == '{' ? '}' : ')'
-          e = find_matching_delimiter(source, i + 1, nxt, inner_close, limit)
+          e = Helper.find_matching_delimiter(source, i + 1, nxt, inner_close, limit)
           e > i + 1 ? e + 1 : limit
         when '"'
-          e = skip_string(source, i + 1, limit)
+          e = Helper.skip_string(source, i + 1, limit)
           e >= i + 1 ? e + 1 : limit
         when '_'
           resource_end_of_value(source, i + 2, limit)
@@ -389,10 +390,10 @@ module Analyzer::Clojure
 
       case source.byte_at(i).unsafe_chr
       when '['
-        binding_end = find_matching_delimiter(source, i, '[', ']', limit)
+        binding_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         binding_end > i ? binding_end + 1 : i
       when '{'
-        binding_end = find_matching_delimiter(source, i, '{', '}', limit)
+        binding_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         binding_end > i ? binding_end + 1 : i
       when '('
         i
@@ -521,10 +522,10 @@ module Analyzer::Clojure
 
       case source.byte_at(i).unsafe_chr
       when '['
-        binding_end = find_matching_delimiter(source, i, '[', ']', limit)
+        binding_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         binding_end > i ? source.byte_slice(i, binding_end - i + 1) : nil
       when '{'
-        binding_end = find_matching_delimiter(source, i, '{', '}', limit)
+        binding_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         binding_end > i ? source.byte_slice(i, binding_end - i + 1) : nil
       when '('
         nil
@@ -542,7 +543,7 @@ module Analyzer::Clojure
     private def route_path_literal(source : String, index : Int32, limit : Int32) : Tuple(String?, Int32)
       i = skip_ws_and_comments(source, index, limit)
       if i < limit && source.byte_at(i).unsafe_chr == '['
-        vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+        vec_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         return {nil, index} if vec_end <= i
         route_path, _ = first_string_literal(source, i + 1, vec_end)
         return {route_path, vec_end}
@@ -556,9 +557,9 @@ module Analyzer::Clojure
       while i < limit
         case source.byte_at(i).unsafe_chr
         when ';'
-          i = skip_comment(source, i, limit)
+          i = Helper.skip_comment(source, i, limit)
         when '"'
-          literal_end = skip_string(source, i, limit)
+          literal_end = Helper.skip_string(source, i, limit)
           return {decode_string_literal(source.byte_slice(i, literal_end - i + 1)), literal_end}
         when '(', '[', '{'
           break
@@ -602,66 +603,12 @@ module Analyzer::Clojure
         if whitespace?(char) || char == ','
           i += 1
         elsif char == ';'
-          i = skip_comment(source, i, limit)
+          i = Helper.skip_comment(source, i, limit)
         else
           break
         end
       end
       i
-    end
-
-    private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
-      i = index
-      while i < limit && source.byte_at(i).unsafe_chr != '\n'
-        i += 1
-      end
-      i
-    end
-
-    private def skip_string(source : String, index : Int32, limit : Int32) : Int32
-      i = index + 1
-      escaping = false
-
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        if escaping
-          escaping = false
-        elsif char == '\\'
-          escaping = true
-        elsif char == '"'
-          return i
-        end
-        i += 1
-      end
-
-      limit - 1
-    end
-
-    private def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
-      depth = 0
-      i = index
-
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        case char
-        when ';'
-          i = skip_comment(source, i, limit)
-        when '"'
-          i = skip_string(source, i, limit)
-        when open_char
-          depth += 1
-        when close_char
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-
-      index
-    end
-
-    private def line_number_for(source : String, index : Int32) : Int32
-      source.byte_slice(0, index).count('\n') + 1
     end
 
     private def whitespace?(char : Char) : Bool

--- a/src/analyzer/analyzers/clojure/pedestal.cr
+++ b/src/analyzer/analyzers/clojure/pedestal.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
+require "./clojure_helper"
 
 module Analyzer::Clojure
   class Pedestal < Analyzer
@@ -81,23 +82,23 @@ module Analyzer::Clojure
       while i < limit
         case source.byte_at(i).unsafe_chr
         when ';'
-          i = skip_comment(source, i, limit)
+          i = Helper.skip_comment(source, i, limit)
         when '"'
-          i = skip_string(source, i, limit) + 1
+          i = Helper.skip_string(source, i, limit) + 1
         when '('
-          form_end = find_matching_delimiter(source, i, '(', ')', limit)
+          form_end = Helper.find_matching_delimiter(source, i, '(', ')', limit)
           break if form_end <= i
           handled = process_list(source, i, form_end, prefix, path, seen, include_callee, function_callees)
           walk_forms(source, i + 1, form_end, prefix, path, seen, include_callee, function_callees) unless handled
           i = form_end + 1
         when '['
-          vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+          vec_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
           handled = process_route_vector(source, i, vec_end, prefix, path, seen, include_callee, function_callees)
           walk_forms(source, i + 1, vec_end, prefix, path, seen, include_callee, function_callees) unless handled
           i = vec_end + 1
         when '{'
-          map_end = find_matching_delimiter(source, i, '{', '}', limit)
+          map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
           handled = process_route_map(source, i, map_end, prefix, path, seen, include_callee, function_callees)
           walk_forms(source, i + 1, map_end, prefix, path, seen, include_callee, function_callees) unless handled
@@ -160,7 +161,7 @@ module Analyzer::Clojure
       current_prefix = prefix
 
       if i < limit && source.byte_at(i).unsafe_chr == '{'
-        map_end = find_matching_delimiter(source, i, '{', '}', limit)
+        map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         if map_end > i
           current_prefix = join_path(prefix, extract_context(source, i + 1, map_end) || "")
           i = map_end + 1
@@ -169,13 +170,13 @@ module Analyzer::Clojure
 
       i = skip_ws_and_comments(source, i, limit)
       if i < limit && source.byte_at(i).unsafe_chr == '['
-        vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+        vec_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         if vec_end > i
           process_table_route_entries(source, i + 1, vec_end, current_prefix, path, seen, include_callee, function_callees)
           return
         end
       elsif i + 1 < limit && source.byte_at(i).unsafe_chr == '#' && source.byte_at(i + 1).unsafe_chr == '{'
-        set_end = find_matching_delimiter(source, i + 1, '{', '}', limit)
+        set_end = Helper.find_matching_delimiter(source, i + 1, '{', '}', limit)
         if set_end > i + 1
           process_table_route_entries(source, i + 2, set_end, current_prefix, path, seen, include_callee, function_callees)
           return
@@ -199,12 +200,12 @@ module Analyzer::Clojure
 
         case source.byte_at(i).unsafe_chr
         when '['
-          vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+          vec_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
           process_route_vector(source, i, vec_end, current_prefix, path, seen, include_callee, function_callees)
           i = vec_end + 1
         when '{'
-          map_end = find_matching_delimiter(source, i, '{', '}', limit)
+          map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
           if context = extract_context(source, i + 1, map_end)
             current_prefix = join_path(prefix, context)
@@ -234,7 +235,7 @@ module Analyzer::Clojure
         return false
       end
 
-      str_end = skip_string(source, i, vec_end)
+      str_end = Helper.skip_string(source, i, vec_end)
       return false if str_end <= i
 
       route_path = decode_string_literal(source.byte_slice(i, str_end - i + 1))
@@ -271,18 +272,18 @@ module Analyzer::Clojure
 
         case source.byte_at(i).unsafe_chr
         when '{'
-          map_end = find_matching_delimiter(source, i, '{', '}', limit)
+          map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
           process_method_map(source, i + 1, map_end, route_path, path, seen, include_callee, function_callees)
           process_route_map(source, i, map_end, route_path, path, seen, include_callee, function_callees)
           i = map_end + 1
         when '['
-          vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+          vec_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
           process_route_vector(source, i, vec_end, route_path, path, seen, include_callee, function_callees)
           i = vec_end + 1
         when '('
-          form_end = find_matching_delimiter(source, i, '(', ')', limit)
+          form_end = Helper.find_matching_delimiter(source, i, '(', ')', limit)
           break if form_end <= i
           handled = process_list(source, i, form_end, route_path, path, seen, include_callee, function_callees)
           walk_forms(source, i + 1, form_end, route_path, path, seen, include_callee, function_callees) unless handled
@@ -321,7 +322,7 @@ module Analyzer::Clojure
         case key
         when ":path"
           if value_start < value_end && source.byte_at(value_start).unsafe_chr == '"'
-            str_end = skip_string(source, value_start, value_end)
+            str_end = Helper.skip_string(source, value_start, value_end)
             route_path = decode_string_literal(source.byte_slice(value_start, str_end - value_start + 1))
           end
         when ":verbs"
@@ -437,7 +438,7 @@ module Analyzer::Clojure
       return if seen.includes?(key)
       seen << key
 
-      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, line_number_for(source, offset))))
+      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, Helper.line_number_for(source, offset))))
       extract_path_param_names(route_path).each do |name|
         add_param_once(endpoint, name, "path")
       end
@@ -473,13 +474,13 @@ module Analyzer::Clojure
 
       if token.starts_with?('(')
         body = source.byte_slice(value_start, value_end - value_start)
-        line = line_number_for(source, value_start)
+        line = Helper.line_number_for(source, value_start)
         Noir::ClojureCalleeExtractor.attach_to(endpoint, Noir::ClojureCalleeExtractor.callees_for_body(body, path, line))
       elsif handler_name = normalized_handler_symbol(token)
         if callees = function_callees[handler_name]?
           Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
         else
-          endpoint.push_callee(Callee.new(handler_name, path: path, line: line_number_for(source, value_start)))
+          endpoint.push_callee(Callee.new(handler_name, path: path, line: Helper.line_number_for(source, value_start)))
         end
       end
     end
@@ -529,7 +530,7 @@ module Analyzer::Clojure
       each_map_entry(source, start, limit) do |key, _key_pos, value_start, value_end|
         next unless {":context", ":io.pedestal.http/context", "::http/context"}.includes?(key)
         next unless value_start < value_end && source.byte_at(value_start).unsafe_chr == '"'
-        str_end = skip_string(source, value_start, value_end)
+        str_end = Helper.skip_string(source, value_start, value_end)
         return decode_string_literal(source.byte_slice(value_start, str_end - value_start + 1))
       end
       nil
@@ -540,9 +541,9 @@ module Analyzer::Clojure
       while i < limit
         case source.byte_at(i).unsafe_chr
         when ';'
-          i = skip_comment(source, i, limit)
+          i = Helper.skip_comment(source, i, limit)
         when '"'
-          literal_end = skip_string(source, i, limit)
+          literal_end = Helper.skip_string(source, i, limit)
           return {decode_string_literal(source.byte_slice(i, literal_end - i + 1)), literal_end}
         when '(', '[', '{'
           break
@@ -560,16 +561,16 @@ module Analyzer::Clojure
 
       case source.byte_at(i).unsafe_chr
       when '"'
-        e = skip_string(source, i, limit)
+        e = Helper.skip_string(source, i, limit)
         {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)}
       when '('
-        e = find_matching_delimiter(source, i, '(', ')', limit)
+        e = Helper.find_matching_delimiter(source, i, '(', ')', limit)
         e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
       when '['
-        e = find_matching_delimiter(source, i, '[', ']', limit)
+        e = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
       when '{'
-        e = find_matching_delimiter(source, i, '{', '}', limit)
+        e = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
       else
         read_symbol(source, i, limit)
@@ -582,16 +583,16 @@ module Analyzer::Clojure
 
       case source.byte_at(i).unsafe_chr
       when '"'
-        e = skip_string(source, i, limit)
+        e = Helper.skip_string(source, i, limit)
         e >= i ? e + 1 : limit
       when '('
-        e = find_matching_delimiter(source, i, '(', ')', limit)
+        e = Helper.find_matching_delimiter(source, i, '(', ')', limit)
         e > i ? e + 1 : limit
       when '['
-        e = find_matching_delimiter(source, i, '[', ']', limit)
+        e = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         e > i ? e + 1 : limit
       when '{'
-        e = find_matching_delimiter(source, i, '{', '}', limit)
+        e = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         e > i ? e + 1 : limit
       when '\'', '`', '^'
         end_of_value(source, i + 1, limit)
@@ -600,10 +601,10 @@ module Analyzer::Clojure
         case nxt
         when '{', '('
           inner_close = nxt == '{' ? '}' : ')'
-          e = find_matching_delimiter(source, i + 1, nxt, inner_close, limit)
+          e = Helper.find_matching_delimiter(source, i + 1, nxt, inner_close, limit)
           e > i + 1 ? e + 1 : limit
         when '"'
-          e = skip_string(source, i + 1, limit)
+          e = Helper.skip_string(source, i + 1, limit)
           e >= i + 1 ? e + 1 : limit
         when '_'
           end_of_value(source, i + 2, limit)
@@ -645,62 +646,12 @@ module Analyzer::Clojure
         if whitespace?(char) || char == ','
           i += 1
         elsif char == ';'
-          i = skip_comment(source, i, limit)
+          i = Helper.skip_comment(source, i, limit)
         else
           break
         end
       end
       i
-    end
-
-    private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
-      i = index
-      while i < limit && source.byte_at(i).unsafe_chr != '\n'
-        i += 1
-      end
-      i
-    end
-
-    private def skip_string(source : String, index : Int32, limit : Int32) : Int32
-      i = index + 1
-      escaping = false
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        if escaping
-          escaping = false
-        elsif char == '\\'
-          escaping = true
-        elsif char == '"'
-          return i
-        end
-        i += 1
-      end
-      limit - 1
-    end
-
-    private def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
-      depth = 0
-      i = index
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        case char
-        when ';'
-          i = skip_comment(source, i, limit)
-        when '"'
-          i = skip_string(source, i, limit)
-        when open_char
-          depth += 1
-        when close_char
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-      index
-    end
-
-    private def line_number_for(source : String, index : Int32) : Int32
-      source.byte_slice(0, index).count('\n') + 1
     end
 
     private def whitespace?(char : Char) : Bool

--- a/src/analyzer/analyzers/clojure/reitit.cr
+++ b/src/analyzer/analyzers/clojure/reitit.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
+require "./clojure_helper"
 
 module Analyzer::Clojure
   # Reitit is data-driven: routes are a vector tree
@@ -83,22 +84,22 @@ module Analyzer::Clojure
         c = source.byte_at(i).unsafe_chr
         case c
         when ';'
-          i = skip_comment(source, i, limit)
+          i = Helper.skip_comment(source, i, limit)
         when '"'
-          i = skip_string(source, i, limit) + 1
+          i = Helper.skip_string(source, i, limit) + 1
         when '('
-          form_end = find_matching_delimiter(source, i, '(', ')', limit)
+          form_end = Helper.find_matching_delimiter(source, i, '(', ')', limit)
           break if form_end <= i
           walk_forms(source, i + 1, form_end, prefix, path, include_callee, function_callees)
           i = form_end + 1
         when '['
-          vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+          vec_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
           handled = try_process_routes(source, i, vec_end, prefix, path, include_callee, function_callees)
           walk_forms(source, i + 1, vec_end, prefix, path, include_callee, function_callees) unless handled
           i = vec_end + 1
         when '{'
-          map_end = find_matching_delimiter(source, i, '{', '}', limit)
+          map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
           walk_forms(source, i + 1, map_end, prefix, path, include_callee, function_callees)
           i = map_end + 1
@@ -122,7 +123,7 @@ module Analyzer::Clojure
       case source.byte_at(i).unsafe_chr
       when '"'
         # Single route node: ["/path" ...body]
-        str_end = skip_string(source, i, vec_end)
+        str_end = Helper.skip_string(source, i, vec_end)
         return false if str_end <= i
         route_path = decode_string_literal(source.byte_slice(i, str_end - i + 1))
         return false unless route_path.starts_with?("/")
@@ -130,12 +131,12 @@ module Analyzer::Clojure
         true
       when '['
         # List of routes: [["/a" ...] ["/b" ...]]
-        child_end = find_matching_delimiter(source, i, '[', ']', vec_end)
+        child_end = Helper.find_matching_delimiter(source, i, '[', ']', vec_end)
         return false if child_end <= i
         j = skip_ws_and_comments(source, i + 1, child_end)
         return false if j >= child_end
         return false unless source.byte_at(j).unsafe_chr == '"'
-        str_end = skip_string(source, j, child_end)
+        str_end = Helper.skip_string(source, j, child_end)
         return false if str_end <= j
         peek = decode_string_literal(source.byte_slice(j, str_end - j + 1))
         return false unless peek.starts_with?("/")
@@ -159,7 +160,7 @@ module Analyzer::Clojure
         break if i >= limit
         c = source.byte_at(i).unsafe_chr
         if c == '['
-          vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+          vec_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
           process_route_vec(source, i, vec_end, prefix, path, include_callee, function_callees)
           i = vec_end + 1
@@ -180,7 +181,7 @@ module Analyzer::Clojure
       return if i >= vec_end
       return unless source.byte_at(i).unsafe_chr == '"'
 
-      str_end = skip_string(source, i, vec_end)
+      str_end = Helper.skip_string(source, i, vec_end)
       return if str_end <= i
 
       route_path = decode_string_literal(source.byte_slice(i, str_end - i + 1))
@@ -224,12 +225,12 @@ module Analyzer::Clojure
         c = source.byte_at(i).unsafe_chr
         case c
         when '{'
-          map_end = find_matching_delimiter(source, i, '{', '}', limit)
+          map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
           process_route_data_map(source, i + 1, map_end, prefix, path, include_callee, function_callees)
           i = map_end + 1
         when '['
-          vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+          vec_end = Helper.find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
           process_route_vec(source, i, vec_end, prefix, path, include_callee, function_callees)
           i = vec_end + 1
@@ -314,14 +315,14 @@ module Analyzer::Clojure
                               include_callee : Bool,
                               function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)),
                               data_handler : Tuple(Int32, Int32)? = nil)
-      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, line_number_for(source, key_pos))))
+      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, Helper.line_number_for(source, key_pos))))
 
       extract_path_param_names(route_path).each do |name|
         endpoint.push_param(Param.new(name, "", "path"))
       end
 
       if v_start < v_end && source.byte_at(v_start).unsafe_chr == '{'
-        map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
+        map_end = Helper.find_matching_delimiter(source, v_start, '{', '}', v_end)
         if map_end > v_start
           extract_params_from_method_map(source, v_start + 1, map_end, endpoint, route_path)
         end
@@ -342,7 +343,7 @@ module Analyzer::Clojure
       return if v_start >= v_end
 
       if source.byte_at(v_start).unsafe_chr == '{'
-        map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
+        map_end = Helper.find_matching_delimiter(source, v_start, '{', '}', v_end)
         return unless map_end > v_start
         attached = attach_handler_map_callees(source, v_start + 1, map_end, endpoint, path, function_callees)
         # `{:get {:parameters ...}}` carries no method-level handler; fall back
@@ -396,13 +397,13 @@ module Analyzer::Clojure
 
       if token.starts_with?('(')
         body = source.byte_slice(value_start, value_end - value_start)
-        line = line_number_for(source, value_start)
+        line = Helper.line_number_for(source, value_start)
         Noir::ClojureCalleeExtractor.attach_to(endpoint, Noir::ClojureCalleeExtractor.callees_for_body(body, path, line))
       elsif handler_name = normalized_handler_symbol(token)
         if callees = function_callees[handler_name]?
           Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
         else
-          endpoint.push_callee(Callee.new(handler_name, path: path, line: line_number_for(source, value_start)))
+          endpoint.push_callee(Callee.new(handler_name, path: path, line: Helper.line_number_for(source, value_start)))
         end
       end
     end
@@ -440,16 +441,16 @@ module Analyzer::Clojure
 
       case source.byte_at(i).unsafe_chr
       when '"'
-        e = skip_string(source, i, limit)
+        e = Helper.skip_string(source, i, limit)
         {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)}
       when '('
-        e = find_matching_delimiter(source, i, '(', ')', limit)
+        e = Helper.find_matching_delimiter(source, i, '(', ')', limit)
         e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
       when '['
-        e = find_matching_delimiter(source, i, '[', ']', limit)
+        e = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
       when '{'
-        e = find_matching_delimiter(source, i, '{', '}', limit)
+        e = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
       else
         read_symbol(source, i, limit)
@@ -473,7 +474,7 @@ module Analyzer::Clojure
         val_end = end_of_value(source, v_start, limit)
 
         if key == ":parameters" && v_start < val_end && source.byte_at(v_start).unsafe_chr == '{'
-          map_end = find_matching_delimiter(source, v_start, '{', '}', val_end)
+          map_end = Helper.find_matching_delimiter(source, v_start, '{', '}', val_end)
           if map_end > v_start
             extract_param_groups(source, v_start + 1, map_end, endpoint, route_path)
           end
@@ -515,12 +516,12 @@ module Analyzer::Clojure
       names = case source.byte_at(v_start).unsafe_chr
               when '{'
                 # Schema / map literal: `{:x int?, (s/optional-key :y) int?}`.
-                map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
+                map_end = Helper.find_matching_delimiter(source, v_start, '{', '}', v_end)
                 return unless map_end > v_start
                 extract_map_keys(source, v_start + 1, map_end)
               when '['
                 # malli map schema vector: `[:map [:x int?] [:y {…} int?]]`.
-                vec_end = find_matching_delimiter(source, v_start, '[', ']', v_end)
+                vec_end = Helper.find_matching_delimiter(source, v_start, '[', ']', v_end)
                 return unless vec_end > v_start
                 extract_malli_map_keys(source, v_start + 1, vec_end)
               else
@@ -551,7 +552,7 @@ module Analyzer::Clojure
         j = skip_ws_and_comments(source, j, limit)
         break if j >= limit
         if source.byte_at(j).unsafe_chr == '['
-          entry_end = find_matching_delimiter(source, j, '[', ']', limit)
+          entry_end = Helper.find_matching_delimiter(source, j, '[', ']', limit)
           break if entry_end <= j
           if name = first_keyword_in(source, j + 1, entry_end)
             keys << name
@@ -641,16 +642,16 @@ module Analyzer::Clojure
 
       case source.byte_at(i).unsafe_chr
       when '"'
-        e = skip_string(source, i, limit)
+        e = Helper.skip_string(source, i, limit)
         e >= i ? e + 1 : limit
       when '('
-        e = find_matching_delimiter(source, i, '(', ')', limit)
+        e = Helper.find_matching_delimiter(source, i, '(', ')', limit)
         e > i ? e + 1 : limit
       when '['
-        e = find_matching_delimiter(source, i, '[', ']', limit)
+        e = Helper.find_matching_delimiter(source, i, '[', ']', limit)
         e > i ? e + 1 : limit
       when '{'
-        e = find_matching_delimiter(source, i, '{', '}', limit)
+        e = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         e > i ? e + 1 : limit
       when '\'', '`'
         end_of_value(source, i + 1, limit)
@@ -661,10 +662,10 @@ module Analyzer::Clojure
         when '{', '('
           inner_open = nxt
           inner_close = nxt == '{' ? '}' : ')'
-          e = find_matching_delimiter(source, i + 1, inner_open, inner_close, limit)
+          e = Helper.find_matching_delimiter(source, i + 1, inner_open, inner_close, limit)
           e > i + 1 ? e + 1 : limit
         when '"'
-          e = skip_string(source, i + 1, limit)
+          e = Helper.skip_string(source, i + 1, limit)
           e >= i + 1 ? e + 1 : limit
         when '_'
           end_of_value(source, i + 2, limit)
@@ -704,62 +705,12 @@ module Analyzer::Clojure
           # Clojure treats commas as whitespace.
           i += 1
         elsif char == ';'
-          i = skip_comment(source, i, limit)
+          i = Helper.skip_comment(source, i, limit)
         else
           break
         end
       end
       i
-    end
-
-    private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
-      i = index
-      while i < limit && source.byte_at(i).unsafe_chr != '\n'
-        i += 1
-      end
-      i
-    end
-
-    private def skip_string(source : String, index : Int32, limit : Int32) : Int32
-      i = index + 1
-      escaping = false
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        if escaping
-          escaping = false
-        elsif char == '\\'
-          escaping = true
-        elsif char == '"'
-          return i
-        end
-        i += 1
-      end
-      limit - 1
-    end
-
-    private def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
-      depth = 0
-      i = index
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        case char
-        when ';'
-          i = skip_comment(source, i, limit)
-        when '"'
-          i = skip_string(source, i, limit)
-        when open_char
-          depth += 1
-        when close_char
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-      index
-    end
-
-    private def line_number_for(source : String, index : Int32) : Int32
-      source.byte_slice(0, index).count('\n') + 1
     end
 
     private def whitespace?(char : Char) : Bool

--- a/src/analyzer/analyzers/clojure/ring.cr
+++ b/src/analyzer/analyzers/clojure/ring.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../utils/utils"
+require "./clojure_helper"
 
 module Analyzer::Clojure
   # Generic Ring handler analyzer — extracts endpoints from Clojure code that
@@ -60,7 +61,7 @@ module Analyzer::Clojure
         method = METHOD_KEYWORDS[match[1].downcase]
         route = decode_string(match[2])
         next unless route.starts_with?('/')
-        # byte offset (line_number_for uses byte_slice; begin(0) is a char index)
+        # byte offset (Helper.line_number_for uses byte_slice; begin(0) is a char index)
         offset = match.byte_begin(0)
         emit_endpoint(content, path, offset, method, route, seen)
       end
@@ -76,11 +77,11 @@ module Analyzer::Clojure
       while i < end_index
         case source.byte_at(i).unsafe_chr
         when ';'
-          i = skip_comment(source, i, end_index)
+          i = Helper.skip_comment(source, i, end_index)
         when '"'
-          i = skip_string(source, i, end_index) + 1
+          i = Helper.skip_string(source, i, end_index) + 1
         when '('
-          form_end = find_matching_delimiter(source, i, '(', ')', end_index)
+          form_end = Helper.find_matching_delimiter(source, i, '(', ')', end_index)
           break if form_end <= i
 
           symbol_start = skip_ws_and_comments(source, i + 1, form_end)
@@ -153,7 +154,7 @@ module Analyzer::Clojure
             emit_endpoint(source, path, i, "GET", route, seen) if route.starts_with?('/')
           elsif token.starts_with?('(')
             # Fall-through list of keys: `("/a" "/b")` — each string is a route.
-            emit_list_string_keys(source, i + 1, find_matching_delimiter(source, i, '(', ')', limit), path, seen)
+            emit_list_string_keys(source, i + 1, Helper.find_matching_delimiter(source, i, '(', ')', limit), path, seen)
           end
         end
 
@@ -198,11 +199,11 @@ module Analyzer::Clojure
       while i < end_index
         case source.byte_at(i).unsafe_chr
         when ';'
-          i = skip_comment(source, i, end_index)
+          i = Helper.skip_comment(source, i, end_index)
         when '"'
-          i = skip_string(source, i, end_index) + 1
+          i = Helper.skip_string(source, i, end_index) + 1
         when '('
-          form_end = find_matching_delimiter(source, i, '(', ')', end_index)
+          form_end = Helper.find_matching_delimiter(source, i, '(', ')', end_index)
           break if form_end <= i
 
           sym_start = skip_ws_and_comments(source, i + 1, form_end)
@@ -266,7 +267,7 @@ module Analyzer::Clojure
       char = source.byte_at(i).unsafe_chr
       case char
       when '('
-        form_end = find_matching_delimiter(source, i, '(', ')', end_index)
+        form_end = Helper.find_matching_delimiter(source, i, '(', ')', end_index)
         if form_end > i
           token = source.byte_slice(i, form_end - i + 1)
           {token, skip_ws_and_comments(source, form_end + 1, end_index)}
@@ -274,7 +275,7 @@ module Analyzer::Clojure
           {"", i}
         end
       when '['
-        form_end = find_matching_delimiter(source, i, '[', ']', end_index)
+        form_end = Helper.find_matching_delimiter(source, i, '[', ']', end_index)
         if form_end > i
           token = source.byte_slice(i, form_end - i + 1)
           {token, skip_ws_and_comments(source, form_end + 1, end_index)}
@@ -282,7 +283,7 @@ module Analyzer::Clojure
           {"", i}
         end
       when '{'
-        form_end = find_matching_delimiter(source, i, '{', '}', end_index)
+        form_end = Helper.find_matching_delimiter(source, i, '{', '}', end_index)
         if form_end > i
           token = source.byte_slice(i, form_end - i + 1)
           {token, skip_ws_and_comments(source, form_end + 1, end_index)}
@@ -290,7 +291,7 @@ module Analyzer::Clojure
           {"", i}
         end
       when '"'
-        str_end = skip_string(source, i, end_index)
+        str_end = Helper.skip_string(source, i, end_index)
         token = source.byte_slice(i, str_end - i + 1)
         {token, skip_ws_and_comments(source, str_end + 1, end_index)}
       else
@@ -315,7 +316,7 @@ module Analyzer::Clojure
       return if seen.includes?(key)
       seen << key
 
-      line = line_number_for(content, offset)
+      line = Helper.line_number_for(content, offset)
       endpoint = Endpoint.new(route, method, Details.new(PathInfo.new(path, line)))
 
       extract_path_param_names(route).each do |name|
@@ -355,66 +356,12 @@ module Analyzer::Clojure
         if whitespace?(char)
           i += 1
         elsif char == ';'
-          i = skip_comment(source, i, limit)
+          i = Helper.skip_comment(source, i, limit)
         else
           break
         end
       end
       i
-    end
-
-    private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
-      i = index
-      while i < limit && source.byte_at(i).unsafe_chr != '\n'
-        i += 1
-      end
-      i
-    end
-
-    private def skip_string(source : String, index : Int32, limit : Int32) : Int32
-      i = index + 1
-      escaping = false
-
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        if escaping
-          escaping = false
-        elsif char == '\\'
-          escaping = true
-        elsif char == '"'
-          return i
-        end
-        i += 1
-      end
-
-      limit - 1
-    end
-
-    private def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
-      depth = 0
-      i = index
-
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        case char
-        when ';'
-          i = skip_comment(source, i, limit)
-        when '"'
-          i = skip_string(source, i, limit)
-        when open_char
-          depth += 1
-        when close_char
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-
-      index
-    end
-
-    private def line_number_for(source : String, index : Int32) : Int32
-      source.byte_slice(0, index).count('\n') + 1
     end
 
     private def whitespace?(char : Char) : Bool


### PR DESCRIPTION
Closes #2444

All five Clojure analyzers (`cli`, `compojure`, `pedestal`, `reitit`, `ring`) walked s-expressions the same way, and each carried its own private copy of the same four helpers — 20 functionally identical methods, differing only in blank lines. Unlike Dart, Python, Java, Perl, Haskell, Erlang and Gleam, the Clojure directory had no `*_helper.cr`.

This adds `src/analyzer/analyzers/clojure/clojure_helper.cr` with `Analyzer::Clojure::Helper` (`skip_comment`, `skip_string`, `find_matching_delimiter`, `line_number_for`), requires it from all five analyzers, deletes the 20 private copies, and routes every call site through `Helper.`.

Pure refactor: the bodies were copied verbatim, not rewritten. `whitespace?` and the other per-analyzer privates are untouched.

Net: **114 insertions, 371 deletions**.

## Verify
- `crystal tool format --check` — clean
- `lib/ameba/bin/ameba.cr src/analyzer/analyzers/clojure/` — 6 inspected, 0 failures
- `crystal spec spec/functional_test/testers/clojure/` — 410 examples, 0 failures
- A/B over all 13 dirs in `spec/functional_test/fixtures/clojure/`: `noir -f json` output is byte-identical between `main` and this branch, line numbers included.