### PR TITLE
refactor(runner): move status-code probing out of NoirRunner

### DIFF
--- a/spec/unit_test/deliver/status_code_spec.cr
+++ b/spec/unit_test/deliver/status_code_spec.cr
@@ -1,5 +1,5 @@
 require "../../spec_helper"
-require "../../../src/models/noir.cr"
+require "../../../src/deliver/status_code.cr"
 require "../../../src/models/endpoint.cr"
 require "../../../src/utils/http_symbols.cr"
 
@@ -11,8 +11,8 @@ class MockResponse
   end
 end
 
-# Test Runner that mocks external requests
-class TestNoirRunner < NoirRunner
+# Probe that answers from a canned table instead of the network.
+class TestStatusCodeProbe < StatusCodeProbe
   property last_request_method : Symbol?
   property last_request_params : Hash(String, String)?
   property last_request_body : Hash(String, String)?
@@ -39,54 +39,54 @@ class TestNoirRunner < NoirRunner
   end
 end
 
-describe "NoirRunner#update_status_codes" do
+describe StatusCodeProbe do
   options = create_test_options
   options["base"] = YAML::Any.new([YAML::Any.new("noir")])
   options["exclude_codes"] = YAML::Any.new("404")
 
+  probe = -> { TestStatusCodeProbe.new(options, NoirLogger.new(false, false, false, true)) }
+
   it "updates status codes correctly" do
-    runner = TestNoirRunner.new(options)
-    runner.endpoints << Endpoint.new("http://example.com/200", "GET")
-    runner.endpoints << Endpoint.new("http://example.com/500", "GET")
+    endpoints = [
+      Endpoint.new("http://example.com/200", "GET"),
+      Endpoint.new("http://example.com/500", "GET"),
+    ]
 
-    runner.update_status_codes
+    result = probe.call.apply(endpoints)
 
-    runner.endpoints.size.should eq(2)
-    runner.endpoints[0].details.status_code.should eq(200)
-    runner.endpoints[1].details.status_code.should eq(500)
+    result.size.should eq(2)
+    result[0].details.status_code.should eq(200)
+    result[1].details.status_code.should eq(500)
   end
 
   it "excludes endpoints with excluded status codes" do
-    runner = TestNoirRunner.new(options)
-    runner.endpoints << Endpoint.new("http://example.com/200", "GET")
-    runner.endpoints << Endpoint.new("http://example.com/404", "GET")
+    endpoints = [
+      Endpoint.new("http://example.com/200", "GET"),
+      Endpoint.new("http://example.com/404", "GET"),
+    ]
 
-    runner.update_status_codes
+    result = probe.call.apply(endpoints)
 
-    runner.endpoints.size.should eq(1)
-    runner.endpoints[0].url.should eq("http://example.com/200")
+    result.size.should eq(1)
+    result[0].url.should eq("http://example.com/200")
   end
 
   it "handles request failures gracefully" do
-    runner = TestNoirRunner.new(options)
-    runner.endpoints << Endpoint.new("http://example.com/error", "GET")
+    # It should not raise, but catch and log the error (suppressed in test
+    # options) and keep the endpoint in the list.
+    result = probe.call.apply([Endpoint.new("http://example.com/error", "GET")])
 
-    # It should not raise exception, but catch it and log error (which is suppressed in test options)
-    # The endpoint should be kept in the list
-    runner.update_status_codes
-
-    runner.endpoints.size.should eq(1)
-    runner.endpoints[0].url.should eq("http://example.com/error")
+    result.size.should eq(1)
+    result[0].url.should eq("http://example.com/error")
   end
 
   it "passes parameters to perform_request" do
-    runner = TestNoirRunner.new(options)
     endpoint = Endpoint.new("http://example.com/200", "POST")
     endpoint.params << Param.new("id", "1", "query")
     endpoint.params << Param.new("data", "value", "form")
-    runner.endpoints << endpoint
 
-    runner.update_status_codes
+    runner = probe.call
+    runner.apply([endpoint])
 
     params = runner.last_request_params.should_not be_nil
     params["id"].should eq("1")
@@ -98,12 +98,11 @@ describe "NoirRunner#update_status_codes" do
   end
 
   it "passes JSON body to perform_request when JSON param exists" do
-    runner = TestNoirRunner.new(options)
     endpoint = Endpoint.new("http://example.com/200", "POST")
     endpoint.params << Param.new("data", "value", "json")
-    runner.endpoints << endpoint
 
-    runner.update_status_codes
+    runner = probe.call
+    runner.apply([endpoint])
 
     body = runner.last_request_body.should_not be_nil
     body["data"].should eq("value")
