### PR TITLE
refactor(output): derive the -f format catalog from the builder classes

### DIFF
--- a/spec/unit_test/cli/list_command_spec.cr
+++ b/spec/unit_test/cli/list_command_spec.cr
@@ -113,7 +113,7 @@ describe Noir::CLI::ListCommand do
       io = IO::Memory.new
       Noir::CLI::ListCommand.print_formats("json", io)
       doc = JSON.parse(io.to_s)
-      doc["formats"].as_a.map(&.as_s).should eq(Noir::CliValidation::VALID_OUTPUT_FORMATS)
+      doc["formats"].as_a.map(&.as_s).should eq(Noir::OutputFormats::NAMES)
     end
   end
 end

--- a/spec/unit_test/output_builder/formats_spec.cr
+++ b/spec/unit_test/output_builder/formats_spec.cr
@@ -1,0 +1,75 @@
+require "../../spec_helper"
+require "../../../src/output_builder/formats"
+require "../../../src/cli_validation"
+require "../../../src/completions"
+
+# The catalog is derived from the `Noir::OutputFormat` annotation on each
+# builder, so these examples guard the derivation itself: that it stays
+# non-empty and unambiguous, and that everything downstream of it (`-f`
+# validation, the completion scripts) really does read the same list rather
+# than a copy that drifted.
+describe Noir::OutputFormats do
+  it "derives one entry per annotated builder, with a description" do
+    Noir::OutputFormats::ENTRIES.size.should be > 1
+    Noir::OutputFormats::ENTRIES.each do |entry|
+      entry.name.should_not be_empty
+      entry.description.should_not be_empty
+    end
+  end
+
+  it "has no duplicate format names" do
+    names = Noir::OutputFormats::NAMES
+    names.uniq.size.should eq(names.size)
+  end
+
+  it "includes the default format" do
+    Noir::OutputFormats.known?(Noir::OutputFormats::DEFAULT).should be_true
+  end
+
+  it "rejects an unknown format" do
+    Noir::OutputFormats.known?("nope").should be_false
+  end
+
+  it "reports an unrenderable format instead of silently emitting nothing" do
+    rendered = Noir::OutputFormats.render(
+      "nope",
+      {"debug" => YAML::Any.new(false), "verbose" => YAML::Any.new(false),
+       "color" => YAML::Any.new(false), "nolog" => YAML::Any.new(true),
+       "output" => YAML::Any.new("")},
+      [] of Endpoint,
+      [] of PassiveScanResult
+    )
+    rendered.should be_false
+  end
+
+  it "lists every format in the -f help text" do
+    help = Noir::OutputFormats.help_text
+    Noir::OutputFormats::ENTRIES.each do |entry|
+      help.should contain(entry.name)
+      help.should contain(entry.description)
+    end
+  end
+
+  it "offers every format in every shell completion" do
+    scripts = {
+      "zsh"    => generate_zsh_completion_script,
+      "bash"   => generate_bash_completion_script,
+      "fish"   => generate_fish_completion_script,
+      "elvish" => generate_elvish_completion_script,
+    }
+    # Elvish completes `-f` by file, not by an enum list, so only the three
+    # shells whose scripts carry the value list are asserted here.
+    %w[zsh bash fish].each do |shell|
+      Noir::OutputFormats::NAMES.each do |name|
+        scripts[shell].should contain(name)
+      end
+    end
+  end
+
+  it "accepts every catalog format at the CLI validation gate" do
+    Noir::OutputFormats::NAMES.each do |name|
+      options = {"format" => YAML::Any.new(name)}
+      Noir::CliValidation.validate_output_format!(options)
+    end
+  end
+end

--- a/src/cli/commands/list.cr
+++ b/src/cli/commands/list.cr
@@ -4,7 +4,7 @@ require "yaml"
 require "../common"
 require "../../techs/techs"
 require "../../tagger/tagger"
-require "../../cli_validation"
+require "../../output_builder/formats"
 
 # `noir list <techs|taggers|formats>`
 #
@@ -138,8 +138,8 @@ module Noir::CLI::ListCommand
 
   def self.print_formats(format : String = "text", io : IO = STDOUT)
     case format
