### PR TITLE
test(analyzer): cover the cfml_pure components-only narrowing

### DIFF
--- a/spec/unit_test/analyzer/cfml_pure_narrowing_spec.cr
+++ b/spec/unit_test/analyzer/cfml_pure_narrowing_spec.cr
@@ -1,0 +1,49 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzer.cr"
+
+# `cfml_pure` is the one tech noir *narrows* rather than drops when a more
+# specific analyzer is present. The distinction is the point: dropping it
+# outright is what the framework-shadows-framework rules in
+# `NoirTechs::SUPERSEDES` do, and doing that to `cfml_pure` cost real
+# findings — the `access="remote"` methods on a ColdBox app's proxy
+# components are HTTP-callable whatever framework fronts them, and no
+# framework analyzer emits them.
+#
+# The decision had no coverage at all: it lived inline in
+# `analysis_endpoints`, which runs every analyzer, so there was nothing to
+# call. `cfml_components_only?` exists so there is.
+describe "cfml_components_only?" do
+  CFML_FRAMEWORK_TECHS.each do |framework|
+    it "narrows cfml_pure when #{framework} owns the route table" do
+      cfml_components_only?(["cfml_pure", framework]).should be_true
+      cfml_components_only?([framework, "cfml_pure"]).should be_true
+    end
+  end
+
+  it "leaves cfml_pure at full scope when it is the only CFML tech" do
+    cfml_components_only?(["cfml_pure"]).should be_false
+  end
+
+  # The page surface is only owned when a *CFML* framework is present. A
+  # PHP or Java framework in the same monorepo says nothing about who serves
+  # the `.cfm` files.
+  it "ignores non-CFML frameworks" do
+    cfml_components_only?(["cfml_pure", "php_laravel", "java_spring"]).should be_false
+  end
+
+  it "stays false when cfml_pure is not selected" do
+    cfml_components_only?(["cfml_coldbox"]).should be_false
+    cfml_components_only?([] of String).should be_false
+  end
+
+  # Guards the narrowing against being quietly converted back into a drop.
+  # `cfml_pure` must survive tech selection whenever a CFML framework is
+  # present — otherwise the generic analyzer never runs and the
+  # remote-method surface disappears again, which is the regression #2358
+  # is named after on the PHP side.
+  it "keeps cfml_pure in the selected techs so there is something to narrow" do
+    CFML_FRAMEWORK_TECHS.each do |framework|
+      filter_redundant_generic_techs(["cfml_pure", framework]).should contain("cfml_pure")
+    end
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -47,6 +47,23 @@ CFML_FRAMEWORK_TECHS = Set{
   "cfml_fw1",
 }
 
+# Whether the generic CFML analyzer should narrow to components-only mode.
+#
+# This is a *narrowing*, not a supersede, which is why it stays here rather
+# than moving to the catalog's `:supersedes` alongside the four
+# framework-shadows-framework rules. A CFML framework owns the `.cfm` page
+# surface, so dropping `cfml_pure` outright would lose the half no framework
+# analyzer covers — the `access="remote"` methods on a ColdBox app's proxy
+# components, which are HTTP-callable whatever framework fronts them.
+# Narrowing keeps those and still leaves the page surface to its owner.
+#
+# Extracted from `analysis_endpoints` so it can be tested at all: in place
+# it sat inside the function that runs every analyzer.
+def cfml_components_only?(selected_techs : Array(String)) : Bool
+  selected_techs.includes?("cfml_pure") &&
+    selected_techs.any? { |tech| CFML_FRAMEWORK_TECHS.includes?(tech) }
+end
+
 # Drops techs that another detected tech supersedes. The rules live on the
 # superseding tech's catalog entry as `:supersedes`; see the doc on
 # `NoirTechs::SUPERSEDES` for what belongs there and — more importantly —
@@ -93,10 +110,7 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   # Run tech analyzers concurrently to avoid long stalls from a single analyzer
   selected_techs = filter_redundant_generic_techs(techs).select { |t| analyzer.has_key?(t) }
 
-  # A CFML framework owns the `.cfm` page surface, so the generic analyzer
-  # narrows to the half no framework analyzer covers: `access="remote"`
-  # methods on `.cfc` components.
-  if selected_techs.includes?("cfml_pure") && selected_techs.any? { |tech| CFML_FRAMEWORK_TECHS.includes?(tech) }
+  if cfml_components_only?(selected_techs)
     options[Analyzer::Cfml::Pure::COMPONENTS_ONLY_OPTION] = YAML::Any.new(true)
   end
 


### PR DESCRIPTION
Small companion to #2497. Test-only plus a one-line extraction.

## Why

`cfml_pure` is the one tech noir **narrows** rather than drops when a more specific analyzer is present — and the decision had **no coverage at all**. It sat inline in `analysis_endpoints`, the function that runs every analyzer, so there was nothing a spec could call:

```crystal
if selected_techs.includes?("cfml_pure") && selected_techs.any? { |tech| CFML_FRAMEWORK_TECHS.includes?(tech) }
  options[Analyzer::Cfml::Pure::COMPONENTS_ONLY_OPTION] = YAML::Any.new(true)
end
```

Extracted as `cfml_components_only?(selected_techs)`. Naming it also makes the distinction visible in the code: a named *narrowing* sitting beside the catalog-driven *supersede* filter reads as a deliberately different thing, where a bare `if` next to four other `if`s read as one of them.

## Why the distinction matters

Dropping `cfml_pure` outright is what the framework-shadows-framework rules do, and doing it here **cost real findings**: the `access="remote"` methods on a ColdBox app's proxy components are HTTP-callable whatever framework fronts them, and no framework analyzer emits them. Narrowing keeps those and still leaves the `.cfm` page surface to the framework that owns it. This is the CFML half of the same lesson `php_pure` taught in #2358.

## Coverage

Eight examples: each of the four CFML frameworks triggers the narrowing in either input order; a lone `cfml_pure` does not; non-CFML frameworks in the same monorepo do not; and — the regression guard — `cfml_pure` still survives tech selection when a CFML framework is present, because a narrowing only means anything while the analyzer still runs.

## Verification

`crystal spec spec/unit_test` 4687 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1912 files, 0 findings. The four CFML fixtures produce identical endpoints and technologies against a `main` baseline.