@@ -112,10 +111,8 @@ describe "NoirRunner#update_status_codes" do
   end
 
   it "uses GET as the representative status probe for synthetic ANY methods" do
-    runner = TestNoirRunner.new(options)
-    runner.endpoints << Endpoint.new("http://example.com/200", "ANY")
-
-    runner.update_status_codes
+    runner = probe.call
+    runner.apply([Endpoint.new("http://example.com/200", "ANY")])
 
     runner.last_request_method.should eq(:get)
   end
@@ -125,22 +122,17 @@ describe "NoirRunner#update_status_codes" do
     # surfaces can't be HTTP-requested at all — Crest raises "Unsupported
     # scheme" on each. They must pass through untouched, the way SendReq /
     # SendWithProxy already skip them.
-    runner = TestNoirRunner.new(options)
-
     deep_link = Endpoint.new("myapp://accounts/profile", "GET")
     deep_link.protocol = "mobile-scheme"
-    runner.endpoints << deep_link
 
     cli = Endpoint.new("cli://noir/scan", "CLI")
     cli.protocol = "cli"
-    runner.endpoints << cli
 
-    runner.endpoints << Endpoint.new("ws://room:lobby/new_msg", "SEND")
+    runner = probe.call
+    result = runner.apply([deep_link, cli, Endpoint.new("ws://room:lobby/new_msg", "SEND")])
 
-    runner.update_status_codes
-
-    runner.endpoints.size.should eq(3)
+    result.size.should eq(3)
     runner.last_request_method.should be_nil
-    runner.endpoints.each(&.details.status_code.should(be_nil))
+    result.each(&.details.status_code.should(be_nil))
   end
 end

--- a/spec/unit_test/models/noir_spec.cr
+++ b/spec/unit_test/models/noir_spec.cr
@@ -1,6 +1,7 @@
 require "../../spec_helper"
 require "../../../src/models/noir.cr"
 require "../../../src/models/endpoint.cr"
+require "../../../src/optimizer/llm_optimizer.cr"
 require "../../../src/utils/http_symbols.cr"
 
 describe "Initialize" do
@@ -14,19 +15,26 @@ describe "Initialize" do
   end
 end
 
+# These used to run through thin `NoirRunner` wrappers that existed only so
+# the specs had something to call. They talk to the optimizer directly now —
+# same code under test, one less test-only method on the runner.
+private def optimizer_for(options) : LLMEndpointOptimizer
+  LLMEndpointOptimizer.new(NoirLogger.new(false, false, false, true), options)
+end
+
 describe "Methods" do
   options = create_test_options
   options["base"] = YAML::Any.new([YAML::Any.new("noir")])
   options["url"] = YAML::Any.new("https://www.hahwul.com")
-  runner = NoirRunner.new(options)
-
-  runner.endpoints << Endpoint.new("/abcd", "GET")
-  runner.endpoints << Endpoint.new("abcd", "GET")
 
   it "combine_url_and_endpoints" do
-    runner.combine_url_and_endpoints
-    runner.endpoints[0].url.should eq("https://www.hahwul.com/abcd")
-    runner.endpoints[1].url.should eq("https://www.hahwul.com/abcd")
+    endpoints = optimizer_for(options).combine_url_and_endpoints([
+      Endpoint.new("/abcd", "GET"),
+      Endpoint.new("abcd", "GET"),
+    ])
+
+    endpoints[0].url.should eq("https://www.hahwul.com/abcd")
+    endpoints[1].url.should eq("https://www.hahwul.com/abcd")
   end
 end
 
@@ -37,55 +45,56 @@ describe "set-pvalue" do
   options["set_pvalue_header"] = YAML::Any.new([YAML::Any.new("name=FUZZ")])
   options["set_pvalue_cookie"] = YAML::Any.new([YAML::Any.new("name:FUZZ")])
   options["set_pvalue_json"] = YAML::Any.new([YAML::Any.new("name:FUZZ=FUZZ")])
-  runner = NoirRunner.new(options)
+  optimizer = optimizer_for(options)
 
   it "applies pvalue to query parameter" do
-    runner.apply_pvalue("query", "name", "value").should eq("FUZZ")
+    optimizer.apply_pvalue("query", "name", "value").should eq("FUZZ")
   end
 
   it "applies pvalue to header parameter with '=' delimiter" do
-    runner.apply_pvalue("header", "name", "value").should eq("FUZZ")
+    optimizer.apply_pvalue("header", "name", "value").should eq("FUZZ")
   end
 
   it "does not apply pvalue to header parameter when name does not match" do
