### PR TITLE
refactor(locator): give file_map a first-class file registry API

### DIFF
--- a/spec/unit_test/analyzer/crystal_ruby_framework_scope_spec.cr
+++ b/spec/unit_test/analyzer/crystal_ruby_framework_scope_spec.cr
@@ -25,7 +25,7 @@ private def scan_tree(root : String) : Array(Endpoint)
   runner.analyze
   runner.endpoints
 ensure
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
 end
 
 private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)
@@ -111,7 +111,7 @@ describe "analyzer project scoping (crystal, ruby)" do
       runner.detect
       runner.analyze
       runner.endpoints.map(&.url).should contain("/edge/health")
-      CodeLocator.instance.clear("file_map")
+      CodeLocator.instance.reset_files
     ensure
       FileUtils.rm_rf(root) if Dir.exists?(root)
     end

--- a/spec/unit_test/analyzer/csharp_python_framework_scope_spec.cr
+++ b/spec/unit_test/analyzer/csharp_python_framework_scope_spec.cr
@@ -27,7 +27,7 @@ private def scan_tree(root : String) : Array(Endpoint)
   runner.analyze
   runner.endpoints
 ensure
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
 end
 
 private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)

--- a/spec/unit_test/analyzer/file_analyzer_base64_spec.cr
+++ b/spec/unit_test/analyzer/file_analyzer_base64_spec.cr
@@ -21,7 +21,7 @@ describe "Base64 FileAnalyzer hook" do
 
     begin
       locator = CodeLocator.instance
-      locator.push("file_map", file_path)
+      locator.register_path(file_path)
 
       options = create_test_options
       options["base"] = YAML::Any.new([YAML::Any.new(tmp_dir)])
@@ -34,7 +34,7 @@ describe "Base64 FileAnalyzer hook" do
       result[0].url.should eq("/api/secret")
       result[0].method.should eq("GET")
     ensure
-      locator.try &.clear("file_map")
+      locator.try &.reset_files
       FileUtils.rm_rf(tmp_dir)
     end
   end
@@ -47,7 +47,7 @@ describe "Base64 FileAnalyzer hook" do
 
     begin
       locator = CodeLocator.instance
-      locator.push("file_map", file_path)
+      locator.register_path(file_path)
 
       options = create_test_options
       options["base"] = YAML::Any.new([YAML::Any.new(tmp_dir)])
@@ -58,7 +58,7 @@ describe "Base64 FileAnalyzer hook" do
 
       result.size.should eq(0)
     ensure
-      locator.try &.clear("file_map")
+      locator.try &.reset_files
       FileUtils.rm_rf(tmp_dir)
     end
   end
@@ -72,7 +72,7 @@ describe "Base64 FileAnalyzer hook" do
 
     begin
       locator = CodeLocator.instance
-      locator.push("file_map", file_path)
+      locator.register_path(file_path)
 
       options = create_test_options
       options["base"] = YAML::Any.new([YAML::Any.new(tmp_dir)])
@@ -83,7 +83,7 @@ describe "Base64 FileAnalyzer hook" do
 
       result.size.should eq(0)
     ensure
-      locator.try &.clear("file_map")
+      locator.try &.reset_files
       FileUtils.rm_rf(tmp_dir)
     end
   end
@@ -96,7 +96,7 @@ describe "Base64 FileAnalyzer hook" do
 
     begin
       locator = CodeLocator.instance
-      locator.push("file_map", file_path)
+      locator.register_path(file_path)
 
       options = create_test_options
       options["base"] = YAML::Any.new([YAML::Any.new(tmp_dir)])
@@ -107,7 +107,7 @@ describe "Base64 FileAnalyzer hook" do
 
       result.size.should eq(0)
     ensure
-      locator.try &.clear("file_map")
+      locator.try &.reset_files
       FileUtils.rm_rf(tmp_dir)
     end
   end

--- a/spec/unit_test/analyzer/framework_project_scope_crystal_python_spec.cr
+++ b/spec/unit_test/analyzer/framework_project_scope_crystal_python_spec.cr
@@ -11,7 +11,7 @@ private def scan_tree(root : String) : Array(Endpoint)
   runner.analyze
   runner.endpoints
 ensure
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
 end
 
 private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)

--- a/spec/unit_test/analyzer/framework_project_scope_spec.cr
+++ b/spec/unit_test/analyzer/framework_project_scope_spec.cr
@@ -14,7 +14,7 @@ private def scan_tree(root : String) : Array(Endpoint)
   runner.analyze
   runner.endpoints
 ensure
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
 end
 
 private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)

--- a/spec/unit_test/analyzer/js_framework_scope_spec.cr
+++ b/spec/unit_test/analyzer/js_framework_scope_spec.cr
@@ -11,7 +11,7 @@ private def scan_tree(root : String) : Array(Endpoint)
   runner.analyze
   runner.endpoints
 ensure
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
 end
 
 private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)

--- a/spec/unit_test/analyzer/legacy_scan_base_path_spec.cr
+++ b/spec/unit_test/analyzer/legacy_scan_base_path_spec.cr
@@ -15,7 +15,7 @@ private def scan_tree(root : String) : Array(Endpoint)
   runner.analyze
   runner.endpoints
 ensure
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
 end
 
 private def write_file(path : String, content : String)

--- a/spec/unit_test/analyzer/mobile_ios_code_routes_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_code_routes_spec.cr
@@ -15,7 +15,7 @@ describe "Analyzer::Mobile::Ios (code-level route harvesting)" do
 
   CodeLocator.instance.clear("ios-info-plist")
   CodeLocator.instance.clear("ios-entitlements")
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
   CodeLocator.instance.push("ios-info-plist", File.join(base, "Info.plist"))
   swift_path = File.join(base, "Routing.swift")
   CodeLocator.instance.register_file(swift_path, File.read(swift_path))

--- a/spec/unit_test/analyzer/mobile_ios_edge_cases_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_edge_cases_spec.cr
@@ -14,7 +14,7 @@ describe "Analyzer::Mobile::Ios (enum-body-parsing edge cases)" do
 
   CodeLocator.instance.clear("ios-info-plist")
   CodeLocator.instance.clear("ios-entitlements")
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
   CodeLocator.instance.push("ios-info-plist", File.join(base, "Info.plist"))
   swift_path = File.join(base, "RoutingEdgeCases.swift")
   CodeLocator.instance.register_file(swift_path, File.read(swift_path))

