### PR TITLE
refactor(tagger): derive the tagger registry from the tagger classes

### DIFF
--- a/spec/unit_test/tagger/line_bounds_safety_spec.cr
+++ b/spec/unit_test/tagger/line_bounds_safety_spec.cr
@@ -41,14 +41,13 @@ describe "Tagger line-bounds safety" do
     ] of Param, details)
   }
 
-  NoirTaggers::HasFrameworkTaggers.each do |key, info|
-    runner = info[:runner]
-    tech = runner.target_techs.first? || "unknown"
-    it "#{key} does not crash on edge/out-of-range line numbers" do
+  NoirTaggers::FRAMEWORK_ENTRIES.each do |entry|
+    tech = NoirTaggers.target_techs(entry.key).first? || "unknown"
+    it "#{entry.key} does not crash on edge/out-of-range line numbers" do
       file_paths.each do |fp|
         line_values.each do |lv|
           endpoint = build_endpoint.call(fp, lv, tech)
-          tagger = runner.new(options)
+          tagger = NoirTaggers.build(entry.key, options).not_nil!
           # Must not raise regardless of how stale the line ref is.
           tagger.perform([endpoint])
         end
@@ -56,13 +55,12 @@ describe "Tagger line-bounds safety" do
     end
   end
 
-  NoirTaggers::HasTaggers.each do |key, info|
-    runner = info[:runner]
-    it "#{key} does not crash on edge/out-of-range line numbers" do
+  NoirTaggers::PLAIN_ENTRIES.each do |entry|
+    it "#{entry.key} does not crash on edge/out-of-range line numbers" do
       file_paths.each do |fp|
         line_values.each do |lv|
           endpoint = build_endpoint.call(fp, lv, nil)
-          tagger = runner.new(options)
+          tagger = NoirTaggers.build(entry.key, options).not_nil!
           tagger.perform([endpoint])
         end
       end

--- a/spec/unit_test/techs/registry_integrity_spec.cr
+++ b/spec/unit_test/techs/registry_integrity_spec.cr
@@ -3,6 +3,7 @@ require "../../../src/utils/*"
 require "../../../src/techs/techs"
 require "../../../src/detector/detector"
 require "../../../src/analyzer/analyzer"
+require "../../../src/tagger/tagger"
 require "../../../src/models/logger"
 
 # Tech identity lives in three hand-maintained lists with no compile-time
@@ -94,5 +95,73 @@ describe "tech registry integrity" do
     # through. A key it cannot round-trip is unreachable from the CLI.
     unresolvable = catalog.reject { |tech| NoirTechs.similar_to_tech(tech) == tech }
     fail "catalog keys similar_to_tech cannot resolve: #{sorted(unresolvable)}" unless unresolvable.empty?
+  end
+end
+
+# The tagger registry is derived from `Noir::TaggerFor` annotations rather
+# than from a hand-maintained hash literal, but the derivation only sees
+# classes that carry the annotation. A new tagger file that forgets it
+# compiles, ships, and never runs — the exact failure the two literals used
+# to have, moved one step. This sweep is what closes it.
+describe "tagger registry integrity" do
+  catalog = NoirTechs.techs.keys.map(&.to_s).to_set
+  entries = NoirTaggers::ENTRIES
+  keys = entries.map(&.key)
+
+  it "annotates every concrete tagger class" do
+    annotated = keys.to_set
+    declared = [] of String
+
+    # `Tagger::` is not a namespace here — taggers are top-level classes —
+    # so the sweep excludes the two base classes by name instead. They stay
+    # un-annotated on purpose: `spec/unit_test/models/tagger_spec.cr` and
+    # `framework_tagger_spec.cr` instantiate them directly to exercise the
+    # default `perform`, so neither can be made abstract.
+    {% for sub in Tagger.all_subclasses %}
+      {% unless sub.name == "FrameworkTagger" %}
+        declared << {{ sub.stringify }}
+      {% end %}
+    {% end %}
+
+    missing = [] of String
+    {% for sub in Tagger.all_subclasses %}
+      {% unless sub.name == "FrameworkTagger" || sub.annotation(Noir::TaggerFor) %}
+        missing << {{ sub.stringify }}
+      {% end %}
+    {% end %}
+
+    fail "tagger classes with no Noir::TaggerFor annotation (they will never run): #{sorted(missing)}" unless missing.empty?
+    declared.size.should eq annotated.size
+  end
+
+  it "gives each tagger a unique key that is not the 'all' sentinel" do
+    duplicates = keys.tally.select { |_, count| count > 1 }.keys
+    fail "duplicate tagger keys: #{sorted(duplicates)}" unless duplicates.empty?
+    keys.includes?("all").should be_false
+  end
+
+  it "gives every tagger a name and a description" do
+    blank = entries.select { |entry| entry.name.blank? || entry.desc.blank? }.map(&.key)
+    fail "taggers missing name/desc: #{sorted(blank)}" unless blank.empty?
+  end
+
+  it "reports each tagger's key as its runtime name" do
+    # `run_tagger` selects by registry key and then logs failures by the
+    # instance's `name`; the two disagreeing would make an unselectable
+    # tagger, or a warning naming something the user never asked for.
+    options = create_test_options
+    mismatched = entries.compact_map do |entry|
+      instance = NoirTaggers.build(entry.key, options)
+      next "#{entry.key}: not constructible" if instance.nil?
+      "#{entry.key}: name=#{instance.name}" unless instance.name == entry.key
+    end
+    fail "taggers whose runtime name differs from their registry key: #{mismatched}" unless mismatched.empty?
+  end
+
+  it "points every framework tagger at real catalog techs" do
+    unknown = NoirTaggers.framework_taggers.flat_map do |entry|
+      NoirTaggers.target_techs(entry.key).reject { |tech| catalog.includes?(tech) }
+    end.uniq!
+    fail "framework taggers target techs with no catalog entry: #{sorted(unknown)}" unless unknown.empty?
   end
 end

--- a/spec/unit_test/techs/techs_spec.cr
+++ b/spec/unit_test/techs/techs_spec.cr
@@ -74,8 +74,8 @@ describe "Context support metadata" do
   end
 
   it "marks every framework auth tagger target as guard-supported" do
-    target_techs = NoirTaggers.framework_taggers.values.flat_map do |tagger|
-      tagger[:runner].target_techs
+    target_techs = NoirTaggers.framework_taggers.flat_map do |entry|
+      NoirTaggers.target_techs(entry.key)
     end.uniq!
 
     target_techs.each do |tech|

--- a/src/cli/commands/list.cr
+++ b/src/cli/commands/list.cr
@@ -163,14 +163,16 @@ module Noir::CLI::ListCommand
 
   private def self.print_taggers_text(io : IO)
     io.puts "Available taggers:"
