### PR TITLE
refactor: move the accidental globals into namespaces

### DIFF
--- a/spec/unit_test/detector/applicable_lookup_fidelity_spec.cr
+++ b/spec/unit_test/detector/applicable_lookup_fidelity_spec.cr
@@ -23,8 +23,8 @@ private def every_detector(options) : Array(Detector)
   detectors
 end
 
-# `detector_build_applicable_lookup` memoizes `applicable?` by basename
-# for every detector that `detector_path_sensitive?` does not flag. That
+# `Noir::Detection.build_applicable_lookup` memoizes `applicable?` by basename
+# for every detector that `Noir::Detection.path_sensitive?` does not flag. That
 # classifier is probe-based, and a probe whose *basename* independently
 # satisfies `applicable?` masks a directory gate behind it — which is how
 # the Hasura `metadata/**` gate was lost (46/46 → 16 failures) without any
@@ -36,7 +36,7 @@ end
 private def memo_misses(paths : Array(String)) : Array(String)
   options = create_test_options
   detectors = every_detector(options)
-  lookup = detector_build_applicable_lookup(detectors)
+  lookup = Noir::Detection.build_applicable_lookup(detectors)
 
   missed = [] of String
   paths.each do |path|

--- a/spec/unit_test/detector/applicable_lookup_spec.cr
+++ b/spec/unit_test/detector/applicable_lookup_spec.cr
@@ -6,27 +6,27 @@ require "../../../src/detector/detectors/specification/vercel"
 require "../../../src/detector/detectors/java/spring"
 require "../../../src/models/detector"
 
-describe "detector_path_sensitive?" do
+describe "Noir::Detection.path_sensitive?" do
   options = create_test_options
 
   it "flags Supabase (migrations / supabase/ path gates)" do
-    detector_path_sensitive?(Detector::Specification::Supabase.new(options)).should be_true
+    Noir::Detection.path_sensitive?(Detector::Specification::Supabase.new(options)).should be_true
   end
 
   it "flags Grails (grails-app path gate)" do
-    detector_path_sensitive?(Detector::Groovy::Grails.new(options)).should be_true
+    Noir::Detection.path_sensitive?(Detector::Groovy::Grails.new(options)).should be_true
   end
 
   it "flags Vercel (root-placed vercel.json)" do
-    detector_path_sensitive?(Detector::Specification::Vercel.new(options)).should be_true
+    Noir::Detection.path_sensitive?(Detector::Specification::Vercel.new(options)).should be_true
   end
 
   it "does not flag extension-only Spring detector" do
-    detector_path_sensitive?(Detector::Java::Spring.new(options)).should be_false
+    Noir::Detection.path_sensitive?(Detector::Java::Spring.new(options)).should be_false
   end
 end
 
-describe "detector_build_applicable_lookup" do
+describe "Noir::Detection.build_applicable_lookup" do
   options = create_test_options
 
   it "includes Supabase for a migration path but not a bare .sql basename probe" do
@@ -36,7 +36,7 @@ describe "detector_build_applicable_lookup" do
     supabase.set_name
     spring.set_name
     detectors = [supabase.as(Detector), spring.as(Detector)]
-    lookup = detector_build_applicable_lookup(detectors)
+    lookup = Noir::Detection.build_applicable_lookup(detectors)
 
     migration = "proj/supabase/migrations/001_init.sql"
     idxs = lookup.call(migration)
@@ -50,7 +50,7 @@ describe "detector_build_applicable_lookup" do
     grails = Detector::Groovy::Grails.new(options)
     grails.set_name
     detectors = [grails.as(Detector)]
-    lookup = detector_build_applicable_lookup(detectors)
+    lookup = Noir::Detection.build_applicable_lookup(detectors)
 
     path = "app/grails-app/controllers/Foo.groovy"
     lookup.call(path).should contain(0)

--- a/spec/unit_test/detector/detector_for_spec.cr
+++ b/spec/unit_test/detector/detector_for_spec.cr
@@ -84,7 +84,7 @@ describe "detector_for" do
   end
 
   # A separator-free term is a plain substring test over the whole path, and
-  # `detector_path_sensitive?`'s probe does not flag those: it compares
+  # `Noir::Detection.path_sensitive?`'s probe does not flag those: it compares
   # `applicable?("a/b/c/zz.mod")` with `applicable?("zz.mod")`, which agree.
   # Declaring them sensitive would drop the detector out of the basename memo
   # for no correctness gain.

--- a/spec/unit_test/utils/home_spec.cr
+++ b/spec/unit_test/utils/home_spec.cr
@@ -1,9 +1,9 @@
 require "../../../src/utils/home"
 
-describe "get_home test" do
+describe "Noir::Home.path test" do
   it "returns NOIR_HOME environment variable if set" do
     ENV["NOIR_HOME"] = "/custom/noir/home"
-    get_home.should eq("/custom/noir/home")
+    Noir::Home.path.should eq("/custom/noir/home")
     ENV.delete("NOIR_HOME")
   end
 
@@ -15,9 +15,9 @@ describe "get_home test" do
     ENV["NOIR_HOME"] = ""
     begin
       {% unless flag?(:windows) %}
-        get_home.should eq("#{ENV["HOME"]}/.config/noir")
+        Noir::Home.path.should eq("#{ENV["HOME"]}/.config/noir")
       {% end %}
-      get_home.should_not eq("")
+      Noir::Home.path.should_not eq("")
     ensure
       if prev
         ENV["NOIR_HOME"] = prev
@@ -30,14 +30,14 @@ describe "get_home test" do
   it "returns default config directory on Windows" do
     {% if flag?(:windows) %}
       ENV.delete("NOIR_HOME")
-      get_home.should eq("#{ENV["APPDATA"]}\\noir")
+      Noir::Home.path.should eq("#{ENV["APPDATA"]}\\noir")
     {% end %}
   end
 
   it "returns default config directory on non-Windows" do
     {% unless flag?(:windows) %}
       ENV.delete("NOIR_HOME")
-      get_home.should eq("#{ENV["HOME"]}/.config/noir")
+      Noir::Home.path.should eq("#{ENV["HOME"]}/.config/noir")
     {% end %}
   end
 
@@ -48,7 +48,7 @@ describe "get_home test" do
     saved = ENV["NOIR_HOME"]?
     ENV["NOIR_HOME"] = "~/some-noir-home"
     begin