--- a/spec/unit_test/analyzer/mobile_ios_generated_project_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_generated_project_spec.cr
@@ -17,7 +17,7 @@ describe "Analyzer::Mobile::Ios (generated project, no .xcodeproj)" do
   # No .swift/.m/.mm fixtures belong to this spec — clear file_map so a
   # leftover registration from another spec run earlier in the same
   # process can't feed the code-level route harvesting pass below.
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
   CodeLocator.instance.push("ios-info-plist", File.join(base, "App", "Info.plist"))
   CodeLocator.instance.push("ios-entitlements", File.join(base, "App", "App.entitlements"))
   endpoints = Analyzer::Mobile::Ios.new(options).analyze

--- a/spec/unit_test/analyzer/mobile_ios_multi_target_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_multi_target_spec.cr
@@ -24,7 +24,7 @@ describe "Analyzer::Mobile::Ios (multi-target monorepo scoping)" do
 
   CodeLocator.instance.clear("ios-info-plist")
   CodeLocator.instance.clear("ios-entitlements")
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
   CodeLocator.instance.push("ios-info-plist", File.join(base, "Vendor", "AppC", "Info.plist"))
   CodeLocator.instance.push("ios-info-plist", File.join(base, "AppA", "Info.plist"))
   CodeLocator.instance.push("ios-info-plist", File.join(base, "AppB", "Info.plist"))

--- a/spec/unit_test/analyzer/mobile_ios_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_spec.cr
@@ -11,7 +11,7 @@ describe "Analyzer::Mobile::Ios" do
   # No .swift/.m/.mm fixtures belong to this spec — clear file_map so a
   # leftover registration from another spec run earlier in the same
   # process can't feed the code-level route harvesting pass below.
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
   CodeLocator.instance.push("ios-info-plist", File.join(base, "Info.plist"))
   CodeLocator.instance.push("ios-entitlements", File.join(base, "App.entitlements"))
   endpoints = Analyzer::Mobile::Ios.new(options).analyze

--- a/spec/unit_test/analyzer/rust_crate_scope_spec.cr
+++ b/spec/unit_test/analyzer/rust_crate_scope_spec.cr
@@ -15,7 +15,7 @@ private def scan_tree(root : String, techs : String? = nil) : Array(Endpoint)
   runner.analyze
   runner.endpoints
 ensure
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
 end
 
 private def tech_sources(endpoints : Array(Endpoint), technology : String) : Array(String)

--- a/spec/unit_test/detector/detector_spec.cr
+++ b/spec/unit_test/detector/detector_spec.cr
@@ -41,7 +41,7 @@ describe "detect_techs file walker" do
 
       detected = detect_techs([temp_dir], options, [] of PassiveScan, logger)
       techs = detected[0]
-      files = locator.all("file_map")
+      files = locator.all_files
 
       techs.should contain("ios")
       files.should contain(info_plist)
@@ -69,7 +69,7 @@ describe "detect_techs file walker" do
 
       detected = detect_techs([temp_dir], options, [] of PassiveScan, logger)
       techs = detected[0]
-      files = locator.all("file_map")
+      files = locator.all_files
 
       techs.should contain("vercel")
       files.should contain(vercel_json)
@@ -103,7 +103,7 @@ describe "detect_techs file walker" do
 
       detected = detect_techs([temp_dir], options, [] of PassiveScan, logger)
       techs = detected[0]
-      files = locator.all("file_map")
+      files = locator.all_files
 
       techs.should contain("postman")
       files.should contain(postman_json)
@@ -207,7 +207,7 @@ describe "detect_techs file walker" do
         detected = detect_techs([temp_dir], options, [] of PassiveScan, logger)
 
         detected[0].should contain("postman")
-        locator.all("file_map").should contain(postman_json)
+        locator.all_files.should contain(postman_json)
       ensure
         FileUtils.rm_rf(temp_dir) if temp_dir
         CodeLocator.instance.clear_all

--- a/spec/unit_test/detector/mobile/android_scope_spec.cr
+++ b/spec/unit_test/detector/mobile/android_scope_spec.cr
@@ -115,6 +115,6 @@ end
 
 private def cleanup_scope(root : String)
   FileUtils.rm_rf(root) if Dir.exists?(root)
-  CodeLocator.instance.clear("file_map")
+  CodeLocator.instance.reset_files
   CodeLocator.instance.clear("android-manifest")
 end

--- a/spec/unit_test/mobile/linker_spec.cr
+++ b/spec/unit_test/mobile/linker_spec.cr
@@ -17,7 +17,7 @@ describe "NoirMobileLinker" do
 
   # Seed the file_map so ClassIndex#build can find the .kt via files_by_extension.
   locator = CodeLocator.instance
-  locator.clear("file_map")
+  locator.reset_files
   locator.register_file(kt, File.read(kt))
   locator.register_file(alias_kt, File.read(alias_kt))
   locator.register_file(router_java, File.read(router_java))
@@ -105,7 +105,7 @@ describe "NoirMobileLinker" do
       path = File.join(source_dir, "ManyExtrasActivity.java")
       File.write(path, source)
 
-      locator.clear("file_map")
+      locator.reset_files
       locator.register_file(path, source)
 
       endpoint = Endpoint.new("myapp://many", "GET")
@@ -118,7 +118,7 @@ describe "NoirMobileLinker" do
       linked_many.params.map(&.name).should contain("extra11")
     ensure
       FileUtils.rm_rf(root) if Dir.exists?(root)
-      locator.clear("file_map")
+      locator.reset_files
     end
   end
 end
@@ -135,7 +135,7 @@ describe "NoirMobileLinker iOS handlers" do
 
   logger = NoirLogger.new(false, false, false, true)
   locator = CodeLocator.instance
-  locator.clear("file_map")
+  locator.reset_files
   files.each { |path| locator.register_file(path, File.read(path)) }
 
   scheme = Endpoint.new("myapp://", "GET")
@@ -220,7 +220,7 @@ describe "NoirMobileLinker iOS multi-app scoping" do
         SWIFT
 
       locator = CodeLocator.instance
-      locator.clear("file_map")
+      locator.reset_files
       locator.register_file(delegate, File.read(delegate))
 
       endpoint = Endpoint.new("generated://", "GET", Details.new(PathInfo.new(plist)))
@@ -233,7 +233,7 @@ describe "NoirMobileLinker iOS multi-app scoping" do
       linked[0].callees.map(&.name).should contain("GeneratedProjectRouter.route")
     ensure
       FileUtils.rm_rf(root) if root
-      CodeLocator.instance.clear("file_map")
+      CodeLocator.instance.reset_files
     end
   end
 