-    when "json" then io.puts({"formats" => Noir::CliValidation::VALID_OUTPUT_FORMATS}.to_json)
-    when "yaml" then io.puts({"formats" => Noir::CliValidation::VALID_OUTPUT_FORMATS}.to_yaml)
+    when "json" then io.puts({"formats" => Noir::OutputFormats::NAMES}.to_json)
+    when "yaml" then io.puts({"formats" => Noir::OutputFormats::NAMES}.to_yaml)
     else             print_formats_text(io)
     end
   end
@@ -173,10 +173,13 @@ module Noir::CLI::ListCommand
     end
   end
 
+  # The one-line description beside each name is the same string `noir scan
+  # -h` prints, because both read the annotation on the builder class.
   private def self.print_formats_text(io : IO)
     io.puts "Available output formats:"
-    Noir::CliValidation::VALID_OUTPUT_FORMATS.each do |fmt|
-      io.puts " #{fmt.colorize(:green)}"
+    width = Noir::OutputFormats::ENTRIES.max_of(&.name.size)
+    Noir::OutputFormats::ENTRIES.each do |entry|
+      io.puts " #{entry.name.ljust(width).colorize(:green)}  #{entry.description}"
     end
   end
 

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -3,35 +3,11 @@ require "yaml"
 require "./tagger/tagger"
 require "./techs/techs"
 require "./llm/native_tool_calling"
+require "./output_builder/formats"
 
 module Noir::CliValidation
   class Error < Exception
   end
-
-  VALID_OUTPUT_FORMATS = %w[
-    plain
-    yaml
-    json
-    jsonl
-    toml
-    markdown-table
-    sarif
-    html
-    curl
-    httpie
-    powershell
-    adb
-    simctl
-    oas2
-    oas3
-    postman
-    only-url
-    only-param
-    only-header
-    only-cookie
-    only-tag
-    mermaid
-  ]
 
   def self.validate!(options : Hash(String, YAML::Any))
     validate_base_paths!(options)
@@ -257,9 +233,9 @@ module Noir::CliValidation
 
   def self.validate_output_format!(options : Hash(String, YAML::Any))
     format = options["format"].to_s
-    return if VALID_OUTPUT_FORMATS.includes?(format)
+    return if Noir::OutputFormats.known?(format)
 
-    raise Error.new("Invalid output format '#{format}'. Valid formats: #{VALID_OUTPUT_FORMATS.join(", ")}")
+    raise Error.new("Invalid output format '#{format}'. Valid formats: #{Noir::OutputFormats::NAMES.join(", ")}")
   end
 
   # Upper bound for --concurrency. A user asking for hundreds of thousands

--- a/src/completions.cr
+++ b/src/completions.cr
@@ -9,7 +9,11 @@
 # `noir` for backward compatibility with users who haven't switched to
 # the verb form).
 
