### PR TITLE
refactor(analyzer): keep the options hash inside the Analyzer base

### DIFF
--- a/spec/unit_test/analyzer/options_boundary_spec.cr
+++ b/spec/unit_test/analyzer/options_boundary_spec.cr
@@ -53,11 +53,27 @@ describe "analyzer options boundary" do
   end
 
   it "reads the worker count only through the base accessors" do
-    offenders = offending_lines(/@options\[\s*"concurrency"\s*\]/)
+    offenders = offending_lines(/@(?:raw_)?options\[\s*"concurrency"\s*\]/)
 
     fail <<-MSG unless offenders.empty?
       analyzers must call `worker_count` / `bounded_worker_count` instead of
       reading `concurrency` out of the options hash. Offending lines:
+        #{offenders.join("\n  ")}
+      MSG
+  end
+
+  # The general rule the three specific ones above are instances of. The
+  # ivar was renamed `@raw_options` in the base so every pre-existing
+  # reach-through became a compile error — this keeps new ones from
+  # appearing under either spelling.
+  it "does not index the options hash anywhere under src/analyzer" do
+    offenders = offending_lines(/@(?:raw_)?options\[/)
+
+    fail <<-MSG unless offenders.empty?
+      analyzers read options through accessors on `Analyzer`
+      (`callees_needed?`, `worker_count`, `option_flag?`), never by
+      indexing the hash. Add an accessor rather than a fourth spelling.
+      Offending lines:
         #{offenders.join("\n  ")}
       MSG
   end

--- a/src/analyzer/analyzers/cfml/pure.cr
+++ b/src/analyzer/analyzers/cfml/pure.cr
@@ -107,7 +107,7 @@ module Analyzer::Cfml
     end
 
     private def components_only? : Bool
-      any_to_bool(@options[COMPONENTS_ONLY_OPTION]?)
+      option_flag?(COMPONENTS_ONLY_OPTION)
     end
 
     # `.cfc` — only `access="remote"` methods are reachable over HTTP.

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -37,7 +37,7 @@ class Analyzer
   @is_verbose : Bool
   @is_color : Bool
   @is_log : Bool
-  @options : Hash(String, YAML::Any)
+  @raw_options : Hash(String, YAML::Any)
   # path => longest-matching configured base. Populated lazily by
   # `configured_base_for`; only used on multi-base (monorepo) scans.
   @configured_base_cache = {} of String => String
@@ -54,7 +54,7 @@ class Analyzer
     @is_verbose = any_to_bool(options["verbose"])
     @is_color = any_to_bool(options["color"])
     @is_log = any_to_bool(options["nolog"])
-    @options = options
+    @raw_options = options
 
     @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log
   end
@@ -118,21 +118,32 @@ class Analyzer
   # running their callee extractor so the work is skipped on default
   # scans where neither flag is set.
   def callees_needed? : Bool
-    any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+    option_flag?("include_callee") || option_flag?("ai_context")
+  end
+
+  # Reads a boolean option the orchestrator sets on this analyzer's behalf.
+  #
+  # The one remaining caller is the CFML components-only flag, which
+  # `analysis_endpoints` injects. Analyzers have no other business reaching
+  # into the options hash — `callees_needed?` and `worker_count` cover
+  # everything else the layer needs, and
+  # `spec/unit_test/analyzer/options_boundary_spec.cr` keeps it that way.
+  protected def option_flag?(key : String) : Bool
+    any_to_bool(@raw_options[key]?)
   end
 
   # Worker-fiber count for this analyzer's file walk.
   #
   # Nil-safe and floored at 1, matching the shape `src/models/deliver.cr`
   # already used. The 21 call sites this replaces all spelled it
-  # `@options["concurrency"].to_s.to_i`, which raises `KeyError` on a
+  # `@options["concurrency"].to_s.to_i`, which raised `KeyError` on a
   # missing key and `ArgumentError` on a non-numeric one — reachable only
   # by a library embedder building the options hash by hand, since
   # `ConfigInitializer#default_options` always sets it and
   # `validate_concurrency!` rejects anything below 1. A value of `0` used
   # to spawn zero workers, so the analyzer silently produced nothing.
   protected def worker_count : Int32
-    n = @options["concurrency"]?.try(&.to_s.to_i?) || 0
+    n = @raw_options["concurrency"]?.try(&.to_s.to_i?) || 0
     n > 0 ? n : 1
   end
 


### PR DESCRIPTION
Closes the analyzer/options boundary opened in #2490 and continued in #2501. Behaviour-neutral.

## What

`src/analyzer/` now reads the options hash in **exactly zero places**. `callees_needed?`, `worker_count` and the new `option_flag?` cover everything the layer needs, and the ivar is renamed `@raw_options` in the base so any pre-existing reach-through the greps missed becomes a compile error rather than surviving unnoticed.

It built clean on the first try — which is the evidence that the four keys the earlier PRs inventoried really were all of them.

| when the series started | now |
|---|---|
| `include_callee` ×65 | `callees_needed?` |
| `ai_context` ×65 | `callees_needed?` |
| `concurrency` ×21 | `worker_count` |
| `COMPONENTS_ONLY_OPTION` ×1 | `option_flag?` |

## Why not an `Analyzer::Context` struct

That was the obvious design. It is the wrong one here:

- `initialize(options : Hash(String, YAML::Any))` runs through `initialize_analyzers`, 65 subclass overrides, 291 spec files via `create_test_options`, and the documented library API. A struct means changing all of them — or building it *inside* the constructor, in which case it buys nothing three accessors don't.
- The surface it would protect is **one key**: the CFML components-only flag the orchestrator injects.
- Crystal cannot express a private ivar (`private`/`protected` are method modifiers), so a struct is the only *language-level* enforcement available — and it costs the constructor signature to get it. For this much surface, a rename plus a spec gets the same result.

## Enforcement

`options_boundary_spec.cr` gains the general rule the three specific ones were instances of: nothing under `src/analyzer/` may index the options hash, under either spelling. Adding a fourth accessor on the base is the intended way past it.

Taggers needed nothing — `src/tagger/` and `models/framework_tagger.cr` contain zero `@options[...]` reads, and `Tagger`'s ivar is written by `initialize` and never read.

## Verification

A/B over all 665 fixture directories: **byte-identical**, 5,160 endpoints, CFML fixtures included (they exercise `option_flag?`).

`crystal spec spec/unit_test` 4722 examples / `spec/functional_test` 22653 examples, 0 failures. Format check clean; ameba clean on the changed files.