### PR TITLE
refactor(analyzer): add a worker-count accessor on the Analyzer base

### DIFF
--- a/spec/unit_test/analyzer/options_boundary_spec.cr
+++ b/spec/unit_test/analyzer/options_boundary_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "../../../src/models/analyzer"
 
 # `Analyzer#callees_needed?` (src/models/analyzer.cr) has existed, with a doc
 # comment telling analyzers to use it, for as long as the callee flags have.
@@ -51,11 +52,73 @@ describe "analyzer options boundary" do
       MSG
   end
 
+  it "reads the worker count only through the base accessors" do
+    offenders = offending_lines(/@options\[\s*"concurrency"\s*\]/)
+
+    fail <<-MSG unless offenders.empty?
+      analyzers must call `worker_count` / `bounded_worker_count` instead of
+      reading `concurrency` out of the options hash. Offending lines:
+        #{offenders.join("\n  ")}
+      MSG
+  end
+
   # Guards the guard: a typo in the globs above would make both examples pass
   # vacuously, which is the failure mode that makes source-scanning specs
   # worthless.
   it "scans a non-trivial number of analyzer sources" do
     analyzer_sources.size.should be > 200
     analyzer_sources.count { |f| File.read(f).includes?("callees_needed?") }.should be > 50
+  end
+end
+
+# `concurrency` was the last option key the analyzer layer read directly, at
+# 21 sites all spelling it `@options["concurrency"].to_s.to_i`.
+#
+# `worker_count` / `bounded_worker_count` are protected, so reach them the
+# way a subclass would.
+private class WorkerCountProbe < Analyzer
+  def visible_worker_count : Int32
+    worker_count
+  end
+
+  def visible_bounded_worker_count : Int32
+    bounded_worker_count
+  end
+end
+
+private def worker_probe(value : String?) : WorkerCountProbe
+  options = create_test_options
+  if value
+    options["concurrency"] = YAML::Any.new(value)
+  else
+    options.delete("concurrency")
+  end
+  WorkerCountProbe.new(options)
+end
+
+describe "Analyzer worker count" do
+  it "reads a configured worker count" do
+    worker_probe("8").visible_worker_count.should eq 8
+  end
+
+  # Each of these used to raise or spawn zero workers. `0` was the worst:
+  # the analyzer ran, spawned nothing, and reported no endpoints.
+  it "floors at one worker instead of raising or spawning none" do
+    worker_probe("0").visible_worker_count.should eq 1
+    worker_probe("-4").visible_worker_count.should eq 1
+    worker_probe("abc").visible_worker_count.should eq 1
+    worker_probe(nil).visible_worker_count.should eq 1
+  end
+
+  it "caps the shared file walk at MAX_ANALYZER_WORKERS" do
+    worker_probe("1000").visible_bounded_worker_count.should eq Analyzer::MAX_ANALYZER_WORKERS
+    worker_probe("8").visible_bounded_worker_count.should eq 8
+  end
+
+  # The per-analyzer walks deliberately stay uncapped — see the comment on
+  # `bounded_worker_count`. Folding them in would silently drop a
+  # `--concurrency 100` run to 64.
+  it "leaves the uncapped accessor uncapped" do
+    worker_probe("1000").visible_worker_count.should eq 1000
   end
 end

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -50,7 +50,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -128,7 +128,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 path = channel.receive?

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -27,7 +27,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -26,7 +26,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -32,7 +32,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -37,7 +37,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/go_restful.cr
+++ b/src/analyzer/analyzers/go/go_restful.cr
@@ -40,7 +40,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -37,7 +37,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -44,7 +44,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -31,7 +31,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/http.cr
+++ b/src/analyzer/analyzers/go/http.cr
@@ -48,7 +48,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -49,7 +49,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -99,7 +99,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -30,7 +30,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -33,7 +33,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/go/pocketbase.cr
+++ b/src/analyzer/analyzers/go/pocketbase.cr
@@ -26,7 +26,7 @@ module Analyzer::Go
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -40,7 +40,7 @@ module Analyzer::Java
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -42,7 +42,7 @@ module Analyzer::Java
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -65,7 +65,7 @@ module Analyzer::Java
             channel.close
           end
 
-          @options["concurrency"].to_s.to_i.times do
+          worker_count.times do
             wg.spawn do
               loop do
                 begin

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -209,9 +209,7 @@ module Analyzer::AI
       # (see LLM::ACPClient#request); extra workers would only queue.
       return 1 if LLM::ACPClient.acp_provider?(@provider)
 
-      limit = @options["concurrency"]?.try(&.to_s.to_i?) || 1
-      limit = 1 if limit < 1
-      limit = MAX_BUNDLE_WORKERS if limit > MAX_BUNDLE_WORKERS
+      limit = worker_count.clamp(1, MAX_BUNDLE_WORKERS)
       total < limit ? total : limit
     end
 

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -190,7 +190,7 @@ module Analyzer::Python
           channel.close
         end
 