-private FORMATS = "plain yaml json jsonl toml markdown-table sarif html curl httpie powershell adb simctl oas2 oas3 postman only-url only-param only-header only-cookie only-tag mermaid"
+require "./output_builder/formats"
+
+# Space-separated `-f` values, straight off the annotated builder classes so
+# the completion candidates can't drift from the formats the binary accepts.
+private FORMATS = Noir::OutputFormats::NAMES.join(" ")
 
 private SCAN_FLAGS = %w[
   -b --base-path
@@ -408,7 +412,7 @@ def generate_fish_completion_script
     # Scan-time flags (also valid under bare `noir` for v0 compat)
     complete -c noir #{g} -s b -l base-path             -d 'Set base path' -r -F
     complete -c noir #{g} -s u -l url                   -d 'Set base URL' -r
-    complete -c noir #{g} -s f -l format                -d 'Output format' -r -a 'plain yaml json jsonl toml markdown-table sarif html curl httpie powershell adb simctl oas2 oas3 postman only-url only-param only-header only-cookie only-tag mermaid'
+    complete -c noir #{g} -s f -l format                -d 'Output format' -r -a '#{FORMATS}'
     complete -c noir #{g} -s o -l output                -d 'Write result to file' -r -F
     complete -c noir #{g}      -l pvalue                -d 'Set param value TYPE=VAL' -r
     complete -c noir #{g}      -l set-pvalue            -d 'Set pvalue (any)'    -r

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -367,94 +367,18 @@ class NoirRunner
     end
   end
 
+  # Renders the report in the requested format. Which builder that is, and
+  # which formats exist at all, is the annotated-builder catalog's business
+  # (`Noir::OutputFormats`) — this used to be a 70-line `case` that was the
+  # fourth place a format had to be listed.
   def report
-    case options["format"]
-    when "yaml"
-      builder = OutputBuilderYaml.new @options
-      builder.print @endpoints, @passive_results
-    when "json"
-      builder = OutputBuilderJson.new @options
-      builder.print @endpoints, @passive_results
-    when "jsonl"
-      builder = OutputBuilderJsonl.new @options
-      builder.print @endpoints, @passive_results
-    when "toml"
-      builder = OutputBuilderToml.new @options
-      builder.print @endpoints, @passive_results
-    when "markdown-table"
-      builder = OutputBuilderMarkdownTable.new @options
-      builder.print @endpoints
-    when "httpie"
-      builder = OutputBuilderHttpie.new @options
-      builder.print @endpoints
-    when "curl"
-      builder = OutputBuilderCurl.new @options
-      builder.print @endpoints
-    when "powershell"
-      builder = OutputBuilderPowershell.new @options
-      builder.print @endpoints
-    when "adb"
-      builder = OutputBuilderAdb.new @options
-      builder.print @endpoints
-    when "simctl"
-      builder = OutputBuilderSimctl.new @options
-      builder.print @endpoints
-    when "sarif"
-      builder = OutputBuilderSarif.new @options
-      builder.print @endpoints, @passive_results
-    when "oas2"
-      builder = OutputBuilderOas2.new @options
-      builder.print @endpoints
-    when "oas3"
-      builder = OutputBuilderOas3.new @options
-      builder.print @endpoints
-    when "postman"
-      builder = OutputBuilderPostman.new @options
-      builder.print @endpoints
-    when "only-url"
-      builder = OutputBuilderOnlyUrl.new @options
-      builder.print @endpoints
-    when "only-param"
-      builder = OutputBuilderOnlyParam.new @options
-      builder.print @endpoints
-    when "only-header"
-      builder = OutputBuilderOnlyHeader.new @options
-      builder.print @endpoints
-    when "only-cookie"
-      builder = OutputBuilderOnlyCookie.new @options
-      builder.print @endpoints
-    when "only-tag"
-      builder = OutputBuilderOnlyTag.new @options
-      builder.print @endpoints
-    when "mermaid"
-      builder = OutputBuilderMermaid.new @options
-      builder.print @endpoints, @passive_results
-    when "html"
-      builder = OutputBuilderHtml.new @options
-      builder.print @endpoints, @passive_results
-    else
-      builder = OutputBuilderCommon.new @options
+    format = options["format"].to_s
+    return if Noir::OutputFormats.render(format, @options, @endpoints, @passive_results)
 
-      @logger.heading "Endpoint Results:"
-      builder.print @endpoints
-
-      print_passive_results
-    end
-  end
-
-  def print_passive_results
-    unless @passive_results.empty?
-      builder = OutputBuilderPassiveScan.new @options
-      # Separator through the builder, not `@logger.puts`: the logger
-      # `exit(0)`s the process on a broken pipe, so `noir scan . -P -o
-      # report.txt | head` died on this one blank line and the `-o` file
-      # kept the endpoint list but lost every finding. `ob_puts` marks
-      # stdout broken and keeps filling the file. It also puts the blank
-      # line in `-o`, so the saved report matches what stdout showed.
-      builder.ob_puts ""
-      @logger.heading "Passive Results:"
-      builder.print @passive_results
-    end
+    # `CliValidation` rejects an unknown `-f` before a scan starts, so this
+    # only catches a library caller that built the options hash itself:
+    # fall back to the default format rather than printing nothing at all.
+    Noir::OutputFormats.render(Noir::OutputFormats::DEFAULT, @options, @endpoints, @passive_results)
   end
 
   def techs=(value : Array(String))

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -1,5 +1,6 @@
 require "./logger"
 require "./endpoint"
+require "./passive_scan"
 require "../utils/*"
 require "colorize"
 
@@ -55,6 +56,29 @@ module NoirOutputFiles
     file.close unless file.closed?
   rescue IO::Error
   end
+end
+
+# Marks an `OutputBuilder` subclass as the implementation of one
+# `-f/--format` value.
+#
+#     @[Noir::OutputFormat(name: "json", description: "JSON", order: 30)]
+#     class OutputBuilderJson < OutputBuilder
+#
+# `Noir::OutputFormats` reads the catalog off the annotated classes, so this
+# line is the only place a format's name, its help/`noir list formats`
+# description, and the class that renders it are written down. Before it,
+# those three facts lived in five hand-maintained lists (the dispatch `case`
+# in `NoirRunner#report`, `CliValidation::VALID_OUTPUT_FORMATS`, the `-f`
+# help text, and the zsh/bash/fish completion strings) that nothing linked
+# together — a new format silently missed whichever ones the author forgot.
+#
+# `order` decides where the format appears in help output and `noir list
+# formats`; it has no runtime meaning. Values are spaced by 10 so a format
+# can be slotted between two others without renumbering.
+#
+# Builders that are not `-f` values (the diff renderer, the passive-scan
+# section) carry no annotation and stay out of the registry.
+annotation Noir::OutputFormat
 end
 
 class OutputBuilder
@@ -171,6 +195,14 @@ class OutputBuilder
 
   def print
     # After inheriting the class, write an action code here.
+  end
+
+  # Two-argument entry point every `-f` format answers to, so
+  # `Noir::OutputFormats.render` can hand each builder the same pair.
+  # Formats with nothing to say about passive findings inherit this and
+  # implement only `print(endpoints)`.
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+    print(endpoints)
   end
 
   # The block form of `NoirLogger#debug`, not the String one: `bake_endpoint`

--- a/src/options.cr
+++ b/src/options.cr
@@ -1,5 +1,6 @@
 require "./ai_context/features.cr"
 require "./completions.cr"
+require "./output_builder/formats.cr"
 require "./config_initializer.cr"
 require "./banner.cr"
 require "yaml"
@@ -272,31 +273,10 @@ def run_options_parser
     end
 
     parser.separator "\n OUTPUT:".colorize(:blue)
-    parser.on "-f FMT", "--format json", <<-DESC do |v|
-      Output format:
-        plain                Plain text (default)
-        yaml                 YAML
-        json                 JSON
-        jsonl                JSON Lines
-        toml                 TOML
-        markdown-table       Markdown table
-        sarif                SARIF format
-        html                 HTML report
-        curl                 cURL commands
-        httpie               HTTPie commands
-        powershell           PowerShell Invoke-WebRequest commands
-        adb                  ADB commands for Android entry points
-        simctl               simctl commands for iOS entry points
-        oas2                 OpenAPI 2.0 (Swagger)
-        oas3                 OpenAPI 3.0
-        postman              Postman collection
-        only-url             Only endpoint URLs
-        only-param           Only parameters
-        only-header          Only headers
-        only-cookie          Only cookies
-        only-tag             Only tags
-        mermaid              Mermaid diagram
-      DESC
+    # The per-format lines come from the annotated builder classes
+    # (`Noir::OutputFormats`), so a new format shows up in `-h` without this
+    # list having to be updated alongside the builder.
+    parser.on "-f FMT", "--format json", "Output format:\n#{Noir::OutputFormats.help_text}" do |v|
       noir_options["format"] = YAML::Any.new(v)
     end
     parser.on "-o PATH", "--output out.txt", "Write result to file" do |v|

--- a/src/output_builder/adb.cr
+++ b/src/output_builder/adb.cr
@@ -14,6 +14,7 @@ require "./mobile_launch"
 # `xcrun simctl openurl` — a dedicated `-f simctl` format is a follow-up). The
 # dropped endpoints are reported once per category as a warning (to STDERR, so
 # the command list on STDOUT stays pipe-clean).
+@[Noir::OutputFormat(name: "adb", description: "ADB commands for Android entry points", order: 120)]
 class OutputBuilderAdb < OutputBuilder
   include MobileLaunch
 

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -1,7 +1,9 @@
 require "../ai_context/features"
 require "../models/output_builder"
 require "../models/endpoint"
+require "./passive_scan"
 
+@[Noir::OutputFormat(name: "plain", description: "Plain text (default)", order: 10)]
 class OutputBuilderCommon < OutputBuilder
   # Mobile entry points keep method = "GET" internally; the protocol
   # carries the real semantics and drives the display prefix.
@@ -24,6 +26,27 @@ class OutputBuilderCommon < OutputBuilder
                           "path_permissions", "extras"]
 
   @ai_context_features : Set(String)? = nil
