### PR TITLE
refactor(url-path): move join_path onto URLPath and ban the bare names

### DIFF
--- a/spec/unit_test/utils/join_naming_spec.cr
+++ b/spec/unit_test/utils/join_naming_spec.cr
@@ -1,0 +1,56 @@
+require "../../spec_helper"
+require "../../../src/utils/url_path"
+
+# `join_path` / `join_paths` was 21 definitions with 12 distinct behaviours,
+# two of them at top level: `Object#join_paths` (a `File.join` alias, in
+# `src/analyzer/analyzer.cr`) and a variadic `join_path` in
+# `src/utils/utils.cr`. Crystal resolves by type, not by lexical namespace,
+# so unqualified calls in `java/spring.cr` and `kotlin/spring.cr` fell
+# through to the `File.join` one and composed URLs with filesystem-path
+# semantics — `"/portal" + ""` became `"/portal/"`. See #2489.
+#
+# Both names are now banned. Shared semantics live on `Noir::URLPath` under
+# names that state the rule (`join`, `join_trimmed`, `join_absorbing`,
+# `join_rooted`, `absolute_join`); a framework-specific joiner is named
+# after the construct it composes (`nest_join`, `group_join`, `mount_join`,
+# `namespace_join`, `route_scope_join`, …). See #2493.
+#
+# The compiler covers the *call* side for free: with no top-level
+# definition, a bare `join_paths(a, b)` is a compile error. It cannot cover
+# the *definition* side — nothing stops a new `private def join_paths`
+# inside a class, which is exactly how the collision grew to 21. That is
+# what this spec is for.
+#
+# A top-level poison definition would be worse than useless here: Crystal
+# resolves by overload specificity, so re-adding `def join_paths(prefix :
+# String, path : String)` would simply win over a poison `def
+# join_paths(*args)` and the trap would never fire.
+BANNED_JOIN_DEF = /^\s*(?:private\s+|protected\s+)?def\s+(?:self\.)?join_paths?\b/
+
+describe "path-joining method names" do
+  sources = Dir.glob("src/**/*.cr").sort
+
+  it "defines no method named join_path or join_paths under src/" do
+    offenders = sources.flat_map do |file|
+      File.read_lines(file).each_with_index.compact_map do |line, index|
+        "#{file}:#{index + 1}: #{line.strip}" if line.matches?(BANNED_JOIN_DEF)
+      end
+    end
+
+    fail <<-MSG unless offenders.empty?
+      `join_path` / `join_paths` are banned names — they collided across 21
+      definitions with 12 behaviours. Put shared semantics on
+      `Noir::URLPath`, or name the method after the framework construct it
+      composes. Offending definitions:
+        #{offenders.join("\n  ")}
+      MSG
+  end
+
+  # Guards the guard: a typo in the glob would make the example above pass
+  # vacuously, which is the failure mode that makes source-scanning specs
+  # worthless.
+  it "scans the whole source tree" do
+    sources.size.should be > 500
+    sources.count { |f| File.read(f).includes?("Noir::URLPath") }.should be > 20
+  end
+end

--- a/spec/unit_test/utils/url_path_spec.cr
+++ b/spec/unit_test/utils/url_path_spec.cr
@@ -150,3 +150,33 @@ describe "Noir::URLPath.join_rooted" do
     Noir::URLPath.join_rooted("", "").should eq "/"
   end
 end
+
+# Relocated verbatim from `spec/unit_test/utils/utils_spec.cr`, where they
+# covered the top-level `join_path`. Only the receiver changed — the
+# assertions standing unaltered is the evidence the move preserved
+# behaviour.
+describe "Noir::URLPath.absolute_join" do
+  it "joins two segments" do
+    Noir::URLPath.absolute_join("/api", "users").should eq("/api/users")
+  end
+
+  it "collapses a double slash at the boundary" do
+    Noir::URLPath.absolute_join("/api", "/users").should eq("/api/users")
+  end
+
+  it "strips trailing slashes from segments" do
+    Noir::URLPath.absolute_join("api/", "/v1/").should eq("/api/v1")
+  end
+
+  it "skips empty segments" do
+    Noir::URLPath.absolute_join("", "users").should eq("/users")
+  end
+
+  it "joins three segments (variadic)" do
+    Noir::URLPath.absolute_join("a", "b", "c").should eq("/a/b/c")
+  end
+
+  it "always prepends a leading slash" do
+    Noir::URLPath.absolute_join("noslash").should eq("/noslash")
+  end
+end

