### PR TITLE
refactor(url-path): name every local path joiner after the rule it implements

### DIFF
--- a/src/analyzer/analyzers/dart/angel3.cr
+++ b/src/analyzer/analyzers/dart/angel3.cr
@@ -209,7 +209,7 @@ module Analyzer::Dart
         break unless visited.add?(current[:call])
         parent = enclosing_group(current, raw)
         break unless parent
-        prefix = join_path(parent[:own], prefix)
+        prefix = mount_join(parent[:own], prefix)
         current = parent
       end
       prefix
@@ -260,7 +260,7 @@ module Analyzer::Dart
       literal = Helper.extract_string_literal(args[0])
       return unless literal
 
-      url = join_path(prefix, normalize_path(literal))
+      url = mount_join(prefix, normalize_path(literal))
       line = line_number_for_index(content, open_paren)
 
       callees = [] of Noir::DartCalleeExtractor::Entry
@@ -307,7 +307,7 @@ module Analyzer::Dart
       base.gsub(/:([A-Za-z_]\w*)\??/) { "{#{$~[1]}}" }
     end
 
-    private def join_path(prefix : String, sub : String) : String
+    private def mount_join(prefix : String, sub : String) : String
       return sub if prefix.empty?
       left = prefix.rchop('/')
       right = sub.starts_with?('/') ? sub : "/#{sub}"

--- a/src/analyzer/analyzers/dart/shelf.cr
+++ b/src/analyzer/analyzers/dart/shelf.cr
@@ -211,7 +211,7 @@ module Analyzer::Dart
 
         owner = enclosing_class(classes, match_begin)
         prefix = owner ? prefixes[owner]? : nil
-        route_path = normalize_path(prefix ? join_path(prefix, normalize_path(literal)) : literal)
+        route_path = normalize_path(prefix ? mount_join(prefix, normalize_path(literal)) : literal)
 
         line = line_number_for_index(content, match_begin)
         callees = include_callee ? annotation_callees(content, close_paren, path) : [] of Noir::DartCalleeExtractor::Entry
@@ -540,18 +540,18 @@ module Analyzer::Dart
       info = routers[key]?
       if info
         info[:routes].each do |route|
-          full_path = join_path(prefix, route[:path])
+          full_path = mount_join(prefix, route[:path])
           endpoints << build_endpoint(full_path, route[:verb], route[:file], route[:line], route[:callees])
         end
         info[:mounts].each do |mnt|
-          child_prefix = join_path(prefix, mnt[:prefix])
+          child_prefix = mount_join(prefix, mnt[:prefix])
           emit_router(router_key(key[0], mnt[:child]), child_prefix, routers, endpoints, visited)
         end
       end
       visited.delete(key)
     end
 
-    private def join_path(prefix : String, sub : String) : String
+    private def mount_join(prefix : String, sub : String) : String
       left = prefix.rchop('/')
       right = sub.starts_with?('/') ? sub : "/#{sub}"
       result = "#{left}#{right}"

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -200,7 +200,7 @@ module Analyzer::Java
       packages.each_value do |package_config|
         namespace = package_namespace(package_config, packages, Set(String).new)
         package_config.actions.each do |action|
