### PR TITLE
docs: correct the analyzer contribution guides and rewrite the template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ sudo apt install -y just
 
 ```bash
 ./bin/noir -h                                           # Help (includes all output formats)
-./bin/noir --list-techs                                 # List all supported technologies
-./bin/noir --list-taggers                               # List available taggers
+./bin/noir list techs                                   # List all supported technologies
+./bin/noir list taggers                                 # List available taggers
 ./bin/noir -b path/to/source                            # Basic analysis
 ./bin/noir -b . -f json                                 # JSON output (see -h for all formats)
 ./bin/noir -b . --verbose                               # Detailed analysis
@@ -43,11 +43,15 @@ sudo apt install -y just
 ```
 src/
 ├── analyzer/analyzers/     # Endpoint/parameter analyzers by language/framework
+├── analyzer/engines/       # Shared per-language bases (see Analyzer Layering)
 ├── detector/detectors/     # Technology detection by language/framework
+├── cli/                    # Subcommand router and commands (scan, list, config, …)
 ├── ext/                    # External C/C++ bindings (e.g., Tree-sitter integration)
 ├── output_builder/         # Output format generation (JSON, YAML, OAS, etc.)
-├── models/                 # Data structures (includes delivers/, minilexer/)
-├── llm/                    # AI/LLM integration (general/, ollama/)
+├── models/                 # Base classes + data structures (includes minilexer/)
+├── llm/                    # AI/LLM integration (general/, ollama/, acp/)
+├── ai_context/             # AI review-context assembly
+├── mobile/                 # Mobile deep-link linking (Android/iOS)
 ├── optimizer/              # Endpoint normalization/dedup and LLM optimizer
 ├── tagger/taggers/         # Endpoint tagging implementations
 ├── tagger/framework_taggers/ # Framework-specific auth taggers (by language)
@@ -55,7 +59,7 @@ src/
 ├── minilexers/             # Custom lexers
 ├── miniparsers/            # Custom parsers
 ├── passive_scan/           # Passive security scanning
-├── techs/                  # Supported technologies catalog
+├── techs/catalog/          # Technology metadata, one file per language group
 ├── utils/                  # Utility functions
 ├── noir.cr                 # Main entry point
 ├── options.cr              # CLI options parser
@@ -86,16 +90,18 @@ An analyzer is composed of three layers. Keep them separate — a framework adap
 
 **Rule**: the framework adapter receives routes; it does not walk the filesystem or parse tokens itself.
 
-**Reference implementation**: `src/analyzer/analyzers/javascript/hono.cr` on top of `src/miniparsers/js_route_extractor.cr`. Hono is ~205 lines because it follows this split; contrast with analyzers that inline all three responsibilities and grow to 500–800 lines.
+**Reference implementation**: `src/analyzer/analyzers/javascript/hono.cr` on top of `src/miniparsers/js_route_extractor.cr`. It stays thin because it follows this split; contrast with analyzers that inline all three responsibilities.
 
 **Current coverage**:
-- Language engines: PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala (Akka + Scalatra), JavaScript/TypeScript, Python, Go, Java, Kotlin, Perl. CSharp, Scala Play, and some others stay on the `Analyzer` base because their flows orchestrate multiple phases or carry self-contained extraction that doesn't share with other analyzers.
+- Language engines (`src/analyzer/engines/`, subclass count in parentheses): `SpecificationEngine` (45), `JavascriptEngine` (18), `GoEngine` (16), `PythonEngine` (16), `PhpEngine` (15), `RustEngine` (10), `RubyEngine` (8), `CrystalEngine` (6), `CfmlEngine` (5), `ScalaEngine` (5), `SwiftEngine` (3), `PerlEngine` (3), `ElixirEngine` (2). `java_engine.cr` and `kotlin_engine.cr` are **not** engines — they are modules exposing a shared `self.test_path?` and nothing inherits from them.
+- `FileScanEngine` (`src/analyzer/engines/file_scan_engine.cr`) is the shared base *under* seven of those engines (Crystal, Elixir, Perl, Php, Rust, Scala, Swift). It owns the `analyze` + `parallel_file_scan` skeleton those engines used to each carry a copy of.
+- Languages with no engine — including CSharp, Java, Kotlin, Dart, Zig, C++, Clojure, Haskell, Lua and Groovy — extend the `Analyzer` base directly: their flows orchestrate multiple phases or carry self-contained extraction that doesn't share with other analyzers.
 - Route extractors:
   - JavaScript/TypeScript: `js_route_extractor.cr` (used by Hono, Express, Fastify, Koa, NestJS, Restify, AdonisJS, Elysia, Hapi, etc.)
-  - High-fidelity Tree-sitter-based extractors (`*_route_extractor_ts.cr` and `*_parameter_extractor_ts.cr`) utilising vendored libtree-sitter bindings:
-    - Go: `go_route_extractor_ts.cr`
+  - High-fidelity Tree-sitter-based extractors (`*_route_extractor_ts.cr` and `*_parameter_extractor_ts.cr`) utilising vendored libtree-sitter bindings. The Go and Kotlin ones are **directories** of part files behind an umbrella `require`, not single files:
+    - Go: `go_route_extractor_ts.cr` + `go_route_extractor_ts/`
     - Java: `java_route_extractor_ts.cr`, `java_parameter_extractor_ts.cr` (used by Spring, JAX-RS, Micronaut, etc.)
-    - Kotlin: `kotlin_route_extractor_ts.cr`, `kotlin_ktor_route_extractor_ts.cr`, `kotlin_parameter_extractor_ts.cr` (used by Spring, Ktor, etc.)
+    - Kotlin: `kotlin_route_extractor_ts.cr` + `kotlin_route_extractor_ts/`, `kotlin_ktor_route_extractor_ts.cr`, `kotlin_parameter_extractor_ts.cr` (used by Spring, Ktor, etc.)
     - Python: `python_route_extractor_ts.cr` (used by FastAPI, Flask, Django, etc.)
     - Framework-specific AST extractors: `adonisjs_extractor_ts.cr`, `elysia_extractor_ts.cr`, `hapi_extractor_ts.cr`, `http4k_extractor_ts.cr`, `jaxrs_extractor_ts.cr`, `micronaut_extractor_ts.cr`, `jvm_lambda_dsl_extractor_ts.cr`
   - Traditional / Callee Extractors: Used as a fallback or framework-specific extraction across languages (e.g., `cpp_callee_extractor.cr`, `crystal_callee_extractor.cr`, `go_callee_extractor.cr`, `js_callee_extractor.cr`, `ruby_callee_extractor.cr`, etc.).