+
+  # The plain report is the only format that frames itself — a heading over
+  # the endpoint list, and the passive-scan findings appended below a second
+  # one. Both used to sit in `NoirRunner#report`, which forced the runner to
+  # special-case "is this the default format?" on either side of a dispatch
+  # that otherwise treats every format alike.
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+    logger.heading "Endpoint Results:"
+    print(endpoints)
+    return if passive_results.empty?
+
+    # Separator through a builder, not `logger.puts`: the logger `exit(0)`s
+    # the process on a broken pipe, so `noir scan . -P -o report.txt | head`
+    # died on this one blank line and the `-o` file kept the endpoint list
+    # but lost every finding. `ob_puts` marks stdout broken and keeps
+    # filling the file. It also puts the blank line in `-o`, so the saved
+    # report matches what stdout showed.
+    ob_puts ""
+    logger.heading "Passive Results:"
+    OutputBuilderPassiveScan.new(@options).print(passive_results)
+  end
 
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|

--- a/src/output_builder/curl.cr
+++ b/src/output_builder/curl.cr
@@ -3,6 +3,7 @@ require "../models/endpoint"
 require "../utils/http_symbols"
 require "../utils/curl_command"
 
+@[Noir::OutputFormat(name: "curl", description: "cURL commands", order: 90)]
 class OutputBuilderCurl < OutputBuilder
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|

