### PR TITLE
refactor(locator): clear declared keys by lifecycle instead of by hand

### DIFF
--- a/spec/unit_test/models/locator_lifecycle_spec.cr
+++ b/spec/unit_test/models/locator_lifecycle_spec.cr
@@ -1,0 +1,70 @@
+require "../../spec_helper"
+require "../../../src/detector/detector"
+require "../../../src/models/analyzer"
+require "../../../src/models/locator_keys"
+
+# Two detect passes in one process, over two different trees.
+#
+# `detect_techs` used to clear six of the 64 locator keys by hand — the file
+# registry and the five mobile ones. Every specification key survived into
+# the next scan, so a long-lived process (diff mode, or noir used as a
+# library) drained the *previous* codebase's spec files. The only thing
+# masking it was the `File.exists?` guard in
+# `SpecificationEngine#each_spec_file`, which passes whenever the first
+# tree's files are still on disk — i.e. always, in the case that matters.
+#
+# A single-scan fixture sweep cannot see this by construction, which is why
+# it survived long enough to have a comment written about it rather than a
+# fix. This spec is the oracle; it fails on main.
+describe "locator scan lifecycle" do
+  it "does not carry a previous scan's spec registrations into the next" do
+    logger = NoirLogger.new(false, false, false, true)
+    oas3 = File.expand_path("#{__DIR__}/../../functional_test/fixtures/specification/oas3")
+    har = File.expand_path("#{__DIR__}/../../functional_test/fixtures/specification/har")
+    locator = CodeLocator.instance
+
+    detect_techs([oas3], create_test_options, [] of PassiveScan, logger)
+    locator.all(Noir::LocatorKeys::OAS3_JSON).should_not be_empty
+
+    detect_techs([har], create_test_options, [] of PassiveScan, logger)
+
+    locator.all(Noir::LocatorKeys::OAS3_JSON).should be_empty
+    locator.all(Noir::LocatorKeys::HAR_PATH).should_not be_empty
+    locator.all_files.any?(&.includes?("/specification/oas3/")).should be_false
+  end
+end
+
+# The table-driven half: the spec above proves the bug is fixed for one key,
+# this proves it stays fixed for all 63 and for every key added later.
+describe "locator lifecycle reset" do
+  it "clears exactly the keys a phase owns" do
+    locator = CodeLocator.instance
+    array_keys = Noir::LocatorKeys::ARRAY_KEYS
+    single_keys = Noir::LocatorKeys::SINGLE_KEYS
+    express = Noir::LocatorKeys::EXPRESS_ROUTER_PREFIX
+
+    seed = -> do
+      array_keys.each { |key| locator.push(key, "SENTINEL") }
+      single_keys.each { |key| locator.set(key, "SENTINEL") }
+      locator.push(express.key("/app.js"), "SENTINEL")
+    end
+
+    seed.call
+    Noir::LocatorKeys.reset(Noir::LocatorKey::Lifecycle::DetectScoped)
+
+    survivors = array_keys.select { |key| !key.lifecycle.detect_scoped? && locator.all(key).empty? }
+    cleared = array_keys.select { |key| key.lifecycle.detect_scoped? && !locator.all(key).empty? }
+    fail "detect-scoped keys the reset missed: #{cleared.map(&.name).sort!}" unless cleared.empty?
+    fail "keys the reset cleared but does not own: #{survivors.map(&.name).sort!}" unless survivors.empty?
+    single_keys.each do |key|
+      locator.get(key).should be_nil if key.lifecycle.detect_scoped?
+    end
+    # The analyze-scoped namespace is untouched by a detect reset.
+    locator.all(express.key("/app.js")).should eq ["SENTINEL"]
+
+    Noir::LocatorKeys.reset(Noir::LocatorKey::Lifecycle::AnalyzeScoped)
+    locator.all(express.key("/app.js")).should be_empty
+  ensure
+    CodeLocator.instance.clear_all
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -1,6 +1,7 @@
 require "./analyzers/**"
 require "./analyzers/file_analyzers/*"
 require "../miniparsers/extraction_result_cache"
+require "../models/locator_keys"
 require "../techs/techs"
 
 def initialize_analyzers(logger : NoirLogger)