-    NoirTaggers.taggers.each do |tagger, info|
-      io.puts " #{tagger.to_s.colorize(:green)}"
-      info.each { |k, v| io.puts "   #{k.to_s.colorize(:blue)}: #{v}" unless k == :runner }
-    end
+    print_tagger_entries(NoirTaggers.taggers, io)
     io.puts "\nFramework-specific taggers:"
-    NoirTaggers.framework_taggers.each do |tagger, info|
-      io.puts " #{tagger.to_s.colorize(:green)}"
-      info.each { |k, v| io.puts "   #{k.to_s.colorize(:blue)}: #{v}" unless k == :runner }
+    print_tagger_entries(NoirTaggers.framework_taggers, io)
+  end
+
+  private def self.print_tagger_entries(entries : Array(NoirTaggers::Entry), io : IO)
+    entries.each do |entry|
+      io.puts " #{entry.key.colorize(:green)}"
+      io.puts "   #{"name".colorize(:blue)}: #{entry.name}"
+      io.puts "   #{"desc".colorize(:blue)}: #{entry.desc}"
     end
   end
 
@@ -202,9 +204,9 @@ module Noir::CLI::ListCommand
     doc
   end
 
-  # Structured taggers catalog. The `:runner` class reference isn't
-  # serializable (and is an internal detail), so it's dropped — matching the
-  # text view, which also hides it.
+  # Structured taggers catalog. The class that runs each tagger is an
+  # internal detail and is not part of the document — the registry `Entry`
+  # carries only what both views print.
   private def self.taggers_document
     {
       "taggers"           => serialize_taggers(NoirTaggers.taggers),
@@ -212,17 +214,10 @@ module Noir::CLI::ListCommand
     }
   end
 
-  private def self.serialize_taggers(source) : Array(Hash(String, String))
-    entries = [] of Hash(String, String)
-    source.each do |name, info|
-      entry = {"id" => name.to_s}
-      info.each do |k, v|
-        next if k == :runner
-        entry[k.to_s] = v.to_s
-      end
-      entries << entry
+  private def self.serialize_taggers(source : Array(NoirTaggers::Entry)) : Array(Hash(String, String))
+    source.map do |entry|
+      {"id" => entry.key, "name" => entry.name, "desc" => entry.desc}
     end
-    entries
   end
 
   private def self.print_context_support(tech : String, io : IO)

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -157,7 +157,7 @@ class NoirRunner
       NoirTaggers.run_tagger @endpoints, @options, "all"
       if @is_debug
         NoirTaggers.taggers.each do |tagger|
-          @logger.debug "Tagger: #{tagger}"
+          @logger.debug "Tagger: #{tagger.key} (#{tagger.name})"
         end
       end
     elsif !@options["use_taggers"].to_s.empty?

--- a/src/models/tagger.cr
+++ b/src/models/tagger.cr
@@ -1,5 +1,38 @@
 require "./logger"
 
+# Marks a `Tagger` (or `FrameworkTagger`) subclass as one entry in the
+# tagger registry.
+#
+#     @[Noir::TaggerFor(key: "hunt", name: "HuntParam Tagger",
+#       desc: "Identifies common parameters vulnerable to certain vulnerability classes",
+#       order: 10)]
+#     class HuntParamTagger < Tagger
+#
+# `NoirTaggers` reads the registry off the annotated classes, so this line
+# is the only place a tagger's `-T` key, its `noir list taggers` name and
+# description, and the class that runs it are written down. Before it those
+# facts lived in two hand-maintained hash literals; a new tagger file that
+# nobody added to them compiled, shipped, and silently never ran.
+#
+# `key` stays explicit rather than derived from the class name: four of the
+# 43 do not follow from it (`hunt` from `HuntParamTagger`, `oauth` from
+# `OAuthTagger`, `fastapi_auth` from `FastAPIAuthTagger`,
+# `fastendpoints_auth` from `FastEndpointsAuthTagger`). It is also the
+# tagger's `name` at runtime — `Tagger#initialize` reads it back off the
+# class, so the two can no longer disagree.
+#
+# `order` fixes the sequence plain taggers run in, which is user-visible:
+# they run sequentially, `Endpoint#add_tag` appends, and nothing sorts tags
+# before output. Values are spaced by 10 so a tagger can be slotted between
+# two others without renumbering. Framework taggers run under a `WaitGroup`,
+# so for them it only orders `noir list taggers`.
+#
+# The `Tagger` and `FrameworkTagger` base classes carry no annotation and
+# stay out of the registry — which is also why they can remain instantiable
+# for the specs that exercise their default `perform`.
+annotation Noir::TaggerFor
+end
+
 class Tagger
   @logger : NoirLogger
   @options : Hash(String, YAML::Any)
@@ -15,9 +48,25 @@ class Tagger
     @options = options
     @is_color = any_to_bool(options["color"])
     @is_log = any_to_bool(options["nolog"])
-    @name = ""
+    @name = self.class.tagger_key
 
     @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log
+  end
+
+  # The registry key, read off the class's `Noir::TaggerFor` annotation.
+  # Empty on the un-annotated base classes, which keeps `Tagger.new(...).name`
+  # the empty string it has always been.
+  #
+  # Every concrete tagger used to repeat this as `@name = "hunt"` in its own
+  # `initialize` after `super`. `run_tagger` relies on the key and the name
+  # being the same string ("selection is decided before construction"); this
+  # makes that structural instead of a convention 43 files had to observe.
+  def self.tagger_key : String
+    {% if ann = @type.annotation(Noir::TaggerFor) %}
+      {{ ann[:key] }}
+    {% else %}
+      ""
+    {% end %}
   end
 
   def name

