### PR TITLE
refactor(analyzer): route every callee gate through callees_needed?

### DIFF
--- a/spec/unit_test/analyzer/options_boundary_spec.cr
+++ b/spec/unit_test/analyzer/options_boundary_spec.cr
@@ -1,0 +1,61 @@
+require "../../spec_helper"
+
+# `Analyzer#callees_needed?` (src/models/analyzer.cr) has existed, with a doc
+# comment telling analyzers to use it, for as long as the callee flags have.
+# Sixty-five analyzers re-implemented its body inline anyway:
+#
+#     include_callee = any_to_bool(@options["include_callee"]?) ||
+#                      any_to_bool(@options["ai_context"]?)
+#
+# Two of them went further and declared a `private def callees_needed?` whose
+# body — and doc comment — duplicated the base method verbatim.
+#
+# Nothing failed when they drifted, because nothing checked. The cost is not
+# the duplication itself but the coupling it encodes: every one of those
+# lines is an analyzer reaching past its base class into the raw options
+# hash, so the set of keys the analyzer layer depends on could only be
+# discovered by grep. That set is now four keys wide and shrinking.
+#
+# Repo-relative glob: `crystal spec` runs from the repository root (same
+# assumption as spec/unit_test/detector/applicable_lookup_fidelity_spec.cr).
+private def analyzer_sources : Array(String)
+  Dir.glob("src/analyzer/**/*.cr").sort
+end
+
+private def offending_lines(pattern : Regex) : Array(String)
+  analyzer_sources.flat_map do |file|
+    File.read_lines(file).each_with_index.compact_map do |line, index|
+      "#{file}:#{index + 1}: #{line.strip}" if line.matches?(pattern)
+    end
+  end
+end
+
+describe "analyzer options boundary" do
+  it "reads the callee flags only through callees_needed?" do
+    offenders = offending_lines(/@options\[\s*"(?:include_callee|ai_context)"\s*\]/)
+
+    fail <<-MSG unless offenders.empty?
+      analyzers must call `callees_needed?` instead of reading the callee
+      flags out of the options hash. Offending lines:
+        #{offenders.join("\n  ")}
+      MSG
+  end
+
+  it "does not shadow callees_needed? with a local copy" do
+    offenders = offending_lines(/^\s*(?:private\s+|protected\s+)?def\s+callees_needed\?/)
+
+    fail <<-MSG unless offenders.empty?
+      `callees_needed?` is defined once, on `Analyzer`. A subclass copy is a
+      silent fork of the flag semantics. Offending lines:
+        #{offenders.join("\n  ")}
+      MSG
+  end
+
+  # Guards the guard: a typo in the globs above would make both examples pass
+  # vacuously, which is the failure mode that makes source-scanning specs
+  # worthless.
+  it "scans a non-trivial number of analyzer sources" do
+    analyzer_sources.size.should be > 200
+    analyzer_sources.count { |f| File.read(f).includes?("callees_needed?") }.should be > 50
+  end
+end

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -45,7 +45,7 @@ module Analyzer::Clojure
     COMPOJURE_SOURCE_RE = Regex.union("compojure.core", "compojure.api", "defroutes", "(context")
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       all_files.each do |path|
         next unless clojure_file?(path)
 

--- a/src/analyzer/analyzers/clojure/pedestal.cr
+++ b/src/analyzer/analyzers/clojure/pedestal.cr
@@ -43,7 +43,7 @@ module Analyzer::Clojure
     PEDESTAL_SOURCE_RE = Regex.union("io.pedestal", "pedestal.service", "pedestal.route", "defroutes", "table-routes")
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       all_files.each do |path|
         next unless clojure_file?(path)
 

--- a/src/analyzer/analyzers/clojure/reitit.cr
+++ b/src/analyzer/analyzers/clojure/reitit.cr
@@ -42,7 +42,7 @@ module Analyzer::Clojure
     REITIT_SOURCE_RE = Regex.union("reitit.", "metosin/reitit")
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       all_files.each do |path|
         next unless clojure_file?(path)
 

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -39,7 +39,7 @@ module Analyzer::Cpp
     EVIDENCE_RE = Regex.union("CROW_ROUTE", "CROW_BP_ROUTE", "CROW_WEBSOCKET_ROUTE", "route_dynamic")
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       begin
         locator = CodeLocator.instance

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -55,7 +55,7 @@ module Analyzer::Cpp
     JSON_ACCESS_RE = Regex.union("->getJsonObject(", "->getJsonValue(")
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       begin
         locator = CodeLocator.instance