@@ -296,7 +296,7 @@ describe "NoirMobileLinker iOS multi-app scoping" do
         SWIFT
 
       locator = CodeLocator.instance
-      locator.clear("file_map")
+      locator.reset_files
       [delegate, state_machine, unrelated].each { |path| locator.register_file(path, File.read(path)) }
 
       endpoint = Endpoint.new("forwarded://", "GET", Details.new(PathInfo.new(plist)))
@@ -313,7 +313,7 @@ describe "NoirMobileLinker iOS multi-app scoping" do
       names.should_not contain("UnrelatedRouter.route")
     ensure
       FileUtils.rm_rf(root) if root
-      CodeLocator.instance.clear("file_map")
+      CodeLocator.instance.reset_files
     end
   end
 
@@ -351,7 +351,7 @@ describe "NoirMobileLinker iOS multi-app scoping" do
         SWIFT
 
       locator = CodeLocator.instance
-      locator.clear("file_map")
+      locator.reset_files
       locator.register_file(app_a_delegate, File.read(app_a_delegate))
       locator.register_file(app_b_delegate, File.read(app_b_delegate))
 
@@ -377,7 +377,7 @@ describe "NoirMobileLinker iOS multi-app scoping" do
       app_b_callees.should_not contain("AppADeepLinkRouter.route")
     ensure
       FileUtils.rm_rf(root) if root
-      CodeLocator.instance.clear("file_map")
+      CodeLocator.instance.reset_files
     end
   end
 end

--- a/spec/unit_test/models/code_locator_spec.cr
+++ b/spec/unit_test/models/code_locator_spec.cr
@@ -24,7 +24,7 @@ describe "content cache" do
     locator = CodeLocator.new
     locator.register_file("/tmp/noir-cache-spec-a.py", "print('hello')")
 
-    locator.all("file_map").should contain("/tmp/noir-cache-spec-a.py")
+    locator.all_files.should contain("/tmp/noir-cache-spec-a.py")
     locator.content_for("/tmp/noir-cache-spec-a.py").should eq("print('hello')")
   end
 
@@ -33,16 +33,60 @@ describe "content cache" do
     locator.content_for("/does/not/exist.rb").should be_nil
   end
 
-  it "clear(\"file_map\") drops cached content" do
+  it "reset_files drops cached content" do
     locator = CodeLocator.new
     locator.register_file("/tmp/noir-cache-spec-b.py", "x = 1")
     locator.content_for("/tmp/noir-cache-spec-b.py").should_not be_nil
 
-    locator.clear("file_map")
+    locator.reset_files
     locator.content_for("/tmp/noir-cache-spec-b.py").should be_nil
     stats = locator.content_cache_stats
     stats[:bytes].should eq(0)
     stats[:files].should eq(0)
+  end
+
+  # The asymmetry `register_path` and `reset_files` replaced. It used to be a
+  # string comparison behaving differently in `push` and `clear`, explained
+  # only by a comment; registering a path must invalidate the derived views
+  # without discarding content already read for other files.
+  it "register_path invalidates the derived views but keeps cached content" do
+    locator = CodeLocator.new
+    locator.register_file("/tmp/noir-registry-spec.py", "x = 1")
+    locator.files_by_extension(".py").should eq(["/tmp/noir-registry-spec.py"])
+
+    locator.register_path("/tmp/noir-registry-spec-2.py")
+
+    # Index rebuilt to include the new path...
+    locator.files_by_extension(".py").sort.should eq(
+      ["/tmp/noir-registry-spec-2.py", "/tmp/noir-registry-spec.py"])
+    # ...and the first file's content survived.
+    locator.content_for("/tmp/noir-registry-spec.py").should eq("x = 1")
+    # The newly registered one has none, as documented.
+    locator.content_for("/tmp/noir-registry-spec-2.py").should be_nil
+  end
+
+  it "all_files reports registrations in order and reset_files empties it" do
+    locator = CodeLocator.new
+    locator.register_path("/a.rb")
+    locator.register_path("/b.rb")
+    locator.all_files.should eq(["/a.rb", "/b.rb"])
+
+    locator.reset_files
+    locator.all_files.should be_empty
+    locator.files_by_extension(".rb").should be_empty
+  end
+
+  # `reset_files` must not disturb the other 64 keys — the detector calls it
+  # at the top of every scan, and the spec-format keys are drained later.
+  it "reset_files leaves unrelated keys alone" do
+    locator = CodeLocator.new
+    locator.push("oas3-json", "/spec/openapi.json")
+    locator.register_path("/a.rb")
+
+    locator.reset_files
+
+    locator.all_files.should be_empty
+    locator.all("oas3-json").should eq(["/spec/openapi.json"])
   end
 
   it "stops caching once the total budget is exhausted" do
@@ -52,7 +96,7 @@ describe "content cache" do
       locator.register_file("/tmp/noir-cache-spec-c.py", "anything")
       # Budget is 0 bytes, so nothing gets cached, but the path still
       # makes it into file_map.
-      locator.all("file_map").should contain("/tmp/noir-cache-spec-c.py")
+      locator.all_files.should contain("/tmp/noir-cache-spec-c.py")
       locator.content_for("/tmp/noir-cache-spec-c.py").should be_nil
     ensure
       ENV.delete("NOIR_CONTENT_CACHE_MAX_MB")
@@ -100,9 +144,9 @@ end
 describe "basename index" do
   it "groups file_map entries by basename" do
     locator = CodeLocator.new
-    locator.push("file_map", "/a/urls.py")
-    locator.push("file_map", "/b/urls.py")
-    locator.push("file_map", "/c/views.py")
+    locator.register_path("/a/urls.py")
+    locator.register_path("/b/urls.py")
+    locator.register_path("/c/views.py")
 
     locator.files_by_basename("urls.py").should eq(["/a/urls.py", "/b/urls.py"])
     locator.files_by_basename("views.py").should eq(["/c/views.py"])
@@ -113,19 +157,19 @@ describe "basename index" do
   # after the first lookup must not keep serving the stale build.
   it "rebuilds after clear(\"file_map\")" do
     locator = CodeLocator.new
-    locator.push("file_map", "/a/urls.py")
+    locator.register_path("/a/urls.py")
     locator.files_by_basename("urls.py").should eq(["/a/urls.py"])
 
-    locator.clear("file_map")
+    locator.reset_files
     locator.files_by_basename("urls.py").should be_empty
 