-    runner.apply_pvalue("header", "name2", "value").should eq("value")
+    optimizer.apply_pvalue("header", "name2", "value").should eq("value")
   end
 
   it "applies pvalue to cookie parameter with ':' delimiter" do
-    runner.apply_pvalue("cookie", "name", "value").should eq("FUZZ")
+    optimizer.apply_pvalue("cookie", "name", "value").should eq("FUZZ")
   end
 
   it "does not apply pvalue to cookie parameter when name does not match" do
-    runner.apply_pvalue("cookie", "name2", "value").should eq("value")
+    optimizer.apply_pvalue("cookie", "name2", "value").should eq("value")
   end
 
   it "includes '=' in the pvalue for JSON parameter" do
-    runner.apply_pvalue("json", "name", "value").should eq("FUZZ=FUZZ")
+    optimizer.apply_pvalue("json", "name", "value").should eq("FUZZ=FUZZ")
   end
 end
 
 describe "HTTP method validation" do
   options = create_test_options
-  runner = NoirRunner.new(options)
+  optimizer = optimizer_for(options)
 
   it "maintains valid HTTP methods" do
-    runner.endpoints << Endpoint.new("/valid", "GET")
-    runner.endpoints << Endpoint.new("/also-valid", "POST")
-    runner.optimize_endpoints
+    endpoints = optimizer.optimize_endpoints([
+      Endpoint.new("/valid", "GET"),
+      Endpoint.new("/also-valid", "POST"),
+    ])
 
     # Order follows the source-location sort in `optimize_endpoints`;
     # these fixtures carry no code path, so match by URL.
-    runner.endpoints.find! { |endpoint| endpoint.url == "/valid" }.method.should eq("GET")
-    runner.endpoints.find! { |endpoint| endpoint.url == "/also-valid" }.method.should eq("POST")
+    endpoints.find! { |endpoint| endpoint.url == "/valid" }.method.should eq("GET")
+    endpoints.find! { |endpoint| endpoint.url == "/also-valid" }.method.should eq("POST")
   end
 
   it "converts invalid HTTP methods to GET" do
-    runner.endpoints << Endpoint.new("/invalid-method", "INVALID")
-    runner.endpoints << Endpoint.new("/another-invalid", "test")
-    runner.optimize_endpoints
+    endpoints = optimizer.optimize_endpoints([
+      Endpoint.new("/invalid-method", "INVALID"),
+      Endpoint.new("/another-invalid", "test"),
+    ])
 
-    # Both endpoints should now have GET as their method
-    runner.endpoints.each do |endpoint|
+    endpoints.each do |endpoint|
       if endpoint.url.includes?("invalid")
         endpoint.method.should eq("GET")
       end
@@ -94,15 +103,12 @@ describe "HTTP method validation" do
 
   it "preserves all valid HTTP methods" do
     valid_methods = get_allowed_methods
+    endpoints = optimizer.optimize_endpoints(
+      valid_methods.map_with_index { |method, index| Endpoint.new("/endpoint#{index}", method) }
+    )
 
     valid_methods.each_with_index do |method, index|
-      runner.endpoints << Endpoint.new("/endpoint#{index}", method)
-    end
-
-    runner.optimize_endpoints
-
-    valid_methods.each_with_index do |method, index|
-      runner.endpoints.find! { |e| e.url == "/endpoint#{index}" }.method.should eq(method)
+      endpoints.find! { |endpoint| endpoint.url == "/endpoint#{index}" }.method.should eq(method)
     end
   end
 end