--- a/src/analyzer/analyzers/cpp/httplib.cr
+++ b/src/analyzer/analyzers/cpp/httplib.cr
@@ -54,7 +54,7 @@ module Analyzer::Cpp
     @function_body_regex_cache = Hash(String, Regex).new
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       begin
         locator = CodeLocator.instance

--- a/src/analyzer/analyzers/cpp/oatpp.cr
+++ b/src/analyzer/analyzers/cpp/oatpp.cr
@@ -31,7 +31,7 @@ module Analyzer::Cpp
     MACRO_EVIDENCE_RE   = Regex.union("ENDPOINT(", "ENDPOINT_ASYNC(")
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       begin
         locator = CodeLocator.instance

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -35,7 +35,7 @@ module Analyzer::Crystal
       # Apps like invidious register routes as `get "/", Routes::Misc, :home`
       # with the handler defined in a separate controller file. Build the
       # cross-file action index up front so those routes can carry callees.
-      if any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      if callees_needed?
         @action_index = build_crystal_action_index(get_files_by_extension(".cr"))
       end
       super

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -28,7 +28,7 @@ module Analyzer::CSharp
     @param_name_strip_regexes = Hash(String, Regex).new
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       project_roots = Common.project_roots(get_files_by_extension(".csproj"))
       route_patterns_by_scope = load_route_patterns_by_scope(project_roots)
       analyze_controllers(route_patterns_by_scope, project_roots, include_callee)

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -15,7 +15,7 @@ module Analyzer::CSharp
     end
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       # Static Analysis
       locator = CodeLocator.instance
       route_config_file = locator.get("cs-apinet-mvc-routeconfig")

--- a/src/analyzer/analyzers/csharp/fastendpoints.cr
+++ b/src/analyzer/analyzers/csharp/fastendpoints.cr
@@ -31,7 +31,7 @@ module Analyzer::CSharp
     HTTP_VERB_TOKEN_REGEX = /(?:Http\.)?(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)/
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       cs_files = get_files_by_extension(".cs").reject { |f| Common.csharp_test_path?(base_relative_path(f)) }
       # One pass picks the FastEndpoints sources and, from the same content,

--- a/src/analyzer/analyzers/dart/alfred.cr
+++ b/src/analyzer/analyzers/dart/alfred.cr
@@ -43,7 +43,7 @@ module Analyzer::Dart
     ALL_VERBS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       result = [] of Endpoint
       mutex = Mutex.new
 

--- a/src/analyzer/analyzers/dart/angel3.cr
+++ b/src/analyzer/analyzers/dart/angel3.cr
@@ -58,7 +58,7 @@ module Analyzer::Dart
     CALL_REGEX = /(?<![\w$.])([A-Za-z_]\w*)\s*\.\s*([a-zA-Z]+)\s*\(/
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       result = [] of Endpoint
       mutex = Mutex.new
 

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -53,7 +53,7 @@ module Analyzer::Dart
     end
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       result = [] of Endpoint
       mutex = Mutex.new
 

--- a/src/analyzer/analyzers/dart/get_server.cr
+++ b/src/analyzer/analyzers/dart/get_server.cr
@@ -51,7 +51,7 @@ module Analyzer::Dart
       line: Int32)
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       const_map = {} of String => String
       raw_pages = [] of RawPage
       mutex = Mutex.new

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -36,7 +36,7 @@ module Analyzer::Dart
     alias Registration = NamedTuple(base_path: String, class_name: String, path: String)
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       route_classes = {} of RouteClassKey => RouteClass
       registrations = [] of Registration
 

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -78,7 +78,7 @@ module Analyzer::Fsharp
     }
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".fs") || path.ends_with?(".fsx")

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -91,7 +91,7 @@ module Analyzer::Groovy
     BODY_ARGS_KEY_RE = Regex.union("controller:", "action:", "view:", "uri:")
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".groovy")