-        @options["concurrency"].to_s.to_i.times do
+        worker_count.times do
           wg.spawn do
             loop do
               begin

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -121,6 +121,32 @@ class Analyzer
     any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
   end
 
+  # Worker-fiber count for this analyzer's file walk.
+  #
+  # Nil-safe and floored at 1, matching the shape `src/models/deliver.cr`
+  # already used. The 21 call sites this replaces all spelled it
+  # `@options["concurrency"].to_s.to_i`, which raises `KeyError` on a
+  # missing key and `ArgumentError` on a non-numeric one — reachable only
+  # by a library embedder building the options hash by hand, since
+  # `ConfigInitializer#default_options` always sets it and
+  # `validate_concurrency!` rejects anything below 1. A value of `0` used
+  # to spawn zero workers, so the analyzer silently produced nothing.
+  protected def worker_count : Int32
+    n = @options["concurrency"]?.try(&.to_s.to_i?) || 0
+    n > 0 ? n : 1
+  end
+
+  # `worker_count` capped at `MAX_ANALYZER_WORKERS`.
+  #
+  # Deliberately not applied to the per-analyzer walks: those spawn
+  # `--concurrency` fibers uncapped today, and folding them in here would
+  # silently drop a `--concurrency 100` run to 64. Whether the cap should
+  # extend to them is a real question, but it is a behaviour change and
+  # belongs in its own commit.
+  protected def bounded_worker_count : Int32
+    worker_count.clamp(1, MAX_ANALYZER_WORKERS)
+  end
+
   # Resolves the longest configured base that owns `path`. Cross-file
   # indexes key their roots off this, which scopes them per base. Note the
   # designed limitation: nested/overlapping base paths (e.g. `-b /repo
@@ -174,10 +200,7 @@ class Analyzer
         channel.close
       end
 
-      worker_count = @options["concurrency"].to_s.to_i
-      worker_count = MAX_ANALYZER_WORKERS if worker_count > MAX_ANALYZER_WORKERS
-      worker_count = 1 if worker_count < 1
-      worker_count.times do
+      bounded_worker_count.times do
         wg.spawn do
           loop do
             begin
@@ -369,7 +392,7 @@ class FileAnalyzer < Analyzer
         channel.close
       end
 
-      @options["concurrency"].to_s.to_i.times do
+      worker_count.times do
         wg.spawn do
           loop do
             begin


### PR DESCRIPTION
Behaviour-neutral. Completes the analyzer/options boundary work started in #2490.

## Why

`concurrency` was the last option key the analyzer layer read directly, at **21 sites** all spelling it the same way:

```crystal
@options["concurrency"].to_s.to_i.times do
```

That expression raises `KeyError` on a missing key and `ArgumentError` on a non-numeric one — reachable only by a library embedder building the options hash by hand, since `ConfigInitializer#default_options` always sets it and `validate_concurrency!` rejects anything below 1.

Worse: **a value of `0` spawned zero workers.** The analyzer ran, walked nothing, and reported no endpoints without erroring.

## What

- `worker_count` — nil-safe, floored at 1, matching the shape `src/models/deliver.cr` already used.
- `bounded_worker_count` — adds the `MAX_ANALYZER_WORKERS` cap, used only where the cap already applied.

The 20 per-analyzer walks **deliberately stay uncapped**. Folding them into `bounded_worker_count` would silently drop a `--concurrency 100` run to 64 fibers — a real, CLI-reachable change. Whether the cap *should* extend to them is a fair question; it gets its own commit if so, not a side effect of this one.

`unified_ai.cr`'s bundle limit keeps its own `MAX_BUNDLE_WORKERS` clamp; it just stops re-deriving the base number.

## Where the boundary landed

`src/analyzer/` now reads **exactly one** option key directly:

| when the series started | now |
|---|---|
| `include_callee` ×65 | — (via `callees_needed?`) |
| `ai_context` ×65 | — (via `callees_needed?`) |
| `concurrency` ×21 | — (via `worker_count`) |
| `COMPONENTS_ONLY_OPTION` ×1 | ×1 |

`options_boundary_spec.cr` now bans direct `concurrency` reads alongside the callee flags, and covers the accessors at the inputs that used to raise or misbehave: absent, `0`, negative, non-numeric, and above the cap.

## Verification

A/B over all 665 fixture directories: **byte-identical**, 5,160 endpoints. Three representative fixtures (gin, django, spring) additionally produce identical output at both `--concurrency 1` and `--concurrency 256`, which is what covers the clamping decision.

`crystal spec spec/unit_test` 4701 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1911 files, 0 findings.