--- a/src/deliver/status_code.cr
+++ b/src/deliver/status_code.cr
@@ -1,0 +1,115 @@
+require "../models/endpoint"
+require "../models/logger"
+require "../utils/http_symbols"
+require "../utils/utils"
+require "crest"
+
+# Fills in `details.status_code` for every endpoint (`--status-codes`) and
+# drops the ones whose code the user excluded (`--exclude-codes`).
+#
+# Deliberately not a `Deliver` subclass, even though it is the other thing in
+# noir that fires HTTP requests at discovered endpoints. A status probe runs
+# before delivery, ignores `--probe-match` / `--probe-skip`, and sends none of
+# the `--probe-header` values — it exists to answer "does this route respond,
+# and with what", not to replay traffic. Inheriting the sender base would
+# quietly give it all three.
+class StatusCodeProbe
+  @options : Hash(String, YAML::Any)
+  @logger : NoirLogger
+
+  def initialize(@options : Hash(String, YAML::Any), @logger : NoirLogger)
+  end
+
+  def apply(endpoints : Array(Endpoint)) : Array(Endpoint)
+    @logger.sub "➔ Updating status codes."
+
+    excluded = excluded_codes
+    final = [] of Endpoint
+
+    endpoints.each do |endpoint|
+      # Mobile deep links (`myapp://`, `intent://`, `content://`), CLI
+      # command surfaces (`cli://`) and realtime `ws://` event surfaces are
+      # not HTTP requests — the same guard SendReq / SendWithProxy already
+      # apply before probing. Without it every one of them was handed to
+      # Crest, which raised "Unsupported scheme" per endpoint: a mobile scan
+      # with --status-codes printed dozens of `Failed to get status code`
+      # errors for endpoints that can never have one.
+      if endpoint.non_http?
+        final << endpoint
+        next
+      end
+
+      request_method = requestable_http_methods(endpoint.method).first?
+      unless request_method
+        final << endpoint
+        next
+      end
+
+      begin
+        response = request_for(endpoint, request_method)
+        endpoint.details.status_code = response.status_code
+        final << endpoint unless excluded.includes?(response.status_code)
+      rescue e
+        @logger.error "Failed to get status code for #{endpoint.url} (#{e.message})."
+        final << endpoint
+      end
+    end
+
+    final
+  end
+
+  private def request_for(endpoint : Endpoint, request_method : String)
+    return perform_request(get_symbol(request_method), endpoint.url) if endpoint.params.empty?
+
+    endpoint_hash = endpoint.params_to_hash
+    is_json = !endpoint_hash["json"].empty?
+    body = is_json ? endpoint_hash["json"] : endpoint_hash["form"]
+
+    perform_request(
+      get_symbol(request_method),
+      endpoint.url,
+      endpoint_hash["query"],
+      body,
+      is_json
+    )
+  end
+
+  # A Set dedupes repeated codes (--exclude-codes 404,404,500) for free and
+  # gives O(1) membership; empty tokens (a trailing comma) are skipped.
+  private def excluded_codes : Set(Int32)
+    codes = Set(Int32).new
+    raw = @options["exclude_codes"]?.to_s
+    return codes if raw.empty?
+
+    raw.split(",").each do |code|
+      stripped = code.strip
+      next if stripped.empty?
+      codes << stripped.to_i
+    end
+    codes
+  end
+
+  # The single point where a request leaves the process, so specs can drive
+  # `apply` against canned responses by overriding this one method.
+  def perform_request(method, url, params = {} of String => String, form = {} of String => String, json = false)
+    # Verify TLS by default; --tls-skip-verify opts into the insecure
+    # context for self-signed internal hosts (see Deliver#tls_context).
+    tls = if any_to_bool(@options["tls_skip_verify"]?)
+            OpenSSL::SSL::Context::Client.insecure
+          else
+            OpenSSL::SSL::Context::Client.new
+          end
+
+    Crest::Request.execute(
+      method: method,
+      url: url,
+      tls: tls,
+      user_agent: "Noir/#{Noir::VERSION}",
+      params: params,
+      form: form,
+      json: json,
+      handle_errors: false,
+      read_timeout: 5.second
+    )
+  end
+end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -148,7 +148,7 @@ class NoirRunner
 
     # Set status code
     if any_to_bool(@options["status_codes"]) || !@options["exclude_codes"].to_s.empty?
-      update_status_codes
+      @endpoints = StatusCodeProbe.new(@options, @logger).apply(@endpoints)
     end
 
     # Run tagger
@@ -199,123 +199,6 @@ class NoirRunner
     raw = @options["ai_context_features"]?.try(&.to_s) || ""
     features = NoirAIContext.parse_feature_set(raw)
     NoirAIContext.apply_feature_filter(@endpoints, features)