-    locator.push("file_map", "/b/urls.py")
+    locator.register_path("/b/urls.py")
     locator.files_by_basename("urls.py").should eq(["/b/urls.py"])
   end
 
   it "rebuilds after clear_all" do
     locator = CodeLocator.new
-    locator.push("file_map", "/a/urls.py")
+    locator.register_path("/a/urls.py")
     locator.files_by_basename("urls.py").should eq(["/a/urls.py"])
 
     locator.clear_all
@@ -136,19 +180,19 @@ end
 describe "derived index invalidation" do
   it "does not serve a stale basename index after a later push" do
     locator = CodeLocator.new
-    locator.push("file_map", "/a/urls.py")
+    locator.register_path("/a/urls.py")
     locator.files_by_basename("urls.py").should eq(["/a/urls.py"])
 
-    locator.push("file_map", "/b/urls.py")
+    locator.register_path("/b/urls.py")
     locator.files_by_basename("urls.py").should eq(["/a/urls.py", "/b/urls.py"])
   end
 
   it "does not serve a stale extension index after a later push" do
     locator = CodeLocator.new
-    locator.push("file_map", "/a/one.py")
+    locator.register_path("/a/one.py")
     locator.files_by_extension(".py").should eq(["/a/one.py"])
 
-    locator.push("file_map", "/b/two.py")
+    locator.register_path("/b/two.py")
     locator.files_by_extension(".py").should eq(["/a/one.py", "/b/two.py"])
   end
 end

--- a/spec/unit_test/models/file_helper_spec.cr
+++ b/spec/unit_test/models/file_helper_spec.cr
@@ -20,8 +20,8 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/test/file1.cr")
-      locator.push("file_map", "/test/file2.cr")
+      locator.register_path("/test/file1.cr")
+      locator.register_path("/test/file2.cr")
 
       files = helper.all_files
       files.should contain("/test/file1.cr")
@@ -34,9 +34,9 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/test/file1.cr")
-      locator.push("file_map", "/test/file2.rb")
-      locator.push("file_map", "/test/file3.cr")
+      locator.register_path("/test/file1.cr")
+      locator.register_path("/test/file2.rb")
+      locator.register_path("/test/file3.cr")
 
       cr_files = helper.get_files_by_extension(".cr")
       cr_files.size.should eq(2)
@@ -48,7 +48,7 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/test/file1.cr")
+      locator.register_path("/test/file1.cr")
 
       rb_files = helper.get_files_by_extension(".rb")
       rb_files.should be_empty
@@ -60,9 +60,9 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/src/file1.cr")
-      locator.push("file_map", "/app/test/file2.cr")
-      locator.push("file_map", "/lib/file3.cr")
+      locator.register_path("/app/src/file1.cr")
+      locator.register_path("/app/test/file2.cr")
+      locator.register_path("/lib/file3.cr")
 
       app_files = helper.get_files_by_prefix("/app")
       app_files.size.should eq(2)
@@ -74,8 +74,8 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/src/file1.cr")
-      locator.push("file_map", "/app2/src/file2.cr")
+      locator.register_path("/app/src/file1.cr")
+      locator.register_path("/app2/src/file2.cr")
 
       helper.get_files_by_prefix("/app").should eq(["/app/src/file1.cr"])
     end
@@ -84,7 +84,7 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/src/file1.cr")
+      locator.register_path("/app/src/file1.cr")
 
       helper.get_files_by_prefix(File::SEPARATOR.to_s).should eq(["/app/src/file1.cr"])
     end
@@ -95,9 +95,9 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/file1.cr")
-      locator.push("file_map", "/app/file2.rb")
-      locator.push("file_map", "/lib/file3.cr")
+      locator.register_path("/app/file1.cr")
+      locator.register_path("/app/file2.rb")
+      locator.register_path("/lib/file3.cr")
 
       files = helper.get_files_by_prefix_and_extension("/app", ".cr")
       files.size.should eq(1)
@@ -108,8 +108,8 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/file1.cr")
-      locator.push("file_map", "/app2/file2.cr")
+      locator.register_path("/app/file1.cr")
+      locator.register_path("/app2/file2.cr")
 
       helper.get_files_by_prefix_and_extension("/app", ".cr").should eq(["/app/file1.cr"])
     end
@@ -120,10 +120,10 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/shard.yml")
-      locator.push("file_map", "/app/public/style.css")
-      locator.push("file_map", "/app/public/script.js")
-      locator.push("file_map", "/app/src/file.cr")
+      locator.register_path("/app/shard.yml")
+      locator.register_path("/app/public/style.css")
+      locator.register_path("/app/public/script.js")
+      locator.register_path("/app/src/file.cr")
 
       public_files = helper.get_public_files("/app")
       public_files.size.should eq(2)
@@ -135,10 +135,10 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/shard.yml")
-      locator.push("file_map", "/app/modules/admin/shard.yml")
-      locator.push("file_map", "/app/modules/admin/public/admin.css")
-      locator.push("file_map", "/app/public/main.css")
+      locator.register_path("/app/shard.yml")
+      locator.register_path("/app/modules/admin/shard.yml")
+      locator.register_path("/app/modules/admin/public/admin.css")
+      locator.register_path("/app/public/main.css")
 
       public_files = helper.get_public_files("/app")
       public_files.size.should eq(2)
@@ -152,11 +152,11 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/shard.yml")
-      locator.push("file_map", "/app/public/legitimate.css")  # under app/shard.yml — included
-      locator.push("file_map", "/app/docs/public/index.html") # no shard.yml in docs/ — skipped
-      locator.push("file_map", "/app/docs/public/sitemap.xml")
-      locator.push("file_map", "/app/docs/public/robots.txt")
+      locator.register_path("/app/shard.yml")
+      locator.register_path("/app/public/legitimate.css")  # under app/shard.yml — included
+      locator.register_path("/app/docs/public/index.html") # no shard.yml in docs/ — skipped
+      locator.register_path("/app/docs/public/sitemap.xml")
+      locator.register_path("/app/docs/public/robots.txt")
 
       public_files = helper.get_public_files("/app")
       public_files.should eq(["/app/public/legitimate.css"])
@@ -166,10 +166,10 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/shard.yml")
-      locator.push("file_map", "/app/public/app.css")
-      locator.push("file_map", "/app2/shard.yml")
-      locator.push("file_map", "/app2/public/app2.css")
+      locator.register_path("/app/shard.yml")
+      locator.register_path("/app/public/app.css")
+      locator.register_path("/app2/shard.yml")
+      locator.register_path("/app2/public/app2.css")
 
       helper.get_public_files("/app").should eq(["/app/public/app.css"])
     end