--- a/spec/unit_test/utils/utils_spec.cr
+++ b/spec/unit_test/utils/utils_spec.cr
@@ -124,29 +124,3 @@ describe "escape_glob_path" do
     escape_glob_path("/x/{a}[b]*?\\c").should eq("/x/\\{a\\}\\[b\\]\\*\\?\\\\c")
   end
 end
-
-describe "join_path" do
-  it "joins two segments" do
-    join_path("/api", "users").should eq("/api/users")
-  end
-
-  it "collapses a double slash at the boundary" do
-    join_path("/api", "/users").should eq("/api/users")
-  end
-
-  it "strips trailing slashes from segments" do
-    join_path("api/", "/v1/").should eq("/api/v1")
-  end
-
-  it "skips empty segments" do
-    join_path("", "users").should eq("/users")
-  end
-
-  it "joins three segments (variadic)" do
-    join_path("a", "b", "c").should eq("/a/b/c")
-  end
-
-  it "always prepends a leading slash" do
-    join_path("noslash").should eq("/noslash")
-  end
-end

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
 require "./clojure_helper"
+require "../../../utils/url_path"
 
 module Analyzer::Clojure
   class Compojure < Analyzer
@@ -88,7 +89,7 @@ module Analyzer::Clojure
           when "context"
             context_path, _ = route_path_literal(source, after_symbol, form_end)
             context_path = normalize_route_path(context_path) if context_path
-            next_prefix = context_path ? join_path(prefix, context_path) : prefix
+            next_prefix = context_path ? Noir::URLPath.absolute_join(prefix, context_path) : prefix
             scan_forms(source, after_symbol, form_end, next_prefix, path, include_callee)
           when "defroutes", "routes"
             scan_forms(source, after_symbol, form_end, prefix, path, include_callee)
@@ -121,7 +122,7 @@ module Analyzer::Clojure
       return unless raw_route_path
       route_path = normalize_route_path(raw_route_path)
 
-      full_path = join_path(prefix, route_path)
+      full_path = Noir::URLPath.absolute_join(prefix, route_path)
       endpoint = Endpoint.new(full_path, method, Details.new(PathInfo.new(path, Helper.line_number_for(source, form_start))))
 
       path_param_names = extract_path_param_names(route_path)

--- a/src/analyzer/analyzers/clojure/pedestal.cr
+++ b/src/analyzer/analyzers/clojure/pedestal.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
 require "./clojure_helper"
+require "../../../utils/url_path"
 
 module Analyzer::Clojure
   class Pedestal < Analyzer
@@ -130,7 +131,7 @@ module Analyzer::Clojure
         # a phantom endpoint (`join_path` would otherwise force a leading `/`).
         if route_path && route_path.starts_with?("/")
           handler_range = helper_handler_range(source, route_literal_end + 1, list_end)
-          emit_endpoint(source, list_start, join_path(prefix, route_path), method, path, seen, include_callee, function_callees, handler_range)
+          emit_endpoint(source, list_start, Noir::URLPath.absolute_join(prefix, route_path), method, path, seen, include_callee, function_callees, handler_range)
           true
         else
           false
@@ -163,7 +164,7 @@ module Analyzer::Clojure
       if i < limit && source.byte_at(i).unsafe_chr == '{'
         map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
         if map_end > i
-          current_prefix = join_path(prefix, extract_context(source, i + 1, map_end) || "")
+          current_prefix = Noir::URLPath.absolute_join(prefix, extract_context(source, i + 1, map_end) || "")
           i = map_end + 1
         end
       end
@@ -208,7 +209,7 @@ module Analyzer::Clojure
           map_end = Helper.find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
           if context = extract_context(source, i + 1, map_end)