@@ -104,29 +110,30 @@ When adding a new framework in a language that already has an extractor, extend 
 
 **Two engine shapes** — every engine exposes `parallel_file_scan(&block)` as a protected helper. Subclasses pick one of:
 
-- **Simple per-file**: override `abstract def analyze_file(path) : Array(Endpoint)`. The engine's default `analyze` drives the walk and concats the returned endpoints. Used by Php/Rust/Swift/Crystal/Elixir/Scala analyzers.
+- **Simple per-file**: override `abstract def analyze_file(path) : Array(Endpoint)`. `FileScanEngine#analyze` drives the walk and concats the returned endpoints; the engine supplies the candidate list via `scan_target_files` and an optional per-path veto via `scan_accepts?`. Used by Php/Rust/Swift/Crystal/Elixir/Scala analyzers.
 - **Custom `analyze`**: override `analyze` directly and call `parallel_file_scan` when you need closure state, a pre-phase (e.g., Express's `scan_for_router_mounts`), or post-processing (e.g., Hono's `process_static_dirs`, Amber/Kemal's public-dir pass). Used by Ruby/JavaScript/TypeScript analyzers and by the handful of Crystal/Elixir analyzers that override.
 
 ## Adding New Components
 
+**There are no registration lists to edit.** Analyzers, detectors and output formats each join their registry by declaring their own name on the class; the registry is derived from the classes by macro. Adding a name to a hand-maintained list used to be a second place to remember, where forgetting produced no error and no failing spec — just a component that never ran.
+
 ### Analyzers
 1. Create `src/analyzer/analyzers/{language}/{framework}.cr` — framework adapter only. Delegate parsing to the language's route extractor (see **Analyzer Layering** above).
-2. Add functional test: `spec/functional_test/testers/{language}/{framework}_spec.cr`
-3. Add fixtures: `spec/functional_test/fixtures/{language}/{framework}/`
-4. Register in `src/analyzer/analyzer.cr` if needed
-5. Update `src/techs/techs.cr` with technology metadata
+2. Declare the tech inside the class: `analyzer_for "{language}_{framework}"`. This is the whole registration (`src/models/analyzer.cr`); `initialize_analyzers` reads it off `Analyzer.all_subclasses`. Omitting it is a compile error.
+3. Add functional test: `spec/functional_test/testers/{language}/{framework}_spec.cr`
+4. Add fixtures: `spec/functional_test/fixtures/{language}/{framework}/`
+5. Add technology metadata to `src/techs/catalog/{language}.cr`
 
 ### Detectors
 1. Create `src/detector/detectors/{language}/{framework}.cr`
-2. Add unit test: `spec/unit_test/detector/{language}/{framework}_detector_spec.cr`
-3. Register in `src/detector/detector.cr` if needed
-4. Update `src/techs/techs.cr` with technology metadata
+2. Declare the tech and its file gate inside the class: `detector_for "go_hertz", extensions: %w[.go], path_segments: %w[go.mod]` (`src/models/detector.cr`). The gate keys are `extensions:`, `basenames:` and `path_segments:`; pass `idempotent: false` only if `detect` has side effects, such as registering paths in `CodeLocator`.
+3. Add unit test: `spec/unit_test/detector/{language}/{framework}_detector_spec.cr`
+4. Add technology metadata to `src/techs/catalog/{language}.cr`
 
 ### Output Formats
-1. Create `src/output_builder/{format}_builder.cr`
-2. Add unit test: `spec/unit_test/output_builder/{format}_builder_spec.cr`
-3. Register in output builder selection logic
-4. Update `src/options.cr` help text
+1. Create `src/output_builder/{format}.cr` (no `_builder` suffix)
+2. Annotate the class: `@[Noir::OutputFormat(name: "{format}", description: "…", order: 40)]`. `src/output_builder/formats.cr` derives the catalog, the `-f` help text and the render dispatch from the annotation — `src/options.cr` needs no edit.
+3. Add unit test: `spec/unit_test/output_builder/{format}_spec.cr`
 
 ### Taggers
 1. Create `src/tagger/taggers/{tagger_name}.cr`

--- a/docs/content/development/analyzer_architecture/index.ko.md
+++ b/docs/content/development/analyzer_architecture/index.ko.md
@@ -31,18 +31,19 @@ Detector 는 manifest 파일(`go.mod`, `package.json`, `Gemfile` 등) 에 대한
 
 | Layer | 위치 | 책임 |
 |---|---|---|
-| **L0 Language Engine** | `src/analyzer/engines/{lang}_engine.cr` | 파일 순회, 동시성(`parallel_analyze`), 채널 설정, 경로별 에러 핸들링. 언어당 하나. |
-| **L1 Route Extractor** | `src/miniparsers/{lang}_route_extractor.cr` | 소스 내용을 파싱. 문자열(파일 내용) 을 받아 라우트 선언(method, path, location) 을 yield. 파일 I/O 없음, 프레임워크 특화 로직 없음. |
+| **L0 Language Engine** | `src/analyzer/engines/{lang}_engine.cr` | 그 언어의 소스 파일 집합과 경로별 필터. 언어당 하나. 순회 자체는 대부분 `FileScanEngine` 에서 옵니다 — `analyze` + `parallel_file_scan` 을 소유하며, 동시성은 `Analyzer#parallel_analyze` 가 담당합니다. |
+| **L1 Route Extractor** | `src/miniparsers/{lang}_route_extractor*.cr` | 소스 내용을 파싱. 문자열(파일 내용) 을 받아 라우트 선언(method, path, location) 을 yield. 파일 I/O 없음, 프레임워크 특화 로직 없음. |
 | **L2 Framework Adapter** | `src/analyzer/analyzers/{lang}/{framework}.cr` | 프레임워크별 얇은 클래스. Extractor 에서 받은 라우트에 프레임워크별 파라미터 매핑, 필터, 특수 케이스를 적용. |
 
-**Reference implementation**: [`src/analyzer/analyzers/javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr) + [`src/miniparsers/js_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/js_route_extractor.cr). Hono 는 이 분리를 따르기 때문에 ~205줄입니다. 세 책임을 한 클래스에 섞은 분석기는 500–800줄로 커집니다.
+**Reference implementation**: [`src/analyzer/analyzers/javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr) + [`src/miniparsers/js_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/js_route_extractor.cr). Hono 는 이 분리를 따르기 때문에 얇게 유지됩니다. 세 책임을 한 클래스에 섞은 분석기와 비교해 보세요.
 
 ## 현재 커버리지
 
-- **Language engines** (`engines/`): PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala, JavaScript/TypeScript, Python, Go.
-- **Route extractors** (`miniparsers/`): JavaScript (Hono, Express, Fastify, Koa, NestJS, Restify, TypeScript NestJS 에서 사용) + Go (8개 분석기에서 사용).
-- **의도적으로 엔진 밖**: CSharp 의 두 orchestrator, Scala Play (multi-phase 흐름이라 per-file 스캔 안 맞음), Go 의 Chi/Httprouter/Fasthttp (자체 완결 추출). `Analyzer` 를 직접 상속.
-- Python, Kotlin, Java 는 parser 는 있지만 route extractor 층이 아직 없음 (후속 작업).
+- **Language engines** (`engines/`): Specification, JavaScript/TypeScript, Go, Python, PHP, Rust, Ruby, Crystal, CFML, Scala, Swift, Perl, Elixir.
+- **`FileScanEngine`** 은 그중 일곱 개(Crystal, Elixir, Perl, PHP, Rust, Scala, Swift) *아래* 에 있는 공유 베이스입니다. 각 엔진이 바이트 단위로 똑같이 복제해 갖고 있던 파일 순회 스켈레톤을 여기서 소유합니다.
+- `java_engine.cr` 과 `kotlin_engine.cr` 은 파일 이름과 달리 **엔진이 아닙니다.** 공유 `self.test_path?` 하나를 노출하는 module 이고, 상속하는 분석기가 없습니다.
+- **Route extractors** (`miniparsers/`): JavaScript(`js_route_extractor.cr` — Hono, Express, Fastify, Koa, NestJS, Restify, AdonisJS, Elysia, Hapi 등에서 사용) 와 Go/Java/Kotlin/Python 용 Tree-sitter 추출기. Go 와 Kotlin 은 umbrella `require` 뒤의 파트 파일 디렉터리로 나뉘어 있습니다 (`go_route_extractor_ts/`, `kotlin_route_extractor_ts/`).
+- **의도적으로 엔진 밖**: 여러 단계를 조율하거나 자체 완결 추출을 가진 언어들 — CSharp, Java, Kotlin, Dart, Zig, C++, Clojure, Haskell, Lua, Groovy, Scala Play, 그리고 Go 의 Chi/Httprouter/Fasthttp. `Analyzer` 를 직접 상속합니다.
 
 ## 두 가지 엔진 shape
 
@@ -59,7 +60,7 @@ class MyFramework < PhpEngine
 end
 ```
 
-엔진의 기본 `analyze` 가 파일 순회를 돌리고 반환된 엔드포인트를 concat 합니다. 대부분의 Php / Rust / Swift / Crystal / Elixir / Scala 분석기가 이 shape.
+`FileScanEngine#analyze` 가 파일 순회를 돌리고 반환된 엔드포인트를 concat 합니다. 엔진은 `scan_target_files` 로 후보 목록을, `scan_accepts?` 로 선택적인 경로별 거부를 제공합니다. 대부분의 Php / Rust / Swift / Crystal / Elixir / Scala 분석기가 이 shape.
 
 **Shape B. `analyze` 직접 오버라이드** (클로저 상태, pre/post-phase 필요):
 
@@ -89,16 +90,16 @@ Detector 는 대체로 한 줄짜리 매칭입니다.
 # src/detector/detectors/go/hertz.cr
 module Detector::Go
   class Hertz < Detector
+    detector_for "go_hertz", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       filename.includes?("go.mod") && file_contents.includes?("github.com/cloudwego/hertz")
-    end
-
-    def set_name
-      @name = "go_hertz"
     end
   end
 end
 ```
+
+`detector_for` 는 tech 이름을 한 번만 선언하고, `detect` 에 어떤 파일을 넘길지 결정하는 값싼 파일 게이트(`applicable?`) 를 생성합니다. 게이트 키는 `extensions:`, `basenames:`, `path_segments:` 입니다. `detect` 가 부수효과를 가진다면 — 예를 들어 `CodeLocator` 에 스펙 경로를 등록한다면 — `idempotent: false` 도 함께 넘겨야 첫 매칭 이후에도 계속 호출됩니다.
 
 Detector 는 프로젝트의 후보 파일별로 한 번씩 실행됩니다. `true` 를 반환하면 해당 프레임워크가 존재한다고 표시되고 파이프라인이 매칭되는 분석기를 실행합니다.
 
@@ -115,12 +116,10 @@ require "../../../models/detector"
 
 module Detector::Go
   class Hertz < Detector
+    detector_for "go_hertz", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       filename.includes?("go.mod") && file_contents.includes?("github.com/cloudwego/hertz")
-    end
-
-    def set_name
-      @name = "go_hertz"
     end
   end
 end
@@ -135,6 +134,8 @@ require "../../engines/go_engine"
 
 module Analyzer::Go
   class Hertz < GoEngine
+    analyzer_for "go_hertz"
+
     HTTP_METHODS_EXPANDED = %w[GET POST PUT DELETE PATCH OPTIONS HEAD]
 
     def analyze
@@ -157,30 +158,37 @@ end
 핵심 포인트:
 
 - **언어 엔진을 상속**. `get_route_path`, `add_param_to_endpoint`, `collect_package_groups`, `resolve_public_dirs` 등을 별도 구현 없이 그대로 사용.
+- **`analyzer_for` 로 tech 선언**. 이 한 줄이 등록의 전부입니다 — 3단계 참조.
 - **재정의 가능한 메서드 오버라이드**. 프레임워크 파싱이 다르면 `get_static_path`, `get_route_path` 등 재정의 (Mux, GoZero 참조).
 - **`parallel_file_scan` 사용**. 채널 + worker pool 을 재구현하지 말 것.
 
-### 3. 세 곳에 등록
+### 3. tech 메타데이터 선언
+
+**수정해야 할 등록 목록은 없습니다.** 분석기와 detector 레지스트리는 클래스 자체에서 파생됩니다. `initialize_analyzers`(`src/analyzer/analyzer.cr`) 와 `build_detector_list`(`src/detector/detector.cr`) 가 각각 `all_subclasses` 를 훑어 `analyzer_for` / `detector_for` 에서 이름을 읽습니다. 두 목록 모두 예전에는 손으로 관리했고, 항목을 빠뜨리면 에러도 실패하는 스펙도 없이 그저 실행되지 않는 컴포넌트가 생겼습니다.
+
+따라서 추가할 것은 카탈로그 항목 하나뿐이며, `src/techs/catalog/` 아래 언어별 파일에 넣습니다.
 
 ```crystal
-# src/analyzer/analyzer.cr
-{"go_hertz", Go::Hertz},
-
-# src/detector/detector.cr
-Go::Hertz,
-
-# src/techs/techs.cr
+# src/techs/catalog/go.cr
 :go_hertz => {
   :framework => "Hertz",
   :language  => "Go",
-  :similar   => ["hertz", "go-hertz", "cloudwego"],
+  :similar   => ["hertz", "go-hertz", "go_hertz", "cloudwego"],
   :supported => {
     :endpoint => true,
     :method   => true,
     :params   => { :query => true, :path => true, :body => true, :header => true, :cookie => true },
+    :static_path => false,
+    :websocket   => false,
   },
+  # 선택 사항. 이 tech 가 지원하는 AI 컨텍스트 기능을 선언합니다.
+  # CALLEE_SUPPORTED_TECHS 와 AI_CONTEXT_GUARD_SUPPORTED_TECHS 는
+  # 손으로 나열하는 대신 이 플래그에서 파생됩니다.
+  :context => { :callee => true },
 },
 ```
+
+`spec/unit_test/techs/registry_integrity_spec.cr` 이 세 축의 연결을 양방향으로 단언합니다. 모든 분석기와 detector 에 카탈로그 항목이 있어야 하고, 모든 카탈로그 항목은 분석기와 detector 양쪽으로 뒷받침되어야 합니다. 카탈로그 항목이 빠지면 런타임이 아니라 이 스펙에서 실패합니다.
 
 ### 4. Fixture
 
@@ -234,8 +242,7 @@ FunctionalTester.new("fixtures/go/hertz/", {
 ```bash
 just build                 # 깔끔하게 컴파일
 just test                  # unit + functional spec 통과
-crystal tool format --check
-crystal run lib/ameba/bin/ameba.cr
+just check                 # crystal tool format --check + ameba
 
 # 수동 확인
 ./bin/noir -b spec/functional_test/fixtures/{언어}/{프레임워크}
@@ -243,45 +250,37 @@ crystal run lib/ameba/bin/ameba.cr
 
 ## 새 언어 엔진 추가하기
 
-같은 언어에서 2개 이상의 분석기가 파일 순회 패턴을 공유할 때 엔진을 추출합니다. `SwiftEngine` 이 템플릿:
+같은 언어에서 2개 이상의 분석기가 파일 순회 패턴을 공유할 때 엔진을 추출합니다. **`FileScanEngine` 을 상속하세요** — 순회는 이미 거기에 있습니다. 새 엔진은 언어에 특화된 것만 선언합니다. 어떤 파일을 스캔할지, 무엇을 건너뛸지, 그리고 공유하는 라우트 합성 헬퍼입니다.
 
 ```crystal
 # src/analyzer/engines/swift_engine.cr
 require "../../models/analyzer"
 
+require "./file_scan_engine"
+
 module Analyzer::Swift
-  abstract class SwiftEngine < Analyzer
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
+  abstract class SwiftEngine < FileScanEngine
+    # 후보 파일. 모노레포 전체 `file_map` 을 걷는 대신 detector 가 만든
+    # 확장자 인덱스를 쓰세요. 등록된 일반 파일이므로 경로마다
+    # `File.exists?` / `File.directory?` 를 다시 볼 필요가 없습니다.
+    protected def scan_target_files : Array(String)
+      get_files_by_extension(".swift")
     end
 
-    abstract def analyze_file(path : String) : Array(Endpoint)
-
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      begin
-        populate_channel_with_files(channel)
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path) && File.extname(path) == ".swift"
-
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    # 선택적 경로별 거부. 절대 경로가 아니라 스캔 베이스 기준 상대 경로로
+    # 판단해야 합니다. 절대 경로로 컨벤션 필터를 걸면 판단이 체크아웃
+    # 위치에 넘어가서, 같은 트리인데 클론한 디렉터리에 따라 결과가
+    # 달라집니다.
+    protected def scan_accepts?(path : String) : Bool
+      relative = base_relative_path(path)
+      return false if relative.includes?("/Tests/")
+      !relative.includes?("/.build/")
     end
   end
 end
 ```
+
+`FileScanEngine` 이 `analyze`(순회하며 경로마다 `analyze_file` 호출 후 concat), `abstract def analyze_file(path) : Array(Endpoint)` 계약, 그리고 커스텀 `analyze` 가 필요한 서브클래스를 위한 `parallel_file_scan` 을 제공합니다. 채널 + worker pool 을 다시 만들지 마세요. [#2465](https://github.com/owasp-noir/noir/pull/2465) 가 이를 hoist 하기 전까지 아홉 개 엔진이 바이트 단위로 똑같은 복사본을 각자 갖고 있었고, 손으로 복사하는 순간 그 중복이 되살아납니다.
 
 엔진을 추가할 때는 같은 PR 에서 기존 분석기를 상속하도록 마이그레이션하세요. 예시 PR: [#1236](https://github.com/owasp-noir/noir/pull/1236) (Elixir), [#1237](https://github.com/owasp-noir/noir/pull/1237) (Swift), [#1238](https://github.com/owasp-noir/noir/pull/1238) (Crystal).
 
@@ -309,7 +308,7 @@ class MyLangEngine < Analyzer
 end
 ```
 
-정식 예시: [#1243](https://github.com/owasp-noir/noir/pull/1243) (Go `common.cr` split).
+정식 예시: [#1243](https://github.com/owasp-noir/noir/pull/1243) (Go `common.cr` split). 추출기가 한 파일을 넘어서면 그대로 키우지 말고 umbrella `require` 뒤의 파트 파일 디렉터리로 나누세요 — [`go_route_extractor_ts/`](https://github.com/owasp-noir/noir/tree/main/src/miniparsers/go_route_extractor_ts) 는 프레임워크 계열별로, [`kotlin_route_extractor_ts/`](https://github.com/owasp-noir/noir/tree/main/src/miniparsers/kotlin_route_extractor_ts) 는 관심사별로 나뉘어 있습니다.
 
 ## 실행 모델 참고
 
@@ -320,6 +319,7 @@ Noir 는 **single-threaded** 로 빌드됩니다 (`preview_mt` 미사용). `para
 ## 다음에 볼 것
 
 - Reference analyzer: [`javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr)
-- Engine + extractor 쌍: [`engines/go_engine.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/engines/go_engine.cr) + [`miniparsers/go_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/go_route_extractor.cr)
+- 공유 파일 순회 베이스: [`engines/file_scan_engine.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/engines/file_scan_engine.cr)
+- Engine + extractor 쌍: [`engines/go_engine.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/engines/go_engine.cr) + [`miniparsers/go_route_extractor_ts.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/go_route_extractor_ts.cr)
 - Custom shape 예시: [`javascript/express.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/express.cr) (pre-phase + closure state)
 - Framework-adapter-only 예시: [`go/hertz.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/go/hertz.cr) (엔진 리팩터링 이후 첫 프레임워크)

--- a/docs/content/development/analyzer_architecture/index.md
+++ b/docs/content/development/analyzer_architecture/index.md
@@ -31,18 +31,19 @@ Every analyzer is composed of three layers. Keeping them separate is a hard rule
 
 | Layer | Lives in | Responsibility |
 |---|---|---|
-| **L0 Language Engine** | `src/analyzer/engines/{lang}_engine.cr` | File walking, concurrency (`parallel_analyze`), channel setup, per-path error handling. One per language. |
-| **L1 Route Extractor** | `src/miniparsers/{lang}_route_extractor.cr` | Parses source content. Takes a string (file contents), yields route declarations (method, path, location). No file I/O, no framework-specific rules. |
+| **L0 Language Engine** | `src/analyzer/engines/{lang}_engine.cr` | The language's source-file set and per-path filters. One per language. Most engines get the walk itself from `FileScanEngine`, which owns `analyze` + `parallel_file_scan`; concurrency comes from `Analyzer#parallel_analyze`. |
+| **L1 Route Extractor** | `src/miniparsers/{lang}_route_extractor*.cr` | Parses source content. Takes a string (file contents), yields route declarations (method, path, location). No file I/O, no framework-specific rules. |
 | **L2 Framework Adapter** | `src/analyzer/analyzers/{lang}/{framework}.cr` | Thin per-framework class. Consumes routes from the extractor and applies framework-specific param mappings, filters, and special cases. |
 
-**Reference implementation**: [`src/analyzer/analyzers/javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr) on top of [`src/miniparsers/js_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/js_route_extractor.cr). Hono is ~205 lines because it follows the split; contrast with analyzers that inline all three responsibilities and grow to 500–800 lines.
+**Reference implementation**: [`src/analyzer/analyzers/javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr) on top of [`src/miniparsers/js_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/js_route_extractor.cr). It stays thin because it follows the split; contrast with analyzers that inline all three responsibilities.
 
 ## Current coverage
 
-- **Language engines** (in `engines/`): PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala, JavaScript/TypeScript, Python, Go.
-- **Route extractors** (in `miniparsers/`): JavaScript (used by Hono, Express, Fastify, Koa, NestJS, Restify, TypeScript NestJS) and Go (used by eight analyzers).
-- **Deliberately outside the engine stack**: CSharp's two orchestrators and Scala Play (multi-phase flows that don't fit a per-file scan), plus Go's Chi/Httprouter/Fasthttp (self-contained extraction). These inherit from `Analyzer` directly.
-- Python, Kotlin, Java have full parsers (in `miniparsers/`) but no dedicated route extractor yet (a known follow-up).
+- **Language engines** (in `engines/`): Specification, JavaScript/TypeScript, Go, Python, PHP, Rust, Ruby, Crystal, CFML, Scala, Swift, Perl, Elixir.
+- **`FileScanEngine`** sits *under* seven of those (Crystal, Elixir, Perl, PHP, Rust, Scala, Swift) and holds the file-walk skeleton they used to each carry a byte-identical copy of.
+- `java_engine.cr` and `kotlin_engine.cr` are **not** engines despite the filenames — they are modules exposing a shared `self.test_path?`, and no analyzer inherits from them.
+- **Route extractors** (in `miniparsers/`): JavaScript (`js_route_extractor.cr`, used by Hono, Express, Fastify, Koa, NestJS, Restify, AdonisJS, Elysia, Hapi and more) plus Tree-sitter extractors for Go, Java, Kotlin and Python. Go and Kotlin ship as directories of part files behind an umbrella `require` (`go_route_extractor_ts/`, `kotlin_route_extractor_ts/`).
+- **Deliberately outside the engine stack**: languages whose analyzers orchestrate multiple phases or carry self-contained extraction — CSharp, Java, Kotlin, Dart, Zig, C++, Clojure, Haskell, Lua, Groovy, Scala Play, and Go's Chi/Httprouter/Fasthttp. These inherit from `Analyzer` directly.
 
 ## Two engine shapes
 
@@ -59,7 +60,7 @@ class MyFramework < PhpEngine
 end
 ```
 
-The engine's default `analyze` drives the walk and concats returned endpoints. Used by most Php / Rust / Swift / Crystal / Elixir / Scala analyzers.
+`FileScanEngine#analyze` drives the walk and concats returned endpoints; the engine supplies the candidate list through `scan_target_files` and an optional per-path veto through `scan_accepts?`. Used by most Php / Rust / Swift / Crystal / Elixir / Scala analyzers.
 
 **Shape B: custom `analyze`** (for closure state, pre-/post-phases):
 
@@ -89,16 +90,16 @@ Detectors are almost always a one-line match:
 # src/detector/detectors/go/hertz.cr
 module Detector::Go
   class Hertz < Detector
+    detector_for "go_hertz", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       filename.includes?("go.mod") && file_contents.includes?("github.com/cloudwego/hertz")
-    end
-
-    def set_name
-      @name = "go_hertz"
     end
   end
 end
 ```
+
+`detector_for` declares the tech name once and generates the cheap file gate (`applicable?`) that decides which files `detect` is even offered. The gate keys are `extensions:`, `basenames:` and `path_segments:`; a detector whose `detect` has side effects — registering spec paths in `CodeLocator`, say — must also pass `idempotent: false` so the pass keeps calling it after its first match.
 
 The detector runs once per candidate file in the project. Returning `true` marks the framework as present and tells the pipeline to run the matching analyzer.
 
@@ -115,12 +116,10 @@ require "../../../models/detector"
 
 module Detector::Go
   class Hertz < Detector
+    detector_for "go_hertz", extensions: %w[.go], path_segments: %w[go.mod]
+
     def detect(filename : String, file_contents : String) : Bool
       filename.includes?("go.mod") && file_contents.includes?("github.com/cloudwego/hertz")
-    end
-
-    def set_name
-      @name = "go_hertz"
     end
   end
 end
@@ -135,6 +134,8 @@ require "../../engines/go_engine"
 
 module Analyzer::Go
   class Hertz < GoEngine
+    analyzer_for "go_hertz"
+
     HTTP_METHODS_EXPANDED = %w[GET POST PUT DELETE PATCH OPTIONS HEAD]
 
     def analyze
@@ -157,30 +158,37 @@ end
 Key points:
 
 - **Inherit from the language engine** (`GoEngine` here). You get `get_route_path`, `add_param_to_endpoint`, `collect_package_groups`, `resolve_public_dirs` for free.
+- **Declare the tech with `analyzer_for`**. That single line *is* the registration — see step 3.
 - **Override overridable methods** if your framework's parsing differs (`get_static_path`, `get_route_path`; see Mux or GoZero for examples).
 - **Use `parallel_file_scan`** for the file walk; don't re-implement the channel + worker pool.
 
-### 3. Register in three places
+### 3. Declare the tech metadata
+
+There is **no registration list to edit**. The analyzer and detector registries are derived from the classes themselves: `initialize_analyzers` (`src/analyzer/analyzer.cr`) and `build_detector_list` (`src/detector/detector.cr`) each sweep `all_subclasses` and read the name off `analyzer_for` / `detector_for`. Both lists used to be hand-maintained, and forgetting an entry produced no error and no failing spec — just a component that silently never ran.
+
+So the only thing left to add is the catalog entry, in the per-language file under `src/techs/catalog/`:
 
 ```crystal
-# src/analyzer/analyzer.cr
-{"go_hertz", Go::Hertz},
-
-# src/detector/detector.cr
-Go::Hertz,
-
-# src/techs/techs.cr
+# src/techs/catalog/go.cr
 :go_hertz => {
   :framework => "Hertz",
   :language  => "Go",
-  :similar   => ["hertz", "go-hertz", "cloudwego"],
+  :similar   => ["hertz", "go-hertz", "go_hertz", "cloudwego"],
   :supported => {
     :endpoint => true,
     :method   => true,
     :params   => { :query => true, :path => true, :body => true, :header => true, :cookie => true },
+    :static_path => false,
+    :websocket   => false,
   },
+  # Optional. Declares which AI-context capabilities this tech supports;
+  # CALLEE_SUPPORTED_TECHS and AI_CONTEXT_GUARD_SUPPORTED_TECHS are derived
+  # from these flags rather than hand-listed.
+  :context => { :callee => true },
 },
 ```
+
+`spec/unit_test/techs/registry_integrity_spec.cr` asserts the three-way linkage in both directions: every analyzer and detector has a catalog entry, and every catalog entry is backed by both. A missing catalog entry fails there rather than at runtime.
 
 ### 4. Fixture
 
@@ -233,8 +241,7 @@ The tester asserts:
 ```bash
 just build                 # compiles cleanly
 just test                  # unit + functional spec pass
-crystal tool format --check
-crystal run lib/ameba/bin/ameba.cr
+just check                 # crystal tool format --check + ameba
 
 # Manual smoke test
 ./bin/noir -b spec/functional_test/fixtures/{lang}/{framework}
@@ -242,45 +249,38 @@ crystal run lib/ameba/bin/ameba.cr
 
 ## Adding a new language engine
 
-When a language has 2+ analyzers that share a file-walk pattern, extract an engine. Template, using `SwiftEngine` as the model:
+When a language has 2+ analyzers that share a file-walk pattern, extract an engine. **Inherit from `FileScanEngine`** — it already owns the walk. Your engine declares only what is language-specific: which files to scan, which to skip, and any shared route-composition helpers.
 
 ```crystal
 # src/analyzer/engines/swift_engine.cr
 require "../../models/analyzer"
 
+require "./file_scan_engine"
+
 module Analyzer::Swift
-  abstract class SwiftEngine < Analyzer
-    def analyze
-      parallel_file_scan do |path|
-        result.concat(analyze_file(path))
-      end
-      result
+  abstract class SwiftEngine < FileScanEngine
+    # Candidate files. Prefer the detector-built extension index over
+    # walking the whole `file_map` — these are registered regular files,
+    # so no per-path `File.exists?` / `File.directory?` is needed.
+    protected def scan_target_files : Array(String)
+      get_files_by_extension(".swift")
     end
 
-    abstract def analyze_file(path : String) : Array(Endpoint)
-
-    protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      begin
-        populate_channel_with_files(channel)
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path) && File.extname(path) == ".swift"
-
-          begin
-            block.call(path)
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+    # Optional per-path veto. Runs on the scan-base-relative path, never
+    # the absolute one: a convention filter that matches the absolute path
+    # hands the decision to whatever directory the checkout happens to
+    # live in, so the same tree reports different endpoints depending on
+    # where it was cloned.
+    protected def scan_accepts?(path : String) : Bool
+      relative = base_relative_path(path)
+      return false if relative.includes?("/Tests/")
+      !relative.includes?("/.build/")
     end
   end
 end
 ```
+
+`FileScanEngine` supplies `analyze` (walk, call `analyze_file` per path, concat), the `abstract def analyze_file(path) : Array(Endpoint)` contract, and `parallel_file_scan` for subclasses that need a custom `analyze` shape. Do not re-implement the channel + worker pool: nine engines each carried a byte-identical copy of it before [#2465](https://github.com/owasp-noir/noir/pull/2465) hoisted it, and a hand-rolled copy re-opens that duplication.
 
 When adding the engine, migrate existing analyzers to inherit from it in the same PR. See [#1236](https://github.com/owasp-noir/noir/pull/1236) (Elixir), [#1237](https://github.com/owasp-noir/noir/pull/1237) (Swift), [#1238](https://github.com/owasp-noir/noir/pull/1238) (Crystal) for worked examples.
 
@@ -308,7 +308,7 @@ class MyLangEngine < Analyzer
 end
 ```
 
-See [#1243](https://github.com/owasp-noir/noir/pull/1243) (Go `common.cr` split) for the canonical example.
+See [#1243](https://github.com/owasp-noir/noir/pull/1243) (Go `common.cr` split) for the canonical example. Once an extractor outgrows one file, split it into a directory of part files behind an umbrella `require` rather than letting it grow — [`go_route_extractor_ts/`](https://github.com/owasp-noir/noir/tree/main/src/miniparsers/go_route_extractor_ts) is split by framework family, [`kotlin_route_extractor_ts/`](https://github.com/owasp-noir/noir/tree/main/src/miniparsers/kotlin_route_extractor_ts) by concern.
 
 ## Execution model note
 
@@ -319,6 +319,7 @@ A `@result_mutex` plus `append_endpoint` helpers were added to the engines in #2
 ## Where to look next
 
 - Reference analyzer: [`javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr)
-- Reference engine + extractor pair: [`engines/go_engine.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/engines/go_engine.cr) + [`miniparsers/go_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/go_route_extractor.cr)
+- Shared file-walk base: [`engines/file_scan_engine.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/engines/file_scan_engine.cr)
+- Reference engine + extractor pair: [`engines/go_engine.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/engines/go_engine.cr) + [`miniparsers/go_route_extractor_ts.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/go_route_extractor_ts.cr)
 - Custom-shape example: [`javascript/express.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/express.cr) (pre-phase + closure state)
 - Framework-adapter-only example: [`go/hertz.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/go/hertz.cr) (first framework added after the engine refactor)

--- a/src/analyzer/analyzers/example.cr
+++ b/src/analyzer/analyzers/example.cr
@@ -1,32 +1,88 @@
 require "../../models/analyzer"
+require "../engines/file_scan_engine"
 
-class AnalyzerExample < Analyzer
-  def analyze
-    # Source Analysis
-    begin
-      # Pull from the detector-built file_map (via FileHelper) so new
-      # analyzers written against this template inherit subtree
-      # pruning and --exclude-path filtering for free. Still restrict
-      # to files below the analyzer's base_path — file_map spans the
-      # union of every configured base_path, and an analyzer is
-      # typically interested in one of them.
-      all_files.each do |path|
-        next unless base_paths.any? { |base| path_under_root?(path, base) }
-        next unless File.exists?(path)
-        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          file.each_line do |_line|
-            # For example (Add endpoint to result)
-            # endpoint = Endpoint.new("/", "GET")
-            # details = Details.new(PathInfo.new(path, index + 1))
-            # endpoint.details = details
-            # @result << endpoint
-          end
-        end
-      end
-    rescue e
-      logger.debug e
-    end
+# Template for a new framework adapter (layer L2).
+#
+# Copy this file to `src/analyzer/analyzers/{language}/{framework}.cr`,
+# rename the class, and point it at your language's engine. See AGENTS.md
+# §"Analyzer Layering" and
+# docs/content/development/analyzer_architecture/ for the full walkthrough.
+#
+# The three layers, and which one this file is:
+#
+#   L0  Language Engine     src/analyzer/engines/{lang}_engine.cr
+#                           Owns the file set and the walk. Inherit it.
+#   L1  Route Extractor     src/miniparsers/{lang}_route_extractor*.cr
+#                           Owns parsing. Call it.
+#   L2  Framework Adapter   THIS FILE
+#                           Owns framework-specific route/param rules.
+#
+# **Rule**: an adapter receives routes. It does not walk the filesystem and
+# it does not parse tokens. If you find yourself reaching for `Dir.glob`,
+# `File.open` or `each_line` here, the work belongs in L0 or L1 instead.
+#
+# `AnalyzerExample` deliberately sits outside the `Analyzer::` namespace so
+# the registry sweep in `initialize_analyzers` skips it — which is also why
+# it carries no `analyzer_for`. Your real analyzer needs both.
+class AnalyzerExample < FileScanEngine
+  # Shape A — per-file extraction.
+  #
+  # `FileScanEngine#analyze` drives the walk and concatenates whatever each
+  # call returns. Use this shape unless you need state that spans files.
+  def analyze_file(path : String) : Array(Endpoint)
+    endpoints = [] of Endpoint
 
-    @result
+    # `read_file_content` prefers the detector's content cache and falls
+    # back to a disk read, so the file the detector already loaded is free.
+    content = read_file_content(path)
+
+    # Delegate parsing to the language's route extractor. For example:
+    #
+    #   Noir::JSRouteExtractor.extract_routes(path, content, @is_debug).each do |endpoint|
+    #     endpoints << endpoint
+    #   end
+    #
+    # Then apply only the framework-specific parts here — param mapping,
+    # prefix composition, filters.
+    _ = content
+
+    endpoints
   end
+
+  # Candidate files for the walk. A real analyzer inherits this from its
+  # language engine (`PhpEngine`, `GoEngine`, …) and does not redeclare it;
+  # it is spelled out here because this template has no engine above it.
+  #
+  # Prefer the detector-built extension index over walking the whole
+  # `file_map` — these are registered regular files, so no per-path
+  # `File.exists?` / `File.directory?` is needed.
+  protected def scan_target_files : Array(String)
+    get_files_by_extension(".example")
+  end
+
+  # Optional per-path veto, evaluated before `analyze_file`.
+  #
+  # Match on the scan-base-relative path, never the absolute one. A
+  # convention filter that looks at the absolute path hands the decision to
+  # whatever directory the checkout happens to live in, so the same source
+  # tree reports different endpoints depending on where it was cloned.
+  protected def scan_accepts?(path : String) : Bool
+    !base_relative_path(path).includes?("/tests/")
+  end
+
+  # Shape B — custom `analyze`, when you need closure state, a pre-pass or
+  # a post-pass. Override `analyze` instead of `analyze_file` and drive the
+  # walk yourself with `parallel_file_scan`:
+  #
+  #   def analyze
+  #     scan_for_router_mounts            # pre-pass
+  #     parallel_file_scan do |path|
+  #       # ... accumulate into `result` and into local state
+  #     end
+  #     process_static_dirs(result)       # post-pass
+  #     result
+  #   end
+  #
+  # `src/analyzer/analyzers/javascript/hono.cr` is the reference for this
+  # shape; `src/analyzer/engines/php_engine.cr` is the reference for Shape A.
 end


### PR DESCRIPTION
First PR of a structural-contract cleanup series. This one is docs-only plus the analyzer template.

## Why

The contribution docs had drifted far enough that **following them produced code that does not compile**.

`docs/content/development/analyzer_architecture/index.md` still had a "Register in three places" section — an entry in `analyzer.cr`, one in `detector.cr`, and one in `techs.cr`. All three are wrong:

- Both registries have been derived from the classes themselves since #2384 (`analyzer_for` / `detector_for` + an `all_subclasses` macro sweep). There is nothing to register.
- The tech catalog was split into `src/techs/catalog/<group>.cr` in #2466; `techs.cr` is now a 122-line merge index with no per-tech entries.

The same page's "adding a new language engine" template printed a `SwiftEngine` that no longer exists — `abstract class SwiftEngine < Analyzer` with its own `analyze` and a hand-rolled `Channel` + worker pool. #2465 hoisted exactly that skeleton into `FileScanEngine` after finding nine byte-identical copies of it. Copying the template re-created the duplication that PR removed.

`index.ko.md` is a heading-for-heading translation, so it reproduced every error verbatim. Both are fixed together.

## What changed

**`AGENTS.md`** — 12 corrections:

| Was | Now |
|---|---|
| "Update `src/techs/techs.cr`" (×3) | `src/techs/catalog/{language}.cr` |
| "Register in `analyzer.cr` / `detector.cr` if needed" | nothing to register; declare `analyzer_for` / `detector_for` |
| "Create `{format}_builder.cr`" + "register in selection logic" + "update `options.cr` help text" | `src/output_builder/{format}.cr` + one `@[Noir::OutputFormat]` annotation; `options.cr:279` already interpolates `Noir::OutputFormats.help_text` |
| Java/Kotlin listed as language engines | they are modules exposing `self.test_path?`; nothing inherits from them. `SpecificationEngine` (45 subclasses, the largest) and `CfmlEngine` were missing |
| No mention of `FileScanEngine` | named as the shared base under 7 engines |
| `--list-techs` / `--list-taggers` | `noir list techs` / `noir list taggers` (the flags are legacy aliases) |
| Repo tree | adds `src/cli/`, `src/ai_context/`, `src/mobile/`, `analyzer/engines/`; drops the non-existent `models/delivers/`; adds `llm/acp/` |
| Go/Kotlin route extractors as single files | they are directories of part files behind an umbrella `require` |

**`analyzer_architecture/index.md` + `index.ko.md`** — the "Register in three places" section is replaced with "Declare the tech metadata" (catalog entry only, plus a note that `registry_integrity_spec.cr` asserts the linkage both ways); the engine template is rewritten against `FileScanEngine` showing `scan_target_files` / `scan_accepts?`; the detector examples use `detector_for` instead of the removed `set_name` shape; the dead `miniparsers/go_route_extractor.cr` link is fixed; and the stale coverage list is corrected.

**`src/analyzer/analyzers/example.cr`** — rewritten. This is the file anyone adding an analyzer copies first, and it violated the layering rule stated two files away: it walked the filesystem with `all_files.each` + `File.open` and scanned with `each_line`, doing L0 and L1 work inside an L2 adapter. It also omitted `analyzer_for` — now the *only* registration step — and its sample comment referenced an `index` variable that was not in scope, so uncommenting it would not compile. It now inherits `FileScanEngine`, documents both engine shapes, and contains no file I/O.

## Verification

`just build`, `just test` (4658 unit + 22647 functional, 0 failures), `just check` (1909 files, 0 findings), `just docs-i18n-check` (66/66 translated). The new template compiles as part of the build, which is the gap that let the old one rot.

No behaviour change — no A/B fixture sweep needed.