-      result = get_home
+      result = Noir::Home.path
       result.starts_with?('~').should be_false
       {% unless flag?(:windows) %}
         result.should eq("#{ENV["HOME"]}/some-noir-home")

--- a/src/banner.cr
+++ b/src/banner.cr
@@ -1,65 +1,71 @@
-def banner(io : IO = STDERR)
-  # The default art uses extended/box-drawing glyphs that mojibake on a
-  # non-UTF-8 Windows console (CP949, …). Ship an ASCII-only variant on
-  # Windows so the banner renders cleanly there. Both variants are 11 lines
-  # to stay aligned with the `side` text column below.
-  # Pre-declare so the macro-branch assignments are visible below.
-  art = [] of String
-  divider = ""
-  {% if flag?(:windows) %}
-    art = [
-      "          .   |   .          ",
-      "       .  |   |   |  .       ",
-      "      .   |   |   |   .      ",
-      "      |   |   |   |   |      ",
-      "          |   |   |          ",
-      "    #=====================#  ",
-      "          |   |   |          ",
-      "      |   |   |   |   |      ",
-      "      '   |   |   |   '      ",
-      "       '  |   |   |  '       ",
-      "          '   |   '          ",
+# The ASCII banner, printed to STDERR so `-f json` piped to a file stays
+# machine-readable.
+module Noir::Banner
+  extend self
+
+  def print(io : IO = STDERR)
+    # The default art uses extended/box-drawing glyphs that mojibake on a
+    # non-UTF-8 Windows console (CP949, …). Ship an ASCII-only variant on
+    # Windows so the banner renders cleanly there. Both variants are 11 lines
+    # to stay aligned with the `side` text column below.
+    # Pre-declare so the macro-branch assignments are visible below.
+    art = [] of String
+    divider = ""
+    {% if flag?(:windows) %}
+      art = [
+        "          .   |   .          ",
+        "       .  |   |   |  .       ",
+        "      .   |   |   |   .      ",
+        "      |   |   |   |   |      ",
+        "          |   |   |          ",
+        "    #=====================#  ",
+        "          |   |   |          ",
+        "      |   |   |   |   |      ",
+        "      '   |   |   |   '      ",
+        "       '  |   |   |  '       ",
+        "          '   |   '          ",
+      ]
+      divider = "-" * 34
+    {% else %}
+      art = [
+        "           ùç  Y  wù           ",
+        "        ™w£ Í  ±  Í £w2        ",
+        "       ù£   Ï  Ï  Ï   £ù       ",
+        "      ù£    Ï  Ï  Ï  ± £ù      ",
+        "         Ï  Ï  Ï  Ï  Ï         ",
+        "     2YV±ÏÏÏÏÏÏÏÏÏÏÏÏÏ3ÍY2     ",
+        "         Ï  Ï  Ï  Ï  Ï         ",
+        "      ù£ ±  Ï  Ï  Ï  ± £ç      ",
+        "       ù£   Ï  Ï  Ï   £ç       ",
+        "        2w£ Í  ±  Í £©2        ",
+        "           ùw  Y  wù           ",
+      ]
+      divider = "─" * 34
+    {% end %}
+
+    name = "N O I R".colorize(:white).mode(:bold).to_s
+    version = "v#{Noir::VERSION}".colorize(:light_yellow).to_s
+
+    side = [
+      "",
+      "",
+      "  #{name}   #{version}",
+      "  #{divider.colorize(:dark_gray)}",
+      "",
+      "  Hunt every Endpoint,".colorize(:white).to_s,
+      "  expose Shadow APIs,".colorize(:white).to_s,
+      "  map the Attack Surface.".colorize(:white).to_s,
+      "",
+      "  #{"OWASP · github.com/owasp-noir/noir".colorize(:dark_gray)}",
+      "",
     ]
-    divider = "-" * 34
-  {% else %}
-    art = [
-      "           ùç  Y  wù           ",
-      "        ™w£ Í  ±  Í £w2        ",
-      "       ù£   Ï  Ï  Ï   £ù       ",
-      "      ù£    Ï  Ï  Ï  ± £ù      ",
-      "         Ï  Ï  Ï  Ï  Ï         ",
-      "     2YV±ÏÏÏÏÏÏÏÏÏÏÏÏÏ3ÍY2     ",
-      "         Ï  Ï  Ï  Ï  Ï         ",
-      "      ù£ ±  Ï  Ï  Ï  ± £ç      ",
-      "       ù£   Ï  Ï  Ï   £ç       ",
-      "        2w£ Í  ±  Í £©2        ",
-      "           ùw  Y  wù           ",
-    ]
-    divider = "─" * 34
-  {% end %}
 
-  name = "N O I R".colorize(:white).mode(:bold).to_s
-  version = "v#{Noir::VERSION}".colorize(:light_yellow).to_s
+    art_color = Colorize::Color256.new(81)
 
-  side = [
-    "",
-    "",
-    "  #{name}   #{version}",
-    "  #{divider.colorize(:dark_gray)}",
-    "",
-    "  Hunt every Endpoint,".colorize(:white).to_s,
-    "  expose Shadow APIs,".colorize(:white).to_s,
-    "  map the Attack Surface.".colorize(:white).to_s,
-    "",
-    "  #{"OWASP · github.com/owasp-noir/noir".colorize(:dark_gray)}",
-    "",
-  ]
-
-  art_color = Colorize::Color256.new(81)
-
-  io.puts ""
-  art.each_with_index do |line, i|
-    io.puts "#{line.colorize(art_color)}#{side[i]}"
+    io.puts ""
+    art.each_with_index do |line, i|
+      io.puts "#{line.colorize(art_color)}#{side[i]}"
+    end
+    io.puts ""
   end
-  io.puts ""
 end

--- a/src/cli/commands/config.cr
+++ b/src/cli/commands/config.cr
@@ -208,7 +208,7 @@ module Noir::CLI::ConfigCommand
 
   def self.config_path(override : String? = nil) : String
     return File.expand_path(override) if override && !override.empty?
-    File.expand_path(File.join(get_home, "config.yaml"))
+    File.expand_path(File.join(Noir::Home.path, "config.yaml"))
   end
 
   # Resolution order: $VISUAL, $EDITOR, then a platform default.

--- a/src/cli/commands/help.cr
+++ b/src/cli/commands/help.cr
@@ -65,7 +65,7 @@ module Noir::CLI::HelpCommand
   end
 
   def self.print_top_level(io : IO = STDOUT, banner_io : IO = STDERR)
-    banner(banner_io)
+    Noir::Banner.print(banner_io)
 
     cyan = ->(s : String) { Noir::CLI.name(s) }
     green = ->(s : String) { Noir::CLI.section(s) }

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -75,7 +75,7 @@ module Noir::CLI::ScanCommand
     validate_options!(noir_options)
 
     if noir_options["nolog"] == false
-      banner()
+      Noir::Banner.print
     end
 
     run_scan(noir_options)

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -77,7 +77,7 @@ class ConfigInitializer
   # post-CLI merge inside NoirRunner that re-overwrote everything
   # the CLI had just set.
   def initialize(override_path : String? = nil)
-    @config_dir = get_home
+    @config_dir = Noir::Home.path
 
     if override_path && !override_path.empty?
       @config_file = override_path

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -7,6 +7,7 @@ require "wait_group"
 require "../utils/media_filter"
 require "../utils/text_file"
 require "yaml"
+require "../models/locator_keys"
 
 # Reference-typed atomic Boolean. Wrapping `Atomic(Int8)` in a
 # class keeps the underlying byte addressable through an Array
@@ -25,242 +26,260 @@ class AtomicFlag
   end
 end
 
-DETECTOR_IGNORED_DIR_NAMES = Set{
-  # Source control / IDE / agent state
-  ".git", ".idea", ".vscode", ".claude",
-  # Language-specific dependency / build caches
-  "node_modules", "vendor", "__pycache__", ".venv", "venv",
-  ".pytest_cache", ".tox", ".gradle", ".bundle", ".dart_tool",
-  ".cargo", ".terraform",
-  # Zig build outputs / fetched-dependency cache. Vendored deps under
-  # `.zig-cache` carry their own `@import("httpz")` etc. and would
-  # otherwise make every Zig project look like it uses every framework.
-  ".zig-cache", "zig-cache", ".zig-out", "zig-out",
-  # Common build / dist / cache outputs
-  "dist", "build", "target", "out", "tmp", ".cache",
-  ".next", ".nuxt", ".svelte-kit", ".turbo", ".parcel-cache",
-  ".serverless", ".expo",
-  # Test coverage / reports
-  "coverage", ".coverage",
-  # iOS / macOS noise
-  "Pods", "__MACOSX",
-}
+# Detection-pass internals: the ignore lists, the Android source-set
+# resolver, and the `applicable?` memo that keeps the per-file walk off the
+# O(detectors) path.
+#
+# These were seven top-level `def`s and seven SCREAMING constants, each
+# hand-prefixed `detector_` / `DETECTOR_` — a namespace spelled out by
+# convention because there was no module to put them in. `ANDROID_SOURCE_SUBDIRS`
+# and `ANDROID_EMBEDDED_SERVER_MARKER` did not even get the prefix, and were
+# sitting in the global namespace under names generic enough to collide.
+#
+# The two phase entry points (`build_detector_list`, `detect_techs`) stay
+# top-level: they are the detection pass's public surface, called from
+# `NoirRunner` and the specs.
+module Noir::Detection
+  extend self
 
-DETECTOR_IGNORED_DIR_SUFFIXES = Set{
-  # Xcode asset catalogs. They contain images plus many Contents.json
-  # metadata files; none are source/spec files for route detection, and
-  # large iOS apps can carry hundreds of them.
-  ".xcassets",
-}
+  IGNORED_DIR_NAMES = Set{
+    # Source control / IDE / agent state
+    ".git", ".idea", ".vscode", ".claude",
+    # Language-specific dependency / build caches
+    "node_modules", "vendor", "__pycache__", ".venv", "venv",
+    ".pytest_cache", ".tox", ".gradle", ".bundle", ".dart_tool",
+    ".cargo", ".terraform",
+    # Zig build outputs / fetched-dependency cache. Vendored deps under
+    # `.zig-cache` carry their own `@import("httpz")` etc. and would
+    # otherwise make every Zig project look like it uses every framework.
+    ".zig-cache", "zig-cache", ".zig-out", "zig-out",
+    # Common build / dist / cache outputs
+    "dist", "build", "target", "out", "tmp", ".cache",
+    ".next", ".nuxt", ".svelte-kit", ".turbo", ".parcel-cache",
+    ".serverless", ".expo",
+    # Test coverage / reports
+    "coverage", ".coverage",
+    # iOS / macOS noise
+    "Pods", "__MACOSX",
+  }
 
-ANDROID_SOURCE_SUBDIRS = Set{
-  "aidl",
-  "assets",
-  "cpp",
-  "java",
-  "jni",
-  "kotlin",
-  "res",
-}
+  IGNORED_DIR_SUFFIXES = Set{
+    # Xcode asset catalogs. They contain images plus many Contents.json
+    # metadata files; none are source/spec files for route detection, and
+    # large iOS apps can carry hundreds of them.
+    ".xcassets",
+  }
 
-MOBILE_DETECTOR_NAMES = Set{
-  "android",
-  "ios",
-  "well_known_applinks",
-}
+  ANDROID_SOURCE_SUBDIRS = Set{
+    "aidl",
+    "assets",
+    "cpp",
+    "java",
+    "jni",
+    "kotlin",
+    "res",
+  }
 
-# Strong server-routing constructs. A `.kt` / `.java` file that sits
-# inside an Android app's source set is normally scoped to mobile
-# detectors only (an incidental `import ...SpringApplication` must not
-# flag the project as a server). But an Android app can legitimately
-# *embed* an on-device HTTP server — e.g. plain-app runs a local Ktor
-# web server whose routes live under `app/src/main/java/...`. When a
-# file carries one of these markers it is a real server, so the
-# Ktor / http4k / Spring detectors are allowed to run on it. Kept as a
-# single precompiled constant — recompiling it per file would recreate
-# the PCRE2 program on every read.
-ANDROID_EMBEDDED_SERVER_MARKER = /io\.ktor\.server\.|embeddedServer|\brouting\s*\{|\bfun\s+Route\.|org\.http4k\.routing|@RestController|@RequestMapping|@(?:Get|Post|Put|Delete|Patch)Mapping|\bRouterFunction\b/
+  MOBILE_DETECTOR_NAMES = Set{
+    "android",
+    "ios",
+    "well_known_applinks",
+  }
 
-def detector_android_source_prefixes_for_manifest(manifest_path : String) : Array(String)
-  prefixes = [] of String
-  manifest_dir = File.dirname(manifest_path)
-  manifest_dir_parts = manifest_dir.split(File::SEPARATOR)
-  src_index = manifest_dir_parts.rindex("src")
+  # Strong server-routing constructs. A `.kt` / `.java` file that sits
+  # inside an Android app's source set is normally scoped to mobile
+  # detectors only (an incidental `import ...SpringApplication` must not
+  # flag the project as a server). But an Android app can legitimately
+  # *embed* an on-device HTTP server — e.g. plain-app runs a local Ktor
+  # web server whose routes live under `app/src/main/java/...`. When a
+  # file carries one of these markers it is a real server, so the
+  # Ktor / http4k / Spring detectors are allowed to run on it. Kept as a
+  # single precompiled constant — recompiling it per file would recreate
+  # the PCRE2 program on every read.
+  ANDROID_EMBEDDED_SERVER_MARKER = /io\.ktor\.server\.|embeddedServer|\brouting\s*\{|\bfun\s+Route\.|org\.http4k\.routing|@RestController|@RequestMapping|@(?:Get|Post|Put|Delete|Patch)Mapping|\bRouterFunction\b/
 
-  source_set_root = if src_index && src_index == manifest_dir_parts.size - 2
-                      manifest_dir
-                    end
+  def android_source_prefixes_for_manifest(manifest_path : String) : Array(String)
+    prefixes = [] of String
+    manifest_dir = File.dirname(manifest_path)
+    manifest_dir_parts = manifest_dir.split(File::SEPARATOR)
+    src_index = manifest_dir_parts.rindex("src")
 
-  if source_set_root
-    ANDROID_SOURCE_SUBDIRS.each do |subdir|
-      prefixes << File.join(source_set_root, subdir) + File::SEPARATOR
-    end
-  else
-    ANDROID_SOURCE_SUBDIRS.each do |subdir|
-      prefixes << File.join(manifest_dir, subdir) + File::SEPARATOR
-      prefixes << File.join(manifest_dir, "src", subdir) + File::SEPARATOR
-      prefixes << File.join(manifest_dir, "src", "main", subdir) + File::SEPARATOR
-    end
-  end
+    source_set_root = if src_index && src_index == manifest_dir_parts.size - 2
+                        manifest_dir
+                      end
 
-  prefixes
-end
-
-def detector_add_android_source_prefixes_from_dir(dir : String, prefixes : Array(String))
-  manifest_path = File.join(dir, "AndroidManifest.xml")
-  return unless File.exists?(manifest_path)
-
-  begin
-    content = Noir::TextFile.read(manifest_path)
-    return unless content.includes?("<manifest")
-  rescue File::NotFoundError | File::AccessDeniedError
-    return
-  end
-
-  detector_android_source_prefixes_for_manifest(manifest_path).each do |prefix|
-    prefixes << prefix unless prefixes.includes?(prefix)
-  end
-end
-
-def detector_android_source_file?(path : String, prefixes : Array(String)) : Bool
-  prefixes.any? { |prefix| path.starts_with?(prefix) }
-end
-
-def detector_mobile_detector?(name : String) : Bool
-  MOBILE_DETECTOR_NAMES.includes?(name)
-end
-
-# Filenames that detectors match by exact basename (often with path
-# constraints like "must sit at the project root"). These must not share
-# an extension-only cache bucket — e.g. `vercel.json` is not "any .json".
-DETECTOR_SPECIAL_BASENAMES = Set{
-  "package.json", "tsconfig.json", "composer.json", "composer.lock",
-  "vercel.json", "now.json", "netlify.toml", "wrangler.toml",
-  "Gemfile", "Gemfile.lock", "Package.swift", "Cargo.toml", "go.mod",
-  "mix.exs", "pubspec.yaml", "pubspec.lock", "shard.yml", "shard.lock",
-  "build.sbt", "pom.xml", "AndroidManifest.xml", "config.toml",
-  "rebar.config", "erlang.mk", "project.clj", "deps.edn", "stack.yaml",
-  "package.yaml", "gleam.toml", "manifest.toml", "paket.dependencies",
-  "Caddyfile", "Dockerfile", "Makefile", "Rakefile", "serverless.yml",
-  "serverless.yaml", "app.yaml", "openapi.yaml", "openapi.json",
-  "swagger.json", "swagger.yaml",
-}
-
-# Paths that embed directory segments real detectors gate on
-# (`/grails-app/`, `/migrations/`, `/server/api/`, …). Used only to
-# classify path-sensitive detectors — not as production file samples.
-DETECTOR_PATH_SEGMENT_PROBES = [
-  # Extension-free path under grails-app: only matches via the directory
-  # gate (a bare `Foo.groovy` basename is true for other reasons).
-  "proj/grails-app/conf/application",
-  "proj/supabase/migrations/001.sql",
-  "proj/migrations/001.sql",
-  "proj/supabase/config.toml",
-  "proj/server/api/hello.js",
-  "proj/server/routes/hello.js",
-  "proj/pages/api/hello.js",
-  "proj/app/api/hello/route.ts",
-  "proj/routes/+server.ts",
-  "proj/routes/index.dart",
-  "proj/directus/snapshots/snap.json",
-  "proj/wp-content/plugins/x.php",
-  "proj/metadata/databases/tables.yaml",
-  "proj/Magento/module.xml",
-]
-
-# Whether `applicable?` depends on more than the basename (root
-# placement, directory segments, multi-hop path layout). Those
-# detectors must always see the real path in the hot loop.
-def detector_path_sensitive?(detector : Detector) : Bool
-  # Explicit declaration wins. The probe sweep below is a safety net,
-  # not the contract: it is fail-open by construction, so a detector
-  # whose directory gate happens to agree with its basename gate on
-  # every probe would otherwise be memoized as basename-only and lose
-  # the path check entirely.
-  return true if detector.path_sensitive?
-
-  sample_suffixes = [
-    ".java", ".js", ".ts", ".tsx", ".rb", ".py", ".go", ".json", ".yml",
-    ".yaml", ".xml", ".cs", ".kt", ".php", ".cr", ".rs", ".ex", ".swift",
-    ".scala", ".dart", ".groovy", ".pl", ".clj", ".hs", ".lua", ".sql",
-    ".toml", ".bru", ".http", ".sbt", ".gradle", ".aspx", ".fs",
-  ]
-  # Bare names: catch "must sit at project root" checks (Vercel,
-  # Package.swift, …) where `name` is true but `a/b/c/name` is false.
-  basenames = DETECTOR_SPECIAL_BASENAMES.to_a + sample_suffixes.map { |ext| "file#{ext}" }
-  basenames.any? do |name|
-    detector.applicable?("a/b/c/#{name}") != detector.applicable?(name)
-  end || DETECTOR_PATH_SEGMENT_PROBES.any? do |probe|
-    # Directory-segment gates: same basename, different path → different
-    # answer (Supabase `/migrations/`, Grails `/grails-app/`, …).
-    detector.applicable?(probe) != detector.applicable?(File.basename(probe))
-  end
-end
-
-# Build a lookup that turns a path into the list of detector indices
-# whose `applicable?` returns true — without re-walking every detector
-# on every file. Most detectors only inspect extension / basename, so
-# their answers are memoized by basename. Detectors that look at path
-# segments or root placement are classified as path-sensitive and
-# always evaluated against the real path.
-def detector_build_applicable_lookup(detectors : Array(Detector)) : Proc(String, Array(Int32))
-  path_sensitive = [] of Int32
-  detectors.each_with_index do |detector, idx|
-    path_sensitive << idx if detector_path_sensitive?(detector)
-  end
-
-  path_sensitive_set = Set(Int32).new(path_sensitive)
-  # Key by basename, not bare extension: many detectors gate on
-  # basename substrings (`*deploy*.yml`, `*sites*.yaml`) or exact
-  # names (`package.json`). An extension-only key would probe
-  # `file.yml` and drop every basename-qualified match.
-  cache = {} of String => Array(Int32)
-
-  ->(path : String) do
-    base = File.basename(path)
-
-    cached = cache[base]?
-    unless cached
-      idxs = [] of Int32
-      detectors.each_with_index do |detector, idx|
-        next if path_sensitive_set.includes?(idx)
-        idxs << idx if detector.applicable?(base)
+    if source_set_root
+      ANDROID_SOURCE_SUBDIRS.each do |subdir|
+        prefixes << File.join(source_set_root, subdir) + File::SEPARATOR
       end
-      cache[base] = idxs
-      cached = idxs
+    else
+      ANDROID_SOURCE_SUBDIRS.each do |subdir|
+        prefixes << File.join(manifest_dir, subdir) + File::SEPARATOR
+        prefixes << File.join(manifest_dir, "src", subdir) + File::SEPARATOR
+        prefixes << File.join(manifest_dir, "src", "main", subdir) + File::SEPARATOR
+      end
     end
 
-    # Always dup: callers `reject!` android-scope / JSON-spec candidates
-    # in place and must not corrupt the memoized array.
-    result = cached.dup
-    path_sensitive.each do |idx|
-      result << idx if detectors[idx].applicable?(path)
-    end
-    result
+    prefixes
   end
+
+  def add_android_source_prefixes_from_dir(dir : String, prefixes : Array(String))
+    manifest_path = File.join(dir, "AndroidManifest.xml")
+    return unless File.exists?(manifest_path)
+
+    begin
+      content = Noir::TextFile.read(manifest_path)
+      return unless content.includes?("<manifest")
+    rescue File::NotFoundError | File::AccessDeniedError
+      return
+    end
+
+    android_source_prefixes_for_manifest(manifest_path).each do |prefix|
+      prefixes << prefix unless prefixes.includes?(prefix)
+    end
+  end
+
+  def android_source_file?(path : String, prefixes : Array(String)) : Bool
+    prefixes.any? { |prefix| path.starts_with?(prefix) }
+  end
+
+  def mobile_detector?(name : String) : Bool
+    MOBILE_DETECTOR_NAMES.includes?(name)
+  end
+
+  # Filenames that detectors match by exact basename (often with path
+  # constraints like "must sit at the project root"). These must not share
+  # an extension-only cache bucket — e.g. `vercel.json` is not "any .json".
+  SPECIAL_BASENAMES = Set{
+    "package.json", "tsconfig.json", "composer.json", "composer.lock",
+    "vercel.json", "now.json", "netlify.toml", "wrangler.toml",
+    "Gemfile", "Gemfile.lock", "Package.swift", "Cargo.toml", "go.mod",
+    "mix.exs", "pubspec.yaml", "pubspec.lock", "shard.yml", "shard.lock",
+    "build.sbt", "pom.xml", "AndroidManifest.xml", "config.toml",
+    "rebar.config", "erlang.mk", "project.clj", "deps.edn", "stack.yaml",
+    "package.yaml", "gleam.toml", "manifest.toml", "paket.dependencies",
+    "Caddyfile", "Dockerfile", "Makefile", "Rakefile", "serverless.yml",
+    "serverless.yaml", "app.yaml", "openapi.yaml", "openapi.json",
+    "swagger.json", "swagger.yaml",
+  }
+
+  # Paths that embed directory segments real detectors gate on
+  # (`/grails-app/`, `/migrations/`, `/server/api/`, …). Used only to
+  # classify path-sensitive detectors — not as production file samples.
+  PATH_SEGMENT_PROBES = [
+    # Extension-free path under grails-app: only matches via the directory
+    # gate (a bare `Foo.groovy` basename is true for other reasons).
+    "proj/grails-app/conf/application",
+    "proj/supabase/migrations/001.sql",
+    "proj/migrations/001.sql",
+    "proj/supabase/config.toml",
+    "proj/server/api/hello.js",
+    "proj/server/routes/hello.js",
+    "proj/pages/api/hello.js",
+    "proj/app/api/hello/route.ts",
+    "proj/routes/+server.ts",
+    "proj/routes/index.dart",
+    "proj/directus/snapshots/snap.json",
+    "proj/wp-content/plugins/x.php",
+    "proj/metadata/databases/tables.yaml",
+    "proj/Magento/module.xml",
+  ]
+
+  # Whether `applicable?` depends on more than the basename (root
+  # placement, directory segments, multi-hop path layout). Those
+  # detectors must always see the real path in the hot loop.
+  def path_sensitive?(detector : Detector) : Bool
+    # Explicit declaration wins. The probe sweep below is a safety net,
+    # not the contract: it is fail-open by construction, so a detector
+    # whose directory gate happens to agree with its basename gate on
+    # every probe would otherwise be memoized as basename-only and lose
+    # the path check entirely.
+    return true if detector.path_sensitive?
+
+    sample_suffixes = [
+      ".java", ".js", ".ts", ".tsx", ".rb", ".py", ".go", ".json", ".yml",
+      ".yaml", ".xml", ".cs", ".kt", ".php", ".cr", ".rs", ".ex", ".swift",
+      ".scala", ".dart", ".groovy", ".pl", ".clj", ".hs", ".lua", ".sql",
+      ".toml", ".bru", ".http", ".sbt", ".gradle", ".aspx", ".fs",
+    ]
+    # Bare names: catch "must sit at project root" checks (Vercel,
+    # Package.swift, …) where `name` is true but `a/b/c/name` is false.
+    basenames = SPECIAL_BASENAMES.to_a + sample_suffixes.map { |ext| "file#{ext}" }
+    basenames.any? do |name|
+      detector.applicable?("a/b/c/#{name}") != detector.applicable?(name)
+    end || PATH_SEGMENT_PROBES.any? do |probe|
+      # Directory-segment gates: same basename, different path → different
+      # answer (Supabase `/migrations/`, Grails `/grails-app/`, …).
+      detector.applicable?(probe) != detector.applicable?(File.basename(probe))
+    end
+  end
+
+  # Build a lookup that turns a path into the list of detector indices
+  # whose `applicable?` returns true — without re-walking every detector
+  # on every file. Most detectors only inspect extension / basename, so
+  # their answers are memoized by basename. Detectors that look at path
+  # segments or root placement are classified as path-sensitive and
+  # always evaluated against the real path.
+  def build_applicable_lookup(detectors : Array(Detector)) : Proc(String, Array(Int32))
+    path_sensitive = [] of Int32
+    detectors.each_with_index do |detector, idx|
+      path_sensitive << idx if path_sensitive?(detector)
+    end
+
+    path_sensitive_set = Set(Int32).new(path_sensitive)
+    # Key by basename, not bare extension: many detectors gate on
+    # basename substrings (`*deploy*.yml`, `*sites*.yaml`) or exact
+    # names (`package.json`). An extension-only key would probe
+    # `file.yml` and drop every basename-qualified match.
+    cache = {} of String => Array(Int32)
+
+    ->(path : String) do
+      base = File.basename(path)
+
+      cached = cache[base]?
+      unless cached
+        idxs = [] of Int32
+        detectors.each_with_index do |detector, idx|
+          next if path_sensitive_set.includes?(idx)
+          idxs << idx if detector.applicable?(base)
+        end
+        cache[base] = idxs
+        cached = idxs
+      end
+
+      # Always dup: callers `reject!` android-scope / JSON-spec candidates
+      # in place and must not corrupt the memoized array.
+      result = cached.dup
+      path_sensitive.each do |idx|
+        result << idx if detectors[idx].applicable?(path)
+      end
+      result
+    end
+  end
+
+  # The complete detector registry.
+  #
+  # Derived from the classes themselves rather than a hand-maintained list.
+  # Every detector under the `Detector::` namespace is registered by existing;
+  # there is no second place to add it to and therefore no way to write a
+  # detector that silently never runs. That was a real failure mode — it is
+  # how `zap_sites_tree` ended up detectable but unnameable (see
+  # `spec/unit_test/techs/registry_integrity_spec.cr`, which still checks the
+  # remaining hand-maintained lists it cannot yet be derived from).
+  #
+  # The `Detector::` filter is the production contract. `crystal spec`
+  # compiles the suite into one binary, so `all_subclasses` also sees the
+  # throwaway subclasses `spec/unit_test/detector/detector_for_spec.cr`
+  # defines to exercise the base class; those must never join a real scan.
+  #
+  # Sorted by class name so the order is a property of the source, not of
+  # whatever sequence `require "./detectors/**"` happened to produce. Order is
+  # not load-bearing — `techs` is accumulated concurrently across worker
+  # fibers and the optimizer sorts endpoints before output — but a stable
+  # order keeps debug logs and `detector_list` indices comparable between
+  # runs.
 end
 
-# The complete detector registry.
-#
-# Derived from the classes themselves rather than a hand-maintained list.
-# Every detector under the `Detector::` namespace is registered by existing;
-# there is no second place to add it to and therefore no way to write a
-# detector that silently never runs. That was a real failure mode — it is
-# how `zap_sites_tree` ended up detectable but unnameable (see
-# `spec/unit_test/techs/registry_integrity_spec.cr`, which still checks the
-# remaining hand-maintained lists it cannot yet be derived from).
-#
-# The `Detector::` filter is the production contract. `crystal spec`
-# compiles the suite into one binary, so `all_subclasses` also sees the
-# throwaway subclasses `spec/unit_test/detector/detector_for_spec.cr`
-# defines to exercise the base class; those must never join a real scan.
-#
-# Sorted by class name so the order is a property of the source, not of
-# whatever sequence `require "./detectors/**"` happened to produce. Order is
-# not load-bearing — `techs` is accumulated concurrently across worker
-# fibers and the optimizer sorts endpoints before output — but a stable
-# order keeps debug logs and `detector_list` indices comparable between
-# runs.
 def build_detector_list(options : Hash(String, YAML::Any)) : Array(Detector)
   detector_list = [] of Detector
 
@@ -346,12 +365,12 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   # into the next scan in the same process.
   Noir::LocatorKeys.reset(Noir::LocatorKey::Lifecycle::DetectScoped)
 
-  android_source_scope_active = detector_list.any? { |detector| detector_mobile_detector?(detector.name) }
+  android_source_scope_active = detector_list.any? { |detector| Noir::Detection.mobile_detector?(detector.name) }
   android_source_prefixes = [] of String
   # Built once before the reader starts. Replaces the per-file
   # O(detectors) `applicable?` walk with an extension/basename memo
-  # plus a short path-sensitive tail (see detector_build_applicable_lookup).
-  applicable_lookup = detector_build_applicable_lookup(detector_list)
+  # plus a short path-sensitive tail (see Noir::Detection.build_applicable_lookup).
+  applicable_lookup = Noir::Detection.build_applicable_lookup(detector_list)
 
   # A malformed `--exclude-path` glob makes `File.match?` raise
   # `File::BadPatternError`. In practice that means an unterminated `[`
@@ -418,7 +437,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
           # only when a sibling `shard.yml` is present.
           dir_has_shard = File.exists?(File.join(dir, "shard.yml"))
           if android_source_scope_active
-            detector_add_android_source_prefixes_from_dir(dir, android_source_prefixes)
+            Noir::Detection.add_android_source_prefixes_from_dir(dir, android_source_prefixes)
           end
           begin
             Dir.each_child(dir) do |entry|
@@ -429,7 +448,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
               if info.directory?
                 # Subtree prune happens here. Entry name (not full path)
                 # so the base-as-node_modules case from #912 is safe.
-                if DETECTOR_IGNORED_DIR_NAMES.includes?(entry) || DETECTOR_IGNORED_DIR_SUFFIXES.any? { |suffix| entry.ends_with?(suffix) }
+                if Noir::Detection::IGNORED_DIR_NAMES.includes?(entry) || Noir::Detection::IGNORED_DIR_SUFFIXES.any? { |suffix| entry.ends_with?(suffix) }
                   skipped_ignored_dirs += 1
                   next
                 end
@@ -488,13 +507,13 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
               candidate_detector_indices = applicable_lookup.call(full_path)
 
               # An Android source-set file is normally narrowed to the
-              # mobile detectors only (see ANDROID_EMBEDDED_SERVER_MARKER /
+              # mobile detectors only (see Noir::Detection::ANDROID_EMBEDDED_SERVER_MARKER /
               # the Android-source scope spec). The exception — a genuine
               # embedded on-device server — can only be told apart from an
               # incidental framework import by reading the file, so defer
               # the narrowing until after the content read below.
-              android_source_file = detector_android_source_file?(full_path, android_source_prefixes)
-              if android_source_file && candidate_detector_indices.all? { |idx| detector_mobile_detector?(detector_list[idx].name) }
+              android_source_file = Noir::Detection.android_source_file?(full_path, android_source_prefixes)
+              if android_source_file && candidate_detector_indices.all? { |idx| Noir::Detection.mobile_detector?(detector_list[idx].name) }
                 # No server detector is even applicable here, so the
                 # marker check cannot change the outcome — keep the
                 # content-free fast path.
@@ -522,9 +541,9 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
               # available: drop the server-framework detectors unless the
               # file carries a real server-routing construct (an embedded
               # on-device server).
-              if android_source_file && !content.matches?(ANDROID_EMBEDDED_SERVER_MARKER)
+              if android_source_file && !content.matches?(Noir::Detection::ANDROID_EMBEDDED_SERVER_MARKER)
                 candidate_detector_indices.reject! do |idx|
-                  !detector_mobile_detector?(detector_list[idx].name)
+                  !Noir::Detection.mobile_detector?(detector_list[idx].name)
                 end
                 if candidate_detector_indices.empty? && active_passive_scans.empty?
                   # Nothing left to detect and no passive scan to run.

--- a/src/llm/cache.cr
+++ b/src/llm/cache.cr
@@ -59,7 +59,7 @@ module LLM
     end
 
     def self.cache_dir : String
-      File.join(get_home, "cache", "ai")
+      File.join(Noir::Home.path, "cache", "ai")
     end
 
     # Build a deterministic cache key from inputs

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -81,7 +81,7 @@ class Detector
   #
   # A separator-free term (`"go.mod"`) is a plain substring test on the whole
   # path and deliberately does *not* imply sensitivity, because
-  # `detector_path_sensitive?` does not flag those today: the probe compares
+  # `Noir::Detection.path_sensitive?` does not flag those today: the probe compares
   # `applicable?("a/b/c/go.mod")` with `applicable?("go.mod")`, which agree.
   # Declaring them sensitive would drop those detectors out of the basename
   # memo and slow the hot loop for no correctness gain here.
@@ -159,7 +159,7 @@ class Detector
   # that consults the path but does not declare it here has its path
   # gate silently deleted: `applicable?` is only ever asked about the
   # bare filename. That is a false-negative, not a crash, so nothing
-  # fails loudly. `detector_path_sensitive?` also probes for this, but
+  # fails loudly. `Noir::Detection.path_sensitive?` also probes for this, but
   # the probe is fail-open — a probe whose basename independently
   # matches masks the directory gate behind it (this is exactly how the
   # Hasura `metadata/**` gate was lost). Declare it explicitly.

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -38,7 +38,7 @@ class NoirRunner
   def initialize(options)
     @options = options
     @config_file = @options["config_file"].to_s
-    @noir_home = get_home
+    @noir_home = Noir::Home.path
     @passive_scans = [] of PassiveScan
     @passive_results = [] of PassiveScanResult
 

--- a/src/output_builder/html.cr
+++ b/src/output_builder/html.cr
@@ -16,7 +16,7 @@ class OutputBuilderHtml < OutputBuilder
   end
 
   private def build_html(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult)) : String
-    template_path = File.join(get_home, "report-template.html")
+    template_path = File.join(Noir::Home.path, "report-template.html")
 
     if File.exists?(template_path)
       apply_template(template_path, endpoints, passive_results)

--- a/src/utils/home.cr
+++ b/src/utils/home.cr
@@ -1,31 +1,36 @@
 require "../cli/common"
 
-def get_home
-  # NOIR_HOME wins — but only when it's set to a real value. The previous
-  # `ENV.has_key? "NOIR_HOME"` check was also true for an exported-but-empty
-  # `NOIR_HOME=""` (a shell-script bug, an unfilled container env template),
-  # which then resolved rules/config/cache to *relative* paths under the
-  # current working directory: `File.join("", "passive_rules") == "passive_rules"`.
-  # Treat an empty value the same as unset and fall back to the OS default.
-  if noir_home = ENV["NOIR_HOME"]?.presence
-    # Env vars set outside a shell (Docker `ENV`, systemd `Environment=`,
-    # some .env loaders) never get the shell's tilde expansion, so a literal
-    # "~/noir" would otherwise resolve to a bogus "./~/noir" under the cwd.
-    # Expand a leading ~ here so the path lands where the user meant.
-    return noir_home.starts_with?('~') ? File.expand_path(noir_home, home: true) : noir_home
-  end
+# Resolves noir's config/cache/rules directory.
+module Noir::Home
+  extend self
 
-  # Fall back to the per-OS default config location. The base env var must
-  # exist; hardened containers and some CI runners unset HOME/APPDATA, so
-  # fail with a clean CLI error instead of an unhandled `Missing ENV key`
-  # (KeyError) stack trace — matching how every other subcommand errors.
-  {% if flag?(:windows) %}
-    appdata = ENV["APPDATA"]?.presence ||
-              Noir::CLI.die("Cannot locate the noir config directory: neither NOIR_HOME nor APPDATA is set. Set NOIR_HOME to a writable directory.")
-    "#{appdata}\\noir"
-  {% else %}
-    home = ENV["HOME"]?.presence ||
-           Noir::CLI.die("Cannot locate the noir config directory: neither NOIR_HOME nor HOME is set. Set NOIR_HOME to a writable directory.")
-    "#{home}/.config/noir"
-  {% end %}
+  def path
+    # NOIR_HOME wins — but only when it's set to a real value. The previous
+    # `ENV.has_key? "NOIR_HOME"` check was also true for an exported-but-empty
+    # `NOIR_HOME=""` (a shell-script bug, an unfilled container env template),
+    # which then resolved rules/config/cache to *relative* paths under the
+    # current working directory: `File.join("", "passive_rules") == "passive_rules"`.
+    # Treat an empty value the same as unset and fall back to the OS default.
+    if noir_home = ENV["NOIR_HOME"]?.presence
+      # Env vars set outside a shell (Docker `ENV`, systemd `Environment=`,
+      # some .env loaders) never get the shell's tilde expansion, so a literal
+      # "~/noir" would otherwise resolve to a bogus "./~/noir" under the cwd.
+      # Expand a leading ~ here so the path lands where the user meant.
+      return noir_home.starts_with?('~') ? File.expand_path(noir_home, home: true) : noir_home
+    end
+
+    # Fall back to the per-OS default config location. The base env var must
+    # exist; hardened containers and some CI runners unset HOME/APPDATA, so
+    # fail with a clean CLI error instead of an unhandled `Missing ENV key`
+    # (KeyError) stack trace — matching how every other subcommand errors.
+    {% if flag?(:windows) %}
+      appdata = ENV["APPDATA"]?.presence ||
+                Noir::CLI.die("Cannot locate the noir config directory: neither NOIR_HOME nor APPDATA is set. Set NOIR_HOME to a writable directory.")
+      "#{appdata}\\noir"
+    {% else %}
+      home = ENV["HOME"]?.presence ||
+             Noir::CLI.die("Cannot locate the noir config directory: neither NOIR_HOME nor HOME is set. Set NOIR_HOME to a writable directory.")
+      "#{home}/.config/noir"
+    {% end %}
+  end
 end

--- a/src/utils/passive_rules_updater.cr
+++ b/src/utils/passive_rules_updater.cr
@@ -48,7 +48,7 @@ module PassiveRulesUpdater
   # location an end-user owns. Kept out of `effective_rules_path` so
   # the CLI rules subcommand has a stable single answer.
   def self.user_rules_path : String
-    File.join(get_home, "passive_rules")
+    File.join(Noir::Home.path, "passive_rules")
   end
 
   # Where `noir scan -P` should actually read rules from. Preference


### PR DESCRIPTION
Last piece of the structural-contract series. Pure moves — behaviour-neutral by construction.

## Why

`src/` (excluding vendored `ext/`) carried **51 top-level `def`s and 19 SCREAMING constants**, in a codebase where everything else is namespaced. This takes the clearest-cut of them: 17 defs and 7 constants, leaving 34 and 12.

`src/detector/detector.cr` is the bulk. Seven functions and seven constants were hand-prefixed `detector_` / `DETECTOR_` — **a namespace spelled out by convention because there was no module to put them in**. Two did not even get the prefix: `ANDROID_SOURCE_SUBDIRS` and `ANDROID_EMBEDDED_SERVER_MARKER` sat in the global namespace under names generic enough to collide with a future analyzer's.

They move to `Noir::Detection` and drop the prefix, since the module now says it:

```crystal
detector_path_sensitive?(d)          →  Noir::Detection.path_sensitive?(d)
detector_build_applicable_lookup(ds) →  Noir::Detection.build_applicable_lookup(ds)
DETECTOR_IGNORED_DIR_NAMES           →  Noir::Detection::IGNORED_DIR_NAMES
```

`build_detector_list` and `detect_techs` stay top-level: they are the detection pass's public surface, called from `NoirRunner` and the specs, and they sit at the same level as `analysis_endpoints` on the analyzer side.

`banner` becomes `Noir::Banner.print`, `get_home` becomes `Noir::Home.path` — two one-function files whose names were general enough to be reached from anywhere by accident.

## Found while doing it

`detector.cr` was calling `Noir::LocatorKeys.reset` through a **transitive require**. It compiled in a full build and failed the moment a spec compiled the detector alone. Added explicitly — which is what #2502's own notes asked for and did not get here.

## Deliberately still global

`utils/json.cr` and `utils/yaml.cr` predicates, `any_to_bool` (186 call sites), `get_relative_path`, `escape_glob_path`, `regex_matches_with_timeout?`, and all of `utils/http_symbols.cr` — the HTTP verb vocabulary that analyzer, optimizer, output_builder and deliver all read. Those are genuinely program-wide.

`options.cr`'s parsing helpers (8 defs, 5 constants) and the four `generate_*_completion_script` functions are also accidental, and get their own commit rather than being folded in here.

## Verification

`noir -h`, a bare `noir` invocation (banner included), and `NOIR_HOME` resolution are **byte-identical** against a `main` build.

`crystal spec spec/unit_test` 4723 examples / `spec/functional_test` 22653 examples, 0 failures. Format check clean; ameba clean on the changed files.