### PR TITLE
test: make the unit suite independent of example order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,14 @@ jobs:
         run: crystal spec spec/unit_test
       - name: Run functional tests
         run: crystal spec spec/functional_test
+      # Spec files load in directory order, which differs between macOS and
+      # Linux — so an example that depends on state another example left
+      # behind passes locally and fails here, on an unrelated PR. Four such
+      # couplings had accumulated. Randomizing on purpose turns "flaky CI"
+      # into a named failure: crystal prints the seed, and
+      # `crystal spec spec/unit_test --order <seed>` reproduces it exactly.
+      - name: Run unit tests in randomized order
+        run: crystal spec spec/unit_test --order random
   build-snapcraft:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/spec/unit_test/detector/php/wordpress_detector_spec.cr
+++ b/spec/unit_test/detector/php/wordpress_detector_spec.cr
@@ -19,8 +19,28 @@ describe "Detect WordPress" do
     instance.detect("wp-load.php", "<?php require dirname(__FILE__) . '/wp-config.php';").should be_true
   end
 
+  # The `wp-content` branch matches on the *scan-base-relative* path, so it
+  # needs a scan base registered to produce one. Passing a bare relative path
+  # made this example depend on whatever `CodeLocator.scan_base_paths` some
+  # earlier spec happened to leave behind: run this file on its own and it
+  # failed, because with no base registered `base_relative` returns the path
+  # untouched and `"wp-content/..."` has no leading slash to match.
   it "detects WordPress from wp-content path" do
-    instance.detect("wp-content/plugins/foo/foo.php", "<?php // plugin code").should be_true
+    locator = CodeLocator.instance
+    previous_bases = locator.scan_base_paths
+
+    begin
+      locator.scan_base_paths = ["/srv/site"]
+      instance.detect("/srv/site/wp-content/plugins/foo/foo.php", "<?php // plugin code").should be_true
+
+      # And the reason it matches the relative path rather than the absolute
+      # one: a checkout that merely *lives under* a directory called
+      # wp-content must not make every PHP file in it look like WordPress.
+      locator.scan_base_paths = ["/wp-content/mysite"]
+      instance.detect("/wp-content/mysite/app.php", "<?php // plain php").should be_false
+    ensure
+      locator.scan_base_paths = previous_bases
+    end
   end
 
   it "detects WordPress from a plugin header" do

--- a/spec/unit_test/minilexer/golang_spec.cr
+++ b/spec/unit_test/minilexer/golang_spec.cr
@@ -12,9 +12,12 @@ describe "initialize" do
     lexer.mode.should eq(:normal)
   end
 
+  # Its own lexer: mutating the one shared by the examples above makes
+  # "default mode" pass only while it happens to run first.
   it "persistent mode" do
-    lexer.mode = :persistent
-    lexer.mode.should eq(:persistent)
+    persistent_lexer = GolangLexer.new
+    persistent_lexer.mode = :persistent
+    persistent_lexer.mode.should eq(:persistent)
   end
 end
 

--- a/spec/unit_test/models/output_builder_spec.cr
+++ b/spec/unit_test/models/output_builder_spec.cr
@@ -73,10 +73,10 @@ describe "Initialize" do
     File.write(output_file, "old\n")
 
     begin
-      options = create_test_options
-      options["output"] = YAML::Any.new(output_file)
+      file_options = create_test_options
+      file_options["output"] = YAML::Any.new(output_file)
 
-      object = OutputBuilder.new options
+      object = OutputBuilder.new file_options
       object.io = IO::Memory.new
       object.ob_puts "new"
       object.ob_puts "next"
@@ -98,14 +98,14 @@ describe "Initialize" do
     output_file = File.tempname("noir-output-builder-shared")
 
     begin
-      options = create_test_options
-      options["output"] = YAML::Any.new(output_file)
+      file_options = create_test_options
+      file_options["output"] = YAML::Any.new(output_file)
 
-      header = OutputBuilderDiff.new options
+      header = OutputBuilderDiff.new file_options
       header.io = IO::Memory.new
       header.ob_puts "section-header"
 
-      body = OutputBuilderCommon.new options
+      body = OutputBuilderCommon.new file_options
       body.io = IO::Memory.new
       body.ob_puts "endpoint-line"
 
@@ -123,10 +123,10 @@ describe "Initialize" do
     output_file = File.tempname("noir-output-builder-ansi")
 
     begin
-      options = create_test_options
-      options["output"] = YAML::Any.new(output_file)
+      file_options = create_test_options
+      file_options["output"] = YAML::Any.new(output_file)
 
-      object = OutputBuilder.new options
+      object = OutputBuilder.new file_options
       io = IO::Memory.new
       object.io = io
       object.ob_puts "\e[93m/sign\e[39m"
@@ -147,10 +147,10 @@ describe "Initialize" do
     output_file = File.tempname("noir-output-builder-escapes")
 
     begin
-      options = create_test_options
-      options["output"] = YAML::Any.new(output_file)
+      file_options = create_test_options
+      file_options["output"] = YAML::Any.new(output_file)
 
-      object = OutputBuilder.new options
+      object = OutputBuilder.new file_options
       object.io = IO::Memory.new
       object.ob_puts "\e[2J/clear"             # CSI, non-SGR final byte
       object.ob_puts "\e[?1049h/altscreen"     # CSI with a private parameter byte

--- a/spec/unit_test/optimizer/llm_optimizer_spec.cr
+++ b/spec/unit_test/optimizer/llm_optimizer_spec.cr
@@ -126,8 +126,9 @@ describe "LLMEndpointOptimizer" do
 
   describe "full workflow without LLM" do
     it "works as standard optimizer when no LLM config" do