@@ -87,6 +88,11 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   # Drop process-wide extraction memos from any previous scan (diff mode
   # / repeated library use) so fingerprints cannot serve stale tables.
   Noir::ExtractionResultCache.clear_all
+
+  # Same reasoning, for the locator slots written and read inside one
+  # analysis pass (the Express router prefixes). Detector-written keys are
+  # deliberately NOT cleared here — this pass is what drains them.
+  Noir::LocatorKeys.reset(Noir::LocatorKey::Lifecycle::AnalyzeScoped)
 
   analyzer = initialize_analyzers logger
 

--- a/src/analyzer/engines/specification_engine.cr
+++ b/src/analyzer/engines/specification_engine.cr
@@ -34,14 +34,19 @@ module Analyzer::Specification
     # Yield every registered path for `key`, skipping paths that no longer
     # resolve and containing per-file failures.
     #
-    # The `File.exists?` check is load-bearing, not a leftover. Unlike the
-    # language engines — whose paths come from the extension index rebuilt
-    # per scan — these keys are never cleared at the start of a scan
-    # (`detect_techs` clears only `file_map` and the mobile keys, and
-    # `clear_all` runs only between the two halves of a `--diff` run). A
-    # second scan in the same process therefore still sees the first
-    # scan's registrations, and dropping the check would turn stale
-    # entries into read errors.
+    # The `File.exists?` check is load-bearing, not a leftover — but not for
+    # the reason it used to be. It once compensated for these keys never
+    # being cleared: a second scan in the same process saw the first scan's
+    # registrations, and this guard was all that stopped them being read.
+    # `LocatorKeys.reset` now drops them at the top of every detect pass, so
+    # that is no longer what it is for.
+    #
+    # What remains: the detect→analyze window is real wall-clock time on a
+    # large tree, and a file can be deleted or a build directory swept
+    # inside it. Library callers driving `analysis_endpoints` directly, with
+    # their own `Process`-lifetime keys, get no automatic reset by design.
+    # And it is the containment boundary that keeps one vanished file from
+    # becoming a logged read error in each of the 45 spec analyzers.
     #
     # Failures are contained per file: a malformed document is logged and
     # skipped so the remaining files for that analyzer still produce

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -406,6 +406,12 @@ module Noir::CLI::ScanCommand
       app.report
     else
       app.logger.info "Diffing base and diff codebases."
+      # Kept even though `LocatorKeys.reset` now runs at the top of each
+      # phase: this is a real codebase boundary, and `clear_all` is the only
+      # thing that also drops `Process`-lifetime slots a library caller
+      # declared. It does not reset `scan_base_paths` — `NoirRunner#detect`
+      # re-publishes those before anything walks a file, which is why the
+      # first codebase's roots have never been observable here.
       locator = CodeLocator.instance
       locator.clear_all
       app_diff.detect

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -340,15 +340,11 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   locator = CodeLocator.instance
   wg = WaitGroup.new
 
-  # Clear detector-populated locator keys before starting. These arrays
-  # are side effects of idempotent? == false mobile/spec detectors, so
-  # they should represent the current detection run only.
-  locator.reset_files
-  locator.clear(Noir::LocatorKeys::ANDROID_MANIFEST)
-  locator.clear(Noir::LocatorKeys::ANDROID_ASSETLINKS)
-  locator.clear(Noir::LocatorKeys::IOS_INFO_PLIST)
-  locator.clear(Noir::LocatorKeys::IOS_ENTITLEMENTS)
-  locator.clear(Noir::LocatorKeys::IOS_AASA)
+  # Detector-written keys accumulate as side effects of `idempotent? == false`
+  # detectors, so they must represent the current run only. This used to name
+  # six keys by hand and miss the other 58 — every specification key survived
+  # into the next scan in the same process.
+  Noir::LocatorKeys.reset(Noir::LocatorKey::Lifecycle::DetectScoped)
 
   android_source_scope_active = detector_list.any? { |detector| detector_mobile_detector?(detector.name) }
   android_source_prefixes = [] of String

--- a/src/models/locator_keys.cr
+++ b/src/models/locator_keys.cr
@@ -112,4 +112,28 @@ module Noir::LocatorKeys
     "analyzer/javascript/express")
 
   NAMESPACES = [EXPRESS_ROUTER_PREFIX]
