### PR TITLE
refactor(locator): declare every locator key as a typed object

### DIFF
--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -9,8 +9,8 @@ describe "Analyzer::Mobile::Android" do
   manifest = File.expand_path(
     File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "android", "AndroidManifest.xml"))
 
-  CodeLocator.instance.clear("android-manifest")
-  CodeLocator.instance.push("android-manifest", manifest)
+  CodeLocator.instance.clear(Noir::LocatorKeys::ANDROID_MANIFEST)
+  CodeLocator.instance.push(Noir::LocatorKeys::ANDROID_MANIFEST, manifest)
   endpoints = Analyzer::Mobile::Android.new(options).analyze
 
   find = ->(url : String) { endpoints.find { |e| e.url == url } }
@@ -258,8 +258,8 @@ describe "Analyzer::Mobile::Android (gradle kts / package fallback)" do
     File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "android_kts",
       "app", "src", "main", "AndroidManifest.xml"))
 
-  CodeLocator.instance.clear("android-manifest")
-  CodeLocator.instance.push("android-manifest", manifest)
+  CodeLocator.instance.clear(Noir::LocatorKeys::ANDROID_MANIFEST)
+  CodeLocator.instance.push(Noir::LocatorKeys::ANDROID_MANIFEST, manifest)
   endpoints = Analyzer::Mobile::Android.new(options).analyze
 
   find = ->(url : String) { endpoints.find { |e| e.url == url } }
@@ -295,8 +295,8 @@ describe "Analyzer::Mobile::Android (gradle constant reference)" do
     File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "android_gradle_const",
       "app", "src", "main", "AndroidManifest.xml"))
 
-  CodeLocator.instance.clear("android-manifest")
-  CodeLocator.instance.push("android-manifest", manifest)
+  CodeLocator.instance.clear(Noir::LocatorKeys::ANDROID_MANIFEST)
+  CodeLocator.instance.push(Noir::LocatorKeys::ANDROID_MANIFEST, manifest)
   endpoints = Analyzer::Mobile::Android.new(options).analyze
 
   find = ->(url : String) { endpoints.find { |e| e.url == url } }
@@ -321,8 +321,8 @@ describe "Analyzer::Mobile::Android (gradle GString applicationId)" do
     File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "android_gradle_gstring",
       "AndroidManifest.xml"))
 
-  CodeLocator.instance.clear("android-manifest")
-  CodeLocator.instance.push("android-manifest", manifest)
+  CodeLocator.instance.clear(Noir::LocatorKeys::ANDROID_MANIFEST)
+  CodeLocator.instance.push(Noir::LocatorKeys::ANDROID_MANIFEST, manifest)
   endpoints = Analyzer::Mobile::Android.new(options).analyze
 
   find = ->(url : String) { endpoints.find { |e| e.url == url } }

--- a/spec/unit_test/analyzer/mobile_ios_code_routes_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_code_routes_spec.cr
@@ -13,10 +13,10 @@ describe "Analyzer::Mobile::Ios (code-level route harvesting)" do
   options = create_test_options
   base = File.expand_path(File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "ios_code_routes"))
 
-  CodeLocator.instance.clear("ios-info-plist")
-  CodeLocator.instance.clear("ios-entitlements")
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_INFO_PLIST)
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_ENTITLEMENTS)
   CodeLocator.instance.reset_files
-  CodeLocator.instance.push("ios-info-plist", File.join(base, "Info.plist"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_INFO_PLIST, File.join(base, "Info.plist"))
   swift_path = File.join(base, "Routing.swift")
   CodeLocator.instance.register_file(swift_path, File.read(swift_path))
 

--- a/spec/unit_test/analyzer/mobile_ios_edge_cases_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_edge_cases_spec.cr
@@ -12,10 +12,10 @@ describe "Analyzer::Mobile::Ios (enum-body-parsing edge cases)" do
   options = create_test_options
   base = File.expand_path(File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "ios_code_routes_edge_cases"))
 
-  CodeLocator.instance.clear("ios-info-plist")
-  CodeLocator.instance.clear("ios-entitlements")
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_INFO_PLIST)
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_ENTITLEMENTS)
   CodeLocator.instance.reset_files
-  CodeLocator.instance.push("ios-info-plist", File.join(base, "Info.plist"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_INFO_PLIST, File.join(base, "Info.plist"))
   swift_path = File.join(base, "RoutingEdgeCases.swift")
   CodeLocator.instance.register_file(swift_path, File.read(swift_path))
 

--- a/spec/unit_test/analyzer/mobile_ios_generated_project_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_generated_project_spec.cr
@@ -12,14 +12,14 @@ describe "Analyzer::Mobile::Ios (generated project, no .xcodeproj)" do
   base = File.expand_path(File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "ios_generated_project"))
   options["base"] = YAML::Any.new([YAML::Any.new(base)])
 
-  CodeLocator.instance.clear("ios-info-plist")
-  CodeLocator.instance.clear("ios-entitlements")
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_INFO_PLIST)
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_ENTITLEMENTS)
   # No .swift/.m/.mm fixtures belong to this spec — clear file_map so a
   # leftover registration from another spec run earlier in the same
   # process can't feed the code-level route harvesting pass below.
   CodeLocator.instance.reset_files
-  CodeLocator.instance.push("ios-info-plist", File.join(base, "App", "Info.plist"))
-  CodeLocator.instance.push("ios-entitlements", File.join(base, "App", "App.entitlements"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_INFO_PLIST, File.join(base, "App", "Info.plist"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_ENTITLEMENTS, File.join(base, "App", "App.entitlements"))
   endpoints = Analyzer::Mobile::Ios.new(options).analyze
 
   find = ->(url : String) { endpoints.find { |e| e.url == url } }

--- a/spec/unit_test/analyzer/mobile_ios_multi_target_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_multi_target_spec.cr
@@ -22,12 +22,12 @@ describe "Analyzer::Mobile::Ios (multi-target monorepo scoping)" do
   options = create_test_options
   base = File.expand_path(File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "ios_code_routes_multi"))
 
-  CodeLocator.instance.clear("ios-info-plist")
-  CodeLocator.instance.clear("ios-entitlements")
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_INFO_PLIST)
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_ENTITLEMENTS)
   CodeLocator.instance.reset_files
-  CodeLocator.instance.push("ios-info-plist", File.join(base, "Vendor", "AppC", "Info.plist"))
-  CodeLocator.instance.push("ios-info-plist", File.join(base, "AppA", "Info.plist"))
-  CodeLocator.instance.push("ios-info-plist", File.join(base, "AppB", "Info.plist"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_INFO_PLIST, File.join(base, "Vendor", "AppC", "Info.plist"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_INFO_PLIST, File.join(base, "AppA", "Info.plist"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_INFO_PLIST, File.join(base, "AppB", "Info.plist"))
   swift_path = File.join(base, "AppA", "Routing.swift")
   CodeLocator.instance.register_file(swift_path, File.read(swift_path))
 

--- a/spec/unit_test/analyzer/mobile_ios_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_spec.cr
@@ -6,14 +6,14 @@ describe "Analyzer::Mobile::Ios" do
   options = create_test_options
   base = File.expand_path(File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "ios"))
 
-  CodeLocator.instance.clear("ios-info-plist")
-  CodeLocator.instance.clear("ios-entitlements")
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_INFO_PLIST)
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_ENTITLEMENTS)
   # No .swift/.m/.mm fixtures belong to this spec — clear file_map so a
   # leftover registration from another spec run earlier in the same
   # process can't feed the code-level route harvesting pass below.
   CodeLocator.instance.reset_files