-      options["url"] = YAML::Any.new("https://test.com")
-      optimizer = LLMEndpointOptimizer.new(logger, options)
+      example_options = create_test_options
+      example_options["url"] = YAML::Any.new("https://test.com")
+      optimizer = LLMEndpointOptimizer.new(logger, example_options)
 
       endpoints = [
         Endpoint.new("/users/{id}", "GET"),
@@ -150,8 +151,9 @@ describe "LLMEndpointOptimizer" do
 
   describe "handles non-standard patterns without LLM" do
     it "processes wildcard patterns safely" do
-      options["url"] = YAML::Any.new("") # No base URL for this test
-      optimizer = LLMEndpointOptimizer.new(logger, options)
+      example_options = create_test_options
+      example_options["url"] = YAML::Any.new("") # No base URL for this test
+      optimizer = LLMEndpointOptimizer.new(logger, example_options)
       endpoints = [
         Endpoint.new("/api/*/data", "GET"),
         Endpoint.new("/api/users_data__special", "GET"),
@@ -166,16 +168,18 @@ describe "LLMEndpointOptimizer" do
 
   describe "inherits all base functionality" do
     it "applies pvalue configurations" do
-      options["set_pvalue"] = YAML::Any.new([YAML::Any.new("id=TEST_ID")])
-      optimizer = LLMEndpointOptimizer.new(logger, options)
+      example_options = create_test_options
+      example_options["set_pvalue"] = YAML::Any.new([YAML::Any.new("id=TEST_ID")])
+      optimizer = LLMEndpointOptimizer.new(logger, example_options)
 
       result = optimizer.apply_pvalue("path", "id", "original")
       result.should eq("TEST_ID")
     end
 
     it "combines URLs correctly" do
-      options["url"] = YAML::Any.new("https://api.test.com")
-      optimizer = LLMEndpointOptimizer.new(logger, options)
+      example_options = create_test_options
+      example_options["url"] = YAML::Any.new("https://api.test.com")
+      optimizer = LLMEndpointOptimizer.new(logger, example_options)
       endpoints = [Endpoint.new("/users", "GET")]
 
       result = optimizer.combine_url_and_endpoints(endpoints)
@@ -279,9 +283,10 @@ describe "LLMEndpointOptimizer" do
 
   describe "handles complex optimization scenarios" do
     it "processes mixed parameter patterns" do
-      options["url"] = YAML::Any.new("https://api.example.com")
-      options["set_pvalue"] = YAML::Any.new([YAML::Any.new("user_id=123"), YAML::Any.new("post_id=456")])
-      optimizer = LLMEndpointOptimizer.new(logger, options)
+      example_options = create_test_options
+      example_options["url"] = YAML::Any.new("https://api.example.com")
+      example_options["set_pvalue"] = YAML::Any.new([YAML::Any.new("user_id=123"), YAML::Any.new("post_id=456")])
+      optimizer = LLMEndpointOptimizer.new(logger, example_options)
 
       endpoints = [
         Endpoint.new("/users/{user_id}", "GET"),


### PR DESCRIPTION
Spec files load in **directory order**, which differs between macOS and Linux. Four unit examples depended on state a *different* example had left behind, so they passed locally in one order and failed in CI in another — on whichever pull request happened to be running.

#2489 was hit by one of them (`wordpress_detector_spec.cr:23`) having touched none of the code involved. That is the symptom this PR removes.

```
$ crystal spec spec/unit_test --order random     # before
4658 examples, 13 failures
$ crystal spec spec/unit_test --order random     # after
4658 examples, 0 failures
```

Green on 14 seeds tried.

## The four couplings

**`models/output_builder_spec.cr`** — four examples opened with `options = create_test_options`. In Crystal a block **assigns to an enclosing local rather than shadowing it**, so each one silently replaced the `options` that the twelve builder-construction examples above share. Reordered, those started seeing a tempfile path where they expected `"output.json"`:

```
Expected: "output.json"
     got: "/var/folders/.../noir-output-builder-ansi"
```

Renamed the inner ones to `file_options`.

**`optimizer/llm_optimizer_spec.cr`** — five examples set `options["url"]` / `options["set_pvalue"]` on the shared hash, so an earlier example could find a base URL and pvalue substitutions already configured (`got: "https://api.test.com/users/TEST_ID"` where `/users/{id}` was expected). Each now builds its own hash.

**`minilexer/golang_spec.cr`** — `"persistent mode"` flipped the shared lexer's mode, so `"default mode"` passed only while it ran first.

**`detector/php/wordpress_detector_spec.cr`** — the interesting one. The example passed a bare relative path:

```crystal
instance.detect("wp-content/plugins/foo/foo.php", "<?php // plugin code").should be_true
```

but the branch it exercises matches on the **scan-base-relative** path (`relative.includes?("/wp-content/")`). With no base registered, `CodeLocator#base_relative` returns the path untouched — and `"wp-content/..."` has no leading slash to match. **Run that file on its own and it fails.** It had never tested its own claim; it only passed when some earlier spec left `CodeLocator.scan_base_paths` populated.

It now registers a base explicitly, and gained the negative case the detector's own comment describes — a checkout living *under* a directory named `wp-content` must not make every PHP file in it look like WordPress.

## Guard

CI gains a second, randomized unit run. Crystal prints the seed, so a failure reproduces exactly with `crystal spec spec/unit_test --order <seed>` — the difference between a named defect and "CI is flaky again". The default-order run stays as the fast deterministic check.

## Scope

Production code is untouched. The functional suite was already order-independent (verified across three seeds) and is left alone.

Related: `CodeLocator#clear_all` does not reset `@scan_base_paths`, which is what let the wordpress leak persist across specs. That is production behaviour rather than test setup, so it is left for the CodeLocator lifecycle work rather than folded in here.