@@ -178,8 +178,8 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/shard.yml")
-      locator.push("file_map", "/app/src/file.cr")
+      locator.register_path("/app/shard.yml")
+      locator.register_path("/app/src/file.cr")
 
       public_files = helper.get_public_files("/app")
       public_files.should be_empty
@@ -191,9 +191,9 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/assets/style.css")
-      locator.push("file_map", "/app/assets/script.js")
-      locator.push("file_map", "/app/src/file.cr")
+      locator.register_path("/app/assets/style.css")
+      locator.register_path("/app/assets/script.js")
+      locator.register_path("/app/src/file.cr")
 
       asset_files = helper.get_public_dir_files("/app", "assets")
       asset_files.size.should eq(2)
@@ -205,7 +205,7 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/static/images/logo.webp")
+      locator.register_path("/app/static/images/logo.webp")
 
       files = helper.get_public_dir_files("/app", "static/images")
       files.size.should eq(1)
@@ -216,7 +216,7 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/var/www/assets/style.css")
+      locator.register_path("/var/www/assets/style.css")
 
       files = helper.get_public_dir_files("/var/www", "/var/www/assets")
       files.size.should eq(1)
@@ -227,8 +227,8 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/modules/assets/file1.css")
-      locator.push("file_map", "/lib/assets/file2.css")
+      locator.register_path("/app/modules/assets/file1.css")
+      locator.register_path("/lib/assets/file2.css")
 
       files = helper.get_public_dir_files("/app", "assets")
       files.should eq(["/app/modules/assets/file1.css"])
@@ -238,8 +238,8 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/app/assets/file1.css")
-      locator.push("file_map", "/app2/assets/file2.css")
+      locator.register_path("/app/assets/file1.css")
+      locator.register_path("/app2/assets/file2.css")
 
       helper.get_public_dir_files("/app", "assets").should eq(["/app/assets/file1.css"])
     end
@@ -250,10 +250,10 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/a/go.mod")
-      locator.push("file_map", "/b/nested/go.mod")
-      locator.push("file_map", "/c/go.sum")
-      locator.push("file_map", "/d/mygo.mod")
+      locator.register_path("/a/go.mod")
+      locator.register_path("/b/nested/go.mod")
+      locator.register_path("/c/go.sum")
+      locator.register_path("/d/mygo.mod")
 
       helper.get_files_by_basename("go.mod").should eq(["/a/go.mod", "/b/nested/go.mod"])
     end
@@ -271,16 +271,16 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/repo/svc/myproj/urls.py")
-      locator.push("file_map", "/repo/other/urls.py")
-      locator.push("file_map", "/repo/svc/myproj/views.py")
+      locator.register_path("/repo/svc/myproj/urls.py")
+      locator.register_path("/repo/other/urls.py")
+      locator.register_path("/repo/svc/myproj/views.py")
 
       helper.get_files_by_relative_path("myproj/urls.py").should eq(["/repo/svc/myproj/urls.py"])
     end
 
     it "matches when the suffix sits directly under the root" do
       helper = TestHelper.new
-      CodeLocator.instance.push("file_map", "/repo/myproj/urls.py")
+      CodeLocator.instance.register_path("/repo/myproj/urls.py")
 
       helper.get_files_by_relative_path("myproj/urls.py", "/repo").should eq(["/repo/myproj/urls.py"])
     end
@@ -289,8 +289,8 @@ describe "FileHelper" do
       helper = TestHelper.new
       locator = CodeLocator.instance
 
-      locator.push("file_map", "/repo/a/myproj/urls.py")
-      locator.push("file_map", "/repo/b/myproj/urls.py")
+      locator.register_path("/repo/a/myproj/urls.py")
+      locator.register_path("/repo/b/myproj/urls.py")
 
       helper.get_files_by_relative_path("myproj/urls.py", "/repo/a").should eq(["/repo/a/myproj/urls.py"])
     end
@@ -299,7 +299,7 @@ describe "FileHelper" do
       helper = TestHelper.new
       # `Dir.glob` would not treat `notmyproj` as `myproj`; a bare
       # `ends_with?` without the separator would.
-      CodeLocator.instance.push("file_map", "/repo/notmyproj/urls.py")
+      CodeLocator.instance.register_path("/repo/notmyproj/urls.py")
 
       helper.get_files_by_relative_path("myproj/urls.py").should be_empty
     end

--- a/spec/unit_test/tagger/framework_taggers/crystal_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/crystal_auth_spec.cr
@@ -24,7 +24,7 @@ describe "CrystalAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 4))
@@ -46,7 +46,7 @@ describe "CrystalAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 10))
@@ -68,7 +68,7 @@ describe "CrystalAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 18))

--- a/spec/unit_test/tagger/framework_taggers/elixir_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/elixir_auth_spec.cr
@@ -22,7 +22,7 @@ describe "ElixirAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(controller_path, 5))
@@ -45,7 +45,7 @@ describe "ElixirAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(public_path, 4))

--- a/spec/unit_test/tagger/framework_taggers/express_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/express_auth_spec.cr
@@ -25,7 +25,7 @@ describe "ExpressAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 16))
@@ -48,7 +48,7 @@ describe "ExpressAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 21))
@@ -70,7 +70,7 @@ describe "ExpressAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 26))
@@ -137,7 +137,7 @@ describe "ExpressAuthTagger" do
     [base1, base2].each do |b|
       Dir.glob("#{b}/**/*").each do |file|
         next if File.directory?(file)
-        locator.push("file_map", file)
+        locator.register_path(file)
       end
     end
 
@@ -161,7 +161,7 @@ describe "ExpressAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 31))
@@ -181,7 +181,7 @@ describe "ExpressAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # This endpoint has no auth on its own route definition,

