### PR TITLE
refactor(techs): declare tech-supersedes-tech in the techs catalog

### DIFF
--- a/spec/unit_test/analyzer/analyzer_selection_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_selection_spec.cr
@@ -37,4 +37,32 @@ describe "filter_redundant_generic_techs" do
   it "keeps python_starlette when python_fastapi is also present" do
     filter_redundant_generic_techs(["python_fastapi", "python_starlette"]).should eq(["python_fastapi", "python_starlette"])
   end
+
+  # The four supersede rules, which had no unit coverage at all until now —
+  # `spec/functional_test/testers/php/lumen_spec.cr` tested one of them.
+  # Each is asserted in both input orders, because the rules used to be an
+  # `if` chain reading a mutating array and the new form evaluates presence
+  # against the input list.
+  {
+    {"php_lumen", "php_laravel"},
+    {"elixir_bandit", "elixir_plug"},
+    {"zig_jetzig", "zig_httpz"},
+    {"zig_tokamak", "zig_httpz"},
+    {"php_drupal", "php_symfony"},
+    {"php_magento", "php_symfony"},
+  }.each do |superseder, superseded|
+    it "drops #{superseded} when #{superseder} is present" do
+      filter_redundant_generic_techs([superseder, superseded]).should eq([superseder])
+      filter_redundant_generic_techs([superseded, superseder]).should eq([superseder])
+    end
+
+    it "keeps #{superseded} when #{superseder} is absent" do
+      filter_redundant_generic_techs([superseded]).should eq([superseded])
+    end
+  end
+
+  it "preserves input order for the techs it keeps" do
+    techs = ["python_django", "php_laravel", "js_express", "php_lumen", "go_gin"]
+    filter_redundant_generic_techs(techs).should eq(["python_django", "js_express", "php_lumen", "go_gin"])
+  end
 end

--- a/spec/unit_test/techs/registry_integrity_spec.cr
+++ b/spec/unit_test/techs/registry_integrity_spec.cr
@@ -165,3 +165,46 @@ describe "tagger registry integrity" do
     fail "framework taggers target techs with no catalog entry: #{sorted(unknown)}" unless unknown.empty?
   end
 end
+
+# `:supersedes` moved the "when both are detected, X owns the routes" rules
+# out of an `if` chain in `filter_redundant_generic_techs` and onto the
+# superseding tech's catalog entry. A rule is now a data edge between two
+# catalog keys, so it can be checked — the `if` chain could name a tech that
+# no longer existed and nothing would notice.
+describe "tech supersede integrity" do
+  catalog = NoirTechs.techs.keys.map(&.to_s).to_set
+  supersedes = NoirTechs::SUPERSEDES
+
+  it "names only real techs on both ends of every rule" do
+    unknown = supersedes.flat_map do |superseder, targets|
+      ([superseder] + targets).reject { |tech| catalog.includes?(tech) }
+    end.uniq!
+    fail ":supersedes references techs with no catalog entry: #{sorted(unknown)}" unless unknown.empty?
+  end
+
+  it "never lets a tech supersede itself" do
+    self_referential = supersedes.select { |superseder, targets| targets.includes?(superseder) }.keys
+    fail "techs that supersede themselves: #{sorted(self_referential)}" unless self_referential.empty?
+  end
+
+  # What keeps `filter_redundant_generic_techs` order-independent. It
+  # evaluates presence against its input rather than against the array it is
+  # building, which is only equivalent to the old progressive form while no
+  # chain exists. A chain would also be a design mistake in its own right:
+  # if A supersedes B and B supersedes C, whether C survives depends on
+  # whether A is present, which is not what either rule says.
+  it "declares no supersede chains" do
+    superseders = supersedes.keys.to_set
+    chained = supersedes.flat_map { |_, targets| targets }.select { |target| superseders.includes?(target) }.uniq!
+    fail "techs that are both a superseder and superseded: #{sorted(chained)}" unless chained.empty?
+  end
+
+  it "supersedes only techs that have an analyzer to suppress" do
+    # A rule dropping a tech nothing analyzes is dead code that reads as a
+    # live policy decision.
+    logger = NoirLogger.new(false, false, false, true)
+    analyzers = initialize_analyzers(logger).keys.to_set
+    orphaned = supersedes.flat_map { |_, targets| targets }.reject { |t| analyzers.includes?(t) }.uniq!
+    fail ":supersedes drops techs with no analyzer: #{sorted(orphaned)}" unless orphaned.empty?
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -1,6 +1,7 @@
 require "./analyzers/**"
 require "./analyzers/file_analyzers/*"
 require "../miniparsers/extraction_result_cache"