--- a/src/analyzer/analyzers/haskell/scotty.cr
+++ b/src/analyzer/analyzers/haskell/scotty.cr
@@ -29,7 +29,7 @@ module Analyzer::Haskell
     alias HandlerBodies = Hash(HandlerKey, Array(HandlerBody))
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       handler_bodies = include_callee ? build_handler_bodies : HandlerBodies.new
 
       all_files.each do |path|

--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -18,7 +18,7 @@ module Analyzer::Haskell
 
     def analyze
       type_aliases = TypeAliasIndex.new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       handler_bodies = include_callee ? build_handler_bodies : HandlerBodies.new
       server_bindings = include_callee ? build_server_bindings : ServerBindings.new
 

--- a/src/analyzer/analyzers/haskell/yesod.cr
+++ b/src/analyzer/analyzers/haskell/yesod.cr
@@ -16,7 +16,7 @@ module Analyzer::Haskell
 
     def analyze
       processed_route_files = Set(String).new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       handler_bodies = include_callee ? build_handler_bodies : HandlerBodies.new
 
       all_files.each do |path|

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -922,7 +922,7 @@ module Analyzer::Java
     private def collect_method_callees(method : LibTreeSitter::TSNode,
                                        content : String,
                                        path : String) : Array(Tuple(String, String, Int32))
-      return [] of Tuple(String, String, Int32) unless any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      return [] of Tuple(String, String, Int32) unless callees_needed?
       body = Noir::TreeSitter.field(method, "body")
       return [] of Tuple(String, String, Int32) unless body
 

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -40,7 +40,7 @@ module Analyzer::Java
     end
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
       source_cache = Hash(String, String).new

--- a/src/analyzer/analyzers/java/javalin.cr
+++ b/src/analyzer/analyzers/java/javalin.cr
@@ -45,7 +45,7 @@ module Analyzer::Java
     )
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       file_list = all_files()
       file_list.each do |path|
         next if JavaEngine.test_path?(base_relative_path(path))

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -20,7 +20,7 @@ module Analyzer::Java
     )
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
       source_cache = Hash(String, String).new

--- a/src/analyzer/analyzers/java/micronaut.cr
+++ b/src/analyzer/analyzers/java/micronaut.cr
@@ -52,7 +52,7 @@ module Analyzer::Java
     end
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
 
       file_list = all_files()

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -77,7 +77,7 @@ module Analyzer::Java
     # Parse Java controller files to extract header, cookie, and body parameters
     private def parse_controller_files(java_files : Array(String)) : Hash(ScopedKey, ControllerMethod)
       controller_methods = Hash(ScopedKey, ControllerMethod).new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       java_files.each do |path|
         content = read_file_content(path)

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -31,7 +31,7 @@ module Analyzer::Java
     end
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
       source_cache = Hash(String, String).new

--- a/src/analyzer/analyzers/java/spark.cr
+++ b/src/analyzer/analyzers/java/spark.cr
@@ -46,7 +46,7 @@ module Analyzer::Java
     )
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       file_list = all_files()
       file_list.each do |path|
         next if JavaEngine.test_path?(base_relative_path(path))

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -138,7 +138,7 @@ module Analyzer::Java
     end
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
 
       # `.java` from the extension index, tests dropped once. Previous

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -53,7 +53,7 @@ module Analyzer::Java
 
     def analyze
       # Source Analysis
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -64,7 +64,7 @@ module Analyzer::Javascript
     protected def analyze_with_extensions(extensions : Array(String)) : Array(Endpoint)
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       global_prefix_holder = [] of GlobalPrefixConfig
       global_prefix_mutex = Mutex.new
 