+
+  # Drop everything `phase` owns.
+  #
+  # Called at the top of the phase, before it writes anything, so a second
+  # scan in the same process cannot read the first one's registrations. This
+  # replaces a hand-written list at the top of `detect_techs` that named six
+  # of the 64 keys — the other 58 were never cleared at all, which is why
+  # `SpecificationEngine#each_spec_file` needed a `File.exists?` guard to
+  # avoid reading a previous scan's paths.
+  #
+  # The phases are separate on purpose. Detector-written keys are *drained
+  # during analysis*, so clearing them at analysis start would destroy the
+  # scan; the Express keys are written and read inside one analysis pass and
+  # must not survive into the next.
+  def self.reset(phase : ::Noir::LocatorKey::Lifecycle) : Nil
+    locator = CodeLocator.instance
+    ARRAY_KEYS.each { |key| locator.clear(key) if key.lifecycle == phase }
+    SINGLE_KEYS.each { |key| locator.clear(key) if key.lifecycle == phase }
+    NAMESPACES.each { |ns| locator.clear_namespace(ns) if ns.lifecycle == phase }
+
+    # The file registry is not a key (see `CodeLocator#reset_files`), so it
+    # is named here rather than declared in the table above.
+    locator.reset_files if phase.detect_scoped?
+  end
 end


### PR DESCRIPTION
Last of four PRs on `CodeLocator`, after #2499, #2500, #2502. **This one fixes a real bug.**

## The bug

`detect_techs` opened with a hand-written list clearing **six of the 64** locator keys — the file registry and the five mobile ones:

```crystal
locator.reset_files
locator.clear(Noir::LocatorKeys::ANDROID_MANIFEST)
locator.clear(Noir::LocatorKeys::ANDROID_ASSETLINKS)
# … three more
```

The other 58 — every specification key among them — were **never cleared at all**. A second scan in the same process drained the *previous* codebase's registrations. The only thing masking it was the `File.exists?` guard in `SpecificationEngine#each_spec_file`, which passes whenever the first tree's files are still on disk — that is, always, in the case that matters: `--diff`, or noir used as a library.

The comment above that guard had been documenting the bug rather than the fix:

> these keys are never cleared at the start of a scan … A second scan in the same process therefore still sees the first scan's registrations

## The fix

`LocatorKeys.reset(phase)`. Each key declares which phase owns it (#2502), and the phase clears exactly what it owns at its own start, before writing anything.

**The two phases are separate on purpose.** Collapsing them into one "per-scan" reset would be wrong in both directions: detector-written keys are *drained during analysis*, so clearing them at analysis start destroys the scan; the Express router-prefix keys are written and read inside one analysis pass and must not survive into the next.

## Comments that stop being true

The `File.exists?` guard **stays**, but its rationale is rewritten. A comment asserting a removed invariant is worse than no comment — the next reader deletes the guard on its authority. What actually remains: the detect→analyze window is real wall-clock time on a large tree and a file can vanish inside it; library callers driving `analysis_endpoints` with their own `Process`-lifetime keys get no automatic reset by design; and it contains one missing file to one skipped path instead of a logged read error in each of the 45 spec analyzers.

`--diff`'s `clear_all` stays too, now with a comment saying why: it is a real codebase boundary and the only thing that also drops `Process`-lifetime slots.

## Verification

**A single-scan fixture sweep cannot observe this bug by construction** — which is how it survived long enough to have a comment written about it instead of a fix. The oracle is a new spec: two `detect_techs` passes in one process over two different fixture trees, asserting the second does not see the first's registrations.

Confirmed it fails on `main`:

```
Failure/Error: locator.all(Noir::LocatorKeys::OAS3_JSON).should be_empty
  Expected: [".../fixtures/specification/oas3/param_in_path/doc_param_in_json.json"] to be empty
```

Paired with a table-driven example that seeds every declared key and asserts each phase clears exactly its own — so the one-key proof stays true for all 63 and for every key added later.

A/B over all 665 fixture directories: **byte-identical**, 5,160 endpoints. `crystal spec spec/unit_test` 4723 examples / `spec/functional_test` 22653 examples, 0 failures.