+require "../techs/techs"
 
 def initialize_analyzers(logger : NoirLogger)
   # Initializing analyzers
@@ -46,77 +47,19 @@ CFML_FRAMEWORK_TECHS = Set{
   "cfml_fw1",
 }
 
+# Drops techs that another detected tech supersedes. The rules live on the
+# superseding tech's catalog entry as `:supersedes`; see the doc on
+# `NoirTechs::SUPERSEDES` for what belongs there and — more importantly —
+# what must never be added.
+#
+# Presence is evaluated against the *input* list rather than the array being
+# filtered, so the result no longer depends on the order the rules happen to
+# be written in. `SUPERSEDES` chains are rejected by the tech-registry
+# integrity spec, which keeps that equivalence true.
 def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
-  filtered = techs.dup
-
-  # NOTE: `php_pure` is deliberately NOT dropped when a framework is
-  # present. It used to be, because it emitted every `.php` file in the
-  # tree as an endpoint and drowned framework scans in paths that are not
-  # web-reachable (`/config/app.php`, `/app/Models/User.php`). That was a
-  # workaround for a defect in the analyzer, and it cost real findings: a
-  # legacy script inside the document root — `public/upload.php` beside a
-  # Laravel app — vanished with it. `Analyzer::Php::Php` now resolves URLs
-  # against the document root, so the noise is gone at the source and the
-  # generic analyzer can run alongside the framework one. See #2358.
-  #
-  # `cfml_pure` used to be dropped for the same reason and paid the same
-  # price — the `remote` methods on a ColdBox app's proxy components are
-  # HTTP-callable whatever framework fronts them, and no framework
-  # analyzer emits them. It now runs in components-only mode instead (see
-  # `CFML_FRAMEWORK_TECHS` below), which keeps those and still leaves the
-  # `.cfm` page surface to the framework that owns it.
-
-  # Lumen and Laravel share enough surface (Illuminate namespaces, the `routes/`
-  # convention) that the Laravel detector also fires on Lumen projects. When
-  # Lumen is the actual framework, the Laravel signal is just noise.
-  if filtered.includes?("php_lumen") && filtered.includes?("php_laravel")
-    filtered.reject!("php_laravel")
-  end
-
-  # Bandit hosts the same `Plug.Router` modules the Plug analyzer
-  # already understands, so both detectors fire on a Bandit project.
-  # When both are present, the Bandit signal is the more specific one
-  # (it tells you which HTTP server is actually serving the routes);
-  # keep it and drop the redundant Plug entry so endpoints aren't
-  # extracted twice with two different technology tags. The Phoenix
-  # analyzer is unaffected — it owns the Phoenix.Router DSL.
-  if filtered.includes?("elixir_bandit") && filtered.includes?("elixir_plug")
-    filtered.reject!("elixir_plug")
-  end
-
-  # Jetzig and Tokamak are both built on top of http.zig (httpz), so a
-  # project that vendors either framework's source also carries the
-  # `@import("httpz")` / `.httpz` dependency markers the httpz detector
-  # keys on. When the more specific framework is present it owns the
-  # routing DSL; keep it and drop the redundant httpz entry so the httpz
-  # analyzer doesn't also scan the framework's internals.
-  if filtered.includes?("zig_httpz") && (filtered.includes?("zig_jetzig") || filtered.includes?("zig_tokamak"))
-    filtered.reject!("zig_httpz")
-  end
-
-  # Drupal and Magento are both built on Symfony components, so their
-  # composer.json pulls in `symfony/*` and the Symfony detector fires on
-  # every Drupal/Magento project. Those apps do not expose Symfony-native
-  # routes (Drupal uses `*.routing.yml`, Magento uses `webapi.xml` /
-  # `routes.xml`), and the Symfony YAML analyzer would otherwise
-  # double-parse Drupal routing files that happen to sit under a `config`
-  # path. Keep the specific CMS analyzer and drop the redundant Symfony
-  # entry so endpoints aren't extracted twice under a misleading tech tag.
-  if filtered.includes?("php_symfony") && (filtered.includes?("php_drupal") || filtered.includes?("php_magento"))
-    filtered.reject!("php_symfony")
-  end
-
-  # NOTE: do not add "generic stdlib analyzer is redundant when framework
-  # X is present" rules here. `techs` is a flat, repo-wide list with no
-  # path granularity, so a framework detected anywhere suppresses the
-  # generic analyzer *everywhere*. In a monorepo that silently drops real
-  # attack surface: a standalone `net/http` admin listener exposing
-  # /debug/pprof next to a Gin API, or a standalone Starlette service next
-  # to a FastAPI one. Framework-vs-framework rules above are safe because
-  # both analyzers target the same routing DSL; framework-vs-stdlib rules
-  # are not. Scoping this correctly needs a per-tech path map from the
-  # detector (the detect loop does know the file), not a global list.
-  filtered
+  drop = Set(String).new
+  techs.each { |tech| NoirTechs.supersedes(tech).each { |target| drop << target } }
+  techs.reject { |tech| drop.includes?(tech) }
 end
 
 def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLogger)