-            current_prefix = join_path(prefix, context)
+            current_prefix = Noir::URLPath.absolute_join(prefix, context)
           else
             process_route_map(source, i, map_end, current_prefix, path, seen, include_callee, function_callees)
           end
@@ -241,7 +242,7 @@ module Analyzer::Clojure
       route_path = decode_string_literal(source.byte_slice(i, str_end - i + 1))
       return false unless route_path.starts_with?("/")
 
-      full_path = join_path(prefix, route_path)
+      full_path = Noir::URLPath.absolute_join(prefix, route_path)
       body_start = skip_ws_and_comments(source, str_end + 1, vec_end)
       return true if body_start >= vec_end
 
@@ -300,7 +301,7 @@ module Analyzer::Clojure
                                   seen : Set(String),
                                   include_callee : Bool,
                                   function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry))) : Bool
-      context_prefix = join_path(prefix, extract_context(source, map_start + 1, map_end) || "")
+      context_prefix = Noir::URLPath.absolute_join(prefix, extract_context(source, map_start + 1, map_end) || "")
       verbose = process_verbose_map(source, map_start + 1, map_end, context_prefix, path, seen, include_callee, function_callees)
       path_keyed = process_path_keyed_map(source, map_start + 1, map_end, context_prefix, path, seen, include_callee, function_callees)
       verbose || path_keyed
@@ -341,7 +342,7 @@ module Analyzer::Clojure
       route_path_value = route_path
       return false unless route_path_value
 
-      full_path = join_path(prefix, route_path_value)
+      full_path = Noir::URLPath.absolute_join(prefix, route_path_value)
       if range = verbs_range
         v_start, v_end = range
         if v_start < v_end && source.byte_at(v_start).unsafe_chr == '{'
@@ -372,7 +373,7 @@ module Analyzer::Clojure
         next unless route_path.starts_with?("/")
         handled = true
 
-        full_path = join_path(prefix, route_path)
+        full_path = Noir::URLPath.absolute_join(prefix, route_path)
         if value_start < value_end
           case source.byte_at(value_start).unsafe_chr
           when '{'

--- a/src/analyzer/analyzers/clojure/reitit.cr
+++ b/src/analyzer/analyzers/clojure/reitit.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
 require "./clojure_helper"
+require "../../../utils/url_path"
 
 module Analyzer::Clojure
   # Reitit is data-driven: routes are a vector tree
@@ -185,7 +186,7 @@ module Analyzer::Clojure
       return if str_end <= i
 
       route_path = decode_string_literal(source.byte_slice(i, str_end - i + 1))
-      new_prefix = join_path(prefix, route_path)
+      new_prefix = Noir::URLPath.absolute_join(prefix, route_path)
 
       # `["/path" handler]` — a bare handler (symbol / `#'var` / inline
       # `(fn …)`) in the data position is reitit shorthand for

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -341,7 +341,7 @@ module Analyzer::Kotlin
             Dir.glob("#{escape_glob_path(full_resource_path)}/**/*") do |file|
               next if File.directory?(file)
               relative_path = file.sub(full_resource_path, "")
-              full_url = join_path(webflux_base_path, relative_path)
+              full_url = Noir::URLPath.absolute_join(webflux_base_path, relative_path)
               @result << Endpoint.new(full_url, "GET", Details.new(PathInfo.new(file)))
             end
           end
@@ -351,7 +351,7 @@ module Analyzer::Kotlin
             Dir.glob("#{escape_glob_path(file_path)}/**/*") do |file|
               next if File.directory?(file)
               relative_path = file.sub(file_path, "")
-              full_url = join_path(webflux_base_path, relative_path)
+              full_url = Noir::URLPath.absolute_join(webflux_base_path, relative_path)
               @result << Endpoint.new(full_url, "GET", Details.new(PathInfo.new(file)))
             end
           end

--- a/src/utils/url_path.cr
+++ b/src/utils/url_path.cr
@@ -111,5 +111,26 @@ module Noir
       return "/" if joined.empty?
       joined.starts_with?('/') ? joined : "/#{joined}"
     end