--- a/src/output_builder/formats.cr
+++ b/src/output_builder/formats.cr
@@ -1,0 +1,92 @@
+require "../models/output_builder"
+require "./adb"
+require "./common"
+require "./curl"
+require "./html"
+require "./httpie"
+require "./json"
+require "./jsonl"
+require "./markdown_table"
+require "./mermaid"
+require "./oas2"
+require "./oas3"
+require "./only-cookie"
+require "./only-header"
+require "./only-param"
+require "./only-tag"
+require "./only-url"
+require "./postman"
+require "./powershell"
+require "./sarif"
+require "./simctl"
+require "./toml"
+require "./yaml"
+
+# The catalog of `-f/--format` values, derived from the `Noir::OutputFormat`
+# annotation each builder carries.
+#
+# Everything that needs to know which formats exist reads it from here: the
+# scan's report dispatch, `--format` validation, the `-f` help text, `noir
+# list formats`, and the four shell completion generators. A format joins all
+# of them by annotating its builder class — the annotation is the only place
+# its name, description and renderer are written down.
+module Noir::OutputFormats
+  record Entry, name : String, description : String
+
+  # Ordered by the annotation's `order:`, so help output and `noir list
+  # formats` group related formats (structured → command → spec → only-* →
+  # diagram) instead of following `require` order.
+  ENTRIES = begin
+    {% begin %}
+      [
+        {% for builder in OutputBuilder.all_subclasses
+                            .select(&.annotation(Noir::OutputFormat))
+                            .sort_by { |sub| sub.annotation(Noir::OutputFormat)[:order] } %}
+          {% format = builder.annotation(Noir::OutputFormat) %}
+          Entry.new({{ format[:name] }}, {{ format[:description] }}),
+        {% end %}
+      ] of Entry
+    {% end %}
+  end
+
+  NAMES = ENTRIES.map(&.name)
+
+  # The format used when `-f` is absent, and the fallback for a value that
+  # reached the runner without passing validation (library callers construct
+  # the options hash directly).
+  DEFAULT = "plain"
+
+  def self.known?(name : String) : Bool
+    NAMES.includes?(name)
+  end
+
+  # Renders the report in `format`, returning false when no builder claims
+  # that name so the caller can fall back to `DEFAULT`.
+  #
+  # Each `when` branch instantiates one concrete builder, so the call is
+  # resolved per class rather than through the `OutputBuilder` base type —
+  # which is what lets builders keep their own `print` overloads.
+  def self.render(format : String,
+                  options : Hash(String, YAML::Any),
+                  endpoints : Array(Endpoint),
+                  passive_results : Array(PassiveScanResult)) : Bool
+    {% begin %}
+      case format
+      {% for builder in OutputBuilder.all_subclasses.select(&.annotation(Noir::OutputFormat)) %}
+      when {{ builder.annotation(Noir::OutputFormat)[:name] }}
+        {{ builder }}.new(options).print(endpoints, passive_results)
+      {% end %}
+      else
+        return false
+      end
+    {% end %}
+    true
+  end
+
+  # `-f` help block for the CLI option parser, indented to sit under the
+  # flag's description.
+  def self.help_text(indent : String = "  ") : String
+    width = ENTRIES.max_of(&.name.size) + 2
+    ENTRIES.map { |entry| "#{indent}#{entry.name.ljust(width)} #{entry.description}" }.join("\n")
+  end
+end