--- a/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
@@ -17,7 +17,7 @@ def run_go_auth(fixture_lines : Array(String), url : String, method : String, li
   locator = CodeLocator.instance
   Dir.glob("#{tmpdir}/**/*").each do |f|
     next if File.directory?(f)
-    locator.push("file_map", f)
+    locator.register_path(f)
   end
 
   noir_options = create_test_options
@@ -55,7 +55,7 @@ describe "GoAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 29))
@@ -78,7 +78,7 @@ describe "GoAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 34))
@@ -100,7 +100,7 @@ describe "GoAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 24))
@@ -122,7 +122,7 @@ describe "GoAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 13))
@@ -163,7 +163,7 @@ describe "GoAuthTagger (expanded targets)" do
       locator = CodeLocator.instance
       Dir.glob("#{fixture_base}/**/*").each do |file|
         next if File.directory?(file)
-        locator.push("file_map", file)
+        locator.register_path(file)
       end
 
       details = Details.new(PathInfo.new(main_path, 29))

--- a/spec/unit_test/tagger/framework_taggers/go_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_security_spec.cr
@@ -40,7 +40,7 @@ private def seed_file_map(fixture_base : String)
   locator.clear_all
   Dir.glob("#{fixture_base}/**/*").each do |file|
     next if File.directory?(file)
-    locator.push("file_map", file)
+    locator.register_path(file)
   end
 end
 

--- a/spec/unit_test/tagger/framework_taggers/hono_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/hono_auth_spec.cr
@@ -26,7 +26,7 @@ describe "HonoAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 12))
@@ -49,7 +49,7 @@ describe "HonoAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 19))
@@ -71,7 +71,7 @@ describe "HonoAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 45))
@@ -93,7 +93,7 @@ describe "HonoAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 50))

--- a/spec/unit_test/tagger/framework_taggers/java_misc_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/java_misc_auth_spec.cr
@@ -19,7 +19,7 @@ describe "JavaMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # Line 9: router.get("/api/secure").handler(ctx -> {
@@ -43,7 +43,7 @@ describe "JavaMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # Line 9: router.get("/admin/dashboard").handler(ctx -> {
@@ -66,7 +66,7 @@ describe "JavaMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # Line 8: router.get("/api/profile").handler(ctx -> {
@@ -89,7 +89,7 @@ describe "JavaMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # Line 8: router.get("/public/health").handler(ctx -> {

--- a/spec/unit_test/tagger/framework_taggers/js_misc_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/js_misc_auth_spec.cr
@@ -23,7 +23,7 @@ describe "JsMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 4))
@@ -46,7 +46,7 @@ describe "JsMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 9))
@@ -68,7 +68,7 @@ describe "JsMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 14))
@@ -90,7 +90,7 @@ describe "JsMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 19))
@@ -112,7 +112,7 @@ describe "JsMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 33))

--- a/spec/unit_test/tagger/framework_taggers/ktor_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/ktor_auth_spec.cr
@@ -26,7 +26,7 @@ describe "KtorAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 15))
@@ -49,7 +49,7 @@ describe "KtorAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 15))
@@ -70,7 +70,7 @@ describe "KtorAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 10))
@@ -90,7 +90,7 @@ describe "KtorAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 33))
@@ -110,7 +110,7 @@ describe "KtorAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 27))

--- a/spec/unit_test/tagger/framework_taggers/python_misc_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/python_misc_auth_spec.cr
@@ -29,7 +29,7 @@ describe "PythonMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 10))
@@ -52,7 +52,7 @@ describe "PythonMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 15))
@@ -74,7 +74,7 @@ describe "PythonMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # MainHandler has get_current_user inherited from BaseHandler
@@ -99,7 +99,7 @@ describe "PythonMiscAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(app_path, 19))

--- a/spec/unit_test/tagger/framework_taggers/rust_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/rust_auth_spec.cr
@@ -29,7 +29,7 @@ describe "RustAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 18))
@@ -52,7 +52,7 @@ describe "RustAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 25))
@@ -74,7 +74,7 @@ describe "RustAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 31))
@@ -96,7 +96,7 @@ describe "RustAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 6))
@@ -116,7 +116,7 @@ describe "RustAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(main_path, 12))

--- a/spec/unit_test/tagger/framework_taggers/rust_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/rust_security_spec.cr
@@ -31,7 +31,7 @@ private def load_fixture(base : String) : Hash(String, YAML::Any)
   locator = CodeLocator.instance
   Dir.glob("#{base}/**/*").each do |file|
     next if File.directory?(file)
-    locator.push("file_map", file)
+    locator.register_path(file)
   end
   options
 end

--- a/spec/unit_test/tagger/framework_taggers/scala_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/scala_auth_spec.cr
@@ -18,7 +18,7 @@ describe "ScalaAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # Routes.scala line 10: get { complete("Secure content") }
@@ -42,7 +42,7 @@ describe "ScalaAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # Routes.scala line 21: get { complete("OAuth resource") }
@@ -65,7 +65,7 @@ describe "ScalaAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # Routes.scala line 32: get { complete("Admin settings") }
@@ -88,7 +88,7 @@ describe "ScalaAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     # HealthRoutes.scala line 11: get { complete("ok") }

--- a/spec/unit_test/tagger/framework_taggers/spring_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/spring_auth_spec.cr
@@ -10,7 +10,7 @@ def run_spring_class_level(source : String, line : Int32, ext : String = "java")
   Dir.mkdir_p(tmpdir)
   file = File.join(tmpdir, "AdminController.#{ext}")
   File.write(file, source)
-  CodeLocator.instance.push("file_map", file)
+  CodeLocator.instance.register_path(file)
 
   noir_options = create_test_options
   noir_options["base"] = YAML::Any.new(tmpdir)
@@ -57,7 +57,7 @@ describe "SpringAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(controller_path, 14))
@@ -79,7 +79,7 @@ describe "SpringAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(controller_path, 14))
@@ -102,7 +102,7 @@ describe "SpringAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(controller_path, 20))
@@ -124,7 +124,7 @@ describe "SpringAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(controller_path, 26))
@@ -146,7 +146,7 @@ describe "SpringAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     details = Details.new(PathInfo.new(open_controller_path, 9))
@@ -166,7 +166,7 @@ describe "SpringAuthTagger" do
     locator = CodeLocator.instance
     Dir.glob("#{fixture_base}/**/*").each do |file|
       next if File.directory?(file)
-      locator.push("file_map", file)
+      locator.register_path(file)
     end
 
     endpoint = Endpoint.new("/api/other", "GET")
@@ -207,7 +207,7 @@ describe "SpringAuthTagger" do
 
       noir_options = create_test_options
       noir_options["base"] = YAML::Any.new(temp_dir)
-      CodeLocator.instance.push("file_map", config_path)
+      CodeLocator.instance.register_path(config_path)
 
       endpoint = Endpoint.new("/web/dashboard", "GET")
 
@@ -250,7 +250,7 @@ describe "SpringAuthTagger" do
 
       noir_options = create_test_options
       noir_options["base"] = YAML::Any.new(temp_dir)
-      CodeLocator.instance.push("file_map", config_path)
+      CodeLocator.instance.register_path(config_path)
 
       public_endpoint = Endpoint.new("/public/health", "GET")
       protected_endpoint = Endpoint.new("/secure/data", "GET")
@@ -292,7 +292,7 @@ describe "SpringAuthTagger" do
 
       noir_options = create_test_options
       noir_options["base"] = YAML::Any.new(temp_dir)
-      CodeLocator.instance.push("file_map", config_path)
+      CodeLocator.instance.register_path(config_path)
 
       public_get = Endpoint.new("/public/status", "GET")
       protected_post = Endpoint.new("/public/status", "POST")
@@ -331,7 +331,7 @@ describe "SpringAuthTagger" do
 
       noir_options = create_test_options
       noir_options["base"] = YAML::Any.new(temp_dir)
-      CodeLocator.instance.push("file_map", config_path)
+      CodeLocator.instance.register_path(config_path)
 
       public_endpoint = Endpoint.new("/user/register", "POST")
       protected_endpoint = Endpoint.new("/user/profile", "GET")
@@ -369,7 +369,7 @@ describe "SpringAuthTagger" do
 
       noir_options = create_test_options
       noir_options["base"] = YAML::Any.new(temp_dir)
-      CodeLocator.instance.push("file_map", config_path)
+      CodeLocator.instance.register_path(config_path)
 
       endpoint = Endpoint.new("/api/v1/teams/{nation}", "GET")
 

--- a/spec/unit_test/tagger/framework_taggers/spring_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/spring_security_spec.cr
@@ -31,7 +31,7 @@ private def load_fixture_files(fixture_base : String)
   locator = CodeLocator.instance
   Dir.glob("#{fixture_base}/**/*").each do |file|
     next if File.directory?(file)
-    locator.push("file_map", file)
+    locator.register_path(file)
   end
 end
 
@@ -165,7 +165,7 @@ describe "SpringSecurityTagger" do
       path = File.join(Dir.tempdir, "ValidatedController-#{Process.pid}-#{Time.utc.to_unix_ms}.java")
       begin
         File.write(path, source)
-        CodeLocator.instance.push("file_map", path)
+        CodeLocator.instance.register_path(path)
         endpoint = build_endpoint(path, 9, "/health", "GET")
 
         SpringSecurityTagger.new(global_options).perform([endpoint])
@@ -197,7 +197,7 @@ describe "SpringSecurityTagger" do
       path = File.join(Dir.tempdir, "ValidatedController-#{Process.pid}-#{Time.utc.to_unix_ms}.java")
       begin
         File.write(path, source)
-        CodeLocator.instance.push("file_map", path)
+        CodeLocator.instance.register_path(path)
         endpoint = build_endpoint(path, 10, "/search", "GET")
         endpoint.push_param(Param.new("q", "", "query"))
 
@@ -233,7 +233,7 @@ describe "SpringSecurityTagger" do
       path = File.join(Dir.tempdir, "ArticleController-#{Process.pid}-#{Time.utc.to_unix_ms}.kt")
       begin
         File.write(path, source)
-        CodeLocator.instance.push("file_map", path)
+        CodeLocator.instance.register_path(path)
         list_endpoint = build_endpoint(path, 10, "/articles", "GET")
         create_endpoint = build_endpoint(path, 14, "/articles", "POST")
 
@@ -359,7 +359,7 @@ describe "SpringSecurityTagger" do
       begin
         Dir.mkdir_p(dir)
         File.write(path, source)
-        CodeLocator.instance.push("file_map", path)
+        CodeLocator.instance.register_path(path)
 
         options = create_test_options
         options["base"] = YAML::Any.new(dir)

--- a/spec/unit_test/utils/utf16_source_spec.cr
+++ b/spec/unit_test/utils/utf16_source_spec.cr
@@ -110,7 +110,7 @@ describe "scanning a UTF-16 project" do
       runner.detect
       runner.analyze
       runner.endpoints.map(&.url).should contain("/api/Users/GetAll")
-      CodeLocator.instance.clear("file_map")
+      CodeLocator.instance.reset_files
     ensure
       FileUtils.rm_rf(root) if Dir.exists?(root)
     end

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -232,7 +232,7 @@ module Analyzer::AI
 
     private def select_target_paths(adapter : LLM::Adapter) : Array(String)
       locator = CodeLocator.instance
-      all_paths = locator.all("file_map")
+      all_paths = locator.all_files
 
       if all_paths.size > 10
         logger.debug_sub "AI::Filtering files using LLM"

--- a/src/analyzer/analyzers/mobile/ios.cr
+++ b/src/analyzer/analyzers/mobile/ios.cr
@@ -182,7 +182,7 @@ module Analyzer::Mobile
       #
       # The glob stays as the fallback for when `file_map` is empty,
       # which means the analyzer is running without a detector pass in
-      # front of it (specs drive it that way, and `clear("file_map")` is
+      # front of it (specs drive it that way, and `reset_files` is
       # explicit about it). That is "no scan context", not "scanned and
       # found nothing" — the latter must not re-walk the tree, or the
       # expensive case would be exactly the one the index was added for.

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -343,7 +343,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   # Clear detector-populated locator keys before starting. These arrays
   # are side effects of idempotent? == false mobile/spec detectors, so
   # they should represent the current detection run only.
-  locator.clear("file_map")
+  locator.reset_files
   locator.clear("android-manifest")
   locator.clear("android-assetlinks")
   locator.clear("ios-info-plist")
@@ -510,7 +510,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
                 # read/cache content that neither detection nor passive
                 # scan will inspect. Analyzer reads still fall back to
                 # a disk read when a file was not cached here.
-                locator.push("file_map", full_path)
+                locator.register_path(full_path)
                 skipped_content_reads += 1
                 next
               end
@@ -671,6 +671,6 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
     )
   end
 