+
+    # Variadic absolute join: drop empty segments, trim one trailing and
+    # every leading slash from each, and guarantee a rooted result.
+    #
+    # Lived in `src/utils/utils.cr` as a top-level `join_path` — a URL
+    # routine in the generic utils file, one `grep join_path` away from
+    # being mistaken for any of the methods above. It is not expressible
+    # as a fold of them: `absolute_join("api/", "/v1/")` is `"/api/v1"`
+    # where folding `join_rooted` gives `"/api/v1/"`, because the trailing
+    # slash is trimmed per segment rather than at the seam.
+    #
+    # Used by the Clojure analyzers, whose route DSLs compose bare
+    # segments, and by Kotlin Spring's WebFlux path assembly.
+    def self.absolute_join(*segments : String) : String
+      path = segments
+        .reject(&.empty?)
+        .map(&.chomp("/").lstrip("/"))
+        .join("/")
+
+      path.starts_with?("/") ? path : "/#{path}"
+    end
   end
 end

--- a/src/utils/utils.cr
+++ b/src/utils/utils.cr
@@ -31,15 +31,6 @@ def get_relative_path(base_path : String, path : String) : String
   remove_start_slash(relative_path)
 end
 
-def join_path(*segments : String) : String
-  path = segments
-    .reject(&.empty?)
-    .map(&.chomp("/").lstrip("/"))
-    .join("/")
-
-  path.starts_with?("/") ? path : "/#{path}"
-end
-
 def any_to_bool(any) : Bool
   case any.to_s.downcase
   when "false", "no"


### PR DESCRIPTION
Closes the join-naming series (#2489, #2491, #2493). Behaviour-neutral.

## What

`src/utils/utils.cr` held the last top-level joiner — a variadic `join_path`. A URL routine sitting in the generic utils file, one `grep join_path` away from being mistaken for any of the `Noir::URLPath` methods, and reachable by accident from anywhere in the program. It moves to `Noir::URLPath.absolute_join`, body unchanged, along with its twelve call sites (the three Clojure analyzers, whose route DSLs compose bare segments, and Kotlin Spring's WebFlux path assembly).

It earns its own slot rather than folding into `join_rooted`: `absolute_join("api/", "/v1/")` is `/api/v1` where folding `join_rooted` gives `/api/v1/`, because the trailing slash is trimmed **per segment** rather than at the seam.

## The ban

`spec/unit_test/utils/join_naming_spec.cr`: no method named `join_path` or `join_paths` may be defined anywhere under `src/`.

The division of labour is deliberate:

- **The compiler owns the call side, for free.** With no top-level definition left, a bare `join_paths(a, b)` is `undefined local variable or method`. That is what makes #2489's silent `File.join` fallthrough *impossible* rather than merely fixed.
- **The type system cannot own the definition side.** Nothing stops a new `private def join_paths` inside a class — which is exactly how the collision grew to 21 definitions with 12 distinct behaviours. Only a source scan sees it.
- **A poison definition would be worse than useless.** Crystal resolves by overload specificity, so re-adding a two-argument `join_paths` would simply win over a poison `def join_paths(*args)` and the trap would never fire.

The spec also asserts its own glob actually matched the tree — a source-scanning spec that silently matches nothing is worse than no spec. Verified it bites by re-adding a `join_paths` to `utils.cr`:

```
src/utils/utils.cr:74: def join_paths(a : String, b : String) : String
```

## Where the series landed

`Noir::URLPath` now holds the five shared rules — `join`, `join_trimmed`, `join_absorbing`, `join_rooted`, `absolute_join` — each named for what it does at the seam. Every other joiner is named for the framework construct it composes (`nest_join`, `group_join`, `mount_join`, `namespace_join`, `route_scope_join`, …). `grep join_paths src/` now returns nothing, so there is no longer a wrong one to pick.

## Verification

The six `join_path` examples move to `url_path_spec.cr` with **only the receiver changed** — the assertions standing unaltered is the evidence the move preserved behaviour.

STRICT A/B over all 665 fixture directories, against a baseline rebuilt from current `main`: byte-identical, 5,160 endpoints.

`crystal spec spec/unit_test` 4674 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1911 files, 0 findings.