### PR TITLE
refactor(tagger): set the tagger name from its registry key

### DIFF
--- a/src/tagger/framework_taggers/crystal/crystal_auth.cr
+++ b/src/tagger/framework_taggers/crystal/crystal_auth.cr
@@ -35,11 +35,6 @@ class CrystalAuthTagger < FrameworkTagger
     {/context\.session/, "Crystal session check"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "crystal_auth"
-  end
-
   def self.target_techs : Array(String)
     ["crystal_kemal", "crystal_amber", "crystal_lucky", "crystal_grip", "crystal_marten"]
   end

--- a/src/tagger/framework_taggers/csharp/aspnet_auth.cr
+++ b/src/tagger/framework_taggers/csharp/aspnet_auth.cr
@@ -27,11 +27,6 @@ class AspnetAuthTagger < FrameworkTagger
     {/HttpContext\.User/, "ASP.NET HttpContext.User check"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "aspnet_auth"
-  end
-
   def self.target_techs : Array(String)
     ["cs_aspnet_mvc", "cs_aspnet_core_mvc", "cs_aspnet_core_minimal_api", "cs_carter"]
   end

--- a/src/tagger/framework_taggers/csharp/fastendpoints_auth.cr
+++ b/src/tagger/framework_taggers/csharp/fastendpoints_auth.cr
@@ -10,11 +10,6 @@ class FastEndpointsAuthTagger < FrameworkTagger
   POLICY_PATTERN          = /\bPolicy\s*\(/
   CLAIMS_PATTERN          = /\bClaims\s*\(/
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "fastendpoints_auth"
-  end
-
   def self.target_techs : Array(String)
     ["cs_fastendpoints"]
   end

--- a/src/tagger/framework_taggers/elixir/elixir_auth.cr
+++ b/src/tagger/framework_taggers/elixir/elixir_auth.cr
@@ -41,7 +41,6 @@ class ElixirAuthTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "elixir_auth"
     @auth_scopes = [] of {prefix: String, description: String}
   end
 

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -48,7 +48,6 @@ class GoAuthTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "go_auth"
     @middleware_scopes = [] of {prefix: String, middleware: String, description: String, root_group: Bool}
   end
 

--- a/src/tagger/framework_taggers/go/go_security.cr
+++ b/src/tagger/framework_taggers/go/go_security.cr
@@ -72,7 +72,6 @@ class GoSecurityTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "go_security"
     @middleware_scopes = [] of NamedTuple(prefix: String, tag: String, description: String)
   end
 

--- a/src/tagger/framework_taggers/java/java_misc_auth.cr
+++ b/src/tagger/framework_taggers/java/java_misc_auth.cr
@@ -33,11 +33,6 @@ class JavaMiscAuthTagger < FrameworkTagger
     {/<auth-constraint>/, "web.xml auth-constraint"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "java_misc_auth"
-  end
-
   def self.target_techs : Array(String)
     ["java_vertx", "java_armeria", "java_jsp"]
   end

--- a/src/tagger/framework_taggers/java/spring_auth.cr
+++ b/src/tagger/framework_taggers/java/spring_auth.cr
@@ -28,7 +28,6 @@ class SpringAuthTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "spring_auth"
     @security_rules = [] of NamedTuple(pattern: String, method: String?, description: String, protected_rule: Bool)
   end
 

--- a/src/tagger/framework_taggers/java/spring_security.cr
+++ b/src/tagger/framework_taggers/java/spring_security.cr
@@ -75,7 +75,6 @@ class SpringSecurityTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "spring_security"
     @csrf_disable_scopes = [] of String
     @csrf_ignored_scopes = [] of String
     @header_weak_scopes = [] of NamedTuple(pattern: String, kind: Symbol)

--- a/src/tagger/framework_taggers/javascript/express_auth.cr
+++ b/src/tagger/framework_taggers/javascript/express_auth.cr
@@ -27,7 +27,6 @@ class ExpressAuthTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "express_auth"
     @app_use_auth_patterns = [] of {prefix: String, description: String}
   end
 

--- a/src/tagger/framework_taggers/javascript/hono_auth.cr
+++ b/src/tagger/framework_taggers/javascript/hono_auth.cr
@@ -29,7 +29,6 @@ class HonoAuthTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "hono_auth"
     @use_auth_scopes = [] of {prefix: String, description: String}
   end
 

--- a/src/tagger/framework_taggers/javascript/js_misc_auth.cr
+++ b/src/tagger/framework_taggers/javascript/js_misc_auth.cr
@@ -43,11 +43,6 @@ class JsMiscAuthTagger < FrameworkTagger
     {/\bauthMiddleware\b/, "authMiddleware"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "js_misc_auth"
-  end
-
   def self.target_techs : Array(String)
     ["js_fastify", "js_koa", "js_restify", "js_nuxtjs"]
   end

--- a/src/tagger/framework_taggers/javascript/nestjs_auth.cr
+++ b/src/tagger/framework_taggers/javascript/nestjs_auth.cr
@@ -45,7 +45,6 @@ class NestjsAuthTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "nestjs_auth"
     @class_guards = Hash(String, String).new
   end
 

--- a/src/tagger/framework_taggers/kotlin/ktor_auth.cr
+++ b/src/tagger/framework_taggers/kotlin/ktor_auth.cr
@@ -19,7 +19,6 @@ class KtorAuthTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "ktor_auth"
     @auth_scopes = [] of {prefix: String, description: String}
   end
 

--- a/src/tagger/framework_taggers/perl/perl_auth.cr
+++ b/src/tagger/framework_taggers/perl/perl_auth.cr
@@ -44,11 +44,6 @@ class PerlAuthTagger < FrameworkTagger
 
   GLOBAL_GUARD_BLOCK_START = /\bhook\s+before\b|\bbefore\s*=>\s*sub\b|\bsub\s+auto\b|\bsub\s+begin\b/
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "perl_auth"
-  end
-
   def self.target_techs : Array(String)
     ["perl_dancer2", "perl_mojolicious", "perl_catalyst"]
   end

--- a/src/tagger/framework_taggers/php/php_auth.cr
+++ b/src/tagger/framework_taggers/php/php_auth.cr
@@ -75,11 +75,6 @@ class PhpAuthTagger < FrameworkTagger
     {/\bauthFilter\b/i, "CodeIgniter authFilter"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "php_auth"
-  end
-
   def self.target_techs : Array(String)
     [
       "php_laravel", "php_symfony", "php_cakephp", "php_pure",

--- a/src/tagger/framework_taggers/python/django_auth.cr
+++ b/src/tagger/framework_taggers/python/django_auth.cr
@@ -26,11 +26,6 @@ class DjangoAuthTagger < FrameworkTagger
     /permission_classes\s*=\s*\(.*DjangoModelPermissions/,
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "django_auth"
-  end
-
   def self.target_techs : Array(String)
     ["python_django"]
   end

--- a/src/tagger/framework_taggers/python/fastapi_auth.cr
+++ b/src/tagger/framework_taggers/python/fastapi_auth.cr
@@ -31,11 +31,6 @@ class FastAPIAuthTagger < FrameworkTagger
     {/:\s*HTTPAuthorizationCredentials\s*=\s*Security/, "FastAPI HTTP authorization"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "fastapi_auth"
-  end
-
   def self.target_techs : Array(String)
     ["python_fastapi"]
   end

--- a/src/tagger/framework_taggers/python/flask_auth.cr
+++ b/src/tagger/framework_taggers/python/flask_auth.cr
@@ -24,11 +24,6 @@ class FlaskAuthTagger < FrameworkTagger
     {/\@authenticated/, "authenticated"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "flask_auth"
-  end
-
   def self.target_techs : Array(String)
     ["python_flask"]
   end

--- a/src/tagger/framework_taggers/python/python_misc_auth.cr
+++ b/src/tagger/framework_taggers/python/python_misc_auth.cr
@@ -23,11 +23,6 @@ class PythonMiscAuthTagger < FrameworkTagger
     {/\@authenticated/, "Tornado @authenticated"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "python_misc_auth"
-  end
-
   def self.target_techs : Array(String)
     ["python_sanic", "python_tornado"]
   end

--- a/src/tagger/framework_taggers/ruby/rails_security.cr
+++ b/src/tagger/framework_taggers/ruby/rails_security.cr
@@ -52,11 +52,6 @@ class RailsSecurityTagger < FrameworkTagger
   MASS_ASSIGN_WRITER_PATTERN =
     /\.(?:new|create|create!|update|update!|update_attributes|update_attributes!|assign_attributes)\s*\(\s*params\[/
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "rails_security"
-  end
-
   def self.target_techs : Array(String)
     ["ruby_rails"]
   end

--- a/src/tagger/framework_taggers/ruby/ruby_auth.cr
+++ b/src/tagger/framework_taggers/ruby/ruby_auth.cr
@@ -79,11 +79,6 @@ class RubyAuthTagger < FrameworkTagger
     Regex.union(sources)
   end
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "ruby_auth"
-  end
-
   def self.target_techs : Array(String)
     ["ruby_rails", "ruby_sinatra", "ruby_hanami", "ruby_grape", "ruby_roda"]
   end

--- a/src/tagger/framework_taggers/rust/rust_auth.cr
+++ b/src/tagger/framework_taggers/rust/rust_auth.cr
@@ -44,7 +44,6 @@ class RustAuthTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "rust_auth"
     @middleware_scopes = [] of {prefix: String, description: String}
   end
 

--- a/src/tagger/framework_taggers/rust/rust_security.cr
+++ b/src/tagger/framework_taggers/rust/rust_security.cr
@@ -113,7 +113,6 @@ class RustSecurityTagger < FrameworkTagger
 
   def initialize(options : Hash(String, YAML::Any))
     super
-    @name = "rust_security"
     @protections = [] of Protection
   end
 

--- a/src/tagger/framework_taggers/scala/scala_auth.cr
+++ b/src/tagger/framework_taggers/scala/scala_auth.cr
@@ -34,11 +34,6 @@ class ScalaAuthTagger < FrameworkTagger
     {/userOption/, "Scalatra userOption check"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "scala_auth"
-  end
-
   def self.target_techs : Array(String)
     ["scala_play", "scala_akka", "scala_scalatra", "java_play"]
   end

--- a/src/tagger/framework_taggers/swift/swift_auth.cr
+++ b/src/tagger/framework_taggers/swift/swift_auth.cr
@@ -35,11 +35,6 @@ class SwiftAuthTagger < FrameworkTagger
     {/HBAuthenticator/, "Hummingbird HBAuthenticator"},
   ]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "swift_auth"
-  end
-
   def self.target_techs : Array(String)
     ["swift_vapor", "swift_kitura", "swift_hummingbird"]
   end

--- a/src/tagger/taggers/account_recovery.cr
+++ b/src/tagger/taggers/account_recovery.cr
@@ -50,11 +50,6 @@ class AccountRecoveryTagger < Tagger
     "account", "recover", "recovery",
   }
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "account_recovery"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set

--- a/src/tagger/taggers/admin.cr
+++ b/src/tagger/taggers/admin.cr
@@ -43,11 +43,6 @@ class AdminTagger < Tagger
 
   READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS"}
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "admin"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       is_admin_url = admin_url?(endpoint.url)

--- a/src/tagger/taggers/api_docs.cr
+++ b/src/tagger/taggers/api_docs.cr
@@ -33,11 +33,6 @@ class ApiDocsTagger < Tagger
   # source used `-`, `_`, or no separator at all.
   DOC_SEGMENTS_NORMALIZED = DOC_SEGMENTS.map(&.gsub(/[-_]/, "")).to_set
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "api_docs"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       segments = doc_segments(endpoint.url)

--- a/src/tagger/taggers/cors.cr
+++ b/src/tagger/taggers/cors.cr
@@ -3,11 +3,6 @@ require "../../models/endpoint"
 
 @[Noir::TaggerFor(key: "cors", name: "CORS Tagger", desc: "Identifies CORS endpoints", order: 30)]
 class CorsTagger < Tagger
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "cors"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       # CORS is a header-level concern: `Origin` and the whole

--- a/src/tagger/taggers/crypto.cr
+++ b/src/tagger/taggers/crypto.cr
@@ -55,11 +55,6 @@ class CryptoTagger < Tagger
     "checksum", "cipher", "key_id", "kid", "certificate", "cert", "csr",
   }
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "crypto"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set

--- a/src/tagger/taggers/debug.cr
+++ b/src/tagger/taggers/debug.cr
@@ -47,11 +47,6 @@ class DebugTagger < Tagger
     "trace", "traces", "console", "dump", "dumps", "prometheus",
   }
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "debug"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set

--- a/src/tagger/taggers/file_upload.cr
+++ b/src/tagger/taggers/file_upload.cr
@@ -42,11 +42,6 @@ class FileUploadTagger < Tagger
   # (`POST /media`) still tags.
   SEGMENT_ONLY_PATH_PARTS = Set{"media"}
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "file_upload"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       has_upload_param = endpoint.params.any? { |param| upload_param?(param) }

--- a/src/tagger/taggers/graphql.cr
+++ b/src/tagger/taggers/graphql.cr
@@ -16,11 +16,6 @@ class GraphqlTagger < Tagger
   # values (a JSON body, a search string) for GraphQL syntax.
   BODY_PARAM_NAMES = Set{"query", "mutation", "subscription", "graphql", "gql"}
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "graphql"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       names = endpoint.params.map(&.name.to_s.downcase)

--- a/src/tagger/taggers/hunt_param.cr
+++ b/src/tagger/taggers/hunt_param.cr
@@ -42,11 +42,6 @@ class HuntParamTagger < Tagger
     },
   }
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "hunt"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       # HUNT word lists model HTTP parameter vulnerabilities (SSRF via a

--- a/src/tagger/taggers/jwt.cr
+++ b/src/tagger/taggers/jwt.cr
@@ -31,11 +31,6 @@ class JwtTagger < Tagger
 
   AUTH_PATH_PARTS = Set{"auth", "authenticate", "authentication", "login", "signin", "sign_in", "token", "refresh", "jwt"}
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "jwt"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       signals = endpoint.params.count { |param| jwt_signal?(param) }

--- a/src/tagger/taggers/mcp.cr
+++ b/src/tagger/taggers/mcp.cr
@@ -6,11 +6,6 @@ class McpTagger < Tagger
   LEGACY_SSE_SEGMENT      = "sse"
   LEGACY_MESSAGE_SEGMENTS = ["message", "messages"]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "mcp"
-  end
-
   def perform(endpoints : Array(Endpoint))
     legacy_prefixes = legacy_mcp_prefixes(endpoints)
 

--- a/src/tagger/taggers/oauth.cr
+++ b/src/tagger/taggers/oauth.cr
@@ -37,11 +37,6 @@ class OAuthTagger < Tagger
   # param-corroborated checks below miss them.
   OAUTH_FLOW_VERB_SEGMENTS = Set{"callback", "authorize", "authorization", "redirect"}
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "oauth"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set

--- a/src/tagger/taggers/payment.cr
+++ b/src/tagger/taggers/payment.cr
@@ -47,11 +47,6 @@ class PaymentTagger < Tagger
     "subtotal", "balance", "total_amount", "amount_due", "grand_total",
   }
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "payment"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set

--- a/src/tagger/taggers/pii.cr
+++ b/src/tagger/taggers/pii.cr
@@ -51,11 +51,6 @@ class PiiTagger < Tagger
     "marital_status",
   }
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "pii"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set

--- a/src/tagger/taggers/soap.cr
+++ b/src/tagger/taggers/soap.cr
@@ -17,11 +17,6 @@ class SoapTagger < Tagger
   # (e.g. a `/products/soap` store listing).
   URL_MARKERS = ["?wsdl", ".wsdl", ".asmx"]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "soap"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       check = soap_header?(endpoint) || soap_url?(endpoint.url)

--- a/src/tagger/taggers/webhook.cr
+++ b/src/tagger/taggers/webhook.cr
@@ -64,11 +64,6 @@ class WebhookTagger < Tagger
     "svix_id", "svix_signature", "svix_timestamp",
   }
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "webhook"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       header_names = endpoint.params.compact_map do |param|

--- a/src/tagger/taggers/websocket.cr
+++ b/src/tagger/taggers/websocket.cr
@@ -29,11 +29,6 @@ class WebsocketTagger < Tagger
   # ordinary HTTP endpoints.
   URL_MARKERS = ["socket.io", "sockjs"]
 
-  def initialize(options : Hash(String, YAML::Any))
-    super
-    @name = "websocket"
-  end
-
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       if websocket?(endpoint)


### PR DESCRIPTION
Small follow-up to #2494. Behaviour-neutral.

#2494 made `Tagger#initialize` read `@name` off the class's `Noir::TaggerFor` annotation. That left all 43 concrete taggers still assigning the same string a second time:

```crystal
def initialize(options : Hash(String, YAML::Any))
  super
  @name = "cors"
end
```

**Thirty-two of those initializers did nothing else** and are deleted outright. The other eleven keep whatever real setup they do — `GoAuthTagger` still initializes `@middleware_scopes` — and lose only the `@name` line.

## Why it matters beyond tidiness

`run_tagger` selects taggers by registry key and then reports failures by the instance's `name`:

```crystal
next unless is_all || use_taggers_arr.includes?(entry.key)
...
logger.warning "Tagger '#{entry.key}' failed: …"
```

Those being the same string was a convention that 43 files had to observe. A typo in one would have produced a tagger that runs but warns under a name the user never asked for — or, in the framework-tagger path which logs `local_instance.name`, a warning naming a tagger that isn't in the registry at all. It is now structural, and `registry_integrity_spec.cr` asserts it directly.

## Verification

`noir list taggers` byte-identical. A/B over 665 fixture directories with `-T`, comparing **raw tag arrays in order**: 1,215 tags, no difference.

`crystal spec spec/unit_test` 4677 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1910 files, 0 findings.