-  CodeLocator.instance.push("ios-info-plist", File.join(base, "Info.plist"))
-  CodeLocator.instance.push("ios-entitlements", File.join(base, "App.entitlements"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_INFO_PLIST, File.join(base, "Info.plist"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_ENTITLEMENTS, File.join(base, "App.entitlements"))
   endpoints = Analyzer::Mobile::Ios.new(options).analyze
 
   find = ->(url : String) { endpoints.find { |e| e.url == url } }

--- a/spec/unit_test/analyzer/mobile_well_known_spec.cr
+++ b/spec/unit_test/analyzer/mobile_well_known_spec.cr
@@ -6,10 +6,10 @@ describe "Analyzer::Mobile::WellKnown" do
   options = create_test_options
   base = File.expand_path(File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "well_known", ".well-known"))
 
-  CodeLocator.instance.clear("android-assetlinks")
-  CodeLocator.instance.clear("ios-aasa")
-  CodeLocator.instance.push("android-assetlinks", File.join(base, "assetlinks.json"))
-  CodeLocator.instance.push("ios-aasa", File.join(base, "apple-app-site-association"))
+  CodeLocator.instance.clear(Noir::LocatorKeys::ANDROID_ASSETLINKS)
+  CodeLocator.instance.clear(Noir::LocatorKeys::IOS_AASA)
+  CodeLocator.instance.push(Noir::LocatorKeys::ANDROID_ASSETLINKS, File.join(base, "assetlinks.json"))
+  CodeLocator.instance.push(Noir::LocatorKeys::IOS_AASA, File.join(base, "apple-app-site-association"))
   endpoints = Analyzer::Mobile::WellKnown.new(options).analyze
 
   find = ->(url : String) { endpoints.find { |e| e.url == url } }

--- a/spec/unit_test/analyzer/specification/apache_httpd_spec.cr
+++ b/spec/unit_test/analyzer/specification/apache_httpd_spec.cr
@@ -6,8 +6,8 @@ private def analyze_apache(content : String, ext = ".conf")
   path = File.tempname("apache", ext)
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "apache-httpd-spec"
-  locator.push "apache-httpd-spec", path
+  locator.clear Noir::LocatorKeys::APACHE_HTTPD_SPEC
+  locator.push Noir::LocatorKeys::APACHE_HTTPD_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::ApacheHttpd.new options

--- a/spec/unit_test/analyzer/specification/apisix_spec.cr
+++ b/spec/unit_test/analyzer/specification/apisix_spec.cr
@@ -4,8 +4,8 @@ require "../../../../src/analyzer/analyzers/specification/apisix"
 
 private def analyze_apisix(yaml_content : String? = nil, json_content : String? = nil) : Array(Endpoint)
   locator = CodeLocator.instance
-  locator.clear "apisix-yaml"
-  locator.clear "apisix-json"
+  locator.clear Noir::LocatorKeys::APISIX_YAML
+  locator.clear Noir::LocatorKeys::APISIX_JSON
 
   yaml_path = nil
   json_path = nil
@@ -13,13 +13,13 @@ private def analyze_apisix(yaml_content : String? = nil, json_content : String? 
   if yaml_content
     yaml_path = File.tempname("apisix", ".yaml")
     File.write(yaml_path, yaml_content)
-    locator.push "apisix-yaml", yaml_path
+    locator.push Noir::LocatorKeys::APISIX_YAML, yaml_path
   end
 
   if json_content
     json_path = File.tempname("apisix", ".json")
     File.write(json_path, json_content)
-    locator.push "apisix-json", json_path
+    locator.push Noir::LocatorKeys::APISIX_JSON, json_path
   end
 
   analyzer = Analyzer::Specification::Apisix.new(create_test_options)

--- a/spec/unit_test/analyzer/specification/appwrite_spec.cr
+++ b/spec/unit_test/analyzer/specification/appwrite_spec.cr
@@ -6,15 +6,15 @@ private def analyze_appwrite(content : String)
   path = File.tempname("appwrite", ".json")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "appwrite-config"
-  locator.push "appwrite-config", path
+  locator.clear Noir::LocatorKeys::APPWRITE_CONFIG
+  locator.push Noir::LocatorKeys::APPWRITE_CONFIG, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Appwrite.new options
   analyzer.analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "appwrite-config"
+  locator.clear Noir::LocatorKeys::APPWRITE_CONFIG
   File.delete(path) if path && File.exists?(path)
 end
 

--- a/spec/unit_test/analyzer/specification/aws_cdk_spec.cr
+++ b/spec/unit_test/analyzer/specification/aws_cdk_spec.cr
@@ -6,8 +6,8 @@ private def analyze_cdk(content : String, ext = ".ts")
   path = File.tempname("cdk", ext)
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "aws-cdk-spec"
-  locator.push "aws-cdk-spec", path
+  locator.clear Noir::LocatorKeys::AWS_CDK_SPEC
+  locator.push Noir::LocatorKeys::AWS_CDK_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::AwsCdk.new options

--- a/spec/unit_test/analyzer/specification/aws_cloudformation_spec.cr
+++ b/spec/unit_test/analyzer/specification/aws_cloudformation_spec.cr
@@ -6,8 +6,8 @@ private def analyze_template(content : String, ext = ".yaml")
   path = File.tempname("template", ext)
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "aws-cloudformation-spec"
-  locator.push "aws-cloudformation-spec", path
+  locator.clear Noir::LocatorKeys::AWS_CLOUDFORMATION_SPEC
+  locator.push Noir::LocatorKeys::AWS_CLOUDFORMATION_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::AwsCloudformation.new options

--- a/spec/unit_test/analyzer/specification/azure_functions_spec.cr
+++ b/spec/unit_test/analyzer/specification/azure_functions_spec.cr
@@ -10,8 +10,8 @@ private def analyze_azure(content : String, function_dir = "MyFunc", host_json :
   host_path = File.join(dir, "host.json")
   File.write(host_path, host_json) if host_json
   locator = CodeLocator.instance
-  locator.clear "azure-functions-spec"
-  locator.push "azure-functions-spec", path
+  locator.clear Noir::LocatorKeys::AZURE_FUNCTIONS_SPEC
+  locator.push Noir::LocatorKeys::AZURE_FUNCTIONS_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::AzureFunctions.new options

--- a/spec/unit_test/analyzer/specification/caddy_spec.cr
+++ b/spec/unit_test/analyzer/specification/caddy_spec.cr
@@ -8,8 +8,8 @@ private def analyze_caddy(content : String, ext = "")
   path = name
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "caddy-spec"
-  locator.push "caddy-spec", path
+  locator.clear Noir::LocatorKeys::CADDY_SPEC
+  locator.push Noir::LocatorKeys::CADDY_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Caddy.new options

--- a/spec/unit_test/analyzer/specification/cloudflare_wrangler_spec.cr
+++ b/spec/unit_test/analyzer/specification/cloudflare_wrangler_spec.cr
@@ -6,8 +6,8 @@ private def analyze_wrangler(content : String, ext = ".toml")
   path = File.tempname("wrangler", ext)
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "cloudflare-wrangler-spec"
-  locator.push "cloudflare-wrangler-spec", path
+  locator.clear Noir::LocatorKeys::CLOUDFLARE_WRANGLER_SPEC
+  locator.push Noir::LocatorKeys::CLOUDFLARE_WRANGLER_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::CloudflareWrangler.new options

--- a/spec/unit_test/analyzer/specification/directus_spec.cr
+++ b/spec/unit_test/analyzer/specification/directus_spec.cr
@@ -6,15 +6,15 @@ private def analyze_directus(content : String)
   path = File.tempname("snapshot", ".yaml")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "directus-snapshot"
-  locator.push "directus-snapshot", path
+  locator.clear Noir::LocatorKeys::DIRECTUS_SNAPSHOT
+  locator.push Noir::LocatorKeys::DIRECTUS_SNAPSHOT, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Directus.new options
   analyzer.analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "directus-snapshot"
+  locator.clear Noir::LocatorKeys::DIRECTUS_SNAPSHOT
   File.delete(path) if path && File.exists?(path)
 end
 

--- a/spec/unit_test/analyzer/specification/graphql_sdl_spec.cr
+++ b/spec/unit_test/analyzer/specification/graphql_sdl_spec.cr
@@ -6,14 +6,14 @@ private def analyze_sdl(content : String, path : String? = nil)
   sdl_path = path || File.tempname("noir_graphql_sdl_", ".graphql")
   File.write(sdl_path, content)
   locator = CodeLocator.instance
-  locator.clear "graphql-sdl"
-  locator.push "graphql-sdl", sdl_path
+  locator.clear Noir::LocatorKeys::GRAPHQL_SDL
+  locator.push Noir::LocatorKeys::GRAPHQL_SDL, sdl_path
 
   options = create_test_options
   analyzer = Analyzer::Specification::GraphqlSdl.new options
   analyzer.analyze
 ensure
-  CodeLocator.instance.clear "graphql-sdl"
+  CodeLocator.instance.clear Noir::LocatorKeys::GRAPHQL_SDL
   File.delete(sdl_path) if sdl_path && File.exists?(sdl_path)
 end
 

--- a/spec/unit_test/analyzer/specification/hasura_spec.cr
+++ b/spec/unit_test/analyzer/specification/hasura_spec.cr
@@ -5,29 +5,29 @@ require "../../../../src/analyzer/analyzers/specification/hasura"
 private def analyze_hasura(tables : String? = nil, rest : String? = nil)
   paths = [] of String
   locator = CodeLocator.instance
-  locator.clear "hasura-tables"
-  locator.clear "hasura-rest-endpoints"
+  locator.clear Noir::LocatorKeys::HASURA_TABLES
+  locator.clear Noir::LocatorKeys::HASURA_REST_ENDPOINTS
 
   if tables
     path = File.tempname("hasura_tables", ".yaml")
     File.write(path, tables)
     paths << path
-    locator.push "hasura-tables", path
+    locator.push Noir::LocatorKeys::HASURA_TABLES, path
   end
 
   if rest
     path = File.tempname("hasura_rest", ".yaml")
     File.write(path, rest)
     paths << path
-    locator.push "hasura-rest-endpoints", path
+    locator.push Noir::LocatorKeys::HASURA_REST_ENDPOINTS, path
   end
 
   options = create_test_options
   Analyzer::Specification::Hasura.new(options).analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "hasura-tables"
-  locator.clear "hasura-rest-endpoints"
+  locator.clear Noir::LocatorKeys::HASURA_TABLES
+  locator.clear Noir::LocatorKeys::HASURA_REST_ENDPOINTS
   paths.try &.each { |p| File.delete(p) if File.exists?(p) }
 end
 

--- a/spec/unit_test/analyzer/specification/http_file_spec.cr
+++ b/spec/unit_test/analyzer/specification/http_file_spec.cr
@@ -6,15 +6,15 @@ private def analyze_http_file(content : String, ext = ".http")
   path = File.tempname("http_file", ext)
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "http-file"
-  locator.push "http-file", path
+  locator.clear Noir::LocatorKeys::HTTP_FILE
+  locator.push Noir::LocatorKeys::HTTP_FILE, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::HttpFile.new options
   analyzer.analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "http-file"
+  locator.clear Noir::LocatorKeys::HTTP_FILE
   File.delete(path) if path && File.exists?(path)
 end
 

--- a/spec/unit_test/analyzer/specification/insomnia_spec.cr
+++ b/spec/unit_test/analyzer/specification/insomnia_spec.cr
@@ -6,17 +6,17 @@ private def analyze_insomnia_json(content : String)
   path = File.tempname("insomnia", ".json")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "insomnia-json"
-  locator.clear "insomnia-yaml"
-  locator.push "insomnia-json", path
+  locator.clear Noir::LocatorKeys::INSOMNIA_JSON
+  locator.clear Noir::LocatorKeys::INSOMNIA_YAML
+  locator.push Noir::LocatorKeys::INSOMNIA_JSON, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Insomnia.new options
   analyzer.analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "insomnia-json"
-  locator.clear "insomnia-yaml"
+  locator.clear Noir::LocatorKeys::INSOMNIA_JSON
+  locator.clear Noir::LocatorKeys::INSOMNIA_YAML
   File.delete(path) if path && File.exists?(path)
 end
 
@@ -24,17 +24,17 @@ private def analyze_insomnia_yaml(content : String)
   path = File.tempname("insomnia", ".yaml")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "insomnia-json"
-  locator.clear "insomnia-yaml"
-  locator.push "insomnia-yaml", path
+  locator.clear Noir::LocatorKeys::INSOMNIA_JSON
+  locator.clear Noir::LocatorKeys::INSOMNIA_YAML
+  locator.push Noir::LocatorKeys::INSOMNIA_YAML, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Insomnia.new options
   analyzer.analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "insomnia-json"
-  locator.clear "insomnia-yaml"
+  locator.clear Noir::LocatorKeys::INSOMNIA_JSON
+  locator.clear Noir::LocatorKeys::INSOMNIA_YAML
   File.delete(path) if path && File.exists?(path)
 end
 

--- a/spec/unit_test/analyzer/specification/istio_virtualservice_spec.cr
+++ b/spec/unit_test/analyzer/specification/istio_virtualservice_spec.cr
@@ -6,8 +6,8 @@ private def analyze_vs(content : String)
   path = File.tempname("virtualservice", ".yaml")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "istio-virtualservice-spec"
-  locator.push "istio-virtualservice-spec", path
+  locator.clear Noir::LocatorKeys::ISTIO_VIRTUALSERVICE_SPEC
+  locator.push Noir::LocatorKeys::ISTIO_VIRTUALSERVICE_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::IstioVirtualservice.new options

--- a/spec/unit_test/analyzer/specification/k8s_gateway_api_spec.cr
+++ b/spec/unit_test/analyzer/specification/k8s_gateway_api_spec.cr
@@ -6,8 +6,8 @@ private def analyze_gateway_api(content : String)
   path = File.tempname("httproute", ".yaml")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "k8s-gateway-api-spec"
-  locator.push "k8s-gateway-api-spec", path
+  locator.clear Noir::LocatorKeys::K8S_GATEWAY_API_SPEC
+  locator.push Noir::LocatorKeys::K8S_GATEWAY_API_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::K8sGatewayApi.new options

--- a/spec/unit_test/analyzer/specification/k8s_ingress_spec.cr
+++ b/spec/unit_test/analyzer/specification/k8s_ingress_spec.cr
@@ -6,8 +6,8 @@ private def analyze_ingress(content : String)
   path = File.tempname("ingress", ".yaml")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "k8s-ingress-spec"
-  locator.push "k8s-ingress-spec", path
+  locator.clear Noir::LocatorKeys::K8S_INGRESS_SPEC
+  locator.push Noir::LocatorKeys::K8S_INGRESS_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::K8sIngress.new options

--- a/spec/unit_test/analyzer/specification/kamal_spec.cr
+++ b/spec/unit_test/analyzer/specification/kamal_spec.cr
@@ -6,8 +6,8 @@ private def analyze_kamal(content : String)
   path = File.tempname("deploy", ".yml")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "kamal-spec"
-  locator.push "kamal-spec", path
+  locator.clear Noir::LocatorKeys::KAMAL_SPEC
+  locator.push Noir::LocatorKeys::KAMAL_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Kamal.new options

--- a/spec/unit_test/analyzer/specification/mitmproxy_spec.cr
+++ b/spec/unit_test/analyzer/specification/mitmproxy_spec.cr
@@ -36,8 +36,8 @@ private def analyze_flows(flows : Array(Hash(String, Tnetstring::Value)), url : 
   path = File.tempname("mitmproxy", ".mitm")
   write_flows(path, flows)
   locator = CodeLocator.instance
-  locator.clear "mitmproxy-path"
-  locator.push "mitmproxy-path", path
+  locator.clear Noir::LocatorKeys::MITMPROXY_PATH
+  locator.push Noir::LocatorKeys::MITMPROXY_PATH, path
 
   options = create_test_options
   options["url"] = YAML::Any.new(url)
@@ -214,8 +214,8 @@ describe "Mitmproxy Analyzer" do
 
     begin
       locator = CodeLocator.instance
-      locator.clear "mitmproxy-path"
-      locator.push "mitmproxy-path", path
+      locator.clear Noir::LocatorKeys::MITMPROXY_PATH
+      locator.push Noir::LocatorKeys::MITMPROXY_PATH, path
 
       options = create_test_options
       options["url"] = YAML::Any.new("https://example.com")

--- a/spec/unit_test/analyzer/specification/netlify_spec.cr
+++ b/spec/unit_test/analyzer/specification/netlify_spec.cr
@@ -10,18 +10,18 @@ private def analyze_netlify(redirects_content : String?, toml_content : String?)
   Dir.mkdir_p(temp_dir)
 
   locator = CodeLocator.instance
-  locator.clear "netlify-redirects"
-  locator.clear "netlify-toml"
+  locator.clear Noir::LocatorKeys::NETLIFY_REDIRECTS
+  locator.clear Noir::LocatorKeys::NETLIFY_TOML
 
   begin
     if redirects_content
       File.write(redirects_path, redirects_content)
-      locator.push "netlify-redirects", redirects_path
+      locator.push Noir::LocatorKeys::NETLIFY_REDIRECTS, redirects_path
     end
 
     if toml_content
       File.write(toml_path, toml_content)
-      locator.push "netlify-toml", toml_path
+      locator.push Noir::LocatorKeys::NETLIFY_TOML, toml_path
     end
 
     options = create_test_options

--- a/spec/unit_test/analyzer/specification/nginx_spec.cr
+++ b/spec/unit_test/analyzer/specification/nginx_spec.cr
@@ -6,8 +6,8 @@ private def analyze_nginx(content : String)
   path = File.tempname("nginx", ".conf")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "nginx-spec"
-  locator.push "nginx-spec", path
+  locator.clear Noir::LocatorKeys::NGINX_SPEC
+  locator.push Noir::LocatorKeys::NGINX_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Nginx.new options

--- a/spec/unit_test/analyzer/specification/payload_cms_spec.cr
+++ b/spec/unit_test/analyzer/specification/payload_cms_spec.cr
@@ -5,38 +5,38 @@ require "../../../../src/analyzer/analyzers/specification/payload_cms"
 private def analyze_payload(collection : String? = nil, global : String? = nil, config : String? = nil)
   paths = [] of String
   locator = CodeLocator.instance
-  locator.clear "payload-collection"
-  locator.clear "payload-global"
-  locator.clear "payload-config"
+  locator.clear Noir::LocatorKeys::PAYLOAD_COLLECTION
+  locator.clear Noir::LocatorKeys::PAYLOAD_GLOBAL
+  locator.clear Noir::LocatorKeys::PAYLOAD_CONFIG
 
   if collection
     path = File.tempname("payload_collection", ".ts")
     File.write(path, collection)
     paths << path
-    locator.push "payload-collection", path
+    locator.push Noir::LocatorKeys::PAYLOAD_COLLECTION, path
   end
 
   if global
     path = File.tempname("payload_global", ".ts")
     File.write(path, global)
     paths << path
-    locator.push "payload-global", path
+    locator.push Noir::LocatorKeys::PAYLOAD_GLOBAL, path
   end
 
   if config
     path = File.tempname("payload_config", ".ts")
     File.write(path, config)
     paths << path
-    locator.push "payload-config", path
+    locator.push Noir::LocatorKeys::PAYLOAD_CONFIG, path
   end
 
   options = create_test_options
   Analyzer::Specification::PayloadCms.new(options).analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "payload-collection"
-  locator.clear "payload-global"
-  locator.clear "payload-config"
+  locator.clear Noir::LocatorKeys::PAYLOAD_COLLECTION
+  locator.clear Noir::LocatorKeys::PAYLOAD_GLOBAL
+  locator.clear Noir::LocatorKeys::PAYLOAD_CONFIG
   paths.try &.each { |p| File.delete(p) if File.exists?(p) }
 end
 

--- a/spec/unit_test/analyzer/specification/postman_spec.cr
+++ b/spec/unit_test/analyzer/specification/postman_spec.cr
@@ -6,15 +6,15 @@ private def analyze_postman(content : String)
   path = File.tempname("postman", ".json")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "postman-json"
-  locator.push "postman-json", path
+  locator.clear Noir::LocatorKeys::POSTMAN_JSON
+  locator.push Noir::LocatorKeys::POSTMAN_JSON, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Postman.new options
   analyzer.analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "postman-json"
+  locator.clear Noir::LocatorKeys::POSTMAN_JSON
   File.delete(path) if path && File.exists?(path)
 end
 

--- a/spec/unit_test/analyzer/specification/serverless_framework_spec.cr
+++ b/spec/unit_test/analyzer/specification/serverless_framework_spec.cr
@@ -6,8 +6,8 @@ private def analyze_serverless(content : String, ext = ".yml")
   path = File.tempname("serverless", ext)
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "serverless-framework-spec"
-  locator.push "serverless-framework-spec", path
+  locator.clear Noir::LocatorKeys::SERVERLESS_FRAMEWORK_SPEC
+  locator.push Noir::LocatorKeys::SERVERLESS_FRAMEWORK_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::ServerlessFramework.new options

--- a/spec/unit_test/analyzer/specification/strapi_spec.cr
+++ b/spec/unit_test/analyzer/specification/strapi_spec.cr
@@ -10,16 +10,16 @@ private def analyze_strapi_schema(content : String, name = "article")
   File.write(file, content)
 
   locator = CodeLocator.instance
-  locator.clear "strapi-schema"
-  locator.clear "strapi-routes"
-  locator.push "strapi-schema", file
+  locator.clear Noir::LocatorKeys::STRAPI_SCHEMA
+  locator.clear Noir::LocatorKeys::STRAPI_ROUTES
+  locator.push Noir::LocatorKeys::STRAPI_SCHEMA, file
 
   options = create_test_options
   Analyzer::Specification::Strapi.new(options).analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "strapi-schema"
-  locator.clear "strapi-routes"
+  locator.clear Noir::LocatorKeys::STRAPI_SCHEMA
+  locator.clear Noir::LocatorKeys::STRAPI_ROUTES
   FileUtils.rm_rf(dir) if dir && Dir.exists?(dir)
 end
 
@@ -28,16 +28,16 @@ private def analyze_strapi_routes(content : String)
   File.write(path, content)
 
   locator = CodeLocator.instance
-  locator.clear "strapi-schema"
-  locator.clear "strapi-routes"
-  locator.push "strapi-routes", path
+  locator.clear Noir::LocatorKeys::STRAPI_SCHEMA
+  locator.clear Noir::LocatorKeys::STRAPI_ROUTES
+  locator.push Noir::LocatorKeys::STRAPI_ROUTES, path
 
   options = create_test_options
   Analyzer::Specification::Strapi.new(options).analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "strapi-schema"
-  locator.clear "strapi-routes"
+  locator.clear Noir::LocatorKeys::STRAPI_SCHEMA
+  locator.clear Noir::LocatorKeys::STRAPI_ROUTES
   File.delete(path) if path && File.exists?(path)
 end
 

--- a/spec/unit_test/analyzer/specification/supabase_spec.cr
+++ b/spec/unit_test/analyzer/specification/supabase_spec.cr
@@ -5,30 +5,30 @@ require "../../../../src/analyzer/analyzers/specification/supabase"
 private def analyze_supabase(*migrations : String, config : String? = nil)
   paths = [] of String
   locator = CodeLocator.instance
-  locator.clear "supabase-migration"
-  locator.clear "supabase-config"
+  locator.clear Noir::LocatorKeys::SUPABASE_MIGRATION
+  locator.clear Noir::LocatorKeys::SUPABASE_CONFIG
 
   migrations.each_with_index do |sql, index|
     # Lexical order is chronological for Supabase migration filenames.
     path = File.tempname("#{index}_migration", ".sql")
     File.write(path, sql)
     paths << path
-    locator.push "supabase-migration", path
+    locator.push Noir::LocatorKeys::SUPABASE_MIGRATION, path
   end
 
   if config
     path = File.tempname("config", ".toml")
     File.write(path, config)
     paths << path
-    locator.push "supabase-config", path
+    locator.push Noir::LocatorKeys::SUPABASE_CONFIG, path
   end
 
   options = create_test_options
   Analyzer::Specification::Supabase.new(options).analyze
 ensure
   locator = CodeLocator.instance
-  locator.clear "supabase-migration"
-  locator.clear "supabase-config"
+  locator.clear Noir::LocatorKeys::SUPABASE_MIGRATION
+  locator.clear Noir::LocatorKeys::SUPABASE_CONFIG
   paths.try &.each { |p| File.delete(p) if File.exists?(p) }
 end
 

--- a/spec/unit_test/analyzer/specification/terraform_spec.cr
+++ b/spec/unit_test/analyzer/specification/terraform_spec.cr
@@ -10,11 +10,11 @@ private def analyze_terraform(files : Hash(String, String))
   dir = File.tempname("tf_module")
   Dir.mkdir_p(dir)
   locator = CodeLocator.instance
-  locator.clear "terraform-spec"
+  locator.clear Noir::LocatorKeys::TERRAFORM_SPEC
   files.each do |name, content|
     path = File.join(dir, name)
     File.write(path, content)
-    locator.push "terraform-spec", path
+    locator.push Noir::LocatorKeys::TERRAFORM_SPEC, path
   end
 
   options = create_test_options

--- a/spec/unit_test/analyzer/specification/vercel_spec.cr
+++ b/spec/unit_test/analyzer/specification/vercel_spec.cr
@@ -6,8 +6,8 @@ private def analyze_vercel_config(content : String)
   path = File.tempname("vercel", ".json")
   File.write(path, content)
   locator = CodeLocator.instance
-  locator.clear "vercel-spec"
-  locator.push "vercel-spec", path
+  locator.clear Noir::LocatorKeys::VERCEL_SPEC
+  locator.push Noir::LocatorKeys::VERCEL_SPEC, path
 
   options = create_test_options
   analyzer = Analyzer::Specification::Vercel.new options

--- a/spec/unit_test/detector/mobile/android_scope_spec.cr
+++ b/spec/unit_test/detector/mobile/android_scope_spec.cr
@@ -116,5 +116,5 @@ end
 private def cleanup_scope(root : String)
   FileUtils.rm_rf(root) if Dir.exists?(root)
   CodeLocator.instance.reset_files
-  CodeLocator.instance.clear("android-manifest")
+  CodeLocator.instance.clear(Noir::LocatorKeys::ANDROID_MANIFEST)
 end

--- a/spec/unit_test/detector/specification/apache_httpd_spec.cr
+++ b/spec/unit_test/detector/specification/apache_httpd_spec.cr
@@ -17,10 +17,10 @@ describe "Detect Apache httpd config" do
 
   it "detects .conf with Apache directives" do
     locator = CodeLocator.instance
-    locator.clear "apache-httpd-spec"
+    locator.clear Noir::LocatorKeys::APACHE_HTTPD_SPEC
 
     instance.detect("sites-enabled/api.conf", src).should be_true
-    locator.all("apache-httpd-spec").should eq ["sites-enabled/api.conf"]
+    locator.all(Noir::LocatorKeys::APACHE_HTTPD_SPEC).should eq ["sites-enabled/api.conf"]
   end
 
   it "detects .htaccess files" do
@@ -30,10 +30,10 @@ describe "Detect Apache httpd config" do
 
   it "detects Apache config templates case-insensitively" do
     locator = CodeLocator.instance
-    locator.clear "apache-httpd-spec"
+    locator.clear Noir::LocatorKeys::APACHE_HTTPD_SPEC
 
     instance.detect("conf/extra.conf.in", "  proxypass /api http://backend\n").should be_true
-    locator.all("apache-httpd-spec").should eq ["conf/extra.conf.in"]
+    locator.all(Noir::LocatorKeys::APACHE_HTTPD_SPEC).should eq ["conf/extra.conf.in"]
   end
 
   it "ignores directives that only appear in comments" do

--- a/spec/unit_test/detector/specification/apisix_spec.cr
+++ b/spec/unit_test/detector/specification/apisix_spec.cr
@@ -45,9 +45,9 @@ describe "Detect APISIX route config" do
       YAML
 
     locator = CodeLocator.instance
-    locator.clear "apisix-yaml"
+    locator.clear Noir::LocatorKeys::APISIX_YAML
     instance.detect("config/apisix.yaml", content)
-    locator.all("apisix-yaml").should eq(["config/apisix.yaml"])
+    locator.all(Noir::LocatorKeys::APISIX_YAML).should eq(["config/apisix.yaml"])
   end
 
   it "registers APISIX json files in CodeLocator" do
@@ -64,9 +64,9 @@ describe "Detect APISIX route config" do
       JSON
 
     locator = CodeLocator.instance
-    locator.clear "apisix-json"
+    locator.clear Noir::LocatorKeys::APISIX_JSON
     instance.detect("config/routes.json", content)
-    locator.all("apisix-json").should eq(["config/routes.json"])
+    locator.all(Noir::LocatorKeys::APISIX_JSON).should eq(["config/routes.json"])
   end
 
   it "rejects generic routes yaml without APISIX-specific keys" do

--- a/spec/unit_test/detector/specification/appwrite_spec.cr
+++ b/spec/unit_test/detector/specification/appwrite_spec.cr
@@ -73,8 +73,8 @@ describe "Detect Appwrite config" do
     content = %({"projectId": "demo", "collections": []})
 
     locator = CodeLocator.instance
-    locator.clear "appwrite-config"
+    locator.clear Noir::LocatorKeys::APPWRITE_CONFIG
     instance.detect("appwrite.json", content)
-    locator.all("appwrite-config").should eq(["appwrite.json"])
+    locator.all(Noir::LocatorKeys::APPWRITE_CONFIG).should eq(["appwrite.json"])
   end
 end

--- a/spec/unit_test/detector/specification/asyncapi_spec.cr
+++ b/spec/unit_test/detector/specification/asyncapi_spec.cr
@@ -47,8 +47,8 @@ describe "Detect AsyncAPI Docs" do
       JSON
 
     locator = CodeLocator.instance
-    locator.clear "asyncapi-json"
+    locator.clear Noir::LocatorKeys::ASYNCAPI_JSON
     instance.detect("doc.json", content)
-    locator.all("asyncapi-json").should eq(["doc.json"])
+    locator.all(Noir::LocatorKeys::ASYNCAPI_JSON).should eq(["doc.json"])
   end
 end

--- a/spec/unit_test/detector/specification/aws_cdk_spec.cr
+++ b/spec/unit_test/detector/specification/aws_cdk_spec.cr
@@ -14,10 +14,10 @@ describe "Detect AWS CDK source" do
       TS
 
     locator = CodeLocator.instance
-    locator.clear "aws-cdk-spec"
+    locator.clear Noir::LocatorKeys::AWS_CDK_SPEC
 
     instance.detect("lib/stack.ts", src).should be_true
-    locator.all("aws-cdk-spec").should eq ["lib/stack.ts"]
+    locator.all(Noir::LocatorKeys::AWS_CDK_SPEC).should eq ["lib/stack.ts"]
   end
 
   it "detects Python CDK source" do

--- a/spec/unit_test/detector/specification/aws_cloudformation_spec.cr
+++ b/spec/unit_test/detector/specification/aws_cloudformation_spec.cr
@@ -25,22 +25,22 @@ describe "Detect AWS SAM / CloudFormation templates" do
 
   it "detects SAM template by Transform" do
     locator = CodeLocator.instance
-    locator.clear "aws-cloudformation-spec"
+    locator.clear Noir::LocatorKeys::AWS_CLOUDFORMATION_SPEC
 
     instance.detect("template.yaml", sam_yaml).should be_true
-    locator.all("aws-cloudformation-spec").should eq ["template.yaml"]
+    locator.all(Noir::LocatorKeys::AWS_CLOUDFORMATION_SPEC).should eq ["template.yaml"]
   end
 
   it "detects plain CloudFormation template by AWSTemplateFormatVersion" do
     locator = CodeLocator.instance
-    locator.clear "aws-cloudformation-spec"
+    locator.clear Noir::LocatorKeys::AWS_CLOUDFORMATION_SPEC
 
     instance.detect("template.yml", cfn_yaml).should be_true
   end
 
   it "detects JSON-formatted CloudFormation template" do
     locator = CodeLocator.instance
-    locator.clear "aws-cloudformation-spec"
+    locator.clear Noir::LocatorKeys::AWS_CLOUDFORMATION_SPEC
 
     json = %({"AWSTemplateFormatVersion":"2010-09-09","Resources":{}})
     instance.detect("template.json", json).should be_true

--- a/spec/unit_test/detector/specification/azure_functions_spec.cr
+++ b/spec/unit_test/detector/specification/azure_functions_spec.cr
@@ -9,10 +9,10 @@ describe "Detect Azure Functions function.json" do
   it "detects function.json with httpTrigger binding" do
     src = %({"bindings":[{"type":"httpTrigger","direction":"in","methods":["get"]}]})
     locator = CodeLocator.instance
-    locator.clear "azure-functions-spec"
+    locator.clear Noir::LocatorKeys::AZURE_FUNCTIONS_SPEC
 
     instance.detect("MyFunc/function.json", src).should be_true
-    locator.all("azure-functions-spec").should eq ["MyFunc/function.json"]
+    locator.all(Noir::LocatorKeys::AZURE_FUNCTIONS_SPEC).should eq ["MyFunc/function.json"]
   end
 
   it "rejects function.json without httpTrigger" do

--- a/spec/unit_test/detector/specification/bruno_spec.cr
+++ b/spec/unit_test/detector/specification/bruno_spec.cr
@@ -48,8 +48,8 @@ describe "Detect Bruno Collection" do
       BRU
 
     locator = CodeLocator.instance
-    locator.clear "bruno-bru"
+    locator.clear Noir::LocatorKeys::BRUNO_BRU
     instance.detect("health.bru", content)
-    locator.all("bruno-bru").should eq(["health.bru"])
+    locator.all(Noir::LocatorKeys::BRUNO_BRU).should eq(["health.bru"])
   end
 end

--- a/spec/unit_test/detector/specification/burp_spec.cr
+++ b/spec/unit_test/detector/specification/burp_spec.cr
@@ -26,9 +26,9 @@ describe "Detect Burp Sitemap" do
 
   it "code_locator" do
     locator = CodeLocator.instance
-    locator.clear "burp-sitemap"
+    locator.clear Noir::LocatorKeys::BURP_SITEMAP
     sample = %(<?xml version="1.0"?><items burpVersion="2024.6"></items>)
     instance.detect("sitemap.xml", sample)
-    locator.all("burp-sitemap").should eq(["sitemap.xml"])
+    locator.all(Noir::LocatorKeys::BURP_SITEMAP).should eq(["sitemap.xml"])
   end
 end

--- a/spec/unit_test/detector/specification/caddy_spec.cr
+++ b/spec/unit_test/detector/specification/caddy_spec.cr
@@ -16,10 +16,10 @@ describe "Detect Caddy config" do
 
   it "detects Caddyfile by name" do
     locator = CodeLocator.instance
-    locator.clear "caddy-spec"
+    locator.clear Noir::LocatorKeys::CADDY_SPEC
 
     instance.detect("Caddyfile", caddyfile).should be_true
-    locator.all("caddy-spec").should eq ["Caddyfile"]
+    locator.all(Noir::LocatorKeys::CADDY_SPEC).should eq ["Caddyfile"]
   end
 
   it "detects caddy.json with apps.http shape" do

--- a/spec/unit_test/detector/specification/caido_spec.cr
+++ b/spec/unit_test/detector/specification/caido_spec.cr
@@ -40,9 +40,9 @@ describe "Detect Caido Export" do
       JSON
 
     locator = CodeLocator.instance
-    locator.clear "caido-json"
+    locator.clear Noir::LocatorKeys::CAIDO_JSON
     instance.detect("test_caido.json", content)
-    locator.all("caido-json").should eq(["test_caido.json"])
+    locator.all(Noir::LocatorKeys::CAIDO_JSON).should eq(["test_caido.json"])
   end
 
   it "rejects HAR files" do

--- a/spec/unit_test/detector/specification/cloudflare_wrangler_spec.cr
+++ b/spec/unit_test/detector/specification/cloudflare_wrangler_spec.cr
@@ -9,10 +9,10 @@ describe "Detect Cloudflare wrangler config" do
   it "detects wrangler.toml with compatibility_date" do
     src = "name = \"api\"\ncompatibility_date = \"2024-01-01\"\n"
     locator = CodeLocator.instance
-    locator.clear "cloudflare-wrangler-spec"
+    locator.clear Noir::LocatorKeys::CLOUDFLARE_WRANGLER_SPEC
 
     instance.detect("wrangler.toml", src).should be_true
-    locator.all("cloudflare-wrangler-spec").should eq ["wrangler.toml"]
+    locator.all(Noir::LocatorKeys::CLOUDFLARE_WRANGLER_SPEC).should eq ["wrangler.toml"]
   end
 
   it "detects wrangler.toml with [[routes]]" do

--- a/spec/unit_test/detector/specification/directus_spec.cr
+++ b/spec/unit_test/detector/specification/directus_spec.cr
@@ -89,8 +89,8 @@ describe "Detect Directus snapshot" do
 
   it "registers the path in the code locator" do
     locator = CodeLocator.instance
-    locator.clear "directus-snapshot"
+    locator.clear Noir::LocatorKeys::DIRECTUS_SNAPSHOT
     instance.detect("snapshot.yaml", snapshot)
-    locator.all("directus-snapshot").should eq(["snapshot.yaml"])
+    locator.all(Noir::LocatorKeys::DIRECTUS_SNAPSHOT).should eq(["snapshot.yaml"])
   end
 end

--- a/spec/unit_test/detector/specification/envoy_spec.cr
+++ b/spec/unit_test/detector/specification/envoy_spec.cr
@@ -19,24 +19,24 @@ describe "Detect Envoy route config" do
 
   it "detects envoy yaml route config" do
     locator = CodeLocator.instance
-    locator.clear "envoy-yaml"
+    locator.clear Noir::LocatorKeys::ENVOY_YAML
 
     instance.detect("envoy.yaml", yaml).should be_true
-    locator.all("envoy-yaml").should eq ["envoy.yaml"]
+    locator.all(Noir::LocatorKeys::ENVOY_YAML).should eq ["envoy.yaml"]
   end
 
   it "detects envoy json route config" do
     locator = CodeLocator.instance
-    locator.clear "envoy-json"
+    locator.clear Noir::LocatorKeys::ENVOY_JSON
 
     json = %({"virtual_hosts":[{"name":"backend","domains":["*"]}]})
     instance.detect("envoy.json", json).should be_true
-    locator.all("envoy-json").should eq ["envoy.json"]
+    locator.all(Noir::LocatorKeys::ENVOY_JSON).should eq ["envoy.json"]
   end
 
   it "detects a bootstrap config that nests route_config under a listener filter" do
     locator = CodeLocator.instance
-    locator.clear "envoy-yaml"
+    locator.clear Noir::LocatorKeys::ENVOY_YAML
 
     bootstrap = <<-YAML
       static_resources:
@@ -56,7 +56,7 @@ describe "Detect Envoy route config" do
       YAML
 
     instance.detect("envoy.yaml", bootstrap).should be_true
-    locator.all("envoy-yaml").should eq ["envoy.yaml"]
+    locator.all(Noir::LocatorKeys::ENVOY_YAML).should eq ["envoy.yaml"]
   end
 
   it "rejects yaml without virtual_hosts/domains markers" do

--- a/spec/unit_test/detector/specification/graphql_sdl_spec.cr
+++ b/spec/unit_test/detector/specification/graphql_sdl_spec.cr
@@ -107,8 +107,8 @@ describe "Detect GraphQL SDL" do
   it "registers path in code_locator" do
     content = "type Query { ok: Boolean }"
     locator = CodeLocator.instance
-    locator.clear "graphql-sdl"
+    locator.clear Noir::LocatorKeys::GRAPHQL_SDL
     instance.detect("schema.graphql", content)
-    locator.all("graphql-sdl").should eq(["schema.graphql"])
+    locator.all(Noir::LocatorKeys::GRAPHQL_SDL).should eq(["schema.graphql"])
   end
 end

--- a/spec/unit_test/detector/specification/grpc_spec.cr
+++ b/spec/unit_test/detector/specification/grpc_spec.cr
@@ -62,8 +62,8 @@ describe "Detect gRPC" do
   it "registers the path in code_locator" do
     content = "service S { rpc M(A) returns (B); }"
     locator = CodeLocator.instance
-    locator.clear "grpc-proto"
+    locator.clear Noir::LocatorKeys::GRPC_PROTO
     instance.detect("svc.proto", content)
-    locator.all("grpc-proto").should eq(["svc.proto"])
+    locator.all(Noir::LocatorKeys::GRPC_PROTO).should eq(["svc.proto"])
   end
 end

--- a/spec/unit_test/detector/specification/hasura_spec.cr
+++ b/spec/unit_test/detector/specification/hasura_spec.cr
@@ -108,8 +108,8 @@ describe "Detect Hasura metadata" do
 
   it "registers table and REST paths under separate locator keys" do
     locator = CodeLocator.instance
-    locator.clear "hasura-tables"
-    locator.clear "hasura-rest-endpoints"
+    locator.clear Noir::LocatorKeys::HASURA_TABLES
+    locator.clear Noir::LocatorKeys::HASURA_REST_ENDPOINTS
 
     instance.detect("metadata/databases/default/tables/public_movies.yaml", per_table)
     instance.detect("metadata/rest_endpoints.yaml", <<-YAML)
@@ -119,7 +119,7 @@ describe "Detect Hasura metadata" do
           - GET
       YAML
 
-    locator.all("hasura-tables").should eq(["metadata/databases/default/tables/public_movies.yaml"])
-    locator.all("hasura-rest-endpoints").should eq(["metadata/rest_endpoints.yaml"])
+    locator.all(Noir::LocatorKeys::HASURA_TABLES).should eq(["metadata/databases/default/tables/public_movies.yaml"])
+    locator.all(Noir::LocatorKeys::HASURA_REST_ENDPOINTS).should eq(["metadata/rest_endpoints.yaml"])
   end
 end

--- a/spec/unit_test/detector/specification/http_file_spec.cr
+++ b/spec/unit_test/detector/specification/http_file_spec.cr
@@ -54,8 +54,8 @@ describe "Detect HTTP/REST Client Files" do
     content = "POST https://api.example.com/orders\n"
 
     locator = CodeLocator.instance
-    locator.clear "http-file"
+    locator.clear Noir::LocatorKeys::HTTP_FILE
     instance.detect("orders.http", content)
-    locator.all("http-file").should eq(["orders.http"])
+    locator.all(Noir::LocatorKeys::HTTP_FILE).should eq(["orders.http"])
   end
 end

--- a/spec/unit_test/detector/specification/insomnia_spec.cr
+++ b/spec/unit_test/detector/specification/insomnia_spec.cr
@@ -48,9 +48,9 @@ describe "Detect Insomnia Export" do
       JSON
 
     locator = CodeLocator.instance
-    locator.clear "insomnia-json"
+    locator.clear Noir::LocatorKeys::INSOMNIA_JSON
     instance.detect("test.json", content)
-    locator.all("insomnia-json").should eq(["test.json"])
+    locator.all(Noir::LocatorKeys::INSOMNIA_JSON).should eq(["test.json"])
   end
 
   it "code_locator (yaml)" do
@@ -61,9 +61,9 @@ describe "Detect Insomnia Export" do
       YAML
 
     locator = CodeLocator.instance
-    locator.clear "insomnia-yaml"
+    locator.clear Noir::LocatorKeys::INSOMNIA_YAML
     instance.detect("test.yaml", content)
-    locator.all("insomnia-yaml").should eq(["test.yaml"])
+    locator.all(Noir::LocatorKeys::INSOMNIA_YAML).should eq(["test.yaml"])
   end
 
   it "invalid JSON is ignored" do

--- a/spec/unit_test/detector/specification/istio_virtualservice_spec.cr
+++ b/spec/unit_test/detector/specification/istio_virtualservice_spec.cr
@@ -23,10 +23,10 @@ describe "Detect Istio VirtualService manifest" do
 
   it "detects VirtualService manifest" do
     locator = CodeLocator.instance
-    locator.clear "istio-virtualservice-spec"
+    locator.clear Noir::LocatorKeys::ISTIO_VIRTUALSERVICE_SPEC
 
     instance.detect("mesh/api.yaml", vs).should be_true
-    locator.all("istio-virtualservice-spec").should eq ["mesh/api.yaml"]
+    locator.all(Noir::LocatorKeys::ISTIO_VIRTUALSERVICE_SPEC).should eq ["mesh/api.yaml"]
   end
 
   it "detects a VirtualService manifest with a quoted kind" do

--- a/spec/unit_test/detector/specification/k8s_gateway_api_spec.cr
+++ b/spec/unit_test/detector/specification/k8s_gateway_api_spec.cr
@@ -21,10 +21,10 @@ describe "Detect Kubernetes Gateway API manifests" do
 
   it "detects HTTPRoute manifest" do
     locator = CodeLocator.instance
-    locator.clear "k8s-gateway-api-spec"
+    locator.clear Noir::LocatorKeys::K8S_GATEWAY_API_SPEC
 
     instance.detect("routes/api.yaml", httproute).should be_true
-    locator.all("k8s-gateway-api-spec").should eq ["routes/api.yaml"]
+    locator.all(Noir::LocatorKeys::K8S_GATEWAY_API_SPEC).should eq ["routes/api.yaml"]
   end
 
   it "detects an HTTPRoute manifest with a quoted kind" do

--- a/spec/unit_test/detector/specification/k8s_ingress_spec.cr
+++ b/spec/unit_test/detector/specification/k8s_ingress_spec.cr
@@ -22,10 +22,10 @@ describe "Detect Kubernetes Ingress manifests" do
 
   it "detects networking.k8s.io Ingress YAML" do
     locator = CodeLocator.instance
-    locator.clear "k8s-ingress-spec"
+    locator.clear Noir::LocatorKeys::K8S_INGRESS_SPEC
 
     instance.detect("manifests/ingress.yaml", ingress).should be_true
-    locator.all("k8s-ingress-spec").should eq ["manifests/ingress.yaml"]
+    locator.all(Noir::LocatorKeys::K8S_INGRESS_SPEC).should eq ["manifests/ingress.yaml"]
   end
 
   it "rejects non-Ingress YAML" do
@@ -65,7 +65,7 @@ describe "Detect Kubernetes Ingress manifests" do
 
   it "detects templated Helm Ingress manifests" do
     locator = CodeLocator.instance
-    locator.clear "k8s-ingress-spec"
+    locator.clear Noir::LocatorKeys::K8S_INGRESS_SPEC
 
     src = <<-YAML
       {{- if .Values.ingress.enabled }}
@@ -84,7 +84,7 @@ describe "Detect Kubernetes Ingress manifests" do
       YAML
 
     instance.detect("templates/ingress.yaml", src).should be_true
-    locator.all("k8s-ingress-spec").should eq ["templates/ingress.yaml"]
+    locator.all(Noir::LocatorKeys::K8S_INGRESS_SPEC).should eq ["templates/ingress.yaml"]
   end
 
   it "detects legacy extensions v1beta1 Ingress manifests" do

--- a/spec/unit_test/detector/specification/kamal_spec.cr
+++ b/spec/unit_test/detector/specification/kamal_spec.cr
@@ -20,10 +20,10 @@ describe "Detect Kamal deploy config" do
 
   it "detects a config/deploy.yml with service, image and proxy" do
     locator = CodeLocator.instance
-    locator.clear "kamal-spec"
+    locator.clear Noir::LocatorKeys::KAMAL_SPEC
 
     instance.detect("config/deploy.yml", deploy).should be_true
-    locator.all("kamal-spec").should eq ["config/deploy.yml"]
+    locator.all(Noir::LocatorKeys::KAMAL_SPEC).should eq ["config/deploy.yml"]
   end
 
   it "detects a config that only declares servers (no proxy)" do

--- a/spec/unit_test/detector/specification/kong_spec.cr
+++ b/spec/unit_test/detector/specification/kong_spec.cr
@@ -38,9 +38,9 @@ describe "Detect Kong declarative config" do
       YAML
 
     locator = CodeLocator.instance
-    locator.clear "kong-spec"
+    locator.clear Noir::LocatorKeys::KONG_SPEC
     instance.detect("kong.yml", content)
-    locator.all("kong-spec").should eq(["kong.yml"])
+    locator.all(Noir::LocatorKeys::KONG_SPEC).should eq(["kong.yml"])
   end
 
   it "rejects unrelated yaml without kong markers" do

--- a/spec/unit_test/detector/specification/mitmproxy_spec.cr
+++ b/spec/unit_test/detector/specification/mitmproxy_spec.cr
@@ -38,9 +38,9 @@ describe "Detect mitmproxy flow" do
 
   it "registers the path in CodeLocator on a match" do
     locator = CodeLocator.instance
-    locator.clear "mitmproxy-path"
+    locator.clear Noir::LocatorKeys::MITMPROXY_PATH
     content = String.new(build_flow_bytes)
     instance.detect("flows/recon.flow", content)
-    locator.all("mitmproxy-path").should eq ["flows/recon.flow"]
+    locator.all(Noir::LocatorKeys::MITMPROXY_PATH).should eq ["flows/recon.flow"]
   end
 end

--- a/spec/unit_test/detector/specification/netlify_spec.cr
+++ b/spec/unit_test/detector/specification/netlify_spec.cr
@@ -8,18 +8,18 @@ describe "Detect Netlify routing files" do
 
   it "detects _redirects file and registers its path" do
     locator = CodeLocator.instance
-    locator.clear "netlify-redirects"
+    locator.clear Noir::LocatorKeys::NETLIFY_REDIRECTS
 
     instance.detect("site/_redirects", "/old /new 301").should be_true
-    locator.all("netlify-redirects").should eq ["site/_redirects"]
+    locator.all(Noir::LocatorKeys::NETLIFY_REDIRECTS).should eq ["site/_redirects"]
   end
 
   it "detects netlify.toml file and registers its path" do
     locator = CodeLocator.instance
-    locator.clear "netlify-toml"
+    locator.clear Noir::LocatorKeys::NETLIFY_TOML
 
     instance.detect("site/netlify.toml", "[[redirects]]").should be_true
-    locator.all("netlify-toml").should eq ["site/netlify.toml"]
+    locator.all(Noir::LocatorKeys::NETLIFY_TOML).should eq ["site/netlify.toml"]
   end
 
   it "ignores unrelated filenames" do

--- a/spec/unit_test/detector/specification/nginx_spec.cr
+++ b/spec/unit_test/detector/specification/nginx_spec.cr
@@ -16,10 +16,10 @@ describe "Detect Nginx config" do
 
   it "detects nginx.conf with server/location blocks" do
     locator = CodeLocator.instance
-    locator.clear "nginx-spec"
+    locator.clear Noir::LocatorKeys::NGINX_SPEC
 
     instance.detect("nginx.conf", src).should be_true
-    locator.all("nginx-spec").should eq ["nginx.conf"]
+    locator.all(Noir::LocatorKeys::NGINX_SPEC).should eq ["nginx.conf"]
   end
 
   it "detects .conf fragments" do

--- a/spec/unit_test/detector/specification/oas2_spec.cr
+++ b/spec/unit_test/detector/specification/oas2_spec.cr
@@ -35,8 +35,8 @@ describe "Detect OAS 2.0(Swagger) Docs" do
       JSON
 
     locator = CodeLocator.instance
-    locator.clear "swagger-json"
+    locator.clear Noir::LocatorKeys::SWAGGER_JSON
     instance.detect("docs.json", content)
-    locator.all("swagger-json").should eq(["docs.json"])
+    locator.all(Noir::LocatorKeys::SWAGGER_JSON).should eq(["docs.json"])
   end
 end

--- a/spec/unit_test/detector/specification/oas3_spec.cr
+++ b/spec/unit_test/detector/specification/oas3_spec.cr
@@ -35,8 +35,8 @@ describe "Detect OAS 3.0 Docs" do
       JSON
 
     locator = CodeLocator.instance
-    locator.clear "oas3-json"
+    locator.clear Noir::LocatorKeys::OAS3_JSON
     instance.detect("docs.json", content)
-    locator.all("oas3-json").should eq(["docs.json"])
+    locator.all(Noir::LocatorKeys::OAS3_JSON).should eq(["docs.json"])
   end
 end

--- a/spec/unit_test/detector/specification/openrpc_spec.cr
+++ b/spec/unit_test/detector/specification/openrpc_spec.cr
@@ -49,8 +49,8 @@ describe "Detect OpenRPC Docs" do
       JSON
 
     locator = CodeLocator.instance
-    locator.clear "openrpc-json"
+    locator.clear Noir::LocatorKeys::OPENRPC_JSON
     instance.detect("openrpc.json", content)
-    locator.all("openrpc-json").should eq(["openrpc.json"])
+    locator.all(Noir::LocatorKeys::OPENRPC_JSON).should eq(["openrpc.json"])
   end
 end

--- a/spec/unit_test/detector/specification/payload_cms_spec.cr
+++ b/spec/unit_test/detector/specification/payload_cms_spec.cr
@@ -126,15 +126,15 @@ describe "Detect Payload CMS" do
 
   it "registers collections, globals and configs under separate keys" do
     locator = CodeLocator.instance
-    locator.clear "payload-collection"
-    locator.clear "payload-global"
-    locator.clear "payload-config"
+    locator.clear Noir::LocatorKeys::PAYLOAD_COLLECTION
+    locator.clear Noir::LocatorKeys::PAYLOAD_GLOBAL
+    locator.clear Noir::LocatorKeys::PAYLOAD_CONFIG
 
     instance.detect("src/collections/Posts.ts", collection)
     instance.detect("src/payload.config.ts", "import { buildConfig } from 'payload'\nexport default buildConfig({})")
 
-    locator.all("payload-collection").should eq(["src/collections/Posts.ts"])
-    locator.all("payload-config").should eq(["src/payload.config.ts"])
-    locator.all("payload-global").should eq([] of String)
+    locator.all(Noir::LocatorKeys::PAYLOAD_COLLECTION).should eq(["src/collections/Posts.ts"])
+    locator.all(Noir::LocatorKeys::PAYLOAD_CONFIG).should eq(["src/payload.config.ts"])
+    locator.all(Noir::LocatorKeys::PAYLOAD_GLOBAL).should eq([] of String)
   end
 end

--- a/spec/unit_test/detector/specification/postman_spec.cr
+++ b/spec/unit_test/detector/specification/postman_spec.cr
@@ -47,9 +47,9 @@ describe "Detect Postman Collection" do
       JSON
 
     locator = CodeLocator.instance
-    locator.clear "postman-json"
+    locator.clear Noir::LocatorKeys::POSTMAN_JSON
     instance.detect("test.json", content)
-    locator.all("postman-json").should eq(["test.json"])
+    locator.all(Noir::LocatorKeys::POSTMAN_JSON).should eq(["test.json"])
   end
 
   it "invalid format" do

--- a/spec/unit_test/detector/specification/raml_spec.cr
+++ b/spec/unit_test/detector/specification/raml_spec.cr
@@ -11,9 +11,9 @@ describe "Detect RAML" do
 
   it "code_locator" do
     locator = CodeLocator.instance
-    locator.clear "raml-spec"
+    locator.clear Noir::LocatorKeys::RAML_SPEC
     instance.detect("app.yaml", "#%RAML\nApp: 1")
-    locator.all("raml-spec").should eq(["app.yaml"])
+    locator.all(Noir::LocatorKeys::RAML_SPEC).should eq(["app.yaml"])
   end
 
   it "rejects yaml without the RAML header" do

--- a/spec/unit_test/detector/specification/serverless_framework_spec.cr
+++ b/spec/unit_test/detector/specification/serverless_framework_spec.cr
@@ -22,22 +22,22 @@ describe "Detect Serverless Framework config" do
 
   it "detects serverless.yml with service + provider + functions" do
     locator = CodeLocator.instance
-    locator.clear "serverless-framework-spec"
+    locator.clear Noir::LocatorKeys::SERVERLESS_FRAMEWORK_SPEC
 
     instance.detect("serverless.yml", yaml).should be_true
-    locator.all("serverless-framework-spec").should eq ["serverless.yml"]
+    locator.all(Noir::LocatorKeys::SERVERLESS_FRAMEWORK_SPEC).should eq ["serverless.yml"]
   end
 
   it "detects serverless.yaml" do
     locator = CodeLocator.instance
-    locator.clear "serverless-framework-spec"
+    locator.clear Noir::LocatorKeys::SERVERLESS_FRAMEWORK_SPEC
 
     instance.detect("serverless.yaml", yaml).should be_true
   end
 
   it "detects serverless.json shape" do
     locator = CodeLocator.instance
-    locator.clear "serverless-framework-spec"
+    locator.clear Noir::LocatorKeys::SERVERLESS_FRAMEWORK_SPEC
 
     json = %({"service":"my-api","provider":{"name":"aws"},"functions":{"a":{"handler":"x"}}})
     instance.detect("serverless.json", json).should be_true

--- a/spec/unit_test/detector/specification/smithy_spec.cr
+++ b/spec/unit_test/detector/specification/smithy_spec.cr
@@ -19,8 +19,8 @@ describe "Detect Smithy" do
 
   it "code_locator" do
     locator = CodeLocator.instance
-    locator.clear "smithy-spec"
+    locator.clear Noir::LocatorKeys::SMITHY_SPEC
     instance.detect("service.smithy", "$version: \"2\"\n")
-    locator.all("smithy-spec").should eq(["service.smithy"])
+    locator.all(Noir::LocatorKeys::SMITHY_SPEC).should eq(["service.smithy"])
   end
 end

--- a/spec/unit_test/detector/specification/strapi_spec.cr
+++ b/spec/unit_test/detector/specification/strapi_spec.cr
@@ -135,13 +135,13 @@ describe "Detect Strapi" do
 
   it "registers schema and route paths under separate locator keys" do
     locator = CodeLocator.instance
-    locator.clear "strapi-schema"
-    locator.clear "strapi-routes"
+    locator.clear Noir::LocatorKeys::STRAPI_SCHEMA
+    locator.clear Noir::LocatorKeys::STRAPI_ROUTES
 
     instance.detect("src/api/article/content-types/article/schema.json", schema)
     instance.detect("src/api/article/routes/custom-article.ts", routes)
 
-    locator.all("strapi-schema").should eq(["src/api/article/content-types/article/schema.json"])
-    locator.all("strapi-routes").should eq(["src/api/article/routes/custom-article.ts"])
+    locator.all(Noir::LocatorKeys::STRAPI_SCHEMA).should eq(["src/api/article/content-types/article/schema.json"])
+    locator.all(Noir::LocatorKeys::STRAPI_ROUTES).should eq(["src/api/article/routes/custom-article.ts"])
   end
 end

--- a/spec/unit_test/detector/specification/supabase_spec.cr
+++ b/spec/unit_test/detector/specification/supabase_spec.cr
@@ -87,8 +87,8 @@ describe "Detect Supabase" do
 
   it "registers migration paths in the code locator" do
     locator = CodeLocator.instance
-    locator.clear "supabase-migration"
+    locator.clear Noir::LocatorKeys::SUPABASE_MIGRATION
     instance.detect("supabase/migrations/20240101000000_init.sql", schema)
-    locator.all("supabase-migration").should eq(["supabase/migrations/20240101000000_init.sql"])
+    locator.all(Noir::LocatorKeys::SUPABASE_MIGRATION).should eq(["supabase/migrations/20240101000000_init.sql"])
   end
 end

--- a/spec/unit_test/detector/specification/terraform_spec.cr
+++ b/spec/unit_test/detector/specification/terraform_spec.cr
@@ -21,22 +21,22 @@ describe "Detect Terraform API Gateway config" do
 
   it "detects a .tf file declaring aws_apigatewayv2_route" do
     locator = CodeLocator.instance
-    locator.clear "terraform-spec"
+    locator.clear Noir::LocatorKeys::TERRAFORM_SPEC
 
     instance.detect("main.tf", v2_tf).should be_true
-    locator.all("terraform-spec").should eq ["main.tf"]
+    locator.all(Noir::LocatorKeys::TERRAFORM_SPEC).should eq ["main.tf"]
   end
 
   it "detects a .tf file declaring aws_api_gateway_method" do
     locator = CodeLocator.instance
-    locator.clear "terraform-spec"
+    locator.clear Noir::LocatorKeys::TERRAFORM_SPEC
 
     instance.detect("api.tf", rest_tf).should be_true
   end
 
   it "detects a .tf.json file" do
     locator = CodeLocator.instance
-    locator.clear "terraform-spec"
+    locator.clear Noir::LocatorKeys::TERRAFORM_SPEC
 
     json = %({"resource":{"aws_apigatewayv2_route":{"a":{"route_key":"GET /x"}}}})
     instance.detect("main.tf.json", json).should be_true

--- a/spec/unit_test/detector/specification/traefik_spec.cr
+++ b/spec/unit_test/detector/specification/traefik_spec.cr
@@ -39,9 +39,9 @@ describe "Detect Traefik dynamic config" do
 
   it "code_locator" do
     locator = CodeLocator.instance
-    locator.clear "traefik-spec"
+    locator.clear Noir::LocatorKeys::TRAEFIK_SPEC
     instance.detect("traefik.yaml", "http:\n  routers:\n    api:\n      rule: \"Path(`/v1`)\"")
-    locator.all("traefik-spec").should eq(["traefik.yaml"])
+    locator.all(Noir::LocatorKeys::TRAEFIK_SPEC).should eq(["traefik.yaml"])
   end
 
   it "rejects unrelated yaml" do

--- a/spec/unit_test/detector/specification/vercel_spec.cr
+++ b/spec/unit_test/detector/specification/vercel_spec.cr
@@ -36,9 +36,9 @@ describe "Detect Vercel config" do
 
   it "registers path in code_locator" do
     locator = CodeLocator.instance
-    locator.clear "vercel-spec"
+    locator.clear Noir::LocatorKeys::VERCEL_SPEC
 
     instance.detect("vercel.json", %({"redirects":[{"source":"/old","destination":"/new"}]}))
-    locator.all("vercel-spec").should eq(["vercel.json"])
+    locator.all(Noir::LocatorKeys::VERCEL_SPEC).should eq(["vercel.json"])
   end
 end

--- a/spec/unit_test/detector/specification/wsdl_spec.cr
+++ b/spec/unit_test/detector/specification/wsdl_spec.cr
@@ -16,9 +16,9 @@ describe "Detect WSDL" do
 
   it "code_locator" do
     locator = CodeLocator.instance
-    locator.clear "wsdl-spec"
+    locator.clear Noir::LocatorKeys::WSDL_SPEC
     sample = %(<?xml version="1.0"?><wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"></wsdl:definitions>)
     instance.detect("service.wsdl", sample)
-    locator.all("wsdl-spec").should eq(["service.wsdl"])
+    locator.all(Noir::LocatorKeys::WSDL_SPEC).should eq(["service.wsdl"])
   end
 end

--- a/spec/unit_test/detector/specification/zap_sites_tree_spec.cr
+++ b/spec/unit_test/detector/specification/zap_sites_tree_spec.cr
@@ -23,9 +23,9 @@ describe "Detect ZAP Sites Tree" do
       YAML
 
     locator = CodeLocator.instance
-    locator.clear "zap-sites-tree"
+    locator.clear Noir::LocatorKeys::ZAP_SITES_TREE
     instance.detect("sites.yaml", content)
-    locator.all("zap-sites-tree").should eq(["sites.yaml"])
+    locator.all(Noir::LocatorKeys::ZAP_SITES_TREE).should eq(["sites.yaml"])
   end
 
   it "rejects yaml without the Sites marker" do

--- a/spec/unit_test/models/code_locator_spec.cr
+++ b/spec/unit_test/models/code_locator_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "../../../src/models/locator_keys"
 require "../../../src/utils/utils.cr"
 require "../../../src/models/logger.cr"
 require "../../../src/models/code_locator.cr"
@@ -7,15 +8,25 @@ require "../../../src/options.cr"
 describe "Initialize" do
   locator = CodeLocator.new
 
+  # A library caller declaring its own slot — the escape hatch that replaces
+  # "pass any string and hope". Declaring it is also what gives it a
+  # lifecycle: `Process` means noir's per-phase resets leave it alone.
+  single_key = Noir::LocatorKey(String).new("unittest-single", Noir::LocatorKey::Lifecycle::Process, "spec")
+  array_key = Noir::LocatorKey(Array(String)).new("unittest-array", Noir::LocatorKey::Lifecycle::Process, "spec")
+
   it "getter/setter - string" do
-    locator.set "unittest", "abcd"
-    locator.get("unittest").should eq("abcd")
+    locator.set single_key, "abcd"
+    locator.get(single_key).should eq("abcd")
+  end
+
+  it "returns nil for a single-value key that was never set" do
+    CodeLocator.new.get(single_key).should be_nil
   end
 
   it "all/push - array" do
-    locator.push "unittest", "abcd"
-    locator.push "unittest", "bbbb"
-    locator.all("unittest").should eq(["abcd", "bbbb"])
+    locator.push array_key, "abcd"
+    locator.push array_key, "bbbb"
+    locator.all(array_key).should eq(["abcd", "bbbb"])
   end
 end
 
@@ -80,13 +91,13 @@ describe "content cache" do
   # at the top of every scan, and the spec-format keys are drained later.
   it "reset_files leaves unrelated keys alone" do
     locator = CodeLocator.new
-    locator.push("oas3-json", "/spec/openapi.json")
+    locator.push(Noir::LocatorKeys::OAS3_JSON, "/spec/openapi.json")
     locator.register_path("/a.rb")
 
     locator.reset_files
 
     locator.all_files.should be_empty
-    locator.all("oas3-json").should eq(["/spec/openapi.json"])
+    locator.all(Noir::LocatorKeys::OAS3_JSON).should eq(["/spec/openapi.json"])
   end
 
   it "stops caching once the total budget is exhausted" do

--- a/spec/unit_test/models/locator_keys_spec.cr
+++ b/spec/unit_test/models/locator_keys_spec.cr
@@ -1,0 +1,94 @@
+require "../../spec_helper"
+require "../../../src/models/locator_keys"
+
+# The typed key API means the compiler rejects an undeclared key outright, so
+# these specs cover what a type cannot: that the declarations stay coherent
+# and that none of them is dead.
+#
+# Every example is generated from `DECLARATIONS`, so a key added tomorrow is
+# covered without anyone remembering to cover it.
+describe "locator key registry" do
+  array_keys = Noir::LocatorKeys::ARRAY_KEYS
+  single_keys = Noir::LocatorKeys::SINGLE_KEYS
+
+  it "derives one constant per declaration" do
+    (array_keys.size + single_keys.size).should eq Noir::LocatorKeys::DECLARATIONS.size
+  end
+
+  it "declares each name exactly once" do
+    names = array_keys.map(&.name) + single_keys.map(&.name)
+    duplicates = names.tally.select { |_, count| count > 1 }.keys
+    fail "duplicate key names alias two subsystems onto one slot: #{duplicates.sort}" unless duplicates.empty?
+  end
+
+  it "gives every key a name and an owning subsystem" do
+    blank = (array_keys.map { |k| {k.name, k.owner} } + single_keys.map { |k| {k.name, k.owner} })
+      .select { |name, owner| name.blank? || owner.blank? }
+    fail "keys missing a name or owner: #{blank}" unless blank.empty?
+  end
+
+  # A key referenced only by its own declaration is dead — that is how
+  # `cs-aspnet-core-mvc-entrypoints` survived with zero readers until #2499.
+  # This greps for the constant *identifier*, not the string literal, so it
+  # has no interpolation blind spot.
+  it "keeps every declared key in use" do
+    sources = Dir.glob("src/**/*.cr").reject(&.ends_with?("locator_keys.cr"))
+    contents = sources.map { |file| File.read(file) }
+
+    unused = Noir::LocatorKeys::DECLARATIONS.compact_map do |declaration|
+      constant = declaration[0].to_s
+      constant unless contents.any?(&.includes?(constant))
+    end
+
+    fail "declared keys nothing references: #{unused.sort}" unless unused.empty?
+    sources.size.should be > 500
+  end
+
+  it "namespaces mint keys that carry the namespace lifecycle and owner" do
+    ns = Noir::LocatorKeys::EXPRESS_ROUTER_PREFIX
+    key = ns.key("/app/server.js", "mountRoutes")
+
+    key.name.should eq "express_router_prefix:/app/server.js:mountRoutes"
+    key.lifecycle.should eq ns.lifecycle
+    key.owner.should eq ns.owner
+    ns.matches?(key.name).should be_true
+    ns.matches?("express_router_prefix").should be_false
+    ns.matches?("other:/app/server.js").should be_false
+  end
+
+  it "keeps namespace-minted keys out of the declared constants" do
+    # They cannot be constants — the names come from scanned paths — which is
+    # why the namespace exists rather than a per-path declaration.
+    ns_prefix = Noir::LocatorKeys::EXPRESS_ROUTER_PREFIX.prefix
+    array_keys.map(&.name).any?(&.starts_with?(ns_prefix)).should be_false
+  end
+end
+
+describe "CodeLocator with typed keys" do
+  it "keeps the two value shapes in separate maps" do
+    locator = CodeLocator.new
+    single = Noir::LocatorKey(String).new("shape-single", Noir::LocatorKey::Lifecycle::Process, "spec")
+    array = Noir::LocatorKey(Array(String)).new("shape-array", Noir::LocatorKey::Lifecycle::Process, "spec")
+
+    locator.set(single, "one")
+    locator.push(array, "two")
+
+    locator.get(single).should eq "one"
+    locator.all(array).should eq ["two"]
+  end
+
+  it "clears a namespace by prefix without touching declared keys" do
+    locator = CodeLocator.new
+    ns = Noir::LocatorKeys::EXPRESS_ROUTER_PREFIX
+
+    locator.push(ns.key("/a.js"), "/api")
+    locator.push(ns.key("/b.js", "mount"), "/v2")
+    locator.push(Noir::LocatorKeys::OAS3_JSON, "/spec/openapi.json")
+
+    locator.clear_namespace(ns)
+
+    locator.all(ns.key("/a.js")).should be_empty
+    locator.all(ns.key("/b.js", "mount")).should be_empty
+    locator.all(Noir::LocatorKeys::OAS3_JSON).should eq ["/spec/openapi.json"]
+  end
+end

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -18,10 +18,9 @@ module Analyzer::CSharp
       include_callee = callees_needed?
       # Static Analysis
       locator = CodeLocator.instance
-      route_config_file = locator.get("cs-apinet-mvc-routeconfig")
-
-      # Analyze RouteConfig.cs for route definitions
-      route_config_path = "#{route_config_file}"
+      # `get` returns `String?` now; the interpolation below used to be the
+      # workaround for its `(String | Array(String))` union.
+      route_config_path = locator.get(Noir::LocatorKeys::CS_APINET_MVC_ROUTECONFIG) || ""
       if File.exists?(route_config_path)
         maproute_check = false
         maproute_buffer = ""
@@ -40,7 +39,7 @@ module Analyzer::CSharp
               buffer.split(",").each do |item|
                 if item.includes? "url:"
                   url = item.gsub(/url:/, "").gsub(/"/, "")
-                  details = Details.new(PathInfo.new(route_config_file, index + 1))
+                  details = Details.new(PathInfo.new(route_config_path, index + 1))
                   @result << Endpoint.new("/#{url}", "GET", details)
                 end
               end

--- a/src/analyzer/analyzers/go/connect_rpc.cr
+++ b/src/analyzer/analyzers/go/connect_rpc.cr
@@ -38,7 +38,7 @@ module Analyzer::Go
 
     def analyze
       locator = CodeLocator.instance
-      proto_files = locator.all("grpc-proto")
+      proto_files = locator.all(Noir::LocatorKeys::GRPC_PROTO)
 
       unless proto_files.empty?
         service_mounts = discover_service_mounts

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -663,7 +663,7 @@ module Analyzer::Javascript
     end
 
     # Push prefix to CodeLocator with deduplication
-    private def push_prefix_to_locator(locator : CodeLocator, key : String, prefix : String, debug_msg : String)
+    private def push_prefix_to_locator(locator : CodeLocator, key : Noir::LocatorKey(Array(String)), prefix : String, debug_msg : String)
       unless locator.all(key).includes?(prefix)
         locator.push(key, prefix)
         @logger.debug debug_msg

--- a/src/analyzer/analyzers/javascript/express_constants.cr
+++ b/src/analyzer/analyzers/javascript/express_constants.cr
@@ -1,12 +1,9 @@
 require "../../../models/analyzer"
+require "../../../models/locator_keys"
 
 module Analyzer::Javascript
   # Constants for Express router prefix tracking in CodeLocator
   module ExpressConstants
-    # Base key prefix for router prefixes stored in CodeLocator
-    # Format: "express_router_prefix:<file_path>" or "express_router_prefix:<file_path>:<function_name>"
-    ROUTER_PREFIX_KEY = "express_router_prefix"
-
     # Common identifiers to skip when scanning for router variables
     SKIP_IDENTIFIERS = ["req", "res", "next", "err", "error", "true", "false", "null", "undefined"]
 
@@ -19,14 +16,17 @@ module Analyzer::Javascript
     # JavaScript/TypeScript file extensions
     JS_EXTENSIONS = [".js", ".ts", ".jsx", ".tsx"]
 
-    # Build a file-level key for CodeLocator
-    def self.file_key(file_path : String) : String
-      "#{ROUTER_PREFIX_KEY}:#{file_path}"
+    # File- and function-level keys for the router prefixes this analyzer
+    # stashes in `CodeLocator`. The names are minted from the scanned path,
+    # so they cannot be constants — they come from the declared
+    # `EXPRESS_ROUTER_PREFIX` namespace instead, which is what puts them
+    # under the same lifecycle and enforcement as every other slot.
+    def self.file_key(file_path : String) : Noir::LocatorKey(Array(String))
+      Noir::LocatorKeys::EXPRESS_ROUTER_PREFIX.key(file_path)
     end
 
-    # Build a function-level key for CodeLocator
-    def self.function_key(file_path : String, function_name : String) : String
-      "#{ROUTER_PREFIX_KEY}:#{file_path}:#{function_name}"
+    def self.function_key(file_path : String, function_name : String) : Noir::LocatorKey(Array(String))
+      Noir::LocatorKeys::EXPRESS_ROUTER_PREFIX.key(file_path, function_name)
     end
   end
 end

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -30,7 +30,7 @@ module Analyzer::Mobile
 
     def analyze
       locator = CodeLocator.instance
-      manifests = locator.all("android-manifest")
+      manifests = locator.all(Noir::LocatorKeys::ANDROID_MANIFEST)
       return @result unless manifests.is_a?(Array(String))
 
       manifests.each do |path|

--- a/src/analyzer/analyzers/mobile/ios.cr
+++ b/src/analyzer/analyzers/mobile/ios.cr
@@ -50,12 +50,12 @@ module Analyzer::Mobile
     def analyze
       locator = CodeLocator.instance
 
-      plists = locator.all("ios-info-plist")
+      plists = locator.all(Noir::LocatorKeys::IOS_INFO_PLIST)
       if plists.is_a?(Array(String))
         plists.each { |path| parse_safely(path) { |doc| parse_info_plist(doc, path) } }
       end
 
-      entitlements = locator.all("ios-entitlements")
+      entitlements = locator.all(Noir::LocatorKeys::IOS_ENTITLEMENTS)
       if entitlements.is_a?(Array(String))
         entitlements.each { |path| parse_safely(path) { |doc| parse_entitlements(doc, path) } }
       end

--- a/src/analyzer/analyzers/mobile/well_known.cr
+++ b/src/analyzer/analyzers/mobile/well_known.cr
@@ -28,10 +28,10 @@ module Analyzer::Mobile
     def analyze
       locator = CodeLocator.instance
 
-      assetlinks = locator.all("android-assetlinks")
+      assetlinks = locator.all(Noir::LocatorKeys::ANDROID_ASSETLINKS)
       assetlinks.each { |path| parse_safely(path) { |json| parse_assetlinks(json, path) } }
 
-      aasa = locator.all("ios-aasa")
+      aasa = locator.all(Noir::LocatorKeys::IOS_AASA)
       aasa.each { |path| parse_safely(path) { |json| parse_aasa(json, path) } }
 
       @result

--- a/src/analyzer/analyzers/specification/apache_httpd.cr
+++ b/src/analyzer/analyzers/specification/apache_httpd.cr
@@ -10,7 +10,7 @@ module Analyzer::Specification
     STATIC_EXTENSIONS = Set{".css", ".js", ".gz", ".br", ".ico", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".woff", ".woff2", ".ttf", ".eot", ".map"}
 
     def analyze
-      each_spec_file("apache-httpd-spec") do |path|
+      each_spec_file(Noir::LocatorKeys::APACHE_HTTPD_SPEC) do |path|
         content = read_file_content(path)
         process_content(content, path)
       end

--- a/src/analyzer/analyzers/specification/apisix.cr
+++ b/src/analyzer/analyzers/specification/apisix.cr
@@ -5,11 +5,11 @@ module Analyzer::Specification
     analyzer_for "apisix"
 
     def analyze
-      each_spec_file("apisix-json") do |path|
+      each_spec_file(Noir::LocatorKeys::APISIX_JSON) do |path|
         process_json(path)
       end
 
-      each_spec_file("apisix-yaml") do |path|
+      each_spec_file(Noir::LocatorKeys::APISIX_YAML) do |path|
         process_yaml(path)
       end
 

--- a/src/analyzer/analyzers/specification/appwrite.cr
+++ b/src/analyzer/analyzers/specification/appwrite.cr
@@ -31,7 +31,7 @@ module Analyzer::Specification
     TAG_SOURCE = "appwrite_analyzer"
 
     def analyze
-      each_spec_file("appwrite-config") do |path|
+      each_spec_file(Noir::LocatorKeys::APPWRITE_CONFIG) do |path|
         content = read_file_content(path)
         parse_config(content, path)
       end

--- a/src/analyzer/analyzers/specification/asyncapi.cr
+++ b/src/analyzer/analyzers/specification/asyncapi.cr
@@ -22,12 +22,12 @@ module Analyzer::Specification
     OPERATIONS_2X = {"publish", "subscribe"}
 
     def analyze
-      each_spec_file_with_details("asyncapi-json") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::ASYNCAPI_JSON) do |path, details|
         content = read_file_content(path)
         process_json(JSON.parse(content), details, path)
       end
 
-      each_spec_file_with_details("asyncapi-yaml") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::ASYNCAPI_YAML) do |path, details|
         content = read_file_content(path)
         process_yaml(YAML.parse(content), details, path)
       end

--- a/src/analyzer/analyzers/specification/aws_cdk.cr
+++ b/src/analyzer/analyzers/specification/aws_cdk.cr
@@ -23,7 +23,7 @@ module Analyzer::Specification
     PY_METHODS_RE  = /methods\s*=\s*\[([^\]]*)\]/
 
     def analyze
-      each_spec_file_with_details("aws-cdk-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::AWS_CDK_SPEC) do |path, details|
         content = read_file_content(path)
         if path.ends_with?(".py")
           process_python(content, details)

--- a/src/analyzer/analyzers/specification/aws_cloudformation.cr
+++ b/src/analyzer/analyzers/specification/aws_cloudformation.cr
@@ -13,7 +13,7 @@ module Analyzer::Specification
     record ApigwResource, name : String, path_part : String, parent : String?
 
     def analyze
-      each_spec_file_with_details("aws-cloudformation-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::AWS_CLOUDFORMATION_SPEC) do |path, details|
         content = read_file_content(path)
         resources = parse_resources(path, content)
         next if resources.empty?

--- a/src/analyzer/analyzers/specification/azure_functions.cr
+++ b/src/analyzer/analyzers/specification/azure_functions.cr
@@ -19,7 +19,7 @@ module Analyzer::Specification
       # Resolve it once per app root instead of per function.
       prefixes = {} of String => String
 
-      each_spec_file_with_details("azure-functions-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::AZURE_FUNCTIONS_SPEC) do |path, details|
         content = read_file_content(path)
         app_root = File.dirname(File.dirname(path))
         prefix = prefixes[app_root] ||= route_prefix_for(app_root)

--- a/src/analyzer/analyzers/specification/bruno.cr
+++ b/src/analyzer/analyzers/specification/bruno.cr
@@ -7,7 +7,7 @@ module Analyzer::Specification
     HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options"}
 
     def analyze
-      each_spec_file("bruno-bru") do |bruno_file|
+      each_spec_file(Noir::LocatorKeys::BRUNO_BRU) do |bruno_file|
         content = read_file_content(bruno_file)
         details = Details.new(PathInfo.new(bruno_file))
         process_bru(content, details)

--- a/src/analyzer/analyzers/specification/burp.cr
+++ b/src/analyzer/analyzers/specification/burp.cr
@@ -12,7 +12,7 @@ module Analyzer::Specification
     analyzer_for "burp"
 
     def analyze
-      each_spec_file("burp-sitemap") do |path|
+      each_spec_file(Noir::LocatorKeys::BURP_SITEMAP) do |path|
         content = read_file_content(path)
         process_file(content, path)
       end

--- a/src/analyzer/analyzers/specification/caddy.cr
+++ b/src/analyzer/analyzers/specification/caddy.cr
@@ -17,7 +17,7 @@ module Analyzer::Specification
     SITE_BLOCK_RE    = /^([A-Za-z0-9_.:\/@*?-]+(?:\s*,\s*[A-Za-z0-9_.:\/@*?-]+)*)\s*\{$/
 
     def analyze
-      each_spec_file_with_details("caddy-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::CADDY_SPEC) do |path, details|
         content = read_file_content(path)
         if path.ends_with?(".json")
           process_json(content, details)

--- a/src/analyzer/analyzers/specification/caido.cr
+++ b/src/analyzer/analyzers/specification/caido.cr
@@ -7,7 +7,7 @@ module Analyzer::Specification
     analyzer_for "caido"
 
     def analyze
-      each_spec_file_with_details("caido-json") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::CAIDO_JSON) do |path, details|
         content = read_file_content(path)
 
         data = JSON.parse(content)

--- a/src/analyzer/analyzers/specification/cloudflare_wrangler.cr
+++ b/src/analyzer/analyzers/specification/cloudflare_wrangler.cr
@@ -21,7 +21,7 @@ module Analyzer::Specification
     TOML_STRING_RE       = /"([^"]+)"/
 
     def analyze
-      each_spec_file_with_details("cloudflare-wrangler-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::CLOUDFLARE_WRANGLER_SPEC) do |path, details|
         content = read_file_content(path)
         if path.ends_with?(".toml")
           process_toml(content, details)

--- a/src/analyzer/analyzers/specification/directus.cr
+++ b/src/analyzer/analyzers/specification/directus.cr
@@ -45,7 +45,7 @@ module Analyzer::Specification
     TAG_SOURCE = "directus_analyzer"
 
     def analyze
-      each_spec_file("directus-snapshot") do |path|
+      each_spec_file(Noir::LocatorKeys::DIRECTUS_SNAPSHOT) do |path|
         content = read_file_content(path)
         parse_snapshot(content, path)
       end

--- a/src/analyzer/analyzers/specification/envoy.cr
+++ b/src/analyzer/analyzers/specification/envoy.cr
@@ -34,12 +34,12 @@ module Analyzer::Specification
     ROUTE_KEY         = YAML::Any.new("route")
 
     def analyze
-      each_spec_file_with_details("envoy-yaml") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::ENVOY_YAML) do |path, details|
         content = read_file_content(path)
         process_yaml(YAML.parse(content), details)
       end
 
-      each_spec_file_with_details("envoy-json") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::ENVOY_JSON) do |path, details|
         content = read_file_content(path)
         process_json(JSON.parse(content), details)
       end

--- a/src/analyzer/analyzers/specification/graphql_sdl.cr
+++ b/src/analyzer/analyzers/specification/graphql_sdl.cr
@@ -14,7 +14,7 @@ module Analyzer::Specification
     analyzer_for "graphql_sdl"
 
     def analyze
-      each_spec_file("graphql-sdl") do |sdl_file|
+      each_spec_file(Noir::LocatorKeys::GRAPHQL_SDL) do |sdl_file|
         content = read_file_content(sdl_file)
         GraphqlSdlParser.parse(content, sdl_file).each { |ep| @result << ep }
       end

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -11,7 +11,7 @@ module Analyzer::Specification
       # `build_message_registry` reads and parses every `.proto` in the
       # codebase, so bail out before it when the detector registered no
       # service definitions to resolve against.
-      return @result if CodeLocator.instance.all("grpc-proto").empty?
+      return @result if CodeLocator.instance.all(Noir::LocatorKeys::GRPC_PROTO).empty?
 
       # Request/response messages are frequently defined in a separate
       # (imported) `.proto`, so resolving params from the service file alone
@@ -19,7 +19,7 @@ module Analyzer::Specification
       # both simple and package-qualified name, and resolve against it.
       registry = build_message_registry
 
-      each_spec_file("grpc-proto") do |proto_file|
+      each_spec_file(Noir::LocatorKeys::GRPC_PROTO) do |proto_file|
         content = read_file_content(proto_file)
         parse_proto(content, proto_file, registry)
       end

--- a/src/analyzer/analyzers/specification/har.cr
+++ b/src/analyzer/analyzers/specification/har.cr
@@ -36,7 +36,7 @@ module Analyzer::Specification
     }
 
     def analyze
-      each_spec_file("har-path") do |har_file|
+      each_spec_file(Noir::LocatorKeys::HAR_PATH) do |har_file|
         data = HAR.from_file(har_file)
         logger.debug "Open #{har_file} file"
         data.entries.each do |entry|

--- a/src/analyzer/analyzers/specification/hasura.cr
+++ b/src/analyzer/analyzers/specification/hasura.cr
@@ -35,11 +35,11 @@ module Analyzer::Specification
     GRAPHQL_IDENTIFIER = /\A[A-Za-z_][A-Za-z0-9_]*\z/
 
     def analyze
-      each_spec_file("hasura-tables") do |path|
+      each_spec_file(Noir::LocatorKeys::HASURA_TABLES) do |path|
         parse_tables(read_file_content(path), path)
       end
 
-      each_spec_file("hasura-rest-endpoints") do |path|
+      each_spec_file(Noir::LocatorKeys::HASURA_REST_ENDPOINTS) do |path|
         parse_rest_endpoints(read_file_content(path), path)
       end
 

--- a/src/analyzer/analyzers/specification/http_file.cr
+++ b/src/analyzer/analyzers/specification/http_file.cr
@@ -19,7 +19,7 @@ module Analyzer::Specification
     HTTP_METHODS = ALLOWED_HTTP_METHODS
 
     def analyze
-      each_spec_file("http-file") do |http_file|
+      each_spec_file(Noir::LocatorKeys::HTTP_FILE) do |http_file|
         content = read_file_content(http_file)
         process_file(content, http_file)
       end

--- a/src/analyzer/analyzers/specification/insomnia.cr
+++ b/src/analyzer/analyzers/specification/insomnia.cr
@@ -9,12 +9,12 @@ module Analyzer::Specification
     HTTP_METHODS = ALLOWED_HTTP_METHODS
 
     def analyze
-      each_spec_file("insomnia-json") do |path|
+      each_spec_file(Noir::LocatorKeys::INSOMNIA_JSON) do |path|
         content = read_file_content(path)
         process_v4(JSON.parse(content), path)
       end
 
-      each_spec_file("insomnia-yaml") do |path|
+      each_spec_file(Noir::LocatorKeys::INSOMNIA_YAML) do |path|
         content = read_file_content(path)
         process_v5(YAML.parse(content), path)
       end

--- a/src/analyzer/analyzers/specification/istio_virtualservice.cr
+++ b/src/analyzer/analyzers/specification/istio_virtualservice.cr
@@ -7,7 +7,7 @@ module Analyzer::Specification
     METHOD_ANY = "ANY"
 
     def analyze
-      each_spec_file_with_details("istio-virtualservice-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::ISTIO_VIRTUALSERVICE_SPEC) do |path, details|
         content = read_file_content(path)
         YAML.parse_all(content).each { |doc| process_doc(doc, details) }
       end

--- a/src/analyzer/analyzers/specification/k8s_gateway_api.cr
+++ b/src/analyzer/analyzers/specification/k8s_gateway_api.cr
@@ -7,7 +7,7 @@ module Analyzer::Specification
     METHOD_ANY = "ANY"
 
     def analyze
-      each_spec_file_with_details("k8s-gateway-api-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::K8S_GATEWAY_API_SPEC) do |path, details|
         content = read_file_content(path)
         YAML.parse_all(content).each { |doc| process_doc(doc, details) }
       end

--- a/src/analyzer/analyzers/specification/k8s_ingress.cr
+++ b/src/analyzer/analyzers/specification/k8s_ingress.cr
@@ -14,7 +14,7 @@ module Analyzer::Specification
     HOST_LINE          = /^[ \t-]*host:\s*(.*)$/
 
     def analyze
-      each_spec_file_with_details("k8s-ingress-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::K8S_INGRESS_SPEC) do |path, details|
         content = read_file_content(path)
         begin
           YAML.parse_all(content).each { |doc| process_doc(doc, details) }

--- a/src/analyzer/analyzers/specification/kamal.cr
+++ b/src/analyzer/analyzers/specification/kamal.cr
@@ -14,7 +14,7 @@ module Analyzer::Specification
     HEALTHCHECK_METHOD       = "GET"
 
     def analyze
-      each_spec_file_with_details("kamal-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::KAMAL_SPEC) do |path, details|
         content = read_file_content(path)
         process_config(YAML.parse(content), details)
       end

--- a/src/analyzer/analyzers/specification/kong.cr
+++ b/src/analyzer/analyzers/specification/kong.cr
@@ -5,7 +5,7 @@ module Analyzer::Specification
     analyzer_for "kong"
 
     def analyze
-      each_spec_file_with_details("kong-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::KONG_SPEC) do |path, details|
         content = read_file_content(path)
         process_doc(YAML.parse(content), details)
       end

--- a/src/analyzer/analyzers/specification/mitmproxy.cr
+++ b/src/analyzer/analyzers/specification/mitmproxy.cr
@@ -14,7 +14,7 @@ module Analyzer::Specification
     LEGACY_LIST_MIN_MAJOR = 3_i64
 
     def analyze
-      each_spec_file("mitmproxy-path") do |path|
+      each_spec_file(Noir::LocatorKeys::MITMPROXY_PATH) do |path|
         bytes = read_binary(path)
         process_file(path, bytes)
       end

--- a/src/analyzer/analyzers/specification/netlify.cr
+++ b/src/analyzer/analyzers/specification/netlify.cr
@@ -13,11 +13,11 @@ module Analyzer::Specification
     ABSOLUTE_SOURCE_RE = /\A[a-z][a-z0-9+.-]*:\/\/([^\/]+)(\/.*)?\z/i
 
     def analyze
-      each_spec_file("netlify-redirects") do |path|
+      each_spec_file(Noir::LocatorKeys::NETLIFY_REDIRECTS) do |path|
         parse_redirects_file(path)
       end
 
-      each_spec_file("netlify-toml") do |path|
+      each_spec_file(Noir::LocatorKeys::NETLIFY_TOML) do |path|
         parse_toml_file(path)
       end
 

--- a/src/analyzer/analyzers/specification/nginx.cr
+++ b/src/analyzer/analyzers/specification/nginx.cr
@@ -13,7 +13,7 @@ module Analyzer::Specification
     METHOD_BLOCK_RE = /^if\s*\(\s*\$request_method\s*=\s*([A-Z]+)\s*\)/
 
     def analyze
-      each_spec_file_with_details("nginx-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::NGINX_SPEC) do |path, details|
         content = read_file_content(path)
         process_content(content, details)
       end

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -314,11 +314,11 @@ module Analyzer::Specification
     end
 
     def analyze
-      each_spec_file("swagger-json") do |path|
+      each_spec_file(Noir::LocatorKeys::SWAGGER_JSON) do |path|
         process_json(path)
       end
 
-      each_spec_file("swagger-yaml") do |path|
+      each_spec_file(Noir::LocatorKeys::SWAGGER_YAML) do |path|
         process_yaml(path)
       end
 

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -385,7 +385,7 @@ module Analyzer::Specification
     end
 
     def analyze
-      each_spec_file_with_details("oas3-json") do |oas3_json, details|
+      each_spec_file_with_details(Noir::LocatorKeys::OAS3_JSON) do |oas3_json, details|
         content = read_file_content(oas3_json)
         json_obj = JSON.parse(content)
 
@@ -400,7 +400,7 @@ module Analyzer::Specification
         process_paths_json(json_obj, base_path, details, oas3_json)
       end
 
-      each_spec_file_with_details("oas3-yaml") do |oas3_yaml, details|
+      each_spec_file_with_details(Noir::LocatorKeys::OAS3_YAML) do |oas3_yaml, details|
         content = read_file_content(oas3_yaml)
         yaml_obj = parse_yaml(content)
 

--- a/src/analyzer/analyzers/specification/odata.cr
+++ b/src/analyzer/analyzers/specification/odata.cr
@@ -35,7 +35,7 @@ module Analyzer::Specification
     alias Operation = NamedTuple(parameters: Array(NamedTuple(name: String, type: String)), kind: String)
 
     def analyze
-      each_spec_file("odata-spec") do |path|
+      each_spec_file(Noir::LocatorKeys::ODATA_SPEC) do |path|
         content = read_file_content(path)
         parse_metadata(content, path)
       end

--- a/src/analyzer/analyzers/specification/openrpc.cr
+++ b/src/analyzer/analyzers/specification/openrpc.cr
@@ -27,7 +27,7 @@ module Analyzer::Specification
     DEFAULT_RPC_PATH = "/"
 
     def analyze
-      each_spec_file_with_details("openrpc-json") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::OPENRPC_JSON) do |path, details|
         content = read_file_content(path)
         process_document(JSON.parse(content), details)
       end

--- a/src/analyzer/analyzers/specification/payload_cms.cr
+++ b/src/analyzer/analyzers/specification/payload_cms.cr
@@ -47,13 +47,13 @@ module Analyzer::Specification
     TAG_SOURCE         = "payload_cms_analyzer"
 
     def analyze
-      api_prefix = resolve_api_prefix(CodeLocator.instance.all("payload-config"))
+      api_prefix = resolve_api_prefix(CodeLocator.instance.all(Noir::LocatorKeys::PAYLOAD_CONFIG))
 
-      each_spec_file("payload-collection") do |path|
+      each_spec_file(Noir::LocatorKeys::PAYLOAD_COLLECTION) do |path|
         parse_collections(read_file_content(path), path, api_prefix)
       end
 
-      each_spec_file("payload-global") do |path|
+      each_spec_file(Noir::LocatorKeys::PAYLOAD_GLOBAL) do |path|
         parse_globals(read_file_content(path), path, api_prefix)
       end
 

--- a/src/analyzer/analyzers/specification/postman.cr
+++ b/src/analyzer/analyzers/specification/postman.cr
@@ -6,7 +6,7 @@ module Analyzer::Specification
     analyzer_for "postman"
 
     def analyze
-      each_spec_file("postman-json") do |postman_file|
+      each_spec_file(Noir::LocatorKeys::POSTMAN_JSON) do |postman_file|
         content = read_file_content(postman_file)
         json_obj = JSON.parse(content)
 

--- a/src/analyzer/analyzers/specification/raml.cr
+++ b/src/analyzer/analyzers/specification/raml.cr
@@ -14,7 +14,7 @@ module Analyzer::Specification
     @libraries = {} of String => ResolvedNode
 
     def analyze
-      each_spec_file("raml-spec") do |raml_spec|
+      each_spec_file(Noir::LocatorKeys::RAML_SPEC) do |raml_spec|
         content = read_file_content(raml_spec)
 
         # Only root API documents (`#%RAML 1.0` / `#%RAML 0.8`) describe

--- a/src/analyzer/analyzers/specification/serverless_framework.cr
+++ b/src/analyzer/analyzers/specification/serverless_framework.cr
@@ -7,7 +7,7 @@ module Analyzer::Specification
     METHOD_ANY = "ANY"
 
     def analyze
-      each_spec_file_with_details("serverless-framework-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::SERVERLESS_FRAMEWORK_SPEC) do |path, details|
         content = read_file_content(path)
         if path.ends_with?(".json")
           process_doc(JSON.parse(content), details)

--- a/src/analyzer/analyzers/specification/smithy.cr
+++ b/src/analyzer/analyzers/specification/smithy.cr
@@ -48,7 +48,7 @@ module Analyzer::Specification
       structures = {} of String => Array(InputMember)
       operations = [] of NamedTuple(name: String, file: String, line: Int32, binding: HttpBinding, input: String?)
 
-      each_spec_file("smithy-spec") do |file|
+      each_spec_file(Noir::LocatorKeys::SMITHY_SPEC) do |file|
         parse_file(read_file_content(file), file, structures, operations)
       end
 

--- a/src/analyzer/analyzers/specification/strapi.cr
+++ b/src/analyzer/analyzers/specification/strapi.cr
@@ -44,11 +44,11 @@ module Analyzer::Specification
     TAG_SOURCE = "strapi_analyzer"
 
     def analyze
-      each_spec_file("strapi-schema") do |path|
+      each_spec_file(Noir::LocatorKeys::STRAPI_SCHEMA) do |path|
         parse_schema(read_file_content(path), path)
       end
 
-      each_spec_file("strapi-routes") do |path|
+      each_spec_file(Noir::LocatorKeys::STRAPI_ROUTES) do |path|
         parse_routes(read_file_content(path), path)
       end
 

--- a/src/analyzer/analyzers/specification/supabase.cr
+++ b/src/analyzer/analyzers/specification/supabase.cr
@@ -38,15 +38,15 @@ module Analyzer::Specification
 
     def analyze
       # Nothing to apply the DDL to, so skip reading `config.toml` as well.
-      return @result if CodeLocator.instance.all("supabase-migration").empty?
+      return @result if CodeLocator.instance.all(Noir::LocatorKeys::SUPABASE_MIGRATION).empty?
 
-      exposed = exposed_schemas(CodeLocator.instance.all("supabase-config"))
+      exposed = exposed_schemas(CodeLocator.instance.all(Noir::LocatorKeys::SUPABASE_CONFIG))
 
       # Migration filenames are `<timestamp>_<name>.sql`, so lexical order
       # is chronological. Applying them in order is what makes a column
       # added in one file and dropped in another come out right.
       state = Noir::PostgresDdlParser::State.new
-      each_spec_file("supabase-migration", sorted: true) do |path|
+      each_spec_file(Noir::LocatorKeys::SUPABASE_MIGRATION, sorted: true) do |path|
         Noir::PostgresDdlParser.apply(read_file_content(path), path, state)
       end
 

--- a/src/analyzer/analyzers/specification/terraform.cr
+++ b/src/analyzer/analyzers/specification/terraform.cr
@@ -44,7 +44,7 @@ module Analyzer::Specification
       # Group files by module directory. A REST resource and the method that
       # references it routinely live in different files of the same module.
       by_dir = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
-      each_spec_file("terraform-spec") do |path|
+      each_spec_file(Noir::LocatorKeys::TERRAFORM_SPEC) do |path|
         by_dir[File.dirname(path)] << path
       end
 

--- a/src/analyzer/analyzers/specification/traefik.cr
+++ b/src/analyzer/analyzers/specification/traefik.cr
@@ -12,7 +12,7 @@ module Analyzer::Specification
       # (a TOML and a YAML dynamic-config pair) is emitted once.
       seen = Set(String).new
 
-      each_spec_file_with_details("traefik-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::TRAEFIK_SPEC) do |path, details|
         content = read_file_content(path)
         if path.ends_with?(".toml")
           process_toml(content, details, seen)

--- a/src/analyzer/analyzers/specification/typespec.cr
+++ b/src/analyzer/analyzers/specification/typespec.cr
@@ -13,7 +13,7 @@ module Analyzer::Specification
     HTTP_VERB_DECORATORS = {"get", "post", "put", "patch", "delete", "head", "options"}
 
     def analyze
-      each_spec_file_with_details("typespec-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::TYPESPEC_SPEC) do |path, details|
         content = read_file_content(path)
         process_file(content, details, path)
       end

--- a/src/analyzer/analyzers/specification/vercel.cr
+++ b/src/analyzer/analyzers/specification/vercel.cr
@@ -9,7 +9,7 @@ module Analyzer::Specification
     METHOD_ANY         = "ANY"
 
     def analyze
-      each_spec_file_with_details("vercel-spec") do |path, details|
+      each_spec_file_with_details(Noir::LocatorKeys::VERCEL_SPEC) do |path, details|
         content = read_file_content(path)
         process_config(JSON.parse(content), details)
       end

--- a/src/analyzer/analyzers/specification/wsdl.cr
+++ b/src/analyzer/analyzers/specification/wsdl.cr
@@ -17,7 +17,7 @@ module Analyzer::Specification
     alias PartRef = NamedTuple(name: String, ref: String, is_element: Bool)
 
     def analyze
-      each_spec_file("wsdl-spec") do |path|
+      each_spec_file(Noir::LocatorKeys::WSDL_SPEC) do |path|
         content = read_file_content(path)
         parse_wsdl(content, path)
       end

--- a/src/analyzer/analyzers/specification/zap_sites_tree.cr
+++ b/src/analyzer/analyzers/specification/zap_sites_tree.cr
@@ -6,7 +6,7 @@ module Analyzer::Specification
     analyzer_for "zap_sites_tree"
 
     def analyze
-      each_spec_file_with_details("zap-sites-tree") do |sites_tree, details|
+      each_spec_file_with_details(Noir::LocatorKeys::ZAP_SITES_TREE) do |sites_tree, details|
         content = read_file_content(sites_tree)
         yaml_obj = YAML.parse(content)
 

--- a/src/analyzer/engines/specification_engine.cr
+++ b/src/analyzer/engines/specification_engine.cr
@@ -1,6 +1,7 @@
 require "../../models/analyzer"
 require "../../models/code_locator"
 require "uri"
+require "../../models/locator_keys"
 
 module Analyzer::Specification
   # Base for the specification-format analyzers (OpenAPI, Postman, HAR,
@@ -12,7 +13,7 @@ module Analyzer::Specification
   # analyzers each open-coded the same drain:
   #
   #     locator = CodeLocator.instance
-  #     files = locator.all("some-key")
+  #     files = locator.all(Noir::LocatorKeys::OAS3_JSON)
   #     return @result unless files.is_a?(Array(String))
   #     files.each do |path|
   #       next unless File.exists?(path)
@@ -53,7 +54,7 @@ module Analyzer::Specification
     # are applied in sequence. Registration order is otherwise whatever the
     # concurrent detector walk produced, so relying on it silently would be a
     # bug.
-    protected def each_spec_file(key : String, sorted : Bool = false, &block : String -> Nil) : Nil
+    protected def each_spec_file(key : Noir::LocatorKey(Array(String)), sorted : Bool = false, &block : String -> Nil) : Nil
       # No `is_a?(Array(String))` guard: `CodeLocator#all` is typed to return
       # `Array(String)`, so the copies of that check in the old analyzers were
       # always true and only read as though `all` might hand back something
@@ -75,7 +76,7 @@ module Analyzer::Specification
 
     # `each_spec_file` plus the `Details` almost every caller builds from
     # the path as its first statement.
-    protected def each_spec_file_with_details(key : String, &block : String, Details -> Nil) : Nil
+    protected def each_spec_file_with_details(key : Noir::LocatorKey(Array(String)), &block : String, Details -> Nil) : Nil
       each_spec_file(key) do |path|
         block.call(path, Details.new(PathInfo.new(path)))
       end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -344,11 +344,11 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   # are side effects of idempotent? == false mobile/spec detectors, so
   # they should represent the current detection run only.
   locator.reset_files
-  locator.clear("android-manifest")
-  locator.clear("android-assetlinks")
-  locator.clear("ios-info-plist")
-  locator.clear("ios-entitlements")
-  locator.clear("ios-aasa")
+  locator.clear(Noir::LocatorKeys::ANDROID_MANIFEST)
+  locator.clear(Noir::LocatorKeys::ANDROID_ASSETLINKS)
+  locator.clear(Noir::LocatorKeys::IOS_INFO_PLIST)
+  locator.clear(Noir::LocatorKeys::IOS_ENTITLEMENTS)
+  locator.clear(Noir::LocatorKeys::IOS_AASA)
 
   android_source_scope_active = detector_list.any? { |detector| detector_mobile_detector?(detector.name) }
   android_source_prefixes = [] of String

--- a/src/detector/detectors/csharp/aspnet_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_mvc.cr
@@ -22,7 +22,7 @@ module Detector::CSharp
 
       if file_contents.includes?(".MapRoute")
         locator = CodeLocator.instance
-        locator.set("cs-apinet-mvc-routeconfig", filename)
+        locator.set(Noir::LocatorKeys::CS_APINET_MVC_ROUTECONFIG, filename)
       end
     end
   end

--- a/src/detector/detectors/mobile/android.cr
+++ b/src/detector/detectors/mobile/android.cr
@@ -9,7 +9,7 @@ module Detector::Mobile
     def detect(filename : String, file_contents : String) : Bool
       if File.basename(filename) == "AndroidManifest.xml" && file_contents.includes?("<manifest")
         locator = CodeLocator.instance
-        locator.push("android-manifest", filename)
+        locator.push(Noir::LocatorKeys::ANDROID_MANIFEST, filename)
         return true
       end
 

--- a/src/detector/detectors/mobile/ios.cr
+++ b/src/detector/detectors/mobile/ios.cr
@@ -10,12 +10,12 @@ module Detector::Mobile
       locator = CodeLocator.instance
 
       if filename.ends_with?(".plist") && file_contents.includes?("CFBundleURLTypes")
-        locator.push("ios-info-plist", filename)
+        locator.push(Noir::LocatorKeys::IOS_INFO_PLIST, filename)
         return true
       end
 
       if filename.ends_with?(".entitlements") && file_contents.includes?("com.apple.developer.associated-domains")
-        locator.push("ios-entitlements", filename)
+        locator.push(Noir::LocatorKeys::IOS_ENTITLEMENTS, filename)
         return true
       end
 

--- a/src/detector/detectors/mobile/well_known.cr
+++ b/src/detector/detectors/mobile/well_known.cr
@@ -23,12 +23,12 @@ module Detector::Mobile
       locator = CodeLocator.instance
 
       if basename == "assetlinks.json" && file_contents.includes?("delegate_permission")
-        locator.push("android-assetlinks", filename)
+        locator.push(Noir::LocatorKeys::ANDROID_ASSETLINKS, filename)
         return true
       end
 
       if aasa_basename?(basename) && file_contents.includes?("applinks")
-        locator.push("ios-aasa", filename)
+        locator.push(Noir::LocatorKeys::IOS_AASA, filename)
         return true
       end
 

--- a/src/detector/detectors/specification/apache_httpd.cr
+++ b/src/detector/detectors/specification/apache_httpd.cr
@@ -29,7 +29,7 @@ module Detector::Specification
       return false unless applicable?(filename)
       return false unless apache_shape?(file_contents)
 
-      CodeLocator.instance.push("apache-httpd-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::APACHE_HTTPD_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/apisix.cr
+++ b/src/detector/detectors/specification/apisix.cr
@@ -14,7 +14,7 @@ module Detector::Specification
 
         data = JSON.parse(file_contents)
         if apisix_routes_json?(data)
-          CodeLocator.instance.push("apisix-json", filename)
+          CodeLocator.instance.push(Noir::LocatorKeys::APISIX_JSON, filename)
           return true
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
@@ -22,7 +22,7 @@ module Detector::Specification
 
         data = YAML.parse(file_contents)
         if apisix_routes_yaml?(data)
-          CodeLocator.instance.push("apisix-yaml", filename)
+          CodeLocator.instance.push(Noir::LocatorKeys::APISIX_YAML, filename)
           return true
         end
       end

--- a/src/detector/detectors/specification/appwrite.cr
+++ b/src/detector/detectors/specification/appwrite.cr
@@ -34,7 +34,7 @@ module Detector::Specification
       return false unless root["projectId"]?.try(&.as_s?)
       return false unless RESOURCE_KEYS.any? { |key| root.has_key?(key) }
 
-      CodeLocator.instance.push("appwrite-config", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::APPWRITE_CONFIG, filename)
       true
     end
 

--- a/src/detector/detectors/specification/asyncapi.cr
+++ b/src/detector/detectors/specification/asyncapi.cr
@@ -23,7 +23,7 @@ module Detector::Specification
           if version.starts_with?("2.") || version.starts_with?("3.")
             check = true
             locator = CodeLocator.instance
-            locator.push("asyncapi-json", filename)
+            locator.push(Noir::LocatorKeys::ASYNCAPI_JSON, filename)
           end
         rescue e
           logger.debug "AsyncAPI JSON detection failed for #{filename}: #{e}"
@@ -35,7 +35,7 @@ module Detector::Specification
           if version.starts_with?("2.") || version.starts_with?("3.")
             check = true
             locator = CodeLocator.instance
-            locator.push("asyncapi-yaml", filename)
+            locator.push(Noir::LocatorKeys::ASYNCAPI_YAML, filename)
           end
         rescue e
           logger.debug "AsyncAPI YAML detection failed for #{filename}: #{e}"

--- a/src/detector/detectors/specification/aws_cdk.cr
+++ b/src/detector/detectors/specification/aws_cdk.cr
@@ -22,7 +22,7 @@ module Detector::Specification
       # CDK utility files that contain imports but no endpoint declarations.
       return false unless cdk_api_construct?(file_contents)
 
-      CodeLocator.instance.push("aws-cdk-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::AWS_CDK_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/aws_cloudformation.cr
+++ b/src/detector/detectors/specification/aws_cloudformation.cr
@@ -23,7 +23,7 @@ module Detector::Specification
                    detect_yaml(file_contents)
                  end
 
-      CodeLocator.instance.push("aws-cloudformation-spec", filename) if detected
+      CodeLocator.instance.push(Noir::LocatorKeys::AWS_CLOUDFORMATION_SPEC, filename) if detected
       detected
     end
 

--- a/src/detector/detectors/specification/azure_functions.cr
+++ b/src/detector/detectors/specification/azure_functions.cr
@@ -16,7 +16,7 @@ module Detector::Specification
       return false unless file_contents.includes?("httpTrigger")
       return false unless valid_json?(file_contents)
 
-      CodeLocator.instance.push("azure-functions-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::AZURE_FUNCTIONS_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/bruno.cr
+++ b/src/detector/detectors/specification/bruno.cr
@@ -13,7 +13,7 @@ module Detector::Specification
       return false unless content_matches?(file_contents, BLOCK_HEADER)
 
       locator = CodeLocator.instance
-      locator.push("bruno-bru", filename)
+      locator.push(Noir::LocatorKeys::BRUNO_BRU, filename)
       true
     end
   end

--- a/src/detector/detectors/specification/burp.cr
+++ b/src/detector/detectors/specification/burp.cr
@@ -17,7 +17,7 @@ module Detector::Specification
       return false unless file_contents.includes?("<items") && file_contents.includes?("burpVersion=")
 
       locator = CodeLocator.instance
-      locator.push("burp-sitemap", filename)
+      locator.push(Noir::LocatorKeys::BURP_SITEMAP, filename)
       true
     end
   end

--- a/src/detector/detectors/specification/caddy.cr
+++ b/src/detector/detectors/specification/caddy.cr
@@ -19,12 +19,12 @@ module Detector::Specification
 
       base = File.basename(filename)
       if CADDYFILE_NAMES.includes?(base)
-        CodeLocator.instance.push("caddy-spec", filename)
+        CodeLocator.instance.push(Noir::LocatorKeys::CADDY_SPEC, filename)
         true
       elsif filename.ends_with?(".json")
         return false unless caddy_json?(file_contents)
         JSON.parse(file_contents)
-        CodeLocator.instance.push("caddy-spec", filename)
+        CodeLocator.instance.push(Noir::LocatorKeys::CADDY_SPEC, filename)
         true
       else
         false

--- a/src/detector/detectors/specification/caido.cr
+++ b/src/detector/detectors/specification/caido.cr
@@ -42,7 +42,7 @@ module Detector::Specification
                             (first.has_key?("is_tls") || first.has_key?("port"))
 
         locator = CodeLocator.instance
-        locator.push("caido-json", filename)
+        locator.push(Noir::LocatorKeys::CAIDO_JSON, filename)
         true
       rescue
         false

--- a/src/detector/detectors/specification/cloudflare_wrangler.cr
+++ b/src/detector/detectors/specification/cloudflare_wrangler.cr
@@ -24,7 +24,7 @@ module Detector::Specification
                    false
                  end
 
-      CodeLocator.instance.push("cloudflare-wrangler-spec", filename) if detected
+      CodeLocator.instance.push(Noir::LocatorKeys::CLOUDFLARE_WRANGLER_SPEC, filename) if detected
       detected
     end
 

--- a/src/detector/detectors/specification/directus.cr
+++ b/src/detector/detectors/specification/directus.cr
@@ -35,7 +35,7 @@ module Detector::Specification
       return false unless root[YAML::Any.new("directus")]?
       return false unless collections_present?(root)
 
-      CodeLocator.instance.push("directus-snapshot", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::DIRECTUS_SNAPSHOT, filename)
       true
     end
 

--- a/src/detector/detectors/specification/envoy.cr
+++ b/src/detector/detectors/specification/envoy.cr
@@ -34,13 +34,13 @@ module Detector::Specification
       if filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         if (data = yaml_any?(file_contents)) && find_virtual_hosts_yaml(data)
           locator = CodeLocator.instance
-          locator.push("envoy-yaml", filename)
+          locator.push(Noir::LocatorKeys::ENVOY_YAML, filename)
           return true
         end
       elsif filename.ends_with?(".json")
         if (data = json_any?(file_contents)) && find_virtual_hosts_json(data)
           locator = CodeLocator.instance
-          locator.push("envoy-json", filename)
+          locator.push(Noir::LocatorKeys::ENVOY_JSON, filename)
           return true
         end
       end

--- a/src/detector/detectors/specification/graphql_sdl.cr
+++ b/src/detector/detectors/specification/graphql_sdl.cr
@@ -26,7 +26,7 @@ module Detector::Specification
       return false unless sdl_document?(file_contents)
 
       locator = CodeLocator.instance
-      locator.push("graphql-sdl", filename)
+      locator.push(Noir::LocatorKeys::GRAPHQL_SDL, filename)
       true
     end
 

--- a/src/detector/detectors/specification/grpc.cr
+++ b/src/detector/detectors/specification/grpc.cr
@@ -16,7 +16,7 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       if filename.ends_with?(".proto") && content_matches?(file_contents, SERVICE_BLOCK)
-        CodeLocator.instance.push("grpc-proto", filename)
+        CodeLocator.instance.push(Noir::LocatorKeys::GRPC_PROTO, filename)
         return true
       end
 

--- a/src/detector/detectors/specification/har.cr
+++ b/src/detector/detectors/specification/har.cr
@@ -21,7 +21,7 @@ module Detector::Specification
             data = HAR.from_string(file_contents)
             if data.version.to_s.includes? "1."
               locator = CodeLocator.instance
-              locator.push("har-path", filename)
+              locator.push(Noir::LocatorKeys::HAR_PATH, filename)
               return true
             end
           rescue e

--- a/src/detector/detectors/specification/hasura.cr
+++ b/src/detector/detectors/specification/hasura.cr
@@ -73,7 +73,7 @@ module Detector::Specification
       end
       return false unless valid
 
-      CodeLocator.instance.push("hasura-rest-endpoints", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::HASURA_REST_ENDPOINTS, filename)
       true
     end
 
@@ -85,7 +85,7 @@ module Detector::Specification
       return false unless data
       return false unless table_document?(data)
 
-      CodeLocator.instance.push("hasura-tables", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::HASURA_TABLES, filename)
       true
     end
 

--- a/src/detector/detectors/specification/http_file.cr
+++ b/src/detector/detectors/specification/http_file.cr
@@ -18,7 +18,7 @@ module Detector::Specification
       return false unless content_matches?(file_contents, REQUEST_LINE)
 
       locator = CodeLocator.instance
-      locator.push("http-file", filename)
+      locator.push(Noir::LocatorKeys::HTTP_FILE, filename)
       true
     end
   end

--- a/src/detector/detectors/specification/insomnia.cr
+++ b/src/detector/detectors/specification/insomnia.cr
@@ -26,7 +26,7 @@ module Detector::Specification
           if type_field == "export" && data["__export_format"]?
             check = true
             locator = CodeLocator.instance
-            locator.push("insomnia-json", filename)
+            locator.push(Noir::LocatorKeys::INSOMNIA_JSON, filename)
           end
         rescue e
           logger.debug "Insomnia JSON detection failed for #{filename}: #{e}"
@@ -45,7 +45,7 @@ module Detector::Specification
              (type_field.starts_with?("collection.") || type_field.starts_with?("spec."))
             check = true
             locator = CodeLocator.instance
-            locator.push("insomnia-yaml", filename)
+            locator.push(Noir::LocatorKeys::INSOMNIA_YAML, filename)
           end
         rescue e
           logger.debug "Insomnia YAML detection failed for #{filename}: #{e}"

--- a/src/detector/detectors/specification/istio_virtualservice.cr
+++ b/src/detector/detectors/specification/istio_virtualservice.cr
@@ -24,7 +24,7 @@ module Detector::Specification
       return false unless virtual_service_present?(file_contents)
       return false unless valid_yaml_documents?(file_contents)
 
-      CodeLocator.instance.push("istio-virtualservice-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::ISTIO_VIRTUALSERVICE_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/k8s_gateway_api.cr
+++ b/src/detector/detectors/specification/k8s_gateway_api.cr
@@ -24,7 +24,7 @@ module Detector::Specification
       return false unless route_present?(file_contents)
       return false unless valid_yaml_documents?(file_contents)
 
-      CodeLocator.instance.push("k8s-gateway-api-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::K8S_GATEWAY_API_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/k8s_ingress.cr
+++ b/src/detector/detectors/specification/k8s_ingress.cr
@@ -17,7 +17,7 @@ module Detector::Specification
       return false unless ingress_markers_present?(file_contents)
       return false unless ingress_document_present?(file_contents)
 
-      CodeLocator.instance.push("k8s-ingress-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::K8S_INGRESS_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/kamal.cr
+++ b/src/detector/detectors/specification/kamal.cr
@@ -11,7 +11,7 @@ module Detector::Specification
       return false unless kamal_markers?(file_contents)
       return false unless kamal_config?(file_contents)
 
-      CodeLocator.instance.push("kamal-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::KAMAL_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/kong.cr
+++ b/src/detector/detectors/specification/kong.cr
@@ -21,7 +21,7 @@ module Detector::Specification
 
       begin
         if kong_doc?(data)
-          CodeLocator.instance.push("kong-spec", filename)
+          CodeLocator.instance.push(Noir::LocatorKeys::KONG_SPEC, filename)
           return true
         end
       rescue e

--- a/src/detector/detectors/specification/mitmproxy.cr
+++ b/src/detector/detectors/specification/mitmproxy.cr
@@ -22,7 +22,7 @@ module Detector::Specification
       return false unless TYPE_MARKERS.any? { |m| file_contents.includes?(m) }
 
       locator = CodeLocator.instance
-      locator.push("mitmproxy-path", filename)
+      locator.push(Noir::LocatorKeys::MITMPROXY_PATH, filename)
       true
     end
   end

--- a/src/detector/detectors/specification/netlify.cr
+++ b/src/detector/detectors/specification/netlify.cr
@@ -15,10 +15,10 @@ module Detector::Specification
 
       case base
       when REDIRECTS_FILE
-        locator.push("netlify-redirects", filename)
+        locator.push(Noir::LocatorKeys::NETLIFY_REDIRECTS, filename)
         true
       when TOML_FILE
-        locator.push("netlify-toml", filename)
+        locator.push(Noir::LocatorKeys::NETLIFY_TOML, filename)
         true
       else
         false

--- a/src/detector/detectors/specification/nginx.cr
+++ b/src/detector/detectors/specification/nginx.cr
@@ -24,7 +24,7 @@ module Detector::Specification
       return false unless applicable?(filename)
       return false unless nginx_shape?(file_contents)
 
-      CodeLocator.instance.push("nginx-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::NGINX_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/oas2.cr
+++ b/src/detector/detectors/specification/oas2.cr
@@ -23,7 +23,7 @@ module Detector::Specification
         begin
           data = JSON.parse(file_contents)
           if data["swagger"].as_s.includes? "2."
-            CodeLocator.instance.push("swagger-json", filename)
+            CodeLocator.instance.push(Noir::LocatorKeys::SWAGGER_JSON, filename)
             return true
           end
         rescue e
@@ -31,7 +31,7 @@ module Detector::Specification
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         if content_matches?(file_contents, SWAGGER2_YAML_MARKER)
-          CodeLocator.instance.push("swagger-yaml", filename)
+          CodeLocator.instance.push(Noir::LocatorKeys::SWAGGER_YAML, filename)
           return true
         end
       end

--- a/src/detector/detectors/specification/oas3.cr
+++ b/src/detector/detectors/specification/oas3.cr
@@ -36,7 +36,7 @@ module Detector::Specification
         begin
           data = JSON.parse(file_contents)
           if data["openapi"].as_s.includes? "3."
-            CodeLocator.instance.push("oas3-json", filename)
+            CodeLocator.instance.push(Noir::LocatorKeys::OAS3_JSON, filename)
             return true
           end
         rescue e
@@ -44,7 +44,7 @@ module Detector::Specification
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         if content_matches?(file_contents, OPENAPI3_YAML_MARKER)
-          CodeLocator.instance.push("oas3-yaml", filename)
+          CodeLocator.instance.push(Noir::LocatorKeys::OAS3_YAML, filename)
           return true
         end
       end

--- a/src/detector/detectors/specification/odata.cr
+++ b/src/detector/detectors/specification/odata.cr
@@ -19,7 +19,7 @@ module Detector::Specification
                           file_contents.includes?("schemas.microsoft.com/ado/")
 
       locator = CodeLocator.instance
-      locator.push("odata-spec", filename)
+      locator.push(Noir::LocatorKeys::ODATA_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/openrpc.cr
+++ b/src/detector/detectors/specification/openrpc.cr
@@ -19,7 +19,7 @@ module Detector::Specification
         if version.starts_with?("1.")
           check = true
           locator = CodeLocator.instance
-          locator.push("openrpc-json", filename)
+          locator.push(Noir::LocatorKeys::OPENRPC_JSON, filename)
         end
       rescue e
         logger.debug "OpenRPC JSON detection failed for #{filename}: #{e}"

--- a/src/detector/detectors/specification/payload_cms.cr
+++ b/src/detector/detectors/specification/payload_cms.cr
@@ -45,18 +45,18 @@ module Detector::Specification
 
       if content_matches?(file_contents, COLLECTION_MARKER) &&
          content_matches?(file_contents, SLUG_MARKER) && content_matches?(file_contents, FIELDS_MARKER)
-        CodeLocator.instance.push("payload-collection", filename)
+        CodeLocator.instance.push(Noir::LocatorKeys::PAYLOAD_COLLECTION, filename)
         detected = true
       end
 
       if content_matches?(file_contents, GLOBAL_MARKER) &&
          content_matches?(file_contents, SLUG_MARKER) && content_matches?(file_contents, FIELDS_MARKER)
-        CodeLocator.instance.push("payload-global", filename)
+        CodeLocator.instance.push(Noir::LocatorKeys::PAYLOAD_GLOBAL, filename)
         detected = true
       end
 
       if content_matches?(file_contents, BUILD_CONFIG)
-        CodeLocator.instance.push("payload-config", filename)
+        CodeLocator.instance.push(Noir::LocatorKeys::PAYLOAD_CONFIG, filename)
         detected = true
       end
 

--- a/src/detector/detectors/specification/postman.cr
+++ b/src/detector/detectors/specification/postman.cr
@@ -29,7 +29,7 @@ module Detector::Specification
 
           if check
             locator = CodeLocator.instance
-            locator.push("postman-json", filename)
+            locator.push(Noir::LocatorKeys::POSTMAN_JSON, filename)
           end
         rescue e
           logger.debug "Postman detection failed for #{filename}: #{e}"

--- a/src/detector/detectors/specification/raml.cr
+++ b/src/detector/detectors/specification/raml.cr
@@ -20,7 +20,7 @@ module Detector::Specification
           if valid_yaml?(file_contents)
             check = true
             locator = CodeLocator.instance
-            locator.push("raml-spec", filename)
+            locator.push(Noir::LocatorKeys::RAML_SPEC, filename)
           end
         end
       end

--- a/src/detector/detectors/specification/serverless_framework.cr
+++ b/src/detector/detectors/specification/serverless_framework.cr
@@ -21,7 +21,7 @@ module Detector::Specification
         return false unless serverless_doc?(data)
       end
 
-      CodeLocator.instance.push("serverless-framework-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::SERVERLESS_FRAMEWORK_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/smithy.cr
+++ b/src/detector/detectors/specification/smithy.cr
@@ -12,7 +12,7 @@ module Detector::Specification
       return false unless file_contents.includes?("$version")
 
       locator = CodeLocator.instance
-      locator.push("smithy-spec", filename)
+      locator.push(Noir::LocatorKeys::SMITHY_SPEC, filename)
       true
     end
   end

--- a/src/detector/detectors/specification/strapi.cr
+++ b/src/detector/detectors/specification/strapi.cr
@@ -68,7 +68,7 @@ module Detector::Specification
       return false unless info
       return false unless info["singularName"]?.try(&.as_s?) || info["pluralName"]?.try(&.as_s?)
 
-      CodeLocator.instance.push("strapi-schema", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::STRAPI_SCHEMA, filename)
       true
     end
 
@@ -77,7 +77,7 @@ module Detector::Specification
       custom = content_matches?(file_contents, ROUTE_MARKER) && content_matches?(file_contents, ROUTE_HANDLER)
       return false unless core_router || custom
 
-      CodeLocator.instance.push("strapi-routes", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::STRAPI_ROUTES, filename)
       true
     end
 

--- a/src/detector/detectors/specification/supabase.cr
+++ b/src/detector/detectors/specification/supabase.cr
@@ -38,7 +38,7 @@ module Detector::Specification
       path = normalize(filename)
 
       if File.basename(path) == "config.toml"
-        CodeLocator.instance.push("supabase-config", filename)
+        CodeLocator.instance.push(Noir::LocatorKeys::SUPABASE_CONFIG, filename)
         return true
       end
 
@@ -48,7 +48,7 @@ module Detector::Specification
         return false unless content_matches?(file_contents, SUPABASE_FINGERPRINT)
       end
 
-      CodeLocator.instance.push("supabase-migration", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::SUPABASE_MIGRATION, filename)
       true
     end
 

--- a/src/detector/detectors/specification/terraform.cr
+++ b/src/detector/detectors/specification/terraform.cr
@@ -23,7 +23,7 @@ module Detector::Specification
       return false unless applicable?(filename)
       return false unless MARKERS.any? { |marker| file_contents.includes?(marker) }
 
-      CodeLocator.instance.push("terraform-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::TERRAFORM_SPEC, filename)
       true
     end
   end

--- a/src/detector/detectors/specification/traefik.cr
+++ b/src/detector/detectors/specification/traefik.cr
@@ -35,7 +35,7 @@ module Detector::Specification
 
       if check
         locator = CodeLocator.instance
-        locator.push("traefik-spec", filename)
+        locator.push(Noir::LocatorKeys::TRAEFIK_SPEC, filename)
       end
 
       check

--- a/src/detector/detectors/specification/typespec.cr
+++ b/src/detector/detectors/specification/typespec.cr
@@ -20,7 +20,7 @@ module Detector::Specification
            file_contents.includes?("@delete")
       return false unless ok
 
-      CodeLocator.instance.push("typespec-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::TYPESPEC_SPEC, filename)
       true
     end
   end

--- a/src/detector/detectors/specification/vercel.cr
+++ b/src/detector/detectors/specification/vercel.cr
@@ -14,7 +14,7 @@ module Detector::Specification
       return false unless applicable?(filename)
       return false unless valid_json?(file_contents)
 
-      CodeLocator.instance.push("vercel-spec", filename)
+      CodeLocator.instance.push(Noir::LocatorKeys::VERCEL_SPEC, filename)
       true
     end
 

--- a/src/detector/detectors/specification/wsdl.cr
+++ b/src/detector/detectors/specification/wsdl.cr
@@ -16,7 +16,7 @@ module Detector::Specification
                           file_contents.includes?("http://www.w3.org/ns/wsdl")
 
       locator = CodeLocator.instance
-      locator.push("wsdl-spec", filename)
+      locator.push(Noir::LocatorKeys::WSDL_SPEC, filename)
       true
     end
   end

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -29,7 +29,7 @@ module Detector::Specification
           if data[0]["node"].as_s.includes? "Sites"
             check = true
             locator = CodeLocator.instance
-            locator.push("zap-sites-tree", filename)
+            locator.push(Noir::LocatorKeys::ZAP_SITES_TREE, filename)
           end
         rescue e
           logger.debug "ZAP sites-tree detection failed for #{filename}: #{e}"

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -11,9 +11,6 @@ require "../utils/text_file"
 module Noir
   # JSRouteExtractor provides a unified interface for extracting routes from JavaScript files
   class JSRouteExtractor
-    # Import constants for key generation
-    ROUTER_PREFIX_KEY = Analyzer::Javascript::ExpressConstants::ROUTER_PREFIX_KEY
-
     def self.extract_routes(file_path : String,
                             content : String? = nil,
                             debug : Bool = false,
@@ -192,16 +189,12 @@ module Noir
         prefixes_by_function = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
         function_names.each do |func_name|
           func_key = Analyzer::Javascript::ExpressConstants.function_key(absolute_file_path, func_name)
-          values = locator.all(func_key)
-          if values.size > 0
-            values.each do |prefix|
-              prefixes_by_function[func_name] << prefix unless prefix.empty?
-            end
-          else
-            value = locator.get(func_key)
-            if value.is_a?(String) && !value.empty?
-              prefixes_by_function[func_name] << value
-            end
+          # The `else` branch this replaces called `get(func_key)` — reading
+          # the single-value map for a key only ever `push`ed to. It could
+          # never return anything, and `get`'s old `rescue → ""` hid that.
+          # Under typed keys it does not compile.
+          locator.all(func_key).each do |prefix|
+            prefixes_by_function[func_name] << prefix unless prefix.empty?
           end
         end
 

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -358,7 +358,7 @@ class FileAnalyzer < Analyzer
     # Hoisted out of the worker loop: this used to re-read the locator's
     # `har-path` array and scan it linearly for every file, i.e.
     # O(files × har_paths) with a fresh Array allocation per file.
-    har_paths = CodeLocator.instance.all("har-path").to_set
+    har_paths = CodeLocator.instance.all(Noir::LocatorKeys::HAR_PATH).to_set
 
     channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -1,6 +1,7 @@
 require "../utils/path_scope"
 require "../utils/utils"
 require "./logger"
+require "./locator_key"
 
 class CodeLocator
   @@instance : CodeLocator? = nil
@@ -108,24 +109,21 @@ class CodeLocator
     @@instance ||= new
   end
 
-  def set(key : String, value : String)
-    @s_map[key] = value
+  def set(key : Noir::LocatorKey(String), value : String)
+    @s_map[key.name] = value
   end
 
-  def get(key : String) : (String | Array(String))
-    @s_map[key]
-  rescue
-    ""
+  # `String?` rather than the old `(String | Array(String))`: the union only
+  # existed because a bare string key carried no type, so `get` could not
+  # promise which map it was reading. Its one caller worked around it by
+  # interpolating the result.
+  def get(key : Noir::LocatorKey(String)) : String?
+    @s_map[key.name]?
   end
 
-  def push(key : String, value : String)
-    # Compat shim: `file_map` is no longer a key. Removed in the PR that
-    # tightens these signatures; until then, a caller reaching for the old
-    # spelling must still get the derived-view invalidation.
-    return register_path(value) if key == FILE_MAP
-
-    @a_map[key] ||= Array(String).new
-    @a_map[key] << value
+  def push(key : Noir::LocatorKey(Array(String)), value : String)
+    @a_map[key.name] ||= Array(String).new
+    @a_map[key.name] << value
   end
 
   # The scanned-file registry.
@@ -208,8 +206,8 @@ class CodeLocator
     {bytes: @content_cache_used, files: @file_contents.size, skipped: @content_cache_skipped, budget: @content_cache_budget}
   end
 
-  def all(key : String) : Array(String)
-    result = @a_map[key]?
+  def all(key : Noir::LocatorKey(Array(String))) : Array(String)
+    result = @a_map[key.name]?
     return result if result
     Array(String).new
   end
@@ -322,12 +320,17 @@ class CodeLocator
     @basename_index[basename]? || Array(String).new
   end
 
-  def clear(key : String)
-    # Compat shim, as in `push`.
-    return reset_files if key == FILE_MAP
+  def clear(key : Noir::LocatorKey)
+    @s_map.delete(key.name)
+    @a_map.delete(key.name)
+  end
 
-    @s_map.delete(key)
-    @a_map.delete(key)
+  # Drops every runtime-minted key under `ns`. Runs at a phase boundary with
+  # no fibers in flight, so a plain reject is enough — no minted-key
+  # bookkeeping to maintain.
+  def clear_namespace(ns : Noir::LocatorKeyNamespace)
+    @a_map.reject! { |name, _| ns.matches?(name) }
+    @s_map.reject! { |name, _| ns.matches?(name) }
   end
 
   def clear_all

--- a/src/models/locator_key.cr
+++ b/src/models/locator_key.cr
@@ -1,0 +1,68 @@
+module Noir
+  # A declared slot in `CodeLocator`.
+  #
+  # `T` is the stored shape: `String` for single-value slots (`set`/`get`),
+  # `Array(String)` for append-only ones (`push`/`all`). `CodeLocator` takes
+  # `LocatorKey(T)` and never a bare `String`, so the compiler is the
+  # registry check — a literal key nobody declared does not build, and
+  # `push`ing to a single-value slot (or `get`ting an append-only one) is a
+  # type error rather than a silently-empty read.
+  #
+  # Before this, the locator was a blackboard of 63 magic strings: a detector
+  # wrote one, an analyzer read it, and nothing connected the two. The only
+  # way to learn that `grpc-proto` has two independent reader families was to
+  # grep for the string.
+  struct LocatorKey(T)
+    enum Lifecycle
+      # Written by the detector pass for the analyzers to drain. Cleared at
+      # the top of `detect_techs`, before the first file is walked.
+      DetectScoped
+
+      # Written and read within one analysis pass. Cleared at the top of
+      # `analysis_endpoints`.
+      AnalyzeScoped
+
+      # Never cleared automatically; only `CodeLocator#clear_all` drops it.
+      # For slots a library caller owns the lifetime of.
+      Process
+    end
+
+    getter name : String
+    getter lifecycle : Lifecycle
+
+    # Subsystem that writes the slot, as a source-path fragment. Read by the
+    # integrity spec, and by whoever next has to work out why a key exists.
+    getter owner : String
+
+    def initialize(@name : String, @lifecycle : Lifecycle, @owner : String)
+    end
+  end
+
+  # A family of keys minted at runtime under one declared prefix
+  # (`<prefix>:<file>` / `<prefix>:<file>:<function>`). Declared once; the
+  # minted keys inherit its lifecycle and are cleared by prefix.
+  #
+  # Exists for the Express router-prefix keys, which are the one family whose
+  # names are not knowable ahead of time — and which, under a
+  # string-constants design, would have stayed invisible to any enforcement.
+  struct LocatorKeyNamespace
+    getter prefix : String
+    getter lifecycle : LocatorKey::Lifecycle
+    getter owner : String
+
+    def initialize(@prefix : String, @lifecycle : LocatorKey::Lifecycle, @owner : String)
+    end
+
+    def key(*parts : String) : LocatorKey(Array(String))
+      name = String.build do |io|
+        io << @prefix
+        parts.each { |part| io << ':' << part }
+      end
+      LocatorKey(Array(String)).new(name, @lifecycle, @owner)
+    end
+
+    def matches?(name : String) : Bool
+      name.starts_with?("#{@prefix}:")
+    end
+  end
+end

--- a/src/models/locator_keys.cr
+++ b/src/models/locator_keys.cr
@@ -1,0 +1,115 @@
+require "./locator_key"
+require "./code_locator"
+
+# Every slot in `CodeLocator`, declared once.
+#
+# The table below is the registry: the constants, the per-phase reset lists,
+# and `spec/unit_test/models/locator_keys_spec.cr` are all generated from it,
+# so a key cannot exist without a lifecycle and a lifecycle cannot be
+# declared for a key nothing uses.
+#
+# Fields: {CONSTANT, name, :array | :single, lifecycle, owning subsystem}.
+#
+# Every one of these is written by the detector pass and drained during
+# analysis, which is what `:detect_scoped` means — see
+# `LocatorKey::Lifecycle`. The runtime-minted Express family below is the
+# only `:analyze_scoped` slot.
+module Noir::LocatorKeys
+  DECLARATIONS = [
+    {:ANDROID_ASSETLINKS, "android-assetlinks", :array, :detect_scoped, "detector/mobile/well_known"},
+    {:ANDROID_MANIFEST, "android-manifest", :array, :detect_scoped, "detector/mobile/android"},
+    {:APACHE_HTTPD_SPEC, "apache-httpd-spec", :array, :detect_scoped, "detector/specification/apache_httpd"},
+    {:APISIX_JSON, "apisix-json", :array, :detect_scoped, "detector/specification/apisix"},
+    {:APISIX_YAML, "apisix-yaml", :array, :detect_scoped, "detector/specification/apisix"},
+    {:APPWRITE_CONFIG, "appwrite-config", :array, :detect_scoped, "detector/specification/appwrite"},
+    {:ASYNCAPI_JSON, "asyncapi-json", :array, :detect_scoped, "detector/specification/asyncapi"},
+    {:ASYNCAPI_YAML, "asyncapi-yaml", :array, :detect_scoped, "detector/specification/asyncapi"},
+    {:AWS_CDK_SPEC, "aws-cdk-spec", :array, :detect_scoped, "detector/specification/aws_cdk"},
+    {:AWS_CLOUDFORMATION_SPEC, "aws-cloudformation-spec", :array, :detect_scoped, "detector/specification/aws_cloudformation"},
+    {:AZURE_FUNCTIONS_SPEC, "azure-functions-spec", :array, :detect_scoped, "detector/specification/azure_functions"},
+    {:BRUNO_BRU, "bruno-bru", :array, :detect_scoped, "detector/specification/bruno"},
+    {:BURP_SITEMAP, "burp-sitemap", :array, :detect_scoped, "detector/specification/burp"},
+    {:CADDY_SPEC, "caddy-spec", :array, :detect_scoped, "detector/specification/caddy"},
+    {:CAIDO_JSON, "caido-json", :array, :detect_scoped, "detector/specification/caido"},
+    {:CLOUDFLARE_WRANGLER_SPEC, "cloudflare-wrangler-spec", :array, :detect_scoped, "detector/specification/cloudflare_wrangler"},
+    {:CS_APINET_MVC_ROUTECONFIG, "cs-apinet-mvc-routeconfig", :single, :detect_scoped, "detector/csharp/aspnet_mvc"},
+    {:DIRECTUS_SNAPSHOT, "directus-snapshot", :array, :detect_scoped, "detector/specification/directus"},
+    {:ENVOY_JSON, "envoy-json", :array, :detect_scoped, "detector/specification/envoy"},
+    {:ENVOY_YAML, "envoy-yaml", :array, :detect_scoped, "detector/specification/envoy"},
+    {:GRAPHQL_SDL, "graphql-sdl", :array, :detect_scoped, "detector/specification/graphql_sdl"},
+    {:GRPC_PROTO, "grpc-proto", :array, :detect_scoped, "detector/specification/grpc"},
+    {:HAR_PATH, "har-path", :array, :detect_scoped, "detector/specification/har"},
+    {:HASURA_REST_ENDPOINTS, "hasura-rest-endpoints", :array, :detect_scoped, "detector/specification/hasura"},
+    {:HASURA_TABLES, "hasura-tables", :array, :detect_scoped, "detector/specification/hasura"},
+    {:HTTP_FILE, "http-file", :array, :detect_scoped, "detector/specification/http_file"},
+    {:INSOMNIA_JSON, "insomnia-json", :array, :detect_scoped, "detector/specification/insomnia"},
+    {:INSOMNIA_YAML, "insomnia-yaml", :array, :detect_scoped, "detector/specification/insomnia"},
+    {:IOS_AASA, "ios-aasa", :array, :detect_scoped, "detector/mobile/well_known"},
+    {:IOS_ENTITLEMENTS, "ios-entitlements", :array, :detect_scoped, "detector/mobile/ios"},
+    {:IOS_INFO_PLIST, "ios-info-plist", :array, :detect_scoped, "detector/mobile/ios"},
+    {:ISTIO_VIRTUALSERVICE_SPEC, "istio-virtualservice-spec", :array, :detect_scoped, "detector/specification/istio_virtualservice"},
+    {:K8S_GATEWAY_API_SPEC, "k8s-gateway-api-spec", :array, :detect_scoped, "detector/specification/k8s_gateway_api"},
+    {:K8S_INGRESS_SPEC, "k8s-ingress-spec", :array, :detect_scoped, "detector/specification/k8s_ingress"},
+    {:KAMAL_SPEC, "kamal-spec", :array, :detect_scoped, "detector/specification/kamal"},
+    {:KONG_SPEC, "kong-spec", :array, :detect_scoped, "detector/specification/kong"},
+    {:MITMPROXY_PATH, "mitmproxy-path", :array, :detect_scoped, "detector/specification/mitmproxy"},
+    {:NETLIFY_REDIRECTS, "netlify-redirects", :array, :detect_scoped, "detector/specification/netlify"},
+    {:NETLIFY_TOML, "netlify-toml", :array, :detect_scoped, "detector/specification/netlify"},
+    {:NGINX_SPEC, "nginx-spec", :array, :detect_scoped, "detector/specification/nginx"},
+    {:OAS3_JSON, "oas3-json", :array, :detect_scoped, "detector/specification/oas3"},
+    {:OAS3_YAML, "oas3-yaml", :array, :detect_scoped, "detector/specification/oas3"},
+    {:ODATA_SPEC, "odata-spec", :array, :detect_scoped, "detector/specification/odata"},
+    {:OPENRPC_JSON, "openrpc-json", :array, :detect_scoped, "detector/specification/openrpc"},
+    {:PAYLOAD_COLLECTION, "payload-collection", :array, :detect_scoped, "detector/specification/payload_cms"},
+    {:PAYLOAD_CONFIG, "payload-config", :array, :detect_scoped, "detector/specification/payload_cms"},
+    {:PAYLOAD_GLOBAL, "payload-global", :array, :detect_scoped, "detector/specification/payload_cms"},
+    {:POSTMAN_JSON, "postman-json", :array, :detect_scoped, "detector/specification/postman"},
+    {:RAML_SPEC, "raml-spec", :array, :detect_scoped, "detector/specification/raml"},
+    {:SERVERLESS_FRAMEWORK_SPEC, "serverless-framework-spec", :array, :detect_scoped, "detector/specification/serverless_framework"},
+    {:SMITHY_SPEC, "smithy-spec", :array, :detect_scoped, "detector/specification/smithy"},
+    {:STRAPI_ROUTES, "strapi-routes", :array, :detect_scoped, "detector/specification/strapi"},
+    {:STRAPI_SCHEMA, "strapi-schema", :array, :detect_scoped, "detector/specification/strapi"},
+    {:SUPABASE_CONFIG, "supabase-config", :array, :detect_scoped, "detector/specification/supabase"},
+    {:SUPABASE_MIGRATION, "supabase-migration", :array, :detect_scoped, "detector/specification/supabase"},
+    {:SWAGGER_JSON, "swagger-json", :array, :detect_scoped, "detector/specification/oas2"},
+    {:SWAGGER_YAML, "swagger-yaml", :array, :detect_scoped, "detector/specification/oas2"},
+    {:TERRAFORM_SPEC, "terraform-spec", :array, :detect_scoped, "detector/specification/terraform"},
+    {:TRAEFIK_SPEC, "traefik-spec", :array, :detect_scoped, "detector/specification/traefik"},
+    {:TYPESPEC_SPEC, "typespec-spec", :array, :detect_scoped, "detector/specification/typespec"},
+    {:VERCEL_SPEC, "vercel-spec", :array, :detect_scoped, "detector/specification/vercel"},
+    {:WSDL_SPEC, "wsdl-spec", :array, :detect_scoped, "detector/specification/wsdl"},
+    {:ZAP_SITES_TREE, "zap-sites-tree", :array, :detect_scoped, "detector/specification/zap_sites_tree"},
+  ]
+
+  {% begin %}
+    {% for d in DECLARATIONS %}
+      {% t = d[2] == :array ? "Array(String)".id : "String".id %}
+      {{ d[0].id }} = ::Noir::LocatorKey({{ t }}).new(
+        {{ d[1] }},
+        ::Noir::LocatorKey::Lifecycle::{{ d[3].id.camelcase }},
+        {{ d[4] }})
+    {% end %}
+
+    # The array literals are what force the constants above into existence.
+    # Do not "simplify" this into per-constant registration side effects:
+    # Crystal may elide an unused constant's initializer, and the reset
+    # lists would silently come up short.
+    ARRAY_KEYS = [
+      {% for d in DECLARATIONS %}{% if d[2] == :array %}{{ d[0].id }},{% end %}{% end %}
+    ] of ::Noir::LocatorKey(Array(String))
+
+    SINGLE_KEYS = [
+      {% for d in DECLARATIONS %}{% if d[2] == :single %}{{ d[0].id }},{% end %}{% end %}
+    ] of ::Noir::LocatorKey(String)
+  {% end %}
+
+  # Runtime-minted key family: `express_router_prefix:<file>[:<function>]`.
+  # Written during analysis by the Express router-mount scanner and by Koa,
+  # read by the shared JS route extractor.
+  EXPRESS_ROUTER_PREFIX = ::Noir::LocatorKeyNamespace.new(
+    "express_router_prefix",
+    ::Noir::LocatorKey::Lifecycle::AnalyzeScoped,
+    "analyzer/javascript/express")
+
+  NAMESPACES = [EXPRESS_ROUTER_PREFIX]
+end


### PR DESCRIPTION
Third of four PRs on `CodeLocator`, after #2499 and #2500. Behaviour-neutral, but wide: ~220 call sites change shape.

## Why

`CodeLocator` was a blackboard of **63 magic strings**. A detector wrote one, an analyzer read it, and nothing connected the two:

```crystal
# src/detector/detectors/mobile/android.cr
locator.push("android-manifest", filename)
# src/analyzer/analyzers/mobile/android.cr
manifests = locator.all("android-manifest")
```

The only way to learn that `grpc-proto` has two independent reader families, or that `caddy-spec` has two writers, was to grep for the string. A typo produced an empty read, not an error.

## What

Keys are declared objects. `LocatorKey(T)` carries the name, the value shape, a lifecycle and the owning subsystem; `CodeLocator` takes `LocatorKey(T)` and never a bare `String`. **The compiler is the registry check** — an undeclared key does not build, and `push`ing to a single-value slot (or `get`ting an append-only one) is a type error rather than a silently empty read.

Two things then fall out of the types rather than out of review:

- **`get` returns `String?`** instead of `(String | Array(String))`. The union existed only because a bare string carried no type, so `get` could not promise which map it was reading — its one caller worked around it by interpolating the result.
- **The dead branch in `js_route_extractor.cr` is deleted because it no longer compiles.** It called `get(func_key)` on a key only ever `push`ed to; unreachable, and `get`'s old `rescue → ""` hid that. It could not be deferred to a follow-up — leaving it would mean landing a PR that does not build.

## Why typed keys and not string constants

The Express router-prefix keys are minted from scanned paths (`express_router_prefix:<file>:<fn>`), so they cannot be constants. They get a declared `LocatorKeyNamespace`, which puts them under the same lifecycle and enforcement as every other slot. Under a string-constants design they would have stayed invisible to any check — and they are exactly where an undeclared key already lived.

`DECLARATIONS` is a single table; the constants and the per-shape lists are both generated from it, so they cannot drift. The array literals are what force the constants into existence — do not "simplify" that into per-constant registration side effects, since Crystal may elide an unused constant's initializer and the reset lists would come up short.

## Source compatibility

This is source-breaking for anyone reaching into the singleton directly. The replacement is strictly better than what it removes:

```crystal
MY_KEY = Noir::LocatorKey(Array(String)).new(
  "myapp-thing", Noir::LocatorKey::Lifecycle::Process, "myapp")
CodeLocator.instance.push(MY_KEY, path)
```

`Process` means noir's per-phase resets leave it alone. A spec covers that path.

## Enforcement

`spec/unit_test/models/locator_keys_spec.cr` is generated from the table, so a key added tomorrow is covered without anyone remembering to cover it. Its load-bearing example greps for constant **identifiers** — not string literals, so it has no interpolation blind spot — and fails on a declared key nothing references. That is the check that would have caught #2499's dead key years earlier.

## Verification

**STRICT A/B** over all 665 fixture directories: **byte-identical** — 5,160 endpoints, 4,775 callee entries, every `details.code_paths[].line` and `callees[].line`.

`crystal spec spec/unit_test` 4716 examples / `spec/functional_test` 22653 examples, 0 failures. `just check` 1915 files, 0 findings.