--- a/src/output_builder/html.cr
+++ b/src/output_builder/html.cr
@@ -8,13 +8,9 @@ require "./html_assets/js"
 require "./html_assets/logo"
 require "html"
 
+@[Noir::OutputFormat(name: "html", description: "HTML report", order: 80)]
 class OutputBuilderHtml < OutputBuilder
-  def print(endpoints : Array(Endpoint))
-    html = build_html(endpoints, [] of PassiveScanResult)
-    ob_puts html
-  end
-
-  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     html = build_html(endpoints, passive_results)
     ob_puts html
   end

--- a/src/output_builder/httpie.cr
+++ b/src/output_builder/httpie.cr
@@ -3,6 +3,7 @@ require "../models/endpoint"
 require "../utils/http_symbols"
 require "json"
 
+@[Noir::OutputFormat(name: "httpie", description: "HTTPie commands", order: 100)]
 class OutputBuilderHttpie < OutputBuilder
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|

--- a/src/output_builder/json.cr
+++ b/src/output_builder/json.cr
@@ -1,13 +1,9 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
+@[Noir::OutputFormat(name: "json", description: "JSON", order: 30)]
 class OutputBuilderJson < OutputBuilder
-  def print(endpoints : Array(Endpoint))
-    message = {"endpoints" => endpoints, "passive_results" => [] of PassiveScanResult}.to_json
-    ob_puts message
-  end
-
-  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     message = {"endpoints" => endpoints, "passive_results" => passive_results}.to_json
     ob_puts message
   end

--- a/src/output_builder/jsonl.cr
+++ b/src/output_builder/jsonl.cr
@@ -2,18 +2,13 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "../models/passive_scan"
 
+@[Noir::OutputFormat(name: "jsonl", description: "JSON Lines", order: 40)]
 class OutputBuilderJsonl < OutputBuilder
-  def print(endpoints : Array(Endpoint))
-    endpoints.each do |endpoint|
-      ob_puts endpoint.to_json
-    end
-  end
-
   # Passive findings were dropped from JSONL entirely (only the JSON builder
   # mapped them). Emit each finding on its own line after the endpoints so a
   # `-P` scan's secrets/etc. survive the JSONL pipeline. Consumers tell the
   # two apart by shape (endpoints carry url/method, findings carry id/info).
-  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     endpoints.each do |endpoint|
       ob_puts endpoint.to_json
     end

--- a/src/output_builder/markdown_table.cr
+++ b/src/output_builder/markdown_table.cr
@@ -1,6 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
+@[Noir::OutputFormat(name: "markdown-table", description: "Markdown table", order: 60)]
 class OutputBuilderMarkdownTable < OutputBuilder
   def print(endpoints : Array(Endpoint))
     ob_puts "| Endpoint | Protocol | Params |"

--- a/src/output_builder/mermaid.cr
+++ b/src/output_builder/mermaid.cr
@@ -2,6 +2,7 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "../models/passive_scan"
 
+@[Noir::OutputFormat(name: "mermaid", description: "Mermaid diagram", order: 220)]
 class OutputBuilderMermaid < OutputBuilder
   # CLI inputs get a plural label; the bucket key is the singular param type.
   CLI_PARAM_LABELS = {"flag" => "flags", "argument" => "arguments", "env" => "env"}