-  logger.debug "Added #{locator.all("file_map").size} files to file_map"
+  logger.debug "Added #{locator.all_files.size} files to file_map"
   {techs.uniq, passive_result}
 end

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -119,24 +119,63 @@ class CodeLocator
   end
 
   def push(key : String, value : String)
+    # Compat shim: `file_map` is no longer a key. Removed in the PR that
+    # tightens these signatures; until then, a caller reaching for the old
+    # spelling must still get the derived-view invalidation.
+    return register_path(value) if key == FILE_MAP
+
     @a_map[key] ||= Array(String).new
     @a_map[key] << value
+  end
 
-    # Pushing into file_map invalidates every derived view of it.
-    #
-    # The extension/basename indexes are memoised behind a `_built`
-    # flag, so without this a lookup taken before a later push would
-    # keep serving the older file list. Nothing pushes to `file_map`
-    # after the detector finishes today — the indexes are only read
-    # during analysis, by which point the map is complete — so this
-    # costs nothing in a normal scan and just stops the caches from
-    # being able to go stale.
-    if key == "file_map"
-      @expanded_file_map = nil
-      @expanded_path_index = nil
-      @extension_index_built = false
-      @basename_index_built = false
-    end
+  # The scanned-file registry.
+  #
+  # `file_map` was never a blackboard key like the other 64. It is a file
+  # registry with four derived views (`@extension_index`, `@basename_index`,
+  # `@expanded_file_map`, `@expanded_path_index`) plus a content cache bolted
+  # to it, and it was the only reason `push` and `clear` each carried an
+  # `if key == "file_map"` branch. Giving it methods makes the coupling
+  # structural instead of a string comparison that behaves differently in two
+  # places.
+  private FILE_MAP = "file_map"
+
+  # Register a path with no content — the detector's content-free fast path,
+  # for files nothing will read during detection or passive scan.
+  #
+  # Invalidates the four derived views but deliberately NOT `@file_contents`.
+  # A newly registered path has no cached content to invalidate, and dropping
+  # the cache here would throw away every file read so far. `content_for`
+  # returning nil for a registered path is the contract — `register_file`
+  # skips over-budget files the same way — so callers keep a `File.read`
+  # fallback regardless.
+  def register_path(path : String)
+    @a_map[FILE_MAP] ||= Array(String).new
+    @a_map[FILE_MAP] << path
+    invalidate_file_views
+  end
+
+  # Every registered path, in registration order.
+  def all_files : Array(String)
+    @a_map[FILE_MAP]? || Array(String).new
+  end
+
+  # Forget every registered file, its cached content, and every derived view.
+  def reset_files
+    @a_map.delete(FILE_MAP)
+    @file_contents.clear
+    @content_cache_used = 0_i64
+    @content_cache_skipped = 0
+    invalidate_file_views
+  end
+
+  # The memoised views are rebuilt on next read; the indexes sit behind a
+  # `_built` flag, so a lookup taken before a later registration would
+  # otherwise keep serving the older file list.
+  private def invalidate_file_views
+    @expanded_file_map = nil
+    @expanded_path_index = nil
+    @extension_index_built = false
+    @basename_index_built = false
   end
 
   # One-shot used by the detector's file reader: push the path into