-          add_route(join_paths(namespace, normalize_action_pattern(action.name)), "ANY", path, action.line,
+          add_route(namespace_join(namespace, normalize_action_pattern(action.name)), "ANY", path, action.line,
             callees: xml_action_callees(action, path))
         end
       end
@@ -366,7 +366,7 @@ module Analyzer::Java
 
         namespaces.each do |class_namespace|
           class_actions.each do |action_path|
-            resolved = action_path.empty? ? join_paths(class_namespace, class_action_base) : resolve_action_path(action_path, class_namespace)
+            resolved = action_path.empty? ? namespace_join(class_namespace, class_action_base) : resolve_action_path(action_path, class_namespace)
             # A class-level @Action defaults to the `execute` handler.
             add_route(resolved, "ANY", path, klass.line, callees: callees_for(root, content, path, klass.name, "execute"))
           end
@@ -376,7 +376,7 @@ module Analyzer::Java
             next if action_paths.empty?
 
             action_paths.each do |action_path|
-              resolved = action_path.empty? ? join_paths(class_namespace, class_action_base) : resolve_action_path(action_path, class_namespace)
+              resolved = action_path.empty? ? namespace_join(class_namespace, class_action_base) : resolve_action_path(action_path, class_namespace)
               add_route(resolved, "ANY", path, method.line, callees: callees_for(root, content, path, klass.name, method.name))
             end
           end
@@ -384,7 +384,7 @@ module Analyzer::Java
           next if class_has_action_annotation || methods.any? { |method| !action_paths_from_annotations(method.annotations).empty? }
           next unless convention_action_class?(klass, config, package_annotations_for_class)
 
-          base_path = join_paths(class_namespace, class_action_base)
+          base_path = namespace_join(class_namespace, class_action_base)
           if rest_controller?(klass, config)
             add_rest_routes(path, base_path, methods, root, content, klass.name)
           else
@@ -600,7 +600,7 @@ module Analyzer::Java
 
         verb, suffix = route
         params = suffix.includes?(":id") ? [Param.new("id", "", "path")] : [] of Param
-        add_route(join_paths(base_path, suffix), verb, path, method.line, params,
+        add_route(namespace_join(base_path, suffix), verb, path, method.line, params,
           callees: callees_for(root, content, path, class_name, method.name))
       end
     end
@@ -641,7 +641,7 @@ module Analyzer::Java
     end
 
     private def resolve_action_path(action_path : String, namespace : String) : String
-      return join_paths(namespace, action_path) unless action_path.starts_with?("/")
+      return namespace_join(namespace, action_path) unless action_path.starts_with?("/")
       normalize_path(action_path)
     end
 
@@ -693,7 +693,7 @@ module Analyzer::Java
       cleaned.gsub(%r{/+}, "/").rstrip('/')
     end
 
-    private def join_paths(prefix : String, suffix : String) : String
+    private def namespace_join(prefix : String, suffix : String) : String
       return normalize_path(prefix) if suffix.empty? || suffix == "/"
       return normalize_path(suffix) if prefix.empty? || prefix == "/"
       normalize_path("#{prefix.rstrip('/')}/#{suffix.lstrip('/')}")

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -158,7 +158,7 @@ module Analyzer::Python
             prefixes = route_table_prefixes[deco.router_name]? || [""]
             if deco.attribute_name == "view"
               prefixes.each do |prefix|
-                class_view_routes[path] << {Helper.join_paths(prefix, deco.path), deco.decorator_line, deco.def_name}
+                class_view_routes[path] << {Helper.normalized_join(prefix, deco.path), deco.decorator_line, deco.def_name}
               end
               next
             end
@@ -171,7 +171,7 @@ module Analyzer::Python
                   path,
                   lines,
                   def_line,
-                  Helper.join_paths(prefix, deco.path),
+                  Helper.normalized_join(prefix, deco.path),
                   deco_method,
                   deco.decorator_line,
                   definition_base_path: current_base_path,
@@ -218,7 +218,7 @@ module Analyzer::Python
                 route_path = orig_match[1]
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                handler_routes[path] << {Helper.join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
+                handler_routes[path] << {Helper.normalized_join(prefix, route_path), method_name.upcase, line_index, handler_name}
               end
             end
 
@@ -235,7 +235,7 @@ module Analyzer::Python
                 static_path = orig_match[1]
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                full_path = static_route_path(Helper.join_paths(prefix, static_path))
+                full_path = static_route_path(Helper.normalized_join(prefix, static_path))
                 result << Endpoint.new(full_path, "GET", Details.new(PathInfo.new(path, line_index + 1)))
               end
             end
@@ -256,7 +256,7 @@ module Analyzer::Python
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
                 expand_aiohttp_methods(method).each do |expanded_method|
-                  handler_routes[path] << {Helper.join_paths(prefix, route_path), expanded_method, line_index, handler_name}
+                  handler_routes[path] << {Helper.normalized_join(prefix, route_path), expanded_method, line_index, handler_name}
                 end
               end
             end
@@ -274,7 +274,7 @@ module Analyzer::Python
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
                 expand_aiohttp_methods(method).each do |expanded_method|
-                  handler_routes[path] << {Helper.join_paths(prefix, route_path), expanded_method, line_index, handler_name}
+                  handler_routes[path] << {Helper.normalized_join(prefix, route_path), expanded_method, line_index, handler_name}
                 end
               end
             end
@@ -290,7 +290,7 @@ module Analyzer::Python
                 route_path = orig_match[1]
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                class_view_routes[path] << {Helper.join_paths(prefix, route_path), line_index, class_name}
+                class_view_routes[path] << {Helper.normalized_join(prefix, route_path), line_index, class_name}
               end
             end
 
@@ -310,7 +310,7 @@ module Analyzer::Python
                 route_path = web_match[2]
                 handler_name = web_match[3]
                 prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
-                  handler_routes[path] << {Helper.join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
+                  handler_routes[path] << {Helper.normalized_join(prefix, route_path), method_name.upcase, line_index, handler_name}
                 end
               end
             end
@@ -325,7 +325,7 @@ module Analyzer::Python
                 route_path = view_match[1]
                 class_name = view_match[2].split(".").last
                 prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
-                  class_view_routes[path] << {Helper.join_paths(prefix, route_path), line_index, class_name}
+                  class_view_routes[path] << {Helper.normalized_join(prefix, route_path), line_index, class_name}
                 end
               end
             end
@@ -738,7 +738,7 @@ module Analyzer::Python
           parent_prefixes = prefixes[parent]? || [""]
           prefixes[child] ||= [] of ::String
           parent_prefixes.each do |parent_prefix|
-            child_prefix = Helper.join_paths(parent_prefix, mount_prefix)
+            child_prefix = Helper.normalized_join(parent_prefix, mount_prefix)
             unless prefixes[child].includes?(child_prefix)
               prefixes[child] << child_prefix
               changed = true

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -74,7 +74,7 @@ module Analyzer::Python
               path,
               lines,
               line_index: deco.decorator_line,
-              route_path: Helper.join_paths(prefix, deco.path),
+              route_path: Helper.normalized_join(prefix, deco.path),
               extra_params: extra_params,
               definition_base_path: current_base_path,
               source: file_content
@@ -171,7 +171,7 @@ module Analyzer::Python
           path,
           lines,
           line_index,
-          Helper.join_paths(prefix, route_path),
+          Helper.normalized_join(prefix, route_path),
           route_match[2],
           callback_name,
           definition_base_path: definition_base_path,
@@ -217,7 +217,7 @@ module Analyzer::Python
 
           prefixes[child_router] ||= [] of ::String
           parent_prefixes.each do |parent_prefix|
-            composed_prefix = Helper.join_paths(parent_prefix, mount_prefix)
+            composed_prefix = Helper.normalized_join(parent_prefix, mount_prefix)
             next if prefixes[child_router].includes?(composed_prefix)
 
             prefixes[child_router] << composed_prefix

--- a/src/analyzer/analyzers/python/python_helper.cr
+++ b/src/analyzer/analyzers/python/python_helper.cr
@@ -12,7 +12,7 @@ module Analyzer::Python
       normalized
     end
 
-    def join_paths(prefix : ::String, path : ::String) : ::String
+    def normalized_join(prefix : ::String, path : ::String) : ::String
       return normalize_path(path) if prefix.empty?
       return normalize_path(prefix) if path.empty?
 

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -416,7 +416,7 @@ module Analyzer::Python
 
           registration_prefixes.each do |registration_prefix|
             full_prefix = compose_sanic_prefix(router_name, registration_prefix, prefix, blueprint_group_prefixes, blueprint_versions)
-            endpoint_path = static_route_path(Helper.join_paths(full_prefix, static_path))
+            endpoint_path = static_route_path(Helper.normalized_join(full_prefix, static_path))
             result << Endpoint.new(endpoint_path, "GET", Details.new(PathInfo.new(path, line_index + 1)))
           end
         end
@@ -818,9 +818,9 @@ module Analyzer::Python
                                      group_prefixes : Hash(::String, ::String),
                                      versions : Hash(::String, ::String),
                                      route_version : ::String? = nil) : ::String
-      base = Helper.join_paths(group_prefixes[router_name]? || "", Helper.join_paths(registration_prefix, prefix))
+      base = Helper.normalized_join(group_prefixes[router_name]? || "", Helper.normalized_join(registration_prefix, prefix))
       version = route_version || versions[router_name]?
-      version && !version.empty? ? Helper.join_paths("/v#{version}", base) : base
+      version && !version.empty? ? Helper.normalized_join("/v#{version}", base) : base
     end
 
     private def fetch_file_content(path : ::String) : ::String
@@ -907,7 +907,7 @@ module Analyzer::Python
       # Create endpoints for each method
       methods.each do |http_method|
         # Create endpoint with the prefix
-        full_path = normalize_sanic_path_params(Helper.join_paths(prefix, route_path))
+        full_path = normalize_sanic_path_params(Helper.normalized_join(prefix, route_path))
         filtered_params = get_filtered_params(http_method, params.dup)
         endpoint = Endpoint.new(full_path, http_method, filtered_params)
         endpoint.protocol = "ws" if route_attr == "websocket"

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -145,7 +145,7 @@ module Analyzer::Ruby
       return unless call = route_call(line, ["mount"])
       return unless m = call.match(/\bat:\s*['"]([^'"]+)['"]/)
 
-      Endpoint.new(join_paths(current_path_prefix(stack), m[1]), "GET", details)
+      Endpoint.new(absolute_segment_join(current_path_prefix(stack), m[1]), "GET", details)
     end
 
     def scan_action_file(endpoint : Endpoint, action_path : String, include_callee : Bool = false)
@@ -168,7 +168,7 @@ module Analyzer::Ruby
     private def root_endpoint(line : String, stack : Array(RouteFrame), details : Details) : RouteEndpoint?
       return unless line.match(/^root(?:\s|\(|\{|$)/)
 
-      endpoint = Endpoint.new(join_paths(current_path_prefix(stack), "/"), "GET", details)
+      endpoint = Endpoint.new(absolute_segment_join(current_path_prefix(stack), "/"), "GET", details)
       RouteEndpoint.new(endpoint, extract_action_target(line))
     end
 
@@ -178,7 +178,7 @@ module Analyzer::Ruby
         next if line.size > verb.size && (line[verb.size].alphanumeric? || line[verb.size] == '_')
 
         if m = line.match(verb_pattern)
-          endpoint = Endpoint.new(join_paths(current_path_prefix(stack), normalize_route_path(m[1])), verb.upcase, details)
+          endpoint = Endpoint.new(absolute_segment_join(current_path_prefix(stack), normalize_route_path(m[1])), verb.upcase, details)
           return RouteEndpoint.new(endpoint, extract_action_target(m[2]))
         end
       end
@@ -251,12 +251,12 @@ module Analyzer::Ruby
       resource_routes(resource[:kind], resource_name, singular).each do |action, method, path_suffix|
         next unless actions.includes?(action)
 
-        endpoint = Endpoint.new(join_paths(current_path_prefix(stack), path_suffix), method, details.dup)
+        endpoint = Endpoint.new(absolute_segment_join(current_path_prefix(stack), path_suffix), method, details.dup)
         routes << RouteEndpoint.new(endpoint, join_action_parts(action_prefix, action))
       end
 
       nested_path = if resource[:kind] == "resources"
-                      join_paths(resource_name, ":#{singular}_id")
+                      absolute_segment_join(resource_name, ":#{singular}_id")
                     else
                       resource_name
                     end
@@ -350,7 +350,7 @@ module Analyzer::Ruby
 
     private def current_path_prefix(stack : Array(RouteFrame)) : String
       parts = stack.map(&.path).reject(&.empty?)
-      join_paths(parts)
+      absolute_segment_join(parts)
     end
 
     private def current_slice(stack : Array(RouteFrame)) : String?
@@ -366,13 +366,13 @@ module Analyzer::Ruby
       join_action_parts(parts)
     end
 
-    private def join_paths(parts : Array(String)) : String
+    private def absolute_segment_join(parts : Array(String)) : String
       normalized = parts.flat_map(&.split('/')).reject(&.empty?)
       normalized.empty? ? "/" : "/#{normalized.join("/")}"
     end
 
-    private def join_paths(prefix : String, suffix : String) : String
-      join_paths([prefix, suffix])
+    private def absolute_segment_join(prefix : String, suffix : String) : String
+      absolute_segment_join([prefix, suffix])
     end
 
     private def normalize_route_path(path : String) : String

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -130,7 +130,7 @@ module Analyzer::Rust
           next unless route
 
           path_str, handlers = route
-          path_str = join_paths(prefix, path_str) unless prefix.empty?
+          path_str = nest_join(prefix, path_str) unless prefix.empty?
           handlers.each do |raw_verb, handler_name|
             # `axum::routing::any(handler)` and service mounts emit
             # the verb "ANY" — fan out into the canonical seven so
@@ -179,7 +179,7 @@ module Analyzer::Rust
             next unless route
 
             path_str, handlers = route
-            path_str = join_paths(active_prefix, path_str) unless active_prefix.empty?
+            path_str = nest_join(active_prefix, path_str) unless active_prefix.empty?
             handlers.each do |raw_verb, handler_name|
               RustEngine.fan_out_verbs(raw_verb).each do |verb|
                 details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
@@ -311,7 +311,7 @@ module Analyzer::Rust
           nest_prefix, nested_router = nest
           resolved_router = resolve_router_argument(nested_router, source, let_router_builders)
           walk_receiver_chain(node, source, prefix, test_regions, mounted_router_names, let_router_builders, skip_ranges, &block)
-          walk_router_builders(resolved_router, source, join_paths(prefix, nest_prefix), test_regions, mounted_router_names, let_router_builders, &block)
+          walk_router_builders(resolved_router, source, nest_join(prefix, nest_prefix), test_regions, mounted_router_names, let_router_builders, &block)
           return
         end
 
@@ -438,7 +438,7 @@ module Analyzer::Rust
 
         if nest = extract_nest_call(node, source)
           nest_prefix, nested_router = nest
-          mounted_prefix = join_paths(active_prefix, nest_prefix)
+          mounted_prefix = nest_join(active_prefix, nest_prefix)
           resolved_router = resolve_router_argument(nested_router, source, let_router_builders)
 
           if router_name = local_router_function_call_name(resolved_router, source)
@@ -574,7 +574,7 @@ module Analyzer::Rust
         return if named.size < 1
         prefix = string_literal_text(named[0], source)
         return unless prefix
-        {join_paths(prefix, "/*"), [{SERVICE_METHOD, nil.as(String?)}]}
+        {nest_join(prefix, "/*"), [{SERVICE_METHOD, nil.as(String?)}]}
       when "fallback", "fallback_service"
         args = Noir::TreeSitter.field(call, "arguments")
         return unless args
@@ -700,7 +700,7 @@ module Analyzer::Rust
       named
     end
 
-    private def join_paths(prefix : String, path : String) : String
+    private def nest_join(prefix : String, path : String) : String
       "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
     end
 
@@ -1100,7 +1100,7 @@ module Analyzer::Rust
           elsif root_path
             p # `path = "/"` registers at the nest root, no trailing slash
           else
-            join_paths(p, attr_path)
+            nest_join(p, attr_path)
           end
         end
         attr_row = Noir::TreeSitter.node_start_row(attr_item) + 1
@@ -1289,7 +1289,7 @@ module Analyzer::Rust
       stack.add(parent)
       if children = edges[parent]?
         children.each do |child, child_prefix|
-          composed = child_prefix.empty? ? prefix : join_paths(prefix, child_prefix)
+          composed = child_prefix.empty? ? prefix : nest_join(prefix, child_prefix)
           add_cross_prefix(index, child, composed)
           propagate_cross_prefix(child, composed, edges, index, stack)
         end

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -64,7 +64,7 @@ module Analyzer::Rust
       if Noir::TreeSitter.node_type(node) == "call_expression" && !RustEngine.inside_test_region?(node, test_regions)
         if scope = decode_scope(node, source)
           seg, block = scope
-          walk_with_prefix(block, source, join_paths(prefix, seg), path, function_index, include_callee, endpoints, test_regions)
+          walk_with_prefix(block, source, absolute_scope_join(prefix, seg), path, function_index, include_callee, endpoints, test_regions)
           return
         end
         if block = decode_pipeline_closure(node, source)
@@ -73,13 +73,13 @@ module Analyzer::Rust
         end
         if assoc = decode_associate(node, source)
           assoc_path, closure_body = assoc
-          process_associate(closure_body, source, join_paths(prefix, assoc_path), path, function_index, include_callee, endpoints)
+          process_associate(closure_body, source, absolute_scope_join(prefix, assoc_path), path, function_index, include_callee, endpoints)
           # fall through to the generic child walk so any nested
           # scope/route inside the closure is still visited.
         end
         if route = decode_to_call(node, source)
           route_path, methods, handler_name = route
-          full_path = join_paths(prefix, route_path)
+          full_path = absolute_scope_join(prefix, route_path)
 
           methods.each do |method|
             details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
@@ -145,7 +145,7 @@ module Analyzer::Rust
       nil
     end
 
-    private def join_paths(prefix : String, route_path : String) : String
+    private def absolute_scope_join(prefix : String, route_path : String) : String
       return ensure_leading_slash(route_path) if prefix.empty?
       combined = "/#{prefix.strip('/')}/#{route_path.lstrip('/')}".rstrip('/')
       combined.empty? ? "/" : combined

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -127,7 +127,7 @@ module Analyzer::Rust
         next if verb_handlers.empty?
 
         prefix = find_chain_prefix(node, source)
-        full_path = join_paths(prefix, route_path)
+        full_path = absolute_scope_join(prefix, route_path)
         row = Noir::TreeSitter.node_start_row(node) + 1
 
         verb_handlers.each do |verb, handler_name|
@@ -193,7 +193,7 @@ module Analyzer::Rust
       nil
     end
 
-    private def join_paths(prefix : String?, route_path : String) : String
+    private def absolute_scope_join(prefix : String?, route_path : String) : String
       p = (prefix || "").strip
       return ensure_leading_slash(route_path) if p.empty?
       combined = "/#{p.strip('/')}/#{route_path.lstrip('/')}"

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -103,7 +103,7 @@ module Analyzer::Rust
             base_url = endpoint.url
             prefixes.each do |pfx|
               ep = endpoint
-              ep.url = join_paths(pfx, base_url)
+              ep.url = filter_chain_join(pfx, base_url)
               endpoints << ep
             end
           end
@@ -249,7 +249,7 @@ module Analyzer::Rust
       parts.empty? ? "" : "/" + parts.join("/")
     end
 
-    private def join_paths(prefix : String, route : String) : String
+    private def filter_chain_join(prefix : String, route : String) : String
       return route if prefix.empty?
       return prefix if route.empty? || route == "/"
       "#{prefix.rstrip('/')}/#{route.lstrip('/')}"

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -64,7 +64,7 @@ module Analyzer::Scala
           route_path = akka_path_from_args(path_args, path_param_names(stripped_line))
 
           # Build full path with prefix
-          full_path = join_paths(prefix_stack, route_path)
+          full_path = pathmatcher_stack_join(prefix_stack, route_path)
 
           # Find HTTP methods in the following lines within the same block
           block = extract_block_from_index(lines, index)
@@ -468,7 +468,7 @@ module Analyzer::Scala
       line.matches?(PATH_DIRECTIVE_RE)
     end
 
-    private def join_paths(prefix_stack : Array(String), route_path : String) : String
+    private def pathmatcher_stack_join(prefix_stack : Array(String), route_path : String) : String
       parts = prefix_stack + [route_path]
       normalized = parts.join("").gsub(%r{/+}, "/")
       normalized = "/#{normalized}" unless normalized.starts_with?("/")

--- a/src/analyzer/analyzers/specification/hasura.cr
+++ b/src/analyzer/analyzers/specification/hasura.cr
@@ -186,7 +186,7 @@ module Analyzer::Specification
 
         name = node[YAML::Any.new("name")]?.try(&.as_s?) || url
         details = Details.new(PathInfo.new(source))
-        full_url = join_path(REST_PREFIX, normalize_colon_path(url))
+        full_url = api_mount_join(REST_PREFIX, normalize_colon_path(url))
 
         methods.each do |method|
           verb = method.as_s?

--- a/src/analyzer/analyzers/specification/payload_cms.cr
+++ b/src/analyzer/analyzers/specification/payload_cms.cr
@@ -91,7 +91,7 @@ module Analyzer::Specification
 
         details = Details.new(PathInfo.new(source, config.line))
         body_params = field_params(config.array("fields"))
-        base = join_path(api_prefix, slug)
+        base = api_mount_join(api_prefix, slug)
 
         emit_collection(base, slug, body_params, config, details)
         emit_auth_routes(base, slug, details) if config.truthy?("auth")
@@ -153,7 +153,7 @@ module Analyzer::Specification
         method = entry["method"]?
         next unless path.is_a?(String) && method.is_a?(String)
 
-        url = join_path(base, normalize_colon_path(path))
+        url = api_mount_join(base, normalize_colon_path(path))
         emit(@result, url, method.upcase, [] of Param, details, "payload", "custom-endpoint:#{slug}", TAG_SOURCE)
       end
     end
@@ -165,7 +165,7 @@ module Analyzer::Specification
 
         details = Details.new(PathInfo.new(source, config.line))
         body_params = field_params(config.array("fields"))
-        url = join_path(join_path(api_prefix, "globals"), slug)
+        url = api_mount_join(api_mount_join(api_prefix, "globals"), slug)
 
         emit(@result, url, "GET", global_query_params, details, "payload", "global-read:#{slug}", TAG_SOURCE)
         # Globals are updated with POST, not PATCH.

--- a/src/analyzer/analyzers/specification/schema_api_common.cr
+++ b/src/analyzer/analyzers/specification/schema_api_common.cr
@@ -50,7 +50,7 @@ module Analyzer::Specification
 
     # Joins a mount prefix to a route path without doubling or dropping
     # the separator.
-    def join_path(prefix : String, path : String) : String
+    def api_mount_join(prefix : String, path : String) : String
       normalized_prefix = prefix.rstrip('/')
       return normalized_prefix.empty? ? "/" : normalized_prefix if path.empty? || path == "/"
 

--- a/src/analyzer/analyzers/specification/strapi.cr
+++ b/src/analyzer/analyzers/specification/strapi.cr
@@ -198,7 +198,7 @@ module Analyzer::Specification
           next unless method.is_a?(String) && path.is_a?(String)
           next if path.empty?
 
-          url = join_path(API_PREFIX, normalize_colon_path(path))
+          url = api_mount_join(API_PREFIX, normalize_colon_path(path))
           details = Details.new(PathInfo.new(source, config.line))
           handler = entry["handler"]?
           label = handler.is_a?(String) ? handler : path

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -344,7 +344,7 @@ module Analyzer::Swift
           # closure and no path argument registers a root-relative route.
           if method_match[2] == "{"
             if verb = route_verb(method)
-              hits << RouteHit.new(verb, join_paths(prefix, "/"), index, nil)
+              hits << RouteHit.new(verb, normalized_route_join(prefix, "/"), index, nil)
             end
             i += (method_match.end(0) || 1) - 1
             next
@@ -383,9 +383,9 @@ module Analyzer::Swift
                                     hits : Array(RouteHit)) : String
       case method
       when "group"
-        join_paths(prefix, parse_route_path(args_str))
+        normalized_route_join(prefix, parse_route_path(args_str))
       when "on"
-        path = join_paths(prefix, parse_route_path(args_str))
+        path = normalized_route_join(prefix, parse_route_path(args_str))
         handler = handler_from_args(args_str)
         on_methods(args_str).each do |http_method|
           hits << RouteHit.new(http_method, path, index, handler)
@@ -393,7 +393,7 @@ module Analyzer::Swift
         prefix
       else
         if verb = route_verb(method)
-          path = join_paths(prefix, parse_route_path(args_str))
+          path = normalized_route_join(prefix, parse_route_path(args_str))
           hits << RouteHit.new(verb, path, index, handler_from_args(args_str))
         end
         prefix
@@ -553,7 +553,7 @@ module Analyzer::Swift
         args = call_arguments(original, m.paren_col + 1)
         args_str = args ? args[0] : ""
         if dsl_emitting?(stack)
-          path = join_paths(current_dsl_prefix(stack), parse_route_path(args_str))
+          path = normalized_route_join(current_dsl_prefix(stack), parse_route_path(args_str))
           hits << RouteHit.new(m.verb.upcase, path, index, handler_from_args(args_str))
         end
         # A trailing closure on this verb is its handler body, not a group.
@@ -561,7 +561,7 @@ module Analyzer::Swift
       when :group
         args = call_arguments(original, m.paren_col + 1)
         args_str = args ? args[0] : ""
-        prefix = join_paths(current_dsl_prefix(stack), parse_route_path(args_str))
+        prefix = normalized_route_join(current_dsl_prefix(stack), parse_route_path(args_str))
         {DslScope.new(:group, prefix), args ? args[1] + 1 : m.end_col}
       else
         # :builder / :body — a route-emitting root rooted at "".
@@ -653,7 +653,7 @@ module Analyzer::Swift
       args = call_arguments(original, match.end(0) || 0)
       return unless args
 
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
+      prefix_by_receiver[variable] = normalized_route_join(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
     end
 
     private def register_group_closure(line : String,
@@ -675,7 +675,7 @@ module Analyzer::Swift
       return unless closure_match
 
       variable = closure_match[1]
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
+      prefix_by_receiver[variable] = normalized_route_join(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
       group_prefix_stack << {variable, brace_depth + 1}
     end
 
@@ -860,7 +860,7 @@ module Analyzer::Swift
     private def chain_group_prefix(expr : String) : String
       prefix = ""
       expr.scan(/\bgroup\s*\(\s*["']([^"']*)["']/) do |m|
-        prefix = join_paths(prefix, parse_route_path("\"#{m[1]}\""))
+        prefix = normalized_route_join(prefix, parse_route_path("\"#{m[1]}\""))
       end
       prefix
     end

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -66,7 +66,7 @@ module Analyzer::Swift
 
         begin
           receiver, method, route_args = route
-          route_path = join_paths(prefix_for_receiver(receiver, prefix_by_receiver), parse_route_path(route_args))
+          route_path = normalized_route_join(prefix_for_receiver(receiver, prefix_by_receiver), parse_route_path(route_args))
 
           details = Details.new(PathInfo.new(path, index + 1))
           endpoint = Endpoint.new(route_path, method, details)
@@ -299,7 +299,7 @@ module Analyzer::Swift
       return unless args
 
       prefix = parse_route_path(args[0])
-      prefix_by_receiver[variable] = join_paths(base_prefix, prefix)
+      prefix_by_receiver[variable] = normalized_route_join(base_prefix, prefix)
     end
 
     private def register_group_closure(line : String,
@@ -318,7 +318,7 @@ module Analyzer::Swift
       return unless closure_match
 
       variable = closure_match[1]
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
+      prefix_by_receiver[variable] = normalized_route_join(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
       group_prefix_stack << {variable, brace_depth + 1}
     end
 

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -43,7 +43,7 @@ module Analyzer::Swift
     # analyzers (which carried byte-identical copies): prefix and path
     # join with exactly one `/`, a bare or root side yields the other
     # side normalized, and repeated slashes collapse.
-    protected def join_paths(prefix : String, path : String) : String
+    protected def normalized_route_join(prefix : String, path : String) : String
       return normalize_path(path) if prefix.empty? || prefix == "/"
       return normalize_path(prefix) if path.empty? || path == "/"
 

--- a/src/miniparsers/go_route_extractor_ts/chi.cr
+++ b/src/miniparsers/go_route_extractor_ts/chi.cr
@@ -299,7 +299,7 @@ module Noir
       return if handler_text.empty?
 
       base_prefix = local_groups[router_name]? || prefix_stack.join
-      resolved = base_prefix.empty? ? path : join_paths(base_prefix, path)
+      resolved = base_prefix.empty? ? path : group_join(base_prefix, path)
       Route.new(router_name, m.upcase, resolved, path, handler_text, Noir::TreeSitter.node_start_row(call))
     end
 
@@ -336,7 +336,7 @@ module Noir
       return if handler_text.empty?
 
       base_prefix = local_groups[router_name]? || prefix_stack.join
-      resolved = base_prefix.empty? ? path : join_paths(base_prefix, path)
+      resolved = base_prefix.empty? ? path : group_join(base_prefix, path)
       Route.new(router_name, "ANY", resolved, path, handler_text, Noir::TreeSitter.node_start_row(call))
     end
 

--- a/src/miniparsers/go_route_extractor_ts/core.cr
+++ b/src/miniparsers/go_route_extractor_ts/core.cr
@@ -890,7 +890,7 @@ module Noir
               if new_parent && Noir::TreeSitter.node_type(new_parent) == "identifier"
                 parent_name = Noir::TreeSitter.node_text(new_parent, source)
                 if parent_prefix = groups[parent_name]?
-                  prefix = join_paths(parent_prefix, prefix)
+                  prefix = group_join(parent_prefix, prefix)
                 end
               end
               groups[Noir::TreeSitter.node_text(var_name_node, source)] = prefix
@@ -916,7 +916,7 @@ module Noir
       if Noir::TreeSitter.node_type(parent_node) == "identifier"
         parent_name = Noir::TreeSitter.node_text(parent_node, source)
         if parent_prefix = groups[parent_name]?
-          prefix = join_paths(parent_prefix, prefix)
+          prefix = group_join(parent_prefix, prefix)
         end
       end
 
@@ -996,8 +996,8 @@ module Noir
       # enclosing closure body whose param matches.
       base_prefix = closure_prefix_for(closure_groups, LibTreeSitter.ts_node_start_byte(call), router_name) ||
                     groups[router_name]? || ""
-      base_prefix = join_paths(base_prefix, chain_prefix) unless chain_prefix.empty?
-      resolved = base_prefix.empty? ? (raw_path.empty? ? "/" : raw_path) : join_paths(base_prefix, raw_path)
+      base_prefix = group_join(base_prefix, chain_prefix) unless chain_prefix.empty?
+      resolved = base_prefix.empty? ? (raw_path.empty? ? "/" : raw_path) : group_join(base_prefix, raw_path)
 
       # Fiber's `app.All(...)` is the same "match any method" intent
       # as Gin's `r.Any(...)` and Echo's `e.Any(...)`. Normalize so
@@ -1070,7 +1070,7 @@ module Noir
       parent_info = router_operand_info(parent, source, groups, group_method, group_aliases, string_values)
       return unless parent_info
       router_name, parent_prefix = parent_info
-      chain_prefix = prefix.empty? ? parent_prefix : join_paths(parent_prefix, prefix)
+      chain_prefix = prefix.empty? ? parent_prefix : group_join(parent_prefix, prefix)
       {router_name, chain_prefix}
     end
 
@@ -1124,7 +1124,7 @@ module Noir
       router_name = Noir::TreeSitter.node_text(operand, source)
       return if NON_ROUTER_OPERANDS.includes?(router_name)
       resolved = if prefix = groups[router_name]?
-                   join_paths(prefix, path_lit)
+                   group_join(prefix, path_lit)
                  else
                    path_lit
                  end
@@ -1189,7 +1189,7 @@ module Noir
       router_name = Noir::TreeSitter.node_text(operand, source)
       return empty if NON_ROUTER_OPERANDS.includes?(router_name)
       resolved = if prefix = groups[router_name]?
-                   join_paths(prefix, path_lit)
+                   group_join(prefix, path_lit)
                  else
                    path_lit
                  end
@@ -1264,7 +1264,7 @@ module Noir
                         closure_prefix_for(result, LibTreeSitter.ts_node_start_byte(node), rname) || ""
         end
 
-        full = recv_prefix.empty? ? ps : join_paths(recv_prefix, ps)
+        full = recv_prefix.empty? ? ps : group_join(recv_prefix, ps)
         result << ClosureGroup.new(
           LibTreeSitter.ts_node_start_byte(body),
           LibTreeSitter.ts_node_end_byte(body),
@@ -1422,7 +1422,7 @@ module Noir
 
       return [] of Route if NON_ROUTER_OPERANDS.includes?(router_name)
       resolved = if prefix = groups[router_name]?
-                   join_paths(prefix, raw_path)
+                   group_join(prefix, raw_path)
                  else
                    raw_path
                  end
@@ -1513,7 +1513,7 @@ module Noir
     # Join a group prefix and a route path with exactly one `/` separator,
     # mirroring `GoRouteExtractor#extract_route_path`. Gin accepts paths
     # without a leading `/` under a group, so this also handles that case.
-    private def join_paths(prefix : String, path : String) : String
+    private def group_join(prefix : String, path : String) : String
       "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
     end
   end

--- a/src/miniparsers/go_route_extractor_ts/restful.cr
+++ b/src/miniparsers/go_route_extractor_ts/restful.cr
@@ -131,7 +131,7 @@ module Noir
              elsif prefix.empty?
                sub_path
              else
-               join_paths(prefix, sub_path)
+               group_join(prefix, sub_path)
              end
       full = "/#{full}" unless full.starts_with?("/")
       RestfulRoute.new(v, full, handler, line, params)

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -224,7 +224,7 @@ module Noir
       end
 
       visiting.delete(r.lexical_name)
-      parent_path.empty? ? r.own_path : join_paths(parent_path, r.own_path)
+      parent_path.empty? ? r.own_path : route_scope_join(parent_path, r.own_path)
     end
 
     private def collect_resource_classes(node : LibTreeSitter::TSNode,
@@ -520,7 +520,7 @@ module Noir
             # its @Resource-composed path; if it can't be resolved, skip
             # rather than emit the bare routing prefix (a misleading "/").
             if rp = resolve_resource_path(type_name, resource_paths)
-              emit_resource_route(node, source, HTTP_VERB_NAMES[name], join_paths(prefix, rp), routes, include_callees)
+              emit_resource_route(node, source, HTTP_VERB_NAMES[name], route_scope_join(prefix, rp), routes, include_callees)
             end
             return
           end
@@ -538,7 +538,7 @@ module Noir
           # (which inherits the enclosing prefix) flow through to the
           # method-route handling below.
           return if path_arg.nil? && call_has_value_arguments?(node) && call_http_method_argument(node, source).nil?
-          new_prefix = path_arg ? join_paths(prefix, path_arg) : prefix
+          new_prefix = path_arg ? route_scope_join(prefix, path_arg) : prefix
           if body = call_lambda_body(node)
             if method = call_http_method_argument(node, source)
               emit_method_route(node, body, source, method, new_prefix, routes, include_callees) if has_handle_call?(body, source)
@@ -557,7 +557,7 @@ module Noir
           type_name = call_type_argument_name(node, source)
           if type_name && (rp = resolve_resource_path(type_name, resource_paths))
             if body = call_lambda_body(node)
-              walk(body, source, join_paths(prefix, rp), routes, string_constants, local_string_constants, depth + 1, include_callees, true, resource_paths)
+              walk(body, source, route_scope_join(prefix, rp), routes, string_constants, local_string_constants, depth + 1, include_callees, true, resource_paths)
             end
             return
           end
@@ -577,7 +577,7 @@ module Noir
           # as a GET route (the served files aren't enumerable from
           # source). The remote path is the first string argument.
           if path = static_mount_path(node, source)
-            routes << Route.new("GET", join_paths(prefix, path), Noir::TreeSitter.node_start_row(node), nil, false, [] of String, [] of String, [] of String, [] of Tuple(String, Int32))
+            routes << Route.new("GET", route_scope_join(prefix, path), Noir::TreeSitter.node_start_row(node), nil, false, [] of String, [] of String, [] of String, [] of Tuple(String, Int32))
           end
           return
         when name == "install"
@@ -618,7 +618,7 @@ module Noir
       return unless path_arg || call_has_lambda?(node)
 
       verb = HTTP_VERB_NAMES[name]
-      full_path = join_paths(prefix, path_arg || "")
+      full_path = route_scope_join(prefix, path_arg || "")
       line = Noir::TreeSitter.node_start_row(node)
 
       # A `post<Body>("/x")` typed-body verb names the request body in its
@@ -1265,7 +1265,7 @@ module Noir
       end
     end
 
-    private def join_paths(prefix : String, suffix : String) : String
+    private def route_scope_join(prefix : String, suffix : String) : String
       return "/" if prefix.empty? && suffix.empty?
       return suffix if prefix.empty?
       return prefix.rstrip('/') if suffix.empty?


### PR DESCRIPTION
Fifth PR of the structural-contract series (after #2488, #2489, #2490, #2491, #2492). Pure rename — no behaviour change.

## Why

Twelve classes each carried a `join_path` / `join_paths` with **different semantics under the same name**. Choosing between them by grepping — which is how anyone meets them — surfaces whichever definition the search hits first, and nothing in the name says how the two differ.

They differ on four axes, and no two agree on all of them:

- does an empty side pass through, or get normalized?
- does a trailing slash survive?
- is a leading slash forced?
- does an interior `//` collapse?

Those differences are real and per-framework, so the fix is **not** to merge them. It is to stop them sharing a name.

## The renames

| was | now | why it is not a `URLPath` method |
|---|---|---|
| `Axum#join_paths` | `nest_join` | bare seam, no empty guards (callers guard) |
| Go extractor `#join_paths` | `group_join` | same |
| Ktor extractor `#join_paths` | `route_scope_join` | `join_absorbing` ∪ `("","") → "/"` |
| `Struts2#join_paths` | `namespace_join` | treats `"/"` as empty on both sides, then re-normalizes |
| `Warp#join_paths` | `filter_chain_join` | `route == "/"` returns the prefix **un-rstripped** |
| `Akka#join_paths` | `pathmatcher_stack_join` | concatenates a prefix *stack* with no separator, then collapses |
| `Gotham` / `Loco#join_paths` | `absolute_scope_join` | rstrips the *result*; `""` → `"/"` |
| `Hanami#join_paths` (both overloads) | `absolute_segment_join` | splits on `/` and drops empties — collapses *all* interior slashes |
| `Angel3` / `Shelf#join_path` | `mount_join` | `rchop` (one slash only), forces `/` on the right side |
| `SchemaApiCommon#join_path` | `api_mount_join` | `path == "/"` collapses onto the prefix |
| `Python::Helper#join_paths` | `normalized_join` | composes Python's own `normalize_path` |
| `SwiftEngine#join_paths` | `normalized_route_join` | treats `"/"` as empty; collapses interior `//` |

Shared semantics keep living on `Noir::URLPath`, whose five methods are already named for their rules (`join`, `join_trimmed`, `join_absorbing`, `join_rooted`, and `absolute_join` after the next PR). A joiner that is none of those five now says so in its name.

`nest_join` and `group_join` stay separate despite identical bodies: both drop `join_trimmed`'s empty-side guards and rely on callers checking `prefix.empty?` first, so hoisting them would mean either changing behaviour or publishing a `URLPath` method with no empty-side contract. #2468 left them for that reason and this PR does not revisit it.

One divergence found and deliberately **not** fixed here: `route_scope_join` returns `""` for `("/", "")` — an empty URL — where every sibling returns `"/"`. That looks like a Ktor bug, but fixing it is a behaviour change and does not belong in a rename. Flagged for a separate `fix(ktor:)`.

## Verification

Pure identifier substitution: **98 insertions, 98 deletions** — not one line added or removed anywhere in the tree.

**STRICT A/B** over all 664 fixture directories — byte-identical: 5,158 endpoints, 4,775 callee entries, including every `details.code_paths[].line` and `callees[].line`. For a rename that touches 24 files, line-number equality is the assertion that matters; a reflowed line would show up there.

`crystal spec spec/unit_test` 4658 examples / `spec/functional_test` 22647 examples, 0 failures. `just check` 1909 files, 0 findings.