--- a/src/techs/catalog/elixir.cr
+++ b/src/techs/catalog/elixir.cr
@@ -22,10 +22,16 @@ module NoirTechs::Catalog
       },
     },
     :elixir_bandit => {
-      :framework => "Bandit",
-      :language  => "Elixir",
-      :similar   => ["bandit", "elixir-bandit", "elixir_bandit"],
-      :supported => {
+      # Bandit hosts the same `Plug.Router` modules the Plug analyzer already
+      # understands, so both detectors fire on a Bandit project. Bandit is the
+      # more specific signal — it names the HTTP server actually serving the
+      # routes — so keeping both would extract every endpoint twice under two
+      # technology tags. Phoenix is unaffected: it owns the Phoenix.Router DSL.
+      :supersedes => ["elixir_plug"],
+      :framework  => "Bandit",
+      :language   => "Elixir",
+      :similar    => ["bandit", "elixir-bandit", "elixir_bandit"],
+      :supported  => {
         :endpoint => true,
         :method   => true,
         :params   => {

--- a/src/techs/catalog/php.cr
+++ b/src/techs/catalog/php.cr
@@ -60,10 +60,15 @@ module NoirTechs::Catalog
       :context => {:callee => true, :guards => true},
     },
     :php_lumen => {
-      :framework => "Lumen",
-      :language  => "PHP",
-      :similar   => ["lumen", "php-lumen", "php_lumen", "laravel/lumen", "laravel-lumen", "lumen-framework"],
-      :supported => {
+      # Lumen and Laravel share enough surface (Illuminate namespaces, the
+      # `routes/` convention) that the Laravel detector also fires on Lumen
+      # projects. When Lumen is the actual framework, the Laravel signal is
+      # just noise.
+      :supersedes => ["php_laravel"],
+      :framework  => "Lumen",
+      :language   => "PHP",
+      :similar    => ["lumen", "php-lumen", "php_lumen", "laravel/lumen", "laravel-lumen", "lumen-framework"],
+      :supported  => {
         :endpoint => true,
         :method   => true,
         :params   => {
@@ -267,10 +272,16 @@ module NoirTechs::Catalog
       },
     },
     :php_drupal => {
-      :framework => "Drupal",
-      :language  => "PHP",
-      :similar   => ["drupal", "php-drupal", "php_drupal", "drupal/core"],
-      :supported => {
+      # Drupal is built on Symfony components, so its composer.json pulls in
+      # `symfony/*` and the Symfony detector fires on every Drupal project.
+      # Drupal exposes no Symfony-native routes (it uses `*.routing.yml`), and
+      # the Symfony YAML analyzer would otherwise double-parse Drupal routing
+      # files that happen to sit under a `config` path.
+      :supersedes => ["php_symfony"],
+      :framework  => "Drupal",
+      :language   => "PHP",
+      :similar    => ["drupal", "php-drupal", "php_drupal", "drupal/core"],
+      :supported  => {
         :endpoint => true,
         :method   => true,
         :params   => {
@@ -285,10 +296,13 @@ module NoirTechs::Catalog
       },
     },
     :php_magento => {
-      :framework => "Magento",
-      :language  => "PHP",
-      :similar   => ["magento", "magento2", "php-magento", "php_magento", "magento/product-community-edition"],
-      :supported => {
+      # Same as Drupal: Symfony components underneath, but the routes live in
+      # `webapi.xml` / `routes.xml` and only the Magento analyzer reads them.
+      :supersedes => ["php_symfony"],
+      :framework  => "Magento",
+      :language   => "PHP",
+      :similar    => ["magento", "magento2", "php-magento", "php_magento", "magento/product-community-edition"],
+      :supported  => {
         :endpoint => true,
         :method   => true,
         :params   => {

--- a/src/techs/catalog/zig.cr
+++ b/src/techs/catalog/zig.cr
@@ -22,10 +22,15 @@ module NoirTechs::Catalog
       },
     },
     :zig_jetzig => {
-      :framework => "Jetzig",
-      :language  => "Zig",
-      :similar   => ["jetzig", "zig-jetzig", "zig_jetzig"],
-      :supported => {
+      # Jetzig is built on http.zig, so a project vendoring it also carries the
+      # `@import("httpz")` / `.httpz` markers the httpz detector keys on. The
+      # framework owns the routing DSL; dropping httpz also stops its analyzer
+      # scanning the framework's own internals.
+      :supersedes => ["zig_httpz"],
+      :framework  => "Jetzig",
+      :language   => "Zig",
+      :similar    => ["jetzig", "zig-jetzig", "zig_jetzig"],
+      :supported  => {
         :endpoint => true,
         :method   => true,
         :params   => {
@@ -98,10 +103,12 @@ module NoirTechs::Catalog
       :context => {:callee => true},
     },
     :zig_tokamak => {
-      :framework => "Tokamak",
-      :language  => "Zig",
-      :similar   => ["tokamak", "zig-tokamak", "zig_tokamak"],
-      :supported => {
+      # Same as Jetzig: Tokamak is built on http.zig and carries its markers.
+      :supersedes => ["zig_httpz"],
+      :framework  => "Tokamak",
+      :language   => "Zig",
+      :similar    => ["tokamak", "zig-tokamak", "zig_tokamak"],
+      :supported  => {
         :endpoint => true,
         :method   => true,
         :params   => {

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -49,6 +49,58 @@ module NoirTechs
     key.to_s if context[:guards]?
   end
 
+  # "When both are detected, X owns the routes and Y is noise" — declared on
+  # X's catalog entry as `:supersedes => ["y"]`.
+  #
+  # These rules used to be an `if` chain in `filter_redundant_generic_techs`,
+  # a global function in `src/analyzer/analyzer.cr`, so adding a framework
+  # that shadows another meant editing the catalog, the analyzer, *and* that
+  # function — and none of the four rules had a unit test.
+  #
+  # ## When a rule belongs here
+  #
+  # Only when both techs target the *same routing DSL*, so the two analyzers
+  # would extract the same endpoints twice under two different technology
+  # tags. Lumen/Laravel, Bandit/Plug, Jetzig/httpz, Drupal/Symfony are all
+  # that shape: one framework is literally built on the other, so the
+  # broader detector fires on every project of the narrower one.
+  #
+  # ## When a rule does NOT belong here
+  #
+  # **Never add "the generic stdlib analyzer is redundant when framework X
+  # is present".** `techs` is a flat, repo-wide list with no path
+  # granularity, so a framework detected *anywhere* would suppress the
+  # generic analyzer *everywhere*. In a monorepo that silently drops real
+  # attack surface: a standalone `net/http` admin listener exposing
+  # /debug/pprof next to a Gin API, or a standalone Starlette service next
+  # to a FastAPI one. Framework-vs-framework rules are safe because both
+  # analyzers target the same DSL; framework-vs-stdlib rules are not.
+  # Scoping that correctly needs a per-tech path map from the detector
+  # (the detect loop does know the file), not a global list.
+  #
+  # `php_pure` and `cfml_pure` are the worked example of getting this wrong.
+  # Both used to be dropped when a framework was present, and both paid for
+  # it: a legacy `public/upload.php` beside a Laravel app vanished from the
+  # report, and so did the `access="remote"` methods on a ColdBox app's
+  # proxy components. `php_pure` now resolves URLs against the document
+  # root (#2358) and `cfml_pure` narrows to components-only mode, so both
+  # run alongside the framework analyzer instead of being suppressed.
+  # Neither carries `:supersedes`, deliberately.
+  #
+  # `:similar` already puts `Array(String)` in the value union, so this key
+  # widens nothing — but narrow with `is_a?(Array)`, not `is_a?(Hash)`.
+  SUPERSEDES = TECHS.compact_map do |key, value|
+    targets = value[:supersedes]?
+    next unless targets.is_a?(Array)
+    {key.to_s, targets.map(&.to_s)}
+  end.to_h
+
+  # Techs that `tech` displaces when both are detected. Empty for the 235
+  # entries that displace nothing.
+  def self.supersedes(tech : String) : Array(String)
+    SUPERSEDES[tech]? || [] of String
+  end
+
   def self.techs
     TECHS
   end


### PR DESCRIPTION
Ninth PR of the structural-contract series. Behaviour-neutral.

## Why

*"When both are detected, X owns the routes and Y is noise"* was an `if` chain in `filter_redundant_generic_techs`, a global function in `src/analyzer/analyzer.cr`. Four rules, 71 lines — and adding a framework that shadows another meant editing the catalog, the analyzer, **and** that function. A third place to remember, in a series whose whole subject is removing those.

The relation now lives on the superseding tech's catalog entry:

```crystal
:php_drupal => {
  # Drupal is built on Symfony components, so its composer.json pulls in
  # `symfony/*` and the Symfony detector fires on every Drupal project…
  :supersedes => ["php_symfony"],
```

`NoirTechs::SUPERSEDES` derives the map exactly the way `CALLEE_SUPPORTED_TECHS` derives from `:context` — narrowing with `is_a?(Array)`, since `:similar` already puts `Array(String)` in the value union so the key widens nothing. `filter_redundant_generic_techs` shrinks from 71 lines to four.

## The one semantic change

Presence is evaluated against the **input** list rather than against the array being filtered. The old form re-read a mutating `filtered`, so with a hypothetical A⊐B⊐C chain the result depended on the order the rules happened to be written in.

No chain exists today, and the integrity spec now forbids one — which is what keeps the two forms equivalent rather than merely equivalent-for-now.

Verified exhaustively before committing: the derivation agrees with the legacy `if` chain on **all 8,192 subsets** of the 13 techs involved. That throwaway proof is deliberately *not* committed — it hard-codes the old chain, so it would fail spuriously the first time a fifth rule is added. The per-rule specs are the durable form.

## The NOTE blocks

The two long rationale blocks above the old `if` chain move to `NoirTechs::SUPERSEDES`, where the key is defined and where every catalog file's header already points readers. The load-bearing half is preserved verbatim:

> **Never add "the generic stdlib analyzer is redundant when framework X is present".** `techs` is a flat, repo-wide list with no path granularity, so a framework detected *anywhere* would suppress the generic analyzer *everywhere* — losing a standalone `net/http` admin listener beside a Gin API, or a standalone Starlette service beside a FastAPI one.

That paragraph is the only thing standing between the catalog and someone adding `:go_gin => {:supersedes => ["go_http"]}` in thirty seconds. `php_pure` and `cfml_pure` are documented there as the worked example of having got this wrong once already (#2358).

## Coverage, where there was almost none

`analyzer_selection_spec.cr` gains, for each of the six rules: both input orders, and an absent-superseder case. Before this, `spec/functional_test/testers/php/lumen_spec.cr` tested exactly one of the four rules and nothing tested the other three.

`registry_integrity_spec.cr` gains four assertions — both ends of every rule name a real tech; no tech supersedes itself; no chains; and no rule drops a tech that has no analyzer to suppress. That last one matters because a rule naming a tech nothing analyzes reads as live policy while being dead code.

## Verification

A/B over all 665 fixture directories, with `details.technology` folded into the normalized shape so a wrong-direction rule would surface immediately: **byte-identical**, 5,160 endpoints, same tech set.

`crystal spec spec/unit_test` 4694 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1910 files, 0 findings.