### PR TITLE
refactor(detector): drop the unread cs-aspnet-core-mvc locator key

### DIFF
--- a/src/detector/detectors/csharp/aspnet_core_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_core_mvc.cr
@@ -2,12 +2,8 @@ require "../../../models/detector"
 
 module Detector::CSharp
   class AspNetCoreMvc < Detector
-    # Side effect: registers `Program.cs` / similar paths in
-    # `CodeLocator` for the analyzer. Must keep running after first
-    # match.
     detector_for "cs_aspnet_core_mvc",
-      extensions: %w[.cs .csproj .vbproj .sln .config],
-      idempotent: false
+      extensions: %w[.cs .csproj .vbproj .sln .config]
 
     def detect(filename : String, file_contents : String) : Bool
       is_csproj = filename.ends_with?(".csproj")
@@ -25,19 +21,16 @@ module Detector::CSharp
                       file_contents.includes?("MapDefaultControllerRoute") ||
                       file_contents.includes?("MapControllers")
 
-      detected = false
-      locator = CodeLocator.instance
-
-      if is_csproj && (uses_aspnetcore || uses_web_sdk)
-        detected = true
-      elsif is_program_file && (uses_aspnetcore || has_mvc_setup)
-        detected = true
-        locator.push("cs-aspnet-core-mvc-entrypoints", filename)
-      elsif is_controller && uses_aspnetcore
-        detected = true
-      end
-
-      detected
+      # A pure predicate. It used to push `Program.cs` paths into
+      # `CodeLocator` under `cs-aspnet-core-mvc-entrypoints`, which nothing
+      # in the tree ever read — the analyzer resolves its entry points
+      # through `get_files_by_extension` instead. That write was the only
+      # reason this detector declared `idempotent: false`, so the flag goes
+      # with it and the detect pass can stop calling this detector once the
+      # tech is known.
+      (is_csproj && (uses_aspnetcore || uses_web_sdk)) ||
+        (is_program_file && (uses_aspnetcore || has_mvc_setup)) ||
+        (is_controller && uses_aspnetcore)
     end
   end
 end


### PR DESCRIPTION
First of four PRs on `CodeLocator`. Behaviour-neutral.

## What

`Detector::CSharp::AspNetCoreMvc#detect` pushed `Program.cs` / `Startup.cs` paths into `CodeLocator` under `cs-aspnet-core-mvc-entrypoints`:

```crystal
elsif is_program_file && (uses_aspnetcore || has_mvc_setup)
  detected = true
  locator.push("cs-aspnet-core-mvc-entrypoints", filename)
```

**Nothing reads that key.** Not the ASP.NET Core MVC analyzer, which resolves its entry points through `get_files_by_extension`; not any spec. `grep` across `src/` and `spec/` returns the write site and nothing else.

## The knock-on

That write was the only reason the detector declared `idempotent: false`, so the flag goes with it.

The flag governs exactly one thing — `src/detector/detector.cr:613` skips a detector on later files once it has matched. With the push gone, `detect` is a pure predicate over `(filename, file_contents)` whose only consumer is the `techs` set, and adding a tech to a set that already contains it cannot change anything. Dropping the flag also stops the detector re-running over every remaining `.cs` file in a C# tree.

The sibling `AspNetMvc` keeps `idempotent: false` — it really does `set` a route-config path from inside `detect`, and the analyzer really does read it.

## How it surfaced

Found while inventorying all 65 locator keys for the lifecycle work in this series. It is the only key in the codebase with a writer and no reader — which is why an inventory found it and reading the file did not. The class comment that justified the flag (*"Side effect: registers `Program.cs` … Must keep running after first match"*) is removed rather than left asserting something no longer true.

## Verification

A/B over all 665 fixture directories with `details.technology` folded into the normalized shape: **byte-identical**, 5,160 endpoints. The C# and ASP.NET fixtures additionally compared with `--include-callee` and `details.code_paths[].line` folded in — identical, which is what covers the idempotency flip.

`crystal spec spec/unit_test` 4679 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1911 files, 0 findings.