@@ -9,11 +10,7 @@ class OutputBuilderMermaid < OutputBuilder
   # Buckets `output_tree` renders explicitly, under a label of their own.
   RENDERED_BUCKETS = Set{"header", "cookie", "query", "json", "form", "path"}
 
-  def print(endpoints : Array(Endpoint))
-    build_mindmap(endpoints)
-  end
-
-  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     build_mindmap(endpoints, passive_results)
   end
 

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -3,6 +3,7 @@ require "../models/endpoint"
 require "./oas_common"
 require "json"
 
+@[Noir::OutputFormat(name: "oas2", description: "OpenAPI 2.0 (Swagger)", order: 140)]
 class OutputBuilderOas2 < OutputBuilder
   include OutputBuilderOasCommon
 

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -3,6 +3,7 @@ require "../models/endpoint"
 require "./oas_common"
 require "json"
 
+@[Noir::OutputFormat(name: "oas3", description: "OpenAPI 3.0", order: 150)]
 class OutputBuilderOas3 < OutputBuilder
   include OutputBuilderOasCommon
 

--- a/src/output_builder/only-cookie.cr
+++ b/src/output_builder/only-cookie.cr
@@ -1,6 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
+@[Noir::OutputFormat(name: "only-cookie", description: "Only cookies", order: 200)]
 class OutputBuilderOnlyCookie < OutputBuilder
   def print(endpoints : Array(Endpoint))
     cookies = [] of String

--- a/src/output_builder/only-header.cr
+++ b/src/output_builder/only-header.cr
@@ -1,6 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
+@[Noir::OutputFormat(name: "only-header", description: "Only headers", order: 190)]
 class OutputBuilderOnlyHeader < OutputBuilder
   def print(endpoints : Array(Endpoint))
     headers = [] of String

--- a/src/output_builder/only-param.cr
+++ b/src/output_builder/only-param.cr
@@ -1,6 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
+@[Noir::OutputFormat(name: "only-param", description: "Only parameters", order: 180)]
 class OutputBuilderOnlyParam < OutputBuilder
   # Excluded rather than an allow-list of what to print. This format exists to
   # feed parameter fuzzers, so the question is which inputs *aren't* wanted:

--- a/src/output_builder/only-tag.cr
+++ b/src/output_builder/only-tag.cr
@@ -1,6 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
+@[Noir::OutputFormat(name: "only-tag", description: "Only tags", order: 210)]
 class OutputBuilderOnlyTag < OutputBuilder
   def print(endpoints : Array(Endpoint))
     tags = [] of Tag

--- a/src/output_builder/only-url.cr
+++ b/src/output_builder/only-url.cr
@@ -1,6 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
+@[Noir::OutputFormat(name: "only-url", description: "Only endpoint URLs", order: 170)]
 class OutputBuilderOnlyUrl < OutputBuilder
   def print(endpoints : Array(Endpoint))
     printed_urls = Set(String).new

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -4,6 +4,7 @@ require "../utils/http_symbols"
 require "uri"
 require "json"
 
+@[Noir::OutputFormat(name: "postman", description: "Postman collection", order: 160)]
 class OutputBuilderPostman < OutputBuilder
   def print(endpoints : Array(Endpoint))
     items = [] of Hash(String, JSON::Any)

--- a/src/output_builder/powershell.cr
+++ b/src/output_builder/powershell.cr
@@ -2,6 +2,7 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "../utils/http_symbols"
 
+@[Noir::OutputFormat(name: "powershell", description: "PowerShell Invoke-WebRequest commands", order: 110)]
 class OutputBuilderPowershell < OutputBuilder
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|

--- a/src/output_builder/sarif.cr
+++ b/src/output_builder/sarif.cr
@@ -2,13 +2,9 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "sarif"
 
+@[Noir::OutputFormat(name: "sarif", description: "SARIF format", order: 70)]
 class OutputBuilderSarif < OutputBuilder
-  def print(endpoints : Array(Endpoint))
-    message = build_sarif(endpoints, [] of PassiveScanResult)
-    ob_puts message
-  end
-
-  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     message = build_sarif(endpoints, passive_results)
     ob_puts message
   end