--- a/src/tagger/framework_taggers/crystal/crystal_auth.cr
+++ b/src/tagger/framework_taggers/crystal/crystal_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "crystal_auth", name: "Crystal Auth Tagger", desc: "Identifies Crystal framework authentication patterns (Kemal, Amber, Lucky)", order: 240)]
 class CrystalAuthTagger < FrameworkTagger
   # Amber auth pipe patterns
   AMBER_AUTH_PATTERNS = [

--- a/src/tagger/framework_taggers/csharp/aspnet_auth.cr
+++ b/src/tagger/framework_taggers/csharp/aspnet_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "aspnet_auth", name: "ASP.NET Auth Tagger", desc: "Identifies ASP.NET authentication patterns ([Authorize], policies)", order: 170)]
 class AspnetAuthTagger < FrameworkTagger
   # ASP.NET [Authorize] attribute patterns
   AUTHORIZE_PATTERNS = [

--- a/src/tagger/framework_taggers/csharp/fastendpoints_auth.cr
+++ b/src/tagger/framework_taggers/csharp/fastendpoints_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "fastendpoints_auth", name: "FastEndpoints Auth Tagger", desc: "Identifies FastEndpoints authentication patterns (Roles, Permissions, Policies)", order: 180)]
 class FastEndpointsAuthTagger < FrameworkTagger
   ALLOW_ANONYMOUS_PATTERN = /\bAllowAnonymous\s*\(/
   ROLES_PATTERN           = /\bRoles\s*\(/

--- a/src/tagger/framework_taggers/elixir/elixir_auth.cr
+++ b/src/tagger/framework_taggers/elixir/elixir_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "elixir_auth", name: "Elixir Auth Tagger", desc: "Identifies Phoenix/Plug authentication patterns (plugs, Guardian, Pow)", order: 190)]
 class ElixirAuthTagger < FrameworkTagger
   # Phoenix pipeline auth plugs
   PLUG_AUTH_PATTERNS = [

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -2,6 +2,7 @@ require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 require "./group_scope"
 
+@[Noir::TaggerFor(key: "go_auth", name: "Go Auth Tagger", desc: "Identifies Go authentication patterns (middleware, JWT, session)", order: 50)]
 class GoAuthTagger < FrameworkTagger
   include GoRouteGroupScope
 

--- a/src/tagger/framework_taggers/go/go_security.cr
+++ b/src/tagger/framework_taggers/go/go_security.cr
@@ -22,6 +22,7 @@ require "./group_scope"
 # tag is worse for a security review than a miss, so only middleware named
 # directly at the registration site is tagged. Cross-file middleware
 # factories are likewise out of scope by design.
+@[Noir::TaggerFor(key: "go_security", name: "Go Security Tagger", desc: "Identifies Go security middleware (CSRF, security headers, rate limiting, body-size limits)", order: 60)]
 class GoSecurityTagger < FrameworkTagger
   include GoRouteGroupScope
 

--- a/src/tagger/framework_taggers/java/java_misc_auth.cr
+++ b/src/tagger/framework_taggers/java/java_misc_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "java_misc_auth", name: "Java Misc Auth Tagger", desc: "Identifies Vert.x/Armeria/JSP authentication patterns", order: 210)]
 class JavaMiscAuthTagger < FrameworkTagger
   # Vert.x auth patterns
   VERTX_AUTH_PATTERNS = [

--- a/src/tagger/framework_taggers/java/spring_auth.cr
+++ b/src/tagger/framework_taggers/java/spring_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "spring_auth", name: "Spring Auth Tagger", desc: "Identifies Spring Security patterns (annotations, security config)", order: 20)]
 class SpringAuthTagger < FrameworkTagger
   ANNOTATION_PATTERNS = [
     /\@PreAuthorize\s*\(/,

--- a/src/tagger/framework_taggers/java/spring_security.cr
+++ b/src/tagger/framework_taggers/java/spring_security.cr
@@ -35,6 +35,7 @@ require "../../../models/endpoint"
 # `@CrossOrigin` and input-validation signals are per-endpoint, line-based
 # walks of the handler the endpoint maps to. Cross-file concerns (a custom
 # Filter bean, a bespoke CorsConfigurationSource) are out of scope.
+@[Noir::TaggerFor(key: "spring_security", name: "Spring Security Tagger", desc: "Identifies Spring security signals beyond auth (CSRF disabled, CORS policy, security headers, input validation)", order: 30)]
 class SpringSecurityTagger < FrameworkTagger
   STATE_CHANGING_METHODS = Set{"POST", "PUT", "PATCH", "DELETE"}
 

--- a/src/tagger/framework_taggers/javascript/express_auth.cr
+++ b/src/tagger/framework_taggers/javascript/express_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "express_auth", name: "Express Auth Tagger", desc: "Identifies Express.js authentication patterns (Passport, JWT, auth middleware)", order: 40)]
 class ExpressAuthTagger < FrameworkTagger
   PASSPORT_PATTERNS = [
     /passport\.authenticate\s*\(/,

--- a/src/tagger/framework_taggers/javascript/hono_auth.cr
+++ b/src/tagger/framework_taggers/javascript/hono_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "hono_auth", name: "Hono Auth Tagger", desc: "Identifies Hono authentication patterns (bearerAuth, jwt, basicAuth, custom middleware)", order: 250)]
 class HonoAuthTagger < FrameworkTagger
   # Hono official auth middleware
   HONO_AUTH_MIDDLEWARE = [

--- a/src/tagger/framework_taggers/javascript/js_misc_auth.cr
+++ b/src/tagger/framework_taggers/javascript/js_misc_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "js_misc_auth", name: "JS Misc Auth Tagger", desc: "Identifies Fastify/Koa/Restify authentication patterns", order: 160)]
 class JsMiscAuthTagger < FrameworkTagger
   MAX_ROUTE_SCOPE_LINES = 12
 

