### PR TITLE
fix(analyzer): stop composing Spring URLs with File.join

### DIFF
--- a/spec/functional_test/fixtures/java/spring_context_bare/src/main/java/com/example/BareController.java
+++ b/spec/functional_test/fixtures/java/spring_context_bare/src/main/java/com/example/BareController.java
@@ -1,0 +1,24 @@
+package com.example;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// No class-level @RequestMapping. The route extractor defaults an unmapped
+// class to an empty prefix, so the servlet context path is the only thing
+// on the left of the join — the case `File.join` composed as "/portal/".
+@RestController
+public class BareController {
+    // Bare @GetMapping with no path argument: resolves to the context path
+    // itself. Spring serves this at /portal, not /portal/.
+    @GetMapping
+    public String root() {
+        return "ok";
+    }
+
+    // Path argument without a leading slash.
+    @PostMapping("users")
+    public String users() {
+        return "ok";
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_context_bare/src/main/resources/application.properties
+++ b/spec/functional_test/fixtures/java/spring_context_bare/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.servlet.context-path=/portal

--- a/spec/functional_test/testers/java/spring_context_bare_spec.cr
+++ b/spec/functional_test/testers/java/spring_context_bare_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+# A controller with no class-level `@RequestMapping` under a configured
+# `server.servlet.context-path`. The route extractor resolves an unmapped
+# class to an empty prefix, so the context path is the only segment on the
+# left of the join — and a bare `@GetMapping` puts an empty string on the
+# right.
+#
+# That pair used to reach the top-level `join_paths` (`File.join`), which
+# appends a separator for an empty trailing segment: `File.join("/portal",
+# "")` is `"/portal/"`. Spring serves the mapping at `/portal`. Every other
+# Java analyzer in the directory composed paths with `Helper.join_paths`;
+# only the two Spring analyzers fell through to the global.
+expected_endpoints = [
+  Endpoint.new("/portal", "GET"),
+  Endpoint.new("/portal/users", "POST"),
+]
+
+FunctionalTester.new("fixtures/java/spring_context_bare/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/utils/url_path_spec.cr
+++ b/spec/unit_test/utils/url_path_spec.cr
@@ -71,3 +71,82 @@ describe "Noir::URLPath.join_trimmed" do
     Noir::URLPath.join_trimmed("/api/", "").should eq "/api"
   end
 end
+
+# The Spring mapping-composition rule, shared by the Java and Kotlin
+# tree-sitter route extractors.
+describe "Noir::URLPath.join_absorbing" do
+  it "absorbs a bare method mapping onto the class prefix" do
+    Noir::URLPath.join_absorbing("/api/article", "").should eq "/api/article"
+    Noir::URLPath.join_absorbing("/api/article/", "").should eq "/api/article"
+  end
+
+  it "keeps the root when an all-slash prefix has no path" do
+    Noir::URLPath.join_absorbing("/", "").should eq "/"
+    Noir::URLPath.join_absorbing("///", "").should eq "/"
+  end
+
+  it "carries an explicit @GetMapping(\"/\") through the seam" do
+    Noir::URLPath.join_absorbing("/api", "/").should eq "/api/"
+  end
+
+  # Deliberate: an unmapped class with a bare mapping resolves to `""`, and
+  # the extractors rely on that staying empty so the analyzer above them can
+  # apply the context path. Adding a root guard here would silently move
+  # every JVM route — `join_rooted` exists for callers that need one.
+  it "returns the path untouched when the prefix is empty" do
+    Noir::URLPath.join_absorbing("", "/users").should eq "/users"
+    Noir::URLPath.join_absorbing("", "").should eq ""
+  end
+
+  it "differs from join_trimmed on an all-slash prefix" do
+    Noir::URLPath.join_trimmed("/", "").should eq ""
+    Noir::URLPath.join_absorbing("/", "").should eq "/"
+  end
+end
+
+# `join_rooted` replaced a top-level `def join_paths(*paths) = File.join(paths)`
+# that unqualified calls in `java/spring.cr` and `kotlin/spring.cr` fell
+# through to. These pin the three inputs where `File.join` was wrong and the
+# two where the other `URLPath` joins would regress.
+describe "Noir::URLPath.join_rooted" do
+  it "absorbs an empty path instead of leaving a trailing slash" do
+    Noir::URLPath.join_rooted("/portal", "").should eq "/portal"
+    Noir::URLPath.join_rooted("/portal/", "").should eq "/portal"
+  end
+
+  it "roots a path that carries no leading slash" do
+    Noir::URLPath.join_rooted("", "users").should eq "/users"
+    Noir::URLPath.join_rooted("", "/users").should eq "/users"
+  end
+
+  it "returns the root when both sides are empty" do
+    Noir::URLPath.join_rooted("", "").should eq "/"
+    Noir::URLPath.join_rooted("/", "").should eq "/"
+  end
+
+  it "collapses repeated slashes at the seam" do
+    Noir::URLPath.join_rooted("/api//", "/users").should eq "/api/users"
+    Noir::URLPath.join_rooted("/api", "//users").should eq "/api/users"
+  end
+
+  # What the File.join-based composition used to produce. Each of these is a
+  # URL Spring's servlet container would not serve at that address.
+  it "differs from File.join where File.join was wrong" do
+    File.join("/portal", "").should eq "/portal/"
+    Noir::URLPath.join_rooted("/portal", "").should eq "/portal"
+
+    File.join("", "users").should eq "users"
+    Noir::URLPath.join_rooted("", "users").should eq "/users"
+
+    File.join("/api//", "/users").should eq "/api//users"
+    Noir::URLPath.join_rooted("/api//", "/users").should eq "/api/users"
+  end
+
+  # And why neither of the existing joins could be reused: both emit an
+  # empty URL for the unmapped-class-with-bare-mapping case.
+  it "differs from join_trimmed and join_absorbing on the empty pair" do
+    Noir::URLPath.join_trimmed("", "").should eq ""
+    Noir::URLPath.join_absorbing("", "").should eq ""
+    Noir::URLPath.join_rooted("", "").should eq "/"
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -198,7 +198,3 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   logger.info "Found #{result.size} endpoints"
   result
 end
-
-def join_paths(*paths : String) : String
-  File.join(paths)
-end

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -5,6 +5,7 @@ require "../../../miniparsers/java_callee_extractor"
 require "../../../utils/spring_property_path"
 require "../../engines/java_engine"
 require "../../../utils/path_scope"
+require "../../../utils/url_path"
 require "yaml"
 
 module Analyzer::Java
@@ -219,19 +220,13 @@ module Analyzer::Java
               )
               merge_route_condition_params(parameters, route.params)
 
-              # Drop the trailing `/` on webflux_base_path when the
-              # route path already starts with one, so the join
-              # doesn't produce `//`.
               base_path = is_internal_client ? "" : configured_base_path
-              if base_path.ends_with?("/") && route.path.starts_with?("/")
-                base_path = base_path[..-2]
-              end
 
               line = route.line + 1
               details = Details.new(PathInfo.new(path, line))
 
               endpoint = Endpoint.new(
-                resolve_endpoint_path(join_paths(base_path, route.path), spring_properties),
+                resolve_endpoint_path(Noir::URLPath.join_rooted(base_path, route.path), spring_properties),
                 route.verb, parameters, details, is_internal_client
               )
 
@@ -261,7 +256,7 @@ module Analyzer::Java
                   # scan already emitted that route — skip the duplicate.
                   next if implementation.annotated_method_names.includes?(entry_route.method_name)
                   implementation.paths.each do |implementation_path|
-                    inherited_path = join_paths(implementation_path, entry_route.path)
+                    inherited_path = Noir::URLPath.join_rooted(implementation_path, entry_route.path)
                     parameter_format = nil
                     parameters = [] of Param
 
@@ -282,7 +277,7 @@ module Analyzer::Java
 
                     details = Details.new(PathInfo.new(entry.path, entry_route.line + 1))
                     endpoint = Endpoint.new(
-                      resolve_endpoint_path(join_paths(configured_base_path, inherited_path), spring_properties),
+                      resolve_endpoint_path(Noir::URLPath.join_rooted(configured_base_path, inherited_path), spring_properties),
                       entry_route.verb, parameters, details
                     )
 
@@ -313,7 +308,7 @@ module Analyzer::Java
               collect_stomp_endpoints(content, constants).each do |entry|
                 endpoint_path, line = entry
                 endpoint = Endpoint.new(
-                  resolve_endpoint_path(join_paths(configured_base_path, endpoint_path), spring_properties),
+                  resolve_endpoint_path(Noir::URLPath.join_rooted(configured_base_path, endpoint_path), spring_properties),
                   "GET", Details.new(PathInfo.new(path, line))
                 )
                 endpoint.protocol = "ws"
@@ -339,7 +334,7 @@ module Analyzer::Java
               collect_resource_handler_endpoints(content, constants).each do |entry|
                 endpoint_path, line = entry
                 @result << Endpoint.new(
-                  resolve_endpoint_path(join_paths(configured_base_path, endpoint_path), spring_properties),
+                  resolve_endpoint_path(Noir::URLPath.join_rooted(configured_base_path, endpoint_path), spring_properties),
                   "GET", Details.new(PathInfo.new(path, line))
                 )
               end
@@ -387,13 +382,13 @@ module Analyzer::Java
               nest_prefix = ""
               nest_prefixes.each do |start_b, end_b, prefix|
                 if pos >= start_b && pos < end_b
-                  nest_prefix = join_paths(nest_prefix, prefix)
+                  nest_prefix = Noir::URLPath.join_rooted(nest_prefix, prefix)
                 end
               end
-              composed = nest_prefix.empty? ? endpoint : join_paths(nest_prefix, endpoint)
+              composed = nest_prefix.empty? ? endpoint : Noir::URLPath.join_rooted(nest_prefix, endpoint)
               details = Details.new(PathInfo.new(path))
               reactive_endpoint = Endpoint.new(
-                resolve_endpoint_path(join_paths(configured_base_path, composed), spring_properties),
+                resolve_endpoint_path(Noir::URLPath.join_rooted(configured_base_path, composed), spring_properties),
                 method, details
               )
 
@@ -665,7 +660,7 @@ module Analyzer::Java
         prefixes = [] of String
         outer_prefixes.each do |outer_prefix|
           class_paths.each do |class_path|
-            prefixes << join_paths(outer_prefix, class_path)
+            prefixes << Noir::URLPath.join_rooted(outer_prefix, class_path)
           end
         end
 
@@ -707,7 +702,7 @@ module Analyzer::Java
         application_prefixes.each do |application_prefix|
           class_prefixes.each do |class_prefix|
             paths.each do |path|
-              endpoints << {verb, join_paths(application_prefix, join_paths(class_prefix, path)), line + 1}
+              endpoints << {verb, Noir::URLPath.join_rooted(application_prefix, Noir::URLPath.join_rooted(class_prefix, path)), line + 1}
             end
           end
         end

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -5,6 +5,7 @@ require "../../../miniparsers/kotlin_callee_extractor"
 require "../../engines/kotlin_engine"
 require "../../../utils/utils.cr"
 require "../../../utils/path_scope"
+require "../../../utils/url_path"
 
 module Analyzer::Kotlin
   class Spring < Analyzer
@@ -725,7 +726,7 @@ module Analyzer::Kotlin
       roots.each do |root|
         graphql_path = graphql_path_from_resources(root) || "/graphql"
         path_config = path_configs[root]? || SpringPathConfig.new
-        paths[root] = join_paths(path_config.web_base_path, graphql_path)
+        paths[root] = Noir::URLPath.join_rooted(path_config.web_base_path, graphql_path)
       end
 
       paths
@@ -891,7 +892,7 @@ module Analyzer::Kotlin
         method_nodes = Noir::TreeSitterKotlinParameterExtractor.index_functions_from(root, content)
 
         stomp_routes.each do |route|
-          route_path = route.verb == "GET" ? join_paths(webflux_base_path, route.path) : route.path
+          route_path = route.verb == "GET" ? Noir::URLPath.join_rooted(webflux_base_path, route.path) : route.path
           line = route.line + 1
           key = "#{route.class_name}##{route.method_name}"
           method = method_nodes[key]?
@@ -1001,17 +1002,11 @@ module Analyzer::Kotlin
             )
           end
 
-          # Drop the trailing `/` on webflux_base_path when the route
-          # path already starts with one, so the join doesn't produce
-          # `//`.
           base_path = webflux_base_path
-          if base_path.ends_with?("/") && route.path.starts_with?("/")
-            base_path = base_path[..-2]
-          end
 
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
-          endpoint = Endpoint.new(join_paths(base_path, route.path), route.verb, parameters, details)
+          endpoint = Endpoint.new(Noir::URLPath.join_rooted(base_path, route.path), route.verb, parameters, details)
           attach_method_security_tags(endpoint, method, content)
 
           # Functional router method references can point at a handler
@@ -1075,7 +1070,7 @@ module Analyzer::Kotlin
 
             pairs.each do |implementation, entry|
               entry_route = entry.route
-              inherited_path = join_paths(implementation.path, entry_route.path)
+              inherited_path = Noir::URLPath.join_rooted(implementation.path, entry_route.path)
 
               parameter_format = Noir::TreeSitterKotlinParameterExtractor.extract_consumes_from(
                 interface_root, interface_source, entry_route.class_name, entry_route.method_name
@@ -1093,7 +1088,7 @@ module Analyzer::Kotlin
 
               details = Details.new(PathInfo.new(entry.path, entry_route.line + 1))
               details.add_path(PathInfo.new(path, implementation.line + 1))
-              endpoint = Endpoint.new(join_paths(base_path, inherited_path), entry_route.verb, parameters, details)
+              endpoint = Endpoint.new(Noir::URLPath.join_rooted(base_path, inherited_path), entry_route.verb, parameters, details)
               attach_method_security_tags(endpoint, method_nodes["#{implementation.class_name}##{entry_route.method_name}"]?, content)
 
               if include_callee && !(implementation.class_name.empty? || entry_route.method_name.empty?)

--- a/src/utils/url_path.cr
+++ b/src/utils/url_path.cr
@@ -80,5 +80,36 @@ module Noir
       end
       "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
     end
+
+    # `join_absorbing` plus the guarantee that the result is a rooted URL
+    # path: never empty, always leading-`/`.
+    #
+    # This is the rule Spring's servlet container applies when it composes
+    # `server.servlet.context-path` with a controller's resolved mapping.
+    # Both sides can legitimately be empty — the Java and Kotlin route
+    # extractors default an unmapped class or a bare `@GetMapping` to `""`
+    # (see `paths = [""] if paths.empty?`) — and the container serves that
+    # as `/`, not as the empty string.
+    #
+    # Spring used to reach `File.join` for this, via a top-level
+    # `join_paths` that unqualified calls fell through to. `File.join`
+    # gets the empty cases right but three others wrong, which is what
+    # this method exists to fix:
+    #
+    #   ("", "")          File.join "/"        join_rooted "/"
+    #   ("/", "")         File.join "/"        join_rooted "/"
+    #   ("", "users")     File.join "users"    join_rooted "/users"
+    #   ("/api", "")      File.join "/api/"    join_rooted "/api"
+    #   ("/api//", "/u")  File.join "/api//u"  join_rooted "/api/u"
+    #
+    # `join_trimmed` and `join_absorbing` are NOT substitutes: both return
+    # `""` for `("", "")`, which would emit an endpoint with an empty URL.
+    # `File.join` is also platform-dependent (`Path` uses the native
+    # separator), so on Windows it composed `"/api\users"`.
+    def self.join_rooted(prefix : String, path : String) : String
+      joined = join_absorbing(prefix, path)
+      return "/" if joined.empty?
+      joined.starts_with?('/') ? joined : "/#{joined}"
+    end
   end
 end


### PR DESCRIPTION
Second PR of the structural-contract series (after #2488). This is the only one in the series that changes output.

## The bug

`src/analyzer/analyzer.cr:202` defined a top-level helper:

```crystal
def join_paths(*paths : String) : String
  File.join(paths)
end
```

Crystal resolves methods by **type**, not by lexical namespace. An unqualified `join_paths(...)` inside a class that neither defines nor includes one therefore falls through to `Object#join_paths`. Sixteen call sites did — eleven in `java/spring.cr`, five in `kotlin/spring.cr`.

Every *other* Java analyzer in that same directory calls `Helper.join_paths` explicitly (`Analyzer::Java::Helper`, byte-identical to `URLPath.join_trimmed`). So the two Spring analyzers alone were composing HTTP URLs with filesystem-path semantics, and nothing in the code said so.

`File.join` gets three of the five relevant inputs wrong:

| input | `File.join` | correct |
|---|---|---|
| `("/portal", "")` | `"/portal/"` | `"/portal"` |
| `("", "users")` | `"users"` | `"/users"` |
| `("/api//", "/u")` | `"/api//u"` | `"/api/u"` |
| `("", "")` | `"/"` | `"/"` ✓ |
| `("/", "")` | `"/"` | `"/"` ✓ |

The first row is reachable and ordinary. Both route extractors default an unmapped class and a bare `@GetMapping` to `""` (`paths = [""] if paths.empty?` — `java_route_extractor_ts.cr:240,540`), so a controller with no class-level `@RequestMapping` under `server.servlet.context-path=/portal` was reported at `/portal/`, which the servlet container does not serve.

It is also a portability bug: `Path` uses the native separator, so a Windows build composed `"/api\users"`.

## The fix

A new `Noir::URLPath.join_rooted` — **not** a reuse of an existing join. `join_trimmed` and `join_absorbing` both return `""` for `("", "")`, so swapping either in would have emitted an endpoint with an empty URL. That would be a regression dressed as a cleanup. `join_rooted` is `join_absorbing` plus a root guarantee, and it agrees with `File.join` on every input where `File.join` was already right.

Also drops the hand-rolled seam collapse both analyzers carried:

```crystal
# Drop the trailing `/` on webflux_base_path when the route path
# already starts with one, so the join doesn't produce `//`.
if base_path.ends_with?("/") && route.path.starts_with?("/")
  base_path = base_path[..-2]
end
```

That was compensating for a join that no longer needs compensating.

The global `join_paths` is deleted. The remaining bare `join_paths` calls elsewhere all resolve to a private method in their own class and are untouched here — renaming those is a separate, output-neutral PR.

## Verification — measured, not assumed

A/B over **all 665 fixture directories** (5,160 endpoints on `main`), normalized to `{method, url, sorted params, sorted tags}`, produces **exactly one difference**:

```
spec_functional_test_fixtures_java_spring_context_bare_.json
<     "url": "/portal/"
>     "url": "/portal"
```

The sixteen pre-existing Spring fixtures come back byte-identical, because every one of their controllers carries both a class-level `@RequestMapping` **and** a path-bearing method mapping — so the seam never sees an empty side. The bug was latent on the corpus, which is why it survived. **The new fixture is what pins it**: `spring_context_bare/` is a context path plus an unmapped controller, the minimum that reproduces it.

> Note for anyone repeating this: `--nolog` suppresses `-f json` output entirely, so an A/B script that passes it compares empty to empty and reports a false pass. Assert the endpoint count is non-zero before trusting a clean diff.

Also added: `join_absorbing` had zero spec coverage despite being the target of both JVM tree-sitter extractors. Both it and `join_rooted` are now covered, including the exact inputs where each disagrees with its neighbours.

`crystal spec spec/unit_test` 4669 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1910 files, 0 findings.