--- a/src/analyzer/analyzers/javascript/nextjs.cr
+++ b/src/analyzer/analyzers/javascript/nextjs.cr
@@ -25,7 +25,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       project_roots = discover_js_project_roots(
         ["\"next\""],
         ["next.config.js", "next.config.ts", "next.config.mjs", "next.config.cjs"]

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -7,7 +7,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       # `routes/` on its own is not a Nitro signal — it is the conventional
       # name for a router directory in Koa, Express, Fastify and most other JS
       # frameworks. Treating every `*/routes/*.ts` in the scan as a Nitro

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -10,7 +10,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       parallel_file_scan(EXTENSIONS) do |path|
         # Focus on server/api and server/routes directories for Nuxt 3

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -51,7 +51,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       parallel_file_scan(EXTENSIONS) do |path|
         # Scan-base-relative, never absolute: `String#index` takes the

--- a/src/analyzer/analyzers/javascript/sveltekit.cr
+++ b/src/analyzer/analyzers/javascript/sveltekit.cr
@@ -43,7 +43,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       project_roots = discover_js_project_roots(
         ["@sveltejs/kit", "\"svelte-kit\""],
         ["svelte.config.js", "svelte.config.ts", "svelte.config.mjs", "svelte.config.cjs"]

--- a/src/analyzer/analyzers/kotlin/http4k.cr
+++ b/src/analyzer/analyzers/kotlin/http4k.cr
@@ -10,7 +10,7 @@ module Analyzer::Kotlin
     HTTP4K_MARKER    = "org.http4k"
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       file_list = all_files()
       kotlin_files = file_list.select do |path|
         File.exists?(path) &&

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -9,7 +9,7 @@ module Analyzer::Kotlin
     KOTLIN_EXTENSION = "kt"
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       file_list = all_files()
       kotlin_files = file_list.select do |path|
         File.exists?(path) &&

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -165,7 +165,7 @@ module Analyzer::Kotlin
       end
       local_string_constants = Hash(String, Hash(String, String)).new
       dto_builder = Noir::TreeSitterKotlinDtoIndex.new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       functional_router_seen = false
 
       all_file_list = all_files()
@@ -844,7 +844,7 @@ module Analyzer::Kotlin
                                     method_index : SpringMethodIndex,
                                     stomp_application_prefixes : Array(String),
                                     graphql_path : String)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       content = read_file_content(path)
       return unless kotlin_spring_route_candidate_file?(content)
 

--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -44,7 +44,7 @@ module Analyzer::Lua
     MOON_ACTION_MARKER_RE = Regex.union("=>", "respond_to")
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       all_files.each do |path|
         next if File.directory?(path)

--- a/src/analyzer/analyzers/lua/lor.cr
+++ b/src/analyzer/analyzers/lua/lor.cr
@@ -57,7 +57,7 @@ module Analyzer::Lua
       route_vars : Set(String)
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       files = collect_files
       return @result if files.empty?

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -27,7 +27,7 @@ module Analyzer::Ruby
     end
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       # Real Grape apps almost always share config/helpers through a custom
       # base class (`class Base < Grape::API`, then `class Users < API::Base`)

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -23,7 +23,7 @@ module Analyzer::Ruby
     record RouteEndpoint, endpoint : Endpoint, target : String?
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       framework_roots = discover_framework_roots("config/routes.rb")
       framework_roots = base_paths if framework_roots.empty?
 

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -1595,13 +1595,6 @@ module Analyzer::Ruby
       end
     end
 
-    # Callees feed both `--include-callee` (direct output) and `--ai-context`
-    # (aggregated review context). Extraction is skipped when neither flag is
-    # set so default scans avoid the controller-body walk per action.
-    private def callees_needed? : Bool
-      any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-    end
-
     private def parent_resources_frame(stack : Array(Frame)) : Frame?
       stack.reverse_each do |f|
         return f if f.kind == :resources

--- a/src/analyzer/analyzers/ruby/roda.cr
+++ b/src/analyzer/analyzers/ruby/roda.cr
@@ -30,7 +30,7 @@ module Analyzer::Ruby
     alias PrefixEntry = NamedTuple(depth: Int32, segments: Array(String), path_params: Array(String))
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb")

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -5,7 +5,7 @@ module Analyzer::Ruby
     analyzer_for "ruby_sinatra"
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -64,7 +64,7 @@ module Analyzer::Rust
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       test_regions = RustEngine.collect_cfg_test_regions(source)
 
       Noir::TreeSitter.parse_rust(source) do |root|

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -84,7 +84,7 @@ module Analyzer::Rust
       # `#[cfg(test)] mod tests { ... }` blocks, which a path filter
       # alone can't tell apart.
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       # `#[cfg(test)] mod tests { ... let app = Router::new().route(...); }`
       # is the canonical place doctests-as-unit-tests register routes in

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -30,7 +30,7 @@ module Analyzer::Rust
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       # Gotham's framework repo parks route registrations inside
       # `#[cfg(test)] mod tests { ... build_router(|route| { route.get(...) }) }`

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -36,7 +36,7 @@ module Analyzer::Rust
       # controllers under `src/controllers/` *and* import `loco_rs`,
       # so the content check alone is sufficient.
       return endpoints unless source.includes?("use loco_rs")
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       # `#[cfg(test)] mod tests { Routes::new().add("/x", get(h)); }` and
       # path-normalization test fixtures live right in the framework's
       # `src/app_routes.rs` etc.; gate them like the other Rust analyzers.

--- a/src/analyzer/analyzers/rust/poem.cr
+++ b/src/analyzer/analyzers/rust/poem.cr
@@ -27,7 +27,7 @@ module Analyzer::Rust
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       # `#[cfg(test)] mod tests { Route::new().at("/x", get(h)); }` blocks
       # would otherwise leak test-only routes; gate like the other Rust

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -55,7 +55,7 @@ module Analyzer::Rust
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       Noir::TreeSitter.parse_rust(source) do |root|
         each_routing_pair(root) do |attr, function|

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -61,7 +61,7 @@ module Analyzer::Rust
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       @current_source = source
       Noir::TreeSitter.parse_rust(source) do |root|

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -118,7 +118,7 @@ module Analyzer::Rust
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       # `crates/core/src/routing.rs`-style `#[cfg(test)] mod tests
       # { Router::with_path(...).get(...) }` blocks would otherwise
       # leak into the endpoint set. See `RustEngine.collect_cfg_test_regions`

--- a/src/analyzer/analyzers/rust/tide.cr
+++ b/src/analyzer/analyzers/rust/tide.cr
@@ -30,7 +30,7 @@ module Analyzer::Rust
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       # Inline `#[cfg(test)] mod test { let mut app = tide::new();
       # app.at("/x").get(h); }` blocks live right in `src/` here, so a

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -46,7 +46,7 @@ module Analyzer::Rust
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = build_function_index(root, source)

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -27,7 +27,7 @@ module Analyzer::Scala
 
     def analyze_file(path : String) : Array(Endpoint)
       content = read_file_content(path)
-      extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
+      extract_routes_from_content(path, content, callees_needed?)
     end
 
     # Extract routes from Akka HTTP DSL

--- a/src/analyzer/analyzers/scala/http4s.cr
+++ b/src/analyzer/analyzers/scala/http4s.cr
@@ -13,7 +13,7 @@ module Analyzer::Scala
 
     def analyze_file(path : String) : Array(Endpoint)
       content = read_file_content(path)
-      extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
+      extract_routes_from_content(path, content, callees_needed?)
     end
 
     private def extract_routes_from_content(path : String, content : String, include_callee : Bool) : Array(Endpoint)

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -39,7 +39,7 @@ module Analyzer::Scala
     def analyze_file(path : String) : Array(Endpoint)
       return [] of Endpoint if scalatra_test_path?(path)
       content = read_file_content(path)
-      extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
+      extract_routes_from_content(path, content, callees_needed?)
     end
 
     # Scalatra (like a servlet container) mounts each servlet/filter at a base

--- a/src/analyzer/analyzers/scala/zio_http.cr
+++ b/src/analyzer/analyzers/scala/zio_http.cr
@@ -9,7 +9,7 @@ module Analyzer::Scala
 
     def analyze_file(path : String) : Array(Endpoint)
       content = read_file_content(path)
-      extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
+      extract_routes_from_content(path, content, callees_needed?)
     end
 
     # Extract routes from ZIO HTTP DSL:

--- a/src/analyzer/analyzers/swift/kitura.cr
+++ b/src/analyzer/analyzers/swift/kitura.cr
@@ -34,7 +34,7 @@ module Analyzer::Swift
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = read_file_content(path).lines
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       handler_bodies = named_handler_bodies(lines)
       router_receivers = collect_router_receivers(lines)
 

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -44,7 +44,7 @@ module Analyzer::Swift
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = read_file_content(path).lines
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       handler_bodies = named_handler_bodies(lines)
       prefix_by_receiver = {} of String => String
       group_prefix_stack = [] of Tuple(String, Int32)

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -483,14 +483,6 @@ module Analyzer::Python
       resolve_python_callee_definitions(callees, base_path, path, source)
     end
 
-    # Callees feed both `--include-callee` (direct output) and `--ai-context`
-    # (aggregated review context). Skip the tree-sitter walk and import-graph
-    # resolution when neither flag is set so default Python scans avoid the
-    # per-handler callee build.
-    private def callees_needed? : Bool
-      any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-    end
-
     # Convenience wrapper around `build_callees_from`: parse + push in
     # one call when one body maps to exactly one endpoint.
     # `Endpoint#push_callee` enforces dedup and the per-endpoint cap.


### PR DESCRIPTION
Third PR of the structural-contract series (after #2488, #2489). Behaviour-neutral.

## Why

`Analyzer#callees_needed?` (`src/models/analyzer.cr:120`) has existed — with a doc comment telling analyzers to consult it — for as long as the two callee flags have. **Sixty-five call sites across 64 analyzers re-implemented its body inline anyway:**

```crystal
include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
```

Two went further and declared a `private def callees_needed?` whose body *and doc comment* duplicated the base method verbatim (`ruby/rails.cr:1601`, `engines/python_engine.cr:490`). Deleting a private override that shadows an identical public base method is behaviour-neutral — the internal calls resolve to the base.

The duplication is not really the cost. Each of those lines is an analyzer reaching past its base class into the raw options hash, so **the set of option keys the analyzer layer actually depends on could only be discovered by grepping**. Before this PR:

```
  65 @options["include_callee"]
  65 @options["ai_context"]
  21 @options["concurrency"]
   1 @options[COMPONENTS_ONLY_OPTION]
```

After it, `src/analyzer/` reads two distinct keys directly, both of which get accessors of their own in follow-up PRs.

## What is deliberately *not* changed

Local variables are kept where they already exist. Several are threaded as parameters through multiple private methods (`zig/zap.cr` passes one through six of them); renaming those is a far larger diff for no gain. The shapes handled are the four the idiom appeared in: local assignment (~57), inline condition (`crystal/kemal.cr`, `java/armeria.cr`), argument position (the four Scala analyzers), and the two private overrides.

> Note for reviewers repeating the search: do **not** grep for bare `include_callee` — 643 lines match, and the overwhelming majority are locals and parameters being passed down, which must not be touched. The authoritative pattern is the full two-`any_to_bool` expression.

## Enforcement

`spec/unit_test/analyzer/options_boundary_spec.cr` makes the idiom unreturnable. It scans `src/analyzer/**/*.cr` for direct reads of either flag and for any local redefinition of `callees_needed?`.

It also asserts the glob matched a non-trivial number of files — a source-scanning spec that silently matches nothing is worse than no spec at all. Verified the spec actually bites by reintroducing the idiom in one analyzer: it failed and named the file and line.

## Verification

**STRICT A/B** over all 664 fixture directories — `--include-callee` on, folding `details.code_paths[].{path,line}` and `callees[].{name,path,line}` into the normalized shape — **byte-identical**:

| | base | head |
|---|---|---|
| endpoints | 5,158 | 5,158 |
| callee entries | 4,775 | 4,775 |
| code-path lines | 5,461 | 5,461 |

STRICT rather than plain because this PR edits 64 files in the exact code path `--include-callee` controls.

`crystal spec spec/unit_test` 4661 examples / `spec/functional_test` 22647 examples, 0 failures. `just check` 1910 files, 0 findings.