--- a/src/output_builder/simctl.cr
+++ b/src/output_builder/simctl.cr
@@ -12,6 +12,7 @@ require "./mobile_launch"
 # domain associations. iOS has no intent/provider analog, so every emitted
 # command is a single `openurl`. Skips are reported per category as a warning
 # to STDERR, so the command list on STDOUT stays pipe-clean.
+@[Noir::OutputFormat(name: "simctl", description: "simctl commands for iOS entry points", order: 130)]
 class OutputBuilderSimctl < OutputBuilder
   include MobileLaunch
 

--- a/src/output_builder/toml.cr
+++ b/src/output_builder/toml.cr
@@ -2,17 +2,11 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "./toml_serializer"
 
+@[Noir::OutputFormat(name: "toml", description: "TOML", order: 50)]
 class OutputBuilderToml < OutputBuilder
   include OutputBuilderTomlSerializer
 
-  def print(endpoints : Array(Endpoint))
-    message = {"endpoints" => endpoints, "passive_results" => [] of PassiveScanResult}.to_json
-    json_obj = JSON.parse(message)
-    toml_output = generate_toml(json_obj.as_h)
-    ob_puts toml_output
-  end
-
-  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     message = {"endpoints" => endpoints, "passive_results" => passive_results}.to_json
     json_obj = JSON.parse(message)
     toml_output = generate_toml(json_obj.as_h)

--- a/src/output_builder/yaml.cr
+++ b/src/output_builder/yaml.cr
@@ -1,13 +1,9 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
+@[Noir::OutputFormat(name: "yaml", description: "YAML", order: 20)]
 class OutputBuilderYaml < OutputBuilder
-  def print(endpoints : Array(Endpoint))
-    message = {"endpoints" => endpoints, "passive_results" => [] of PassiveScanResult}.to_yaml
-    ob_puts message
-  end
-
-  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     message = {"endpoints" => endpoints, "passive_results" => passive_results}.to_yaml
     ob_puts message
   end


### PR DESCRIPTION
## Summary

Adding an output format meant editing five hand-maintained lists that nothing linked together:

- the 70-line dispatch `case` in `NoirRunner#report`
- `Noir::CliValidation::VALID_OUTPUT_FORMATS`
- the `-f` help block in `options.cr`
- the `FORMATS` constant in `completions.cr`
- the same list again, inline, in the fish completion

Nothing failed to compile when one was missed — the format just silently went missing from validation, help, or completion.

Each builder now carries a `@[Noir::OutputFormat(name:, description:, order:)]` annotation, and `Noir::OutputFormats` derives the catalog from the annotated classes at compile time:

- `render` dispatches (one concrete branch per builder, so each keeps its own `print` overloads)
- `NAMES` validates and completes
- `help_text` / `ENTRIES` feed `noir scan -h` and `noir list formats` — which gains the description column for free

A format joins all of them by annotating its class. An annotation is used rather than the `analyzer_for` / `detector_for` macro because the builders are top-level `OutputBuilder*` classes with no namespace to filter `all_subclasses` on; annotations aren't inherited, so a spec's throwaway subclass stays out of the registry.

Two follow-ons fall out of it:

- the seven builders that carried a `print(endpoints)` / `print(endpoints, passive_results)` pair with the same body collapse into one method with a defaulted argument
- the plain report's heading and passive-findings section move from `NoirRunner` into `OutputBuilderCommon`, so the runner no longer special-cases the default format on either side of a format-agnostic dispatch

`NoirRunner#report` goes from 74 lines to 6.

## Test plan

- Built `main` in a separate worktree and diffed output for **all 22 formats over 3 fixture trees (66 pairs) — byte-identical**, including the `-o` file copies and a run with real passive findings (the moved plain-format section).
- `crystal spec spec/unit_test` (4,658) and `crystal spec spec/functional_test` (22,647): 0 failures.
- `crystal tool format --check`, `ameba src/ spec/unit_test`, `typos .`: clean.
- New `spec/unit_test/output_builder/formats_spec.cr` guards the derivation: no duplicate names, every format valid at the CLI gate, present in the help text, and offered by every shell completion.