@@ -146,7 +185,7 @@ class CodeLocator
   # and `content_for(path)` returns `nil` for them — callers must keep
   # a `File.read` fallback.
   def register_file(path : String, content : String)
-    push("file_map", path)
+    register_path(path)
 
     return if @content_cache_budget <= 0
     size = content.bytesize.to_i64
@@ -189,7 +228,7 @@ class CodeLocator
       cached = @expanded_file_map
       return cached if cached
 
-      files = @a_map["file_map"]?
+      files = @a_map[FILE_MAP]?
       built = files ? files.map { |file| {file, File.expand_path(file)} } : [] of Tuple(String, String)
       @expanded_file_map = built
       built
@@ -232,7 +271,7 @@ class CodeLocator
   # flag false so a later lookup retries. Callers must hold `@lock`.
   private def rebuild_path_index(index : Hash(String, Array(String)), & : String -> String) : Bool
     index.clear
-    files = @a_map["file_map"]?
+    files = @a_map[FILE_MAP]?
     return false unless files
     files.each do |file|
       (index[yield file] ||= Array(String).new) << file
@@ -284,19 +323,11 @@ class CodeLocator
   end
 
   def clear(key : String)
+    # Compat shim, as in `push`.
+    return reset_files if key == FILE_MAP
+
     @s_map.delete(key)
     @a_map.delete(key)
-    if key == "file_map"
-      @extension_index.clear
-      @extension_index_built = false
-      @basename_index.clear
-      @basename_index_built = false
-      @file_contents.clear
-      @content_cache_used = 0_i64
-      @content_cache_skipped = 0
-      @expanded_file_map = nil
-      @expanded_path_index = nil
-    end
   end
 
   def clear_all

--- a/src/models/file_helper.cr
+++ b/src/models/file_helper.cr
@@ -13,7 +13,7 @@ module FileHelper
   # Get all files from CodeLocator
   def all_files : Array(String)
     locator = CodeLocator.instance
-    locator.all("file_map")
+    locator.all_files
   end
 
   # `{original, expanded}` pairs for every file, expanded once and cached


### PR DESCRIPTION
Second of four PRs on `CodeLocator`, after #2499. Behaviour-neutral.

## Why

`file_map` was never a blackboard key like the other 64. It is **the scanned-file registry**: four derived views hang off it (`@extension_index`, `@basename_index`, `@expanded_file_map`, `@expanded_path_index`) plus the content cache — and it was the sole reason `push` and `clear` each carried an `if key == "file_map"` branch:

```crystal
def push(key : String, value : String)
  @a_map[key] ||= Array(String).new
  @a_map[key] << value
  if key == "file_map"   # ← invalidate four derived views
```

The same string comparison behaving differently in two methods, reconciled only by a comment. It gets methods instead — `register_path`, `all_files`, `reset_files` — and both `if` branches disappear.

## The asymmetry, now visible

`register_path` invalidates the four derived views but deliberately **not** the content cache: a newly registered path has no cached content to invalidate, and dropping the cache there would discard every file read so far. `reset_files` drops everything, because it means "forget this scan's files".

That was a comment before. It is now two methods with different bodies, plus a spec that fails if they are collapsed:

```crystal
it "register_path invalidates the derived views but keeps cached content"
```

## Why it comes before the typed-key PR

174 of the ~290 spec call sites across the locator surface are `file_map`. Taking it out of the key space first shrinks the typed-key migration from ~420 edits to ~220 — which is the difference between a reviewable diff and a rubber-stamped one.

`push`/`clear` keep a two-line shim for the old spelling so nothing outside this commit silently loses the invalidation. It goes away in the next PR, where `file_map` stops being expressible as a key at all.

## Verification

**STRICT A/B** over all 665 fixture directories: **byte-identical** — 5,160 endpoints, 4,775 callee entries, every `details.code_paths[].line` and `callees[].line`.

STRICT rather than plain because the derived views feed every analyzer's file set. A broken invalidation would change *which files get scanned*, not merely how they are reported — so line-level equality is the assertion that matters here.

`crystal spec spec/unit_test` 4682 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1911 files, 0 findings.