--- a/src/tagger/framework_taggers/javascript/nestjs_auth.cr
+++ b/src/tagger/framework_taggers/javascript/nestjs_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "nestjs_auth", name: "NestJS Auth Tagger", desc: "Identifies NestJS authentication patterns (Guards, decorators)", order: 150)]
 class NestjsAuthTagger < FrameworkTagger
   # NestJS guard decorators
   GUARD_PATTERNS = [

--- a/src/tagger/framework_taggers/kotlin/ktor_auth.cr
+++ b/src/tagger/framework_taggers/kotlin/ktor_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "ktor_auth", name: "Ktor Auth Tagger", desc: "Identifies Ktor authentication patterns (authenticate blocks, principals)", order: 200)]
 class KtorAuthTagger < FrameworkTagger
   # Ktor authenticate block patterns
   AUTHENTICATE_BLOCK_PATTERNS = [

--- a/src/tagger/framework_taggers/perl/perl_auth.cr
+++ b/src/tagger/framework_taggers/perl/perl_auth.cr
@@ -14,6 +14,7 @@ require "../../../models/endpoint"
 # (`$c->user_exists`, `$c->assert_user_roles`, `$c->require_login`,
 # `$self->is_user_authenticated`). This tagger surfaces all of them as a
 # single `auth` tag so reviewers can spot the unprotected routes.
+@[Noir::TaggerFor(key: "perl_auth", name: "Perl Auth Tagger", desc: "Identifies Perl authentication patterns (Dancer2 Auth::Extensible, Mojolicious, Catalyst)", order: 260)]
 class PerlAuthTagger < FrameworkTagger
   # Inline route wrappers from Dancer2::Plugin::Auth::Extensible. These
   # sit between the path and the `sub { ... }` on the route declaration.

--- a/src/tagger/framework_taggers/php/php_auth.cr
+++ b/src/tagger/framework_taggers/php/php_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "php_auth", name: "PHP Auth Tagger", desc: "Identifies PHP authentication patterns (Laravel, Symfony, CakePHP)", order: 140)]
 class PhpAuthTagger < FrameworkTagger
   # Laravel middleware patterns
   LARAVEL_ROUTE_MIDDLEWARE = [

--- a/src/tagger/framework_taggers/python/django_auth.cr
+++ b/src/tagger/framework_taggers/python/django_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "django_auth", name: "Django Auth Tagger", desc: "Identifies Django authentication patterns (decorators, mixins, DRF permissions)", order: 10)]
 class DjangoAuthTagger < FrameworkTagger
   DECORATOR_PATTERNS = [
     /\@login_required/,

--- a/src/tagger/framework_taggers/python/fastapi_auth.cr
+++ b/src/tagger/framework_taggers/python/fastapi_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "fastapi_auth", name: "FastAPI Auth Tagger", desc: "Identifies FastAPI authentication patterns (Depends, Security, OAuth2)", order: 100)]
 class FastAPIAuthTagger < FrameworkTagger
   # Depends() with auth-related callables
   DEPENDS_AUTH_PATTERNS = [

--- a/src/tagger/framework_taggers/python/flask_auth.cr
+++ b/src/tagger/framework_taggers/python/flask_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "flask_auth", name: "Flask Auth Tagger", desc: "Identifies Flask authentication patterns (flask-login, flask-jwt, flask-httpauth)", order: 90)]
 class FlaskAuthTagger < FrameworkTagger
   DECORATOR_PATTERNS = [
     {/\@login_required/, "flask-login login_required"},

--- a/src/tagger/framework_taggers/python/python_misc_auth.cr
+++ b/src/tagger/framework_taggers/python/python_misc_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "python_misc_auth", name: "Python Misc Auth Tagger", desc: "Identifies Sanic/Tornado authentication patterns", order: 110)]
 class PythonMiscAuthTagger < FrameworkTagger
   # Sanic auth patterns
   SANIC_PATTERNS = [

--- a/src/tagger/framework_taggers/ruby/rails_security.cr
+++ b/src/tagger/framework_taggers/ruby/rails_security.cr
@@ -22,6 +22,7 @@ require "../../../models/endpoint"
 # controller the action lives in. Cross-file concerns (a `null_session`
 # base controller inherited by children, a Rack::Attack initializer) are
 # out of scope by design — those live outside the action's own file.
+@[Noir::TaggerFor(key: "rails_security", name: "Rails Security Tagger", desc: "Identifies Rails controller security signals (CSRF protection, mass assignment, rate limiting)", order: 130)]
 class RailsSecurityTagger < FrameworkTagger
   # Class-level macros that turn CSRF verification OFF for (some) actions.
   CSRF_DISABLE_PATTERNS = [

--- a/src/tagger/framework_taggers/ruby/ruby_auth.cr
+++ b/src/tagger/framework_taggers/ruby/ruby_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "ruby_auth", name: "Ruby Auth Tagger", desc: "Identifies Ruby authentication patterns (Devise, Pundit, CanCanCan, Warden)", order: 120)]
 class RubyAuthTagger < FrameworkTagger
   # Rails before_action patterns
   BEFORE_ACTION_PATTERNS = [

--- a/src/tagger/framework_taggers/rust/rust_auth.cr
+++ b/src/tagger/framework_taggers/rust/rust_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "rust_auth", name: "Rust Auth Tagger", desc: "Identifies Rust authentication patterns (guards, extractors, middleware)", order: 70)]
 class RustAuthTagger < FrameworkTagger
   # Actix-Web auth middleware/extractor patterns
   ACTIX_AUTH_PATTERNS = [

--- a/src/tagger/framework_taggers/rust/rust_security.cr
+++ b/src/tagger/framework_taggers/rust/rust_security.cr
@@ -38,6 +38,7 @@ require "../../../models/endpoint"
 # Scope mapping errs toward false *negatives* (a too-narrow prefix tags
 # fewer endpoints) rather than false positives, in keeping with the
 # rest of Noir's tagging.
+@[Noir::TaggerFor(key: "rust_security", name: "Rust Security Tagger", desc: "Identifies Rust framework security protections (CORS, rate limiting, security headers, body-size limits)", order: 80)]
 class RustSecurityTagger < FrameworkTagger
   # A single detected protection: the tag to emit, its human description,
   # the URL prefix it guards, and whether it is a risk (risk variants win

--- a/src/tagger/framework_taggers/scala/scala_auth.cr
+++ b/src/tagger/framework_taggers/scala/scala_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "scala_auth", name: "Scala Auth Tagger", desc: "Identifies Play/Akka/Scalatra authentication patterns", order: 230)]
 class ScalaAuthTagger < FrameworkTagger
   # Play Framework auth patterns
   PLAY_AUTH_PATTERNS = [

--- a/src/tagger/framework_taggers/swift/swift_auth.cr
+++ b/src/tagger/framework_taggers/swift/swift_auth.cr
@@ -1,6 +1,7 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
+@[Noir::TaggerFor(key: "swift_auth", name: "Swift Auth Tagger", desc: "Identifies Vapor/Kitura/Hummingbird authentication patterns", order: 220)]
 class SwiftAuthTagger < FrameworkTagger
   # Vapor middleware patterns
   VAPOR_MIDDLEWARE_PATTERNS = [

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -5,239 +5,77 @@ require "../models/framework_tagger"
 require "wait_group"
 
 module NoirTaggers
-  HasTaggers = {
-    hunt: {
-      name:   "HuntParam Tagger",
-      desc:   "Identifies common parameters vulnerable to certain vulnerability classes",
-      runner: HuntParamTagger,
-    },
-    oauth: {
-      name:   "OAuth Tagger",
-      desc:   "Identifies OAuth endpoints",
-      runner: OAuthTagger,
-    },
-    cors: {
-      name:   "CORS Tagger",
-      desc:   "Identifies CORS endpoints",
-      runner: CorsTagger,
-    },
-    soap: {
-      name:   "SOAP Tagger",
-      desc:   "Identifies SOAP endpoints",
-      runner: SoapTagger,
-    },
-    websocket: {
-      name:   "Websocket Tagger",
-      desc:   "Identifies Websocket endpoints",
-      runner: WebsocketTagger,
-    },
-    graphql: {
-      name:   "GraphQL Tagger",
-      desc:   "Identifies GraphQL endpoints",
-      runner: GraphqlTagger,
-    },
-    mcp: {
-      name:   "MCP Tagger",
-      desc:   "Identifies Model Context Protocol endpoints",
-      runner: McpTagger,
-    },
-    jwt: {
-      name:   "JWT Tagger",
-      desc:   "Identifies JWT authentication endpoints",
-      runner: JwtTagger,
-    },
-    file_upload: {
-      name:   "FileUpload Tagger",
-      desc:   "Identifies file upload endpoints",
-      runner: FileUploadTagger,
-    },
-    pii: {
-      name:   "PII Tagger",
-      desc:   "Identifies endpoints handling personally identifiable information",
-      runner: PiiTagger,
-    },
-    admin: {
-      name:   "Admin Tagger",
-      desc:   "Identifies administrative and privileged endpoints",
-      runner: AdminTagger,
-    },
-    payment: {
-      name:   "Payment Tagger",
-      desc:   "Identifies payment and financial transaction endpoints",
-      runner: PaymentTagger,
-    },
-    webhook: {
-      name:   "Webhook Tagger",
-      desc:   "Identifies inbound webhook and callback endpoints",
-      runner: WebhookTagger,
-    },
-    crypto: {
-      name:   "Crypto Tagger",
-      desc:   "Identifies cryptographic operation endpoints (encryption, signing, hashing, key management)",
-      runner: CryptoTagger,
-    },
-    debug: {
-      name:   "Debug Tagger",
-      desc:   "Identifies debug, diagnostic, and internal-only endpoints (debug consoles, profilers, actuator, pprof, internal APIs)",
-      runner: DebugTagger,
-    },
-    api_docs: {
-      name:   "API Docs Tagger",
-      desc:   "Identifies API documentation/schema endpoints (Swagger, OpenAPI, GraphiQL, ReDoc, WSDL)",
-      runner: ApiDocsTagger,
-    },
-    account_recovery: {
-      name:   "Account Recovery Tagger",
-      desc:   "Identifies credential-management and account-recovery endpoints (password reset/change, MFA/OTP, verification)",
-      runner: AccountRecoveryTagger,
-    },
-  }
+  # One tagger, as declared by its class's `Noir::TaggerFor` annotation.
+  #
+  # `runner` is deliberately not a field. Storing the class object erases
+  # `self.target_techs` — it lives on `FrameworkTagger`, not on `Tagger` —
+  # so every read would need a cast back. The two macro-generated `case`
+  # dispatchers below resolve per concrete class instead, the same shape
+  # `Noir::OutputFormats.render` uses.
+  record Entry, key : String, name : String, desc : String, framework : Bool
 
-  HasFrameworkTaggers = {
-    django_auth: {
-      name:   "Django Auth Tagger",
-      desc:   "Identifies Django authentication patterns (decorators, mixins, DRF permissions)",
-      runner: DjangoAuthTagger,
-    },
-    spring_auth: {
-      name:   "Spring Auth Tagger",
-      desc:   "Identifies Spring Security patterns (annotations, security config)",
-      runner: SpringAuthTagger,
-    },
-    spring_security: {
-      name:   "Spring Security Tagger",
-      desc:   "Identifies Spring security signals beyond auth (CSRF disabled, CORS policy, security headers, input validation)",
-      runner: SpringSecurityTagger,
-    },
-    express_auth: {
-      name:   "Express Auth Tagger",
-      desc:   "Identifies Express.js authentication patterns (Passport, JWT, auth middleware)",
-      runner: ExpressAuthTagger,
-    },
-    go_auth: {
-      name:   "Go Auth Tagger",
-      desc:   "Identifies Go authentication patterns (middleware, JWT, session)",
-      runner: GoAuthTagger,
-    },
-    go_security: {
-      name:   "Go Security Tagger",
-      desc:   "Identifies Go security middleware (CSRF, security headers, rate limiting, body-size limits)",
-      runner: GoSecurityTagger,
-    },
-    rust_auth: {
-      name:   "Rust Auth Tagger",
-      desc:   "Identifies Rust authentication patterns (guards, extractors, middleware)",
-      runner: RustAuthTagger,
-    },
-    rust_security: {
-      name:   "Rust Security Tagger",
-      desc:   "Identifies Rust framework security protections (CORS, rate limiting, security headers, body-size limits)",
-      runner: RustSecurityTagger,
-    },
-    flask_auth: {
-      name:   "Flask Auth Tagger",
-      desc:   "Identifies Flask authentication patterns (flask-login, flask-jwt, flask-httpauth)",
-      runner: FlaskAuthTagger,
-    },
-    fastapi_auth: {
-      name:   "FastAPI Auth Tagger",
-      desc:   "Identifies FastAPI authentication patterns (Depends, Security, OAuth2)",
-      runner: FastAPIAuthTagger,
-    },
-    python_misc_auth: {
-      name:   "Python Misc Auth Tagger",
-      desc:   "Identifies Sanic/Tornado authentication patterns",
-      runner: PythonMiscAuthTagger,
-    },
-    ruby_auth: {
-      name:   "Ruby Auth Tagger",
-      desc:   "Identifies Ruby authentication patterns (Devise, Pundit, CanCanCan, Warden)",
-      runner: RubyAuthTagger,
-    },
-    rails_security: {
-      name:   "Rails Security Tagger",
-      desc:   "Identifies Rails controller security signals (CSRF protection, mass assignment, rate limiting)",
-      runner: RailsSecurityTagger,
-    },
-    php_auth: {
-      name:   "PHP Auth Tagger",
-      desc:   "Identifies PHP authentication patterns (Laravel, Symfony, CakePHP)",
-      runner: PhpAuthTagger,
-    },
-    nestjs_auth: {
-      name:   "NestJS Auth Tagger",
-      desc:   "Identifies NestJS authentication patterns (Guards, decorators)",
-      runner: NestjsAuthTagger,
-    },
-    js_misc_auth: {
-      name:   "JS Misc Auth Tagger",
-      desc:   "Identifies Fastify/Koa/Restify authentication patterns",
-      runner: JsMiscAuthTagger,
-    },
-    aspnet_auth: {
-      name:   "ASP.NET Auth Tagger",
-      desc:   "Identifies ASP.NET authentication patterns ([Authorize], policies)",
-      runner: AspnetAuthTagger,
-    },
-    fastendpoints_auth: {
-      name:   "FastEndpoints Auth Tagger",
-      desc:   "Identifies FastEndpoints authentication patterns (Roles, Permissions, Policies)",
-      runner: FastEndpointsAuthTagger,
-    },
-    elixir_auth: {
-      name:   "Elixir Auth Tagger",
-      desc:   "Identifies Phoenix/Plug authentication patterns (plugs, Guardian, Pow)",
-      runner: ElixirAuthTagger,
-    },
-    ktor_auth: {
-      name:   "Ktor Auth Tagger",
-      desc:   "Identifies Ktor authentication patterns (authenticate blocks, principals)",
-      runner: KtorAuthTagger,
-    },
-    java_misc_auth: {
-      name:   "Java Misc Auth Tagger",
-      desc:   "Identifies Vert.x/Armeria/JSP authentication patterns",
-      runner: JavaMiscAuthTagger,
-    },
-    swift_auth: {
-      name:   "Swift Auth Tagger",
-      desc:   "Identifies Vapor/Kitura/Hummingbird authentication patterns",
-      runner: SwiftAuthTagger,
-    },
-    scala_auth: {
-      name:   "Scala Auth Tagger",
-      desc:   "Identifies Play/Akka/Scalatra authentication patterns",
-      runner: ScalaAuthTagger,
-    },
-    crystal_auth: {
-      name:   "Crystal Auth Tagger",
-      desc:   "Identifies Crystal framework authentication patterns (Kemal, Amber, Lucky)",
-      runner: CrystalAuthTagger,
-    },
-    hono_auth: {
-      name:   "Hono Auth Tagger",
-      desc:   "Identifies Hono authentication patterns (bearerAuth, jwt, basicAuth, custom middleware)",
-      runner: HonoAuthTagger,
-    },
-    perl_auth: {
-      name:   "Perl Auth Tagger",
-      desc:   "Identifies Perl authentication patterns (Dancer2 Auth::Extensible, Mojolicious, Catalyst)",
-      runner: PerlAuthTagger,
-    },
-  }
-
-  def self.taggers
-    HasTaggers
+  # Every annotated tagger, in `order`. Derived from the classes, so a
+  # tagger joins the registry by existing: the two hand-maintained hash
+  # literals this replaces were a second place to remember, where
+  # forgetting produced no error and no failing spec — just a tagger that
+  # never ran.
+  ENTRIES = begin
+    {% begin %}
+      [
+        {% for tagger in Tagger.all_subclasses
+                           .select(&.annotation(Noir::TaggerFor))
+                           .sort_by { |sub| sub.annotation(Noir::TaggerFor)[:order] } %}
+          {% ann = tagger.annotation(Noir::TaggerFor) %}
+          Entry.new({{ ann[:key] }}, {{ ann[:name] }}, {{ ann[:desc] }},
+            {{ tagger.ancestors.includes?(FrameworkTagger) }}),
+        {% end %}
+      ] of Entry
+    {% end %}
   end
 
-  def self.framework_taggers
-    HasFrameworkTaggers
+  PLAIN_ENTRIES     = ENTRIES.reject(&.framework)
+  FRAMEWORK_ENTRIES = ENTRIES.select(&.framework)
+
+  # Instantiates the tagger `key` names, or nil when nothing claims it.
+  def self.build(key : String, options : Hash(String, YAML::Any)) : Tagger?
+    {% begin %}
+      case key
+      {% for tagger in Tagger.all_subclasses.select(&.annotation(Noir::TaggerFor)) %}
+      when {{ tagger.annotation(Noir::TaggerFor)[:key] }}
+        {{ tagger }}.new(options)
+      {% end %}
+      else
+        nil
+      end
+    {% end %}
+  end
+
+  # Techs a framework tagger declares an interest in; empty for plain
+  # taggers, which run against every endpoint.
+  def self.target_techs(key : String) : Array(String)
+    {% begin %}
+      case key
+      {% for tagger in Tagger.all_subclasses
+                         .select { |sub| sub.annotation(Noir::TaggerFor) && sub.ancestors.includes?(FrameworkTagger) } %}
+      when {{ tagger.annotation(Noir::TaggerFor)[:key] }}
+        {{ tagger }}.target_techs
+      {% end %}
+      else
+        [] of String
+      end
+    {% end %}
+  end
+
+  def self.taggers : Array(Entry)
+    PLAIN_ENTRIES
+  end
+
+  def self.framework_taggers : Array(Entry)
+    FRAMEWORK_ENTRIES
   end
 
   def self.available_tagger_names : Array(String)
-    names = [] of String
-    HasTaggers.each_key { |name| names << name.to_s }
-    HasFrameworkTaggers.each_key { |name| names << name.to_s }
+    names = ENTRIES.map(&.key)
     names << "all"
     names.sort
   end
@@ -271,19 +109,20 @@ module NoirTaggers
 
     logger = build_logger(options)
 
-    # Every entry in HasTaggers maps a tagger key to a runnable Tagger
-    # subclass, and the key IS the tagger's `name` — so an unselected tagger
-    # can be skipped without constructing it (each `new` builds a logger and
-    # resolves options). Run the selected ones; a single tagger raising must
-    # not abort the rest of the tagging pass (or, for framework taggers below,
-    # tear down the whole program from inside a fiber) — degrade to "this
-    # tagger failed".
-    HasTaggers.each do |key, tagger|
-      next unless is_all || use_taggers_arr.includes?(key.to_s)
+    # The registry key IS the tagger's `name` (`Tagger#initialize` reads it
+    # back off the class), so an unselected tagger can be skipped without
+    # constructing it — each `new` builds a logger and resolves options. Run
+    # the selected ones in registry order, which is user-visible: tags are
+    # appended in the order taggers run and nothing sorts them before
+    # output. A single tagger raising must not abort the rest of the pass
+    # (or, for framework taggers below, tear down the whole program from
+    # inside a fiber) — degrade to "this tagger failed".
+    PLAIN_ENTRIES.each do |entry|
+      next unless is_all || use_taggers_arr.includes?(entry.key)
       begin
-        tagger[:runner].new(options).perform(endpoints)
+        build(entry.key, options).try(&.perform(endpoints))
       rescue ex
-        logger.warning "Tagger '#{key}' failed: #{ex.message}"
+        logger.warning "Tagger '#{entry.key}' failed: #{ex.message}"
       end
     end
 
@@ -317,15 +156,14 @@ module NoirTaggers
 
     # Collect tagger work items, then run in parallel
     WaitGroup.wait do |wg|
-      HasFrameworkTaggers.each do |key, tagger_info|
+      FRAMEWORK_ENTRIES.each do |entry|
         # The registry key is the tagger's `name`, so selection is decided
         # before construction — an unselected tagger no longer pays for a
         # logger and a base-path resolution just to be discarded.
-        next unless is_all || use_taggers_arr.includes?(key.to_s)
+        next unless is_all || use_taggers_arr.includes?(entry.key)
 
-        target_techs = tagger_info[:runner].target_techs
         matching_endpoints = [] of Endpoint
-        target_techs.each do |tech|
+        target_techs(entry.key).each do |tech|
           if endpoints_by_tech.has_key?(tech)
             matching_endpoints.concat(endpoints_by_tech[tech])
           end
@@ -334,7 +172,8 @@ module NoirTaggers
         next if matching_endpoints.empty?
 
         # Bind to local variables to ensure each fiber captures its own copy
-        local_instance = tagger_info[:runner].new(options)
+        local_instance = build(entry.key, options)
+        next if local_instance.nil?
         local_endpoints = matching_endpoints
 
         wg.spawn do

--- a/src/tagger/taggers/account_recovery.cr
+++ b/src/tagger/taggers/account_recovery.cr
@@ -7,6 +7,7 @@ require "../../models/endpoint"
 # takeover surface: review for reset-token leakage, host-header
 # injection in reset links, account enumeration, missing rate limiting,
 # and weak step-up verification.
+@[Noir::TaggerFor(key: "account_recovery", name: "Account Recovery Tagger", desc: "Identifies credential-management and account-recovery endpoints (password reset/change, MFA/OTP, verification)", order: 170)]
 class AccountRecoveryTagger < Tagger
   # Path segments that on their own mark a credential/recovery action.
   # `password`/`mfa`/`otp`/`forgot` are not benign as a standalone path

--- a/src/tagger/taggers/admin.cr
+++ b/src/tagger/taggers/admin.cr
@@ -5,6 +5,7 @@ require "../../models/endpoint"
 # targets for broken access control, privilege escalation, and forced
 # browsing — surfacing them tells a reviewer where the blast radius of a
 # missing authorization check is largest.
+@[Noir::TaggerFor(key: "admin", name: "Admin Tagger", desc: "Identifies administrative and privileged endpoints", order: 110)]
 class AdminTagger < Tagger
   # Path segments that strongly imply an administrative surface. Matched
   # as whole path segments (after splitting on `/`, `-`, `_`, `.`) so

--- a/src/tagger/taggers/api_docs.cr
+++ b/src/tagger/taggers/api_docs.cr
@@ -6,6 +6,7 @@ require "../../models/endpoint"
 # expose the full API surface (every route, parameter, and model) and
 # are very frequently reachable without authentication, so they are a
 # high-value recon target and an information-disclosure risk.
+@[Noir::TaggerFor(key: "api_docs", name: "API Docs Tagger", desc: "Identifies API documentation/schema endpoints (Swagger, OpenAPI, GraphiQL, ReDoc, WSDL)", order: 160)]
 class ApiDocsTagger < Tagger
   # Matched against slash/dot-delimited segments (hyphens and
   # underscores kept inside a segment) so `/swagger-ui.html`,

--- a/src/tagger/taggers/cors.cr
+++ b/src/tagger/taggers/cors.cr
@@ -1,6 +1,7 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+@[Noir::TaggerFor(key: "cors", name: "CORS Tagger", desc: "Identifies CORS endpoints", order: 30)]
 class CorsTagger < Tagger
   def initialize(options : Hash(String, YAML::Any))
     super

--- a/src/tagger/taggers/crypto.cr
+++ b/src/tagger/taggers/crypto.cr
@@ -9,6 +9,7 @@ require "../../models/endpoint"
 # `key`, `sign`, and `verify` are deliberately *not* standalone signals:
 # "API key", "sign in", and "verify email" are overwhelmingly non-crypto.
 # Bare auth routes (`/signin`, `/signup`) therefore never match here.
+@[Noir::TaggerFor(key: "crypto", name: "Crypto Tagger", desc: "Identifies cryptographic operation endpoints (encryption, signing, hashing, key management)", order: 140)]
 class CryptoTagger < Tagger
   # Unambiguous crypto path segments — one is enough. Matched as whole
   # segments after splitting on `/`, `-`, `_`, `.`. Includes named

--- a/src/tagger/taggers/debug.cr
+++ b/src/tagger/taggers/debug.cr
@@ -8,6 +8,7 @@ require "../../models/endpoint"
 # heap contents, and some allow unsafe diagnostic actions (shutdown, GC,
 # logger changes). Surfacing them points a reviewer at a high-value,
 # frequently-misexposed surface.
+@[Noir::TaggerFor(key: "debug", name: "Debug Tagger", desc: "Identifies debug, diagnostic, and internal-only endpoints (debug consoles, profilers, actuator, pprof, internal APIs)", order: 150)]
 class DebugTagger < Tagger
   # Unambiguous debug/diagnostic path segments — one is enough. Matched
   # as whole segments after splitting on `/`, `-`, `_`, `.`, so

--- a/src/tagger/taggers/file_upload.cr
+++ b/src/tagger/taggers/file_upload.cr
@@ -1,6 +1,7 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+@[Noir::TaggerFor(key: "file_upload", name: "FileUpload Tagger", desc: "Identifies file upload endpoints", order: 90)]
 class FileUploadTagger < Tagger
   # Param names that denote an actual uploaded file regardless of how the
   # value is carried — a `filename`, an `attachment`, a `multipart`

--- a/src/tagger/taggers/graphql.cr
+++ b/src/tagger/taggers/graphql.cr
@@ -1,6 +1,7 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+@[Noir::TaggerFor(key: "graphql", name: "GraphQL Tagger", desc: "Identifies GraphQL endpoints", order: 60)]
 class GraphqlTagger < Tagger
   WORDS = ["query", "mutation", "subscription", "operationname", "__schema", "__type", "graphql", "variables"]
 

--- a/src/tagger/taggers/hunt_param.cr
+++ b/src/tagger/taggers/hunt_param.cr
@@ -1,6 +1,7 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+@[Noir::TaggerFor(key: "hunt", name: "HuntParam Tagger", desc: "Identifies common parameters vulnerable to certain vulnerability classes", order: 10)]
 class HuntParamTagger < Tagger
   PATH_ALLOWED_TAGS     = Set{"idor", "file-inclusion"}
   BODY_LIKE_PARAM_TYPES = Set{"json", "form", "body"}

--- a/src/tagger/taggers/jwt.cr
+++ b/src/tagger/taggers/jwt.cr
@@ -1,6 +1,7 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+@[Noir::TaggerFor(key: "jwt", name: "JWT Tagger", desc: "Identifies JWT authentication endpoints", order: 80)]
 class JwtTagger < Tagger
   STRONG_NAMES = Set{
     "jwt", "bearer", "authorization", "access_token", "refresh_token", "id_token",

--- a/src/tagger/taggers/mcp.cr
+++ b/src/tagger/taggers/mcp.cr
@@ -1,6 +1,7 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+@[Noir::TaggerFor(key: "mcp", name: "MCP Tagger", desc: "Identifies Model Context Protocol endpoints", order: 70)]
 class McpTagger < Tagger
   LEGACY_SSE_SEGMENT      = "sse"
   LEGACY_MESSAGE_SEGMENTS = ["message", "messages"]

--- a/src/tagger/taggers/oauth.cr
+++ b/src/tagger/taggers/oauth.cr
@@ -1,6 +1,7 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+@[Noir::TaggerFor(key: "oauth", name: "OAuth Tagger", desc: "Identifies OAuth endpoints", order: 20)]
 class OAuthTagger < Tagger
   WORDS = Set{
     "grant_type", "code", "redirect_uri", "redirect_url", "client_id", "client_secret",

--- a/src/tagger/taggers/payment.cr
+++ b/src/tagger/taggers/payment.cr
@@ -6,6 +6,7 @@ require "../../models/endpoint"
 # flaws (amount/price tampering, currency confusion, negative amounts),
 # IDOR on financial records, and replay. Surfacing them helps a reviewer
 # focus on the highest-stakes surface.
+@[Noir::TaggerFor(key: "payment", name: "Payment Tagger", desc: "Identifies payment and financial transaction endpoints", order: 120)]
 class PaymentTagger < Tagger
   # Path segments that strongly imply a payment/financial surface.
   # Matched as whole path segments after splitting on `/`, `-`, `_`, `.`.

--- a/src/tagger/taggers/pii.cr
+++ b/src/tagger/taggers/pii.cr
@@ -6,6 +6,7 @@ require "../../models/endpoint"
 # targets for data exposure, broken object-level authorization, and
 # sensitive-data logging — knowing *which* routes touch PII lets a
 # reviewer (or an AI consumer) prioritize accordingly.
+@[Noir::TaggerFor(key: "pii", name: "PII Tagger", desc: "Identifies endpoints handling personally identifiable information", order: 100)]
 class PiiTagger < Tagger
   # Unambiguous, high-signal identifiers. A single one is enough to flag
   # the endpoint because these names rarely appear outside a PII context.

--- a/src/tagger/taggers/soap.cr
+++ b/src/tagger/taggers/soap.cr
@@ -5,6 +5,7 @@ require "../../models/endpoint"
 # specific review (XXE, SOAP-action spoofing, WS-Security handling) that
 # differs from a typical REST/JSON route, so calling them out helps a
 # reviewer pick the right lens.
+@[Noir::TaggerFor(key: "soap", name: "SOAP Tagger", desc: "Identifies SOAP endpoints", order: 40)]
 class SoapTagger < Tagger
   # Request headers that mark a SOAP call. `SOAPAction` is mandatory in
   # SOAP 1.1; `Content-Type: application/soap+xml` is the SOAP 1.2 marker.

--- a/src/tagger/taggers/webhook.cr
+++ b/src/tagger/taggers/webhook.cr
@@ -6,6 +6,7 @@ require "../../models/endpoint"
 # VCS hosts, CI, messaging platforms). They warrant scrutiny for
 # signature verification, replay protection, and source-IP trust, and
 # the handlers often make outbound requests (SSRF surface).
+@[Noir::TaggerFor(key: "webhook", name: "Webhook Tagger", desc: "Identifies inbound webhook and callback endpoints", order: 130)]
 class WebhookTagger < Tagger
   # Unambiguous webhook path segments — one is enough.
   STRONG_PATH_PARTS = Set{"webhook", "webhooks", "ipn"}

--- a/src/tagger/taggers/websocket.cr
+++ b/src/tagger/taggers/websocket.cr
@@ -4,6 +4,7 @@ require "../../models/endpoint"
 # Flags WebSocket endpoints — long-lived, bidirectional channels whose
 # threat model (origin checks on the handshake, per-message authz, no
 # CSRF token on the upgrade) differs from a request/response route.
+@[Noir::TaggerFor(key: "websocket", name: "Websocket Tagger", desc: "Identifies Websocket endpoints", order: 50)]
 class WebsocketTagger < Tagger
   # AsyncAPI specs carry the raw server protocol (`ws`, `wss`,
   # `websocket`); HTTP analyzers set `ws`. Accept every spelling so


### PR DESCRIPTION
Seventh PR of the structural-contract series (after #2488–#2493). Behaviour-neutral.

## Why

`NoirTaggers` kept two hand-maintained hash literals — `HasTaggers` (17 entries) and `HasFrameworkTaggers` (26) — mapping a `-T` key to a display name, a description, and the class that runs it. **A new tagger file that nobody added to them compiled, shipped, and silently never ran.** Nothing linked the two halves together and no spec looked at either.

The analyzer and detector registries stopped working this way in #2384. `registry_integrity_spec.cr` says so in its own header: those lists *"should end up in"* the derived shape, and these specs are the stopgap until they do. This is the tagger half.

## Design

Taggers declare themselves with an annotation, mirroring `Noir::OutputFormat` on the output builders (#2485):

```crystal
@[Noir::TaggerFor(key: "hunt", name: "HuntParam Tagger", desc: "…", order: 10)]
class HuntParamTagger < Tagger
```

Three choices worth calling out, because the obvious alternatives are wrong here:

**Annotation presence selects the class, not `abstract?` + a namespace prefix** (the `detector_for` shape). `Tagger` and `FrameworkTagger` are instantiated *directly* by twelve examples across `models/tagger_spec.cr` and `models/framework_tagger_spec.cr`, which exercise the base `perform`. Making them abstract to exclude them would delete tested behaviour; leaving them un-annotated costs nothing.

**`key` stays explicit** rather than derived from the class name — four of the 43 do not follow from it: `hunt`←`HuntParamTagger`, `oauth`←`OAuthTagger`, `fastapi_auth`←`FastAPIAuthTagger`, `fastendpoints_auth`←`FastEndpointsAuthTagger`.

**`order` is load-bearing, not decoration.** Plain taggers run sequentially in registry order, `Endpoint#add_tag` appends, and nothing sorts tags before output — so registry order is user-visible in `-f json` and `-f only-tag`. Sorting by class name instead would have reordered tag arrays repo-wide.

`Entry` carries no `runner` field: storing the class object erases `self.target_techs` (it lives on `FrameworkTagger`, not `Tagger`), so every read would need a cast back. Two macro-generated `case` dispatchers resolve per concrete class instead — the same shape `Noir::OutputFormats.render` already uses.

`Tagger#initialize` now reads `@name` off the class. `run_tagger`'s invariant that *"the registry key IS the tagger's name"* — previously a comment 43 files had to observe — is structural, and a spec asserts it. The 43 `@name = "…"` assignments are now redundant; removing them is mechanical and gets its own commit.

## Enforcement

`registry_integrity_spec.cr` gains five tagger assertions. The load-bearing one is that **every concrete `Tagger` subclass carries the annotation** — without it, the derivation just moves the silent-omission failure one step. Verified it bites by deleting one annotation:

```
tagger classes with no Noir::TaggerFor annotation (they will never run): ["CorsTagger"]
```

The others: unique keys that don't collide with the `all` sentinel, non-empty name/desc, runtime `name` equals registry key, and every framework tagger's `target_techs` names a real catalog tech.

## Verification

`noir list taggers` is **byte-identical in text, JSON and YAML**.

A/B over 665 fixture directories with `-T`, comparing **raw tag arrays in order** — deliberately not sorted, since sorting would hide exactly the regression at risk here. 1,215 tags, no difference. (The sweep's one reported diff is `spring_context_bare`'s URL, fixed by #2489, which the baseline binary predates — no tag array differs.)

`crystal spec spec/unit_test` 4677 examples, also green under `--order random`; `spec/functional_test` 22653 examples; `just check` 1910 files. 0 failures throughout.