-  end
-
-  def update_status_codes
-    @logger.sub "➔ Updating status codes."
-    final = [] of Endpoint
-
-    # A Set dedupes repeated codes (--exclude-codes 404,404,500) for free and
-    # gives O(1) membership; empty tokens (a trailing comma) are skipped.
-    exclude_codes = Set(Int32).new
-    unless @options["exclude_codes"].to_s.empty?
-      @options["exclude_codes"].to_s.split(",").each do |code|
-        stripped = code.strip
-        next if stripped.empty?
-        exclude_codes << stripped.to_i
-      end
-    end
-
-    @endpoints.each do |endpoint|
-      # Mobile deep links (`myapp://`, `intent://`, `content://`), CLI
-      # command surfaces (`cli://`) and realtime `ws://` event surfaces are
-      # not HTTP requests — the same guard SendReq / SendWithProxy already
-      # apply before probing. Without it every one of them was handed to
-      # Crest, which raised "Unsupported scheme" per endpoint: a mobile scan
-      # with --status-codes printed dozens of `Failed to get status code`
-      # errors for endpoints that can never have one.
-      if endpoint.non_http?
-        final << endpoint
-        next
-      end
-
-      request_method = requestable_http_methods(endpoint.method).first?
-      unless request_method
-        final << endpoint
-        next
-      end
-
-      begin
-        if endpoint.params.empty?
-          response = perform_request(
-            get_symbol(request_method),
-            endpoint.url
-          )
-          endpoint.details.status_code = response.status_code
-          unless exclude_codes.includes?(response.status_code)
-            final << endpoint
-          end
-        else
-          endpoint_hash = endpoint.params_to_hash
-          is_json = false
-          body = if endpoint_hash["json"].empty?
-                   endpoint_hash["form"]
-                 else
-                   is_json = true
-                   endpoint_hash["json"]
-                 end
-
-          response = perform_request(
-            get_symbol(request_method),
-            endpoint.url,
-            endpoint_hash["query"],
-            body,
-            is_json
-          )
-          endpoint.details.status_code = response.status_code
-          unless exclude_codes.includes?(response.status_code)
-            final << endpoint
-          end
-        end
-      rescue e
-        @logger.error "Failed to get status code for #{endpoint.url} (#{e.message})."
-        final << endpoint
-      end
-    end
-
-    @endpoints = final
-  end
-
-  def perform_request(method, url, params = {} of String => String, form = {} of String => String, json = false)
-    # Verify TLS by default; --tls-skip-verify opts into the insecure
-    # context for self-signed internal hosts (see Deliver#tls_context).
-    tls = if any_to_bool(@options["tls_skip_verify"]?)
-            OpenSSL::SSL::Context::Client.insecure
-          else
-            OpenSSL::SSL::Context::Client.new
-          end
-    Crest::Request.execute(
-      method: method,
-      url: url,
-      tls: tls,
-      user_agent: "Noir/#{Noir::VERSION}",
-      params: params,
-      form: form,
-      json: json,
-      handle_errors: false,
-      read_timeout: 5.second
-    )
-  end
-
-  # Backward compatibility wrapper methods for tests
-  def optimize_endpoints
-    optimizer = LLMEndpointOptimizer.new(@logger, @options)
-    @endpoints = optimizer.optimize_endpoints(@endpoints)
-  end
-
-  def combine_url_and_endpoints
-    optimizer = LLMEndpointOptimizer.new(@logger, @options)
-    @endpoints = optimizer.combine_url_and_endpoints(@endpoints)
-  end
-
-  def add_path_parameters
-    optimizer = LLMEndpointOptimizer.new(@logger, @options)
-    @endpoints = optimizer.add_path_parameters(@endpoints)
-  end
-
-  def apply_pvalue(param_type, param_name, param_value) : String
-    optimizer = LLMEndpointOptimizer.new(@logger, @options)
-    optimizer.apply_pvalue(param_type, param_name, param_value)
   end
 
   def deliver


### PR DESCRIPTION
## Summary

`NoirRunner` is the scan pipeline — detect, analyze, report — but it also carried the `--status-codes` implementation: a 75-line loop plus the Crest call and TLS-context setup it needs, none of which the pipeline stages around it can see past. Four more methods existed only so specs had something to call, delegating straight to `LLMEndpointOptimizer`.

- Probing moves to **`StatusCodeProbe`** (`src/deliver/status_code.cr`), beside the other things that send HTTP at discovered endpoints. It deliberately does *not* subclass `Deliver`, and says why in a comment: a status probe runs before delivery and must not inherit `--probe-match` / `--probe-skip` / `--probe-header`. `perform_request` stays the single point where a request leaves the process, so its spec still drives the whole path against canned responses — now against the probe itself rather than a `NoirRunner` subclass.
- The four test-only wrappers (`optimize_endpoints`, `combine_url_and_endpoints`, `add_path_parameters`, `apply_pvalue`) are gone; the specs that used them call `LLMEndpointOptimizer` directly, which is where that logic has lived since the optimizer was extracted.

`NoirRunner`: 463 → 270 lines, and `analyze` now reads as the stage list it is.

## Test plan

- `noir scan <fixture> --status-codes --exclude-codes 404` output is identical to `main`.
- All seven behaviours the old spec covered are preserved (code assignment, exclusion, request failure, query/form params, JSON body, `ANY` → GET, non-HTTP endpoints skipped) — the file moved to `spec/unit_test/deliver/status_code_spec.cr` and targets the probe.
- `crystal spec spec/unit_test` (4,658) and `crystal spec spec/functional_test` (22,647): 0 failures.
- `crystal tool format --check`, `ameba src/ spec/unit_test`, `typos .`: clean.