### PR TITLE
refactor(options): move the CLI parsing helpers into a namespace

### DIFF
--- a/spec/unit_test/ai_context/features_spec.cr
+++ b/spec/unit_test/ai_context/features_spec.cr
@@ -17,7 +17,7 @@ describe "NoirAIContext::FEATURES" do
     # Not `should eq` on a literal list: the point is that the CLI derives
     # from the constant, so a bucket added in one place cannot be missing
     # from the other.
-    AI_CONTEXT_FEATURES.should eq NoirAIContext::ACCEPTED_FEATURES
+    Noir::OptionsParsing::AI_CONTEXT_FEATURES.should eq NoirAIContext::ACCEPTED_FEATURES
   end
 
   it "accepts every bucket plus the all alias, and nothing else" do
@@ -29,7 +29,7 @@ describe "NoirAIContext::FEATURES" do
 
   it "includes sources" do
     NoirAIContext::FEATURES.should contain "sources"
-    AI_CONTEXT_FEATURES.should contain "sources"
+    Noir::OptionsParsing::AI_CONTEXT_FEATURES.should contain "sources"
   end
 
   it "names callee in the singular, as the validator accepts it" do

--- a/spec/unit_test/cli/catalog_spec.cr
+++ b/spec/unit_test/cli/catalog_spec.cr
@@ -34,10 +34,10 @@ describe Noir::CLI::Catalog do
 
   it "offers every command in every shell completion" do
     scripts = [
-      generate_zsh_completion_script,
-      generate_bash_completion_script,
-      generate_fish_completion_script,
-      generate_elvish_completion_script,
+      Noir::Completions::Zsh.script,
+      Noir::Completions::Bash.script,
+      Noir::Completions::Fish.script,
+      Noir::Completions::Elvish.script,
     ]
     Noir::CLI::Catalog::COMMANDS.each do |command|
       scripts.each(&.should(contain(command.name)))
@@ -46,10 +46,10 @@ describe Noir::CLI::Catalog do
 
   it "offers every sub-action in every shell completion" do
     scripts = [
-      generate_zsh_completion_script,
-      generate_bash_completion_script,
-      generate_fish_completion_script,
-      generate_elvish_completion_script,
+      Noir::Completions::Zsh.script,
+      Noir::Completions::Bash.script,
+      Noir::Completions::Fish.script,
+      Noir::Completions::Elvish.script,
     ]
     Noir::CLI::Catalog.completable.each do |(name, values)|
       next if values.empty?
@@ -87,12 +87,12 @@ describe Noir::CLI::ScanFlags do
 
   it "completes every flag in every shell" do
     long_form_scripts = [
-      generate_zsh_completion_script,
-      generate_bash_completion_script,
-      generate_elvish_completion_script,
+      Noir::Completions::Zsh.script,
+      Noir::Completions::Bash.script,
+      Noir::Completions::Elvish.script,
     ]
     # Fish registers long flags as `-l name`, without the leading dashes.
-    fish = generate_fish_completion_script
+    fish = Noir::Completions::Fish.script
 
     Noir::CLI::ScanFlags::FLAGS.each do |flag|
       long_form_scripts.each(&.should(contain(flag.long)))

--- a/spec/unit_test/completions_spec.cr
+++ b/spec/unit_test/completions_spec.cr
@@ -2,25 +2,25 @@ require "../spec_helper"
 require "../../src/completions"
 
 describe "Completion Script Generation" do
-  it "has a generate_zsh_completion_script method" do
-    generate_zsh_completion_script.size.should be > 0
+  it "has a Noir::Completions::Zsh.script method" do
+    Noir::Completions::Zsh.script.size.should be > 0
   end
 
-  it "has a generate_bash_completion_script method" do
-    generate_bash_completion_script.size.should be > 0
+  it "has a Noir::Completions::Bash.script method" do
+    Noir::Completions::Bash.script.size.should be > 0
   end
 
-  it "has a generate_fish_completion_script method" do
-    generate_fish_completion_script.size.should be > 0
+  it "has a Noir::Completions::Fish.script method" do
+    Noir::Completions::Fish.script.size.should be > 0
   end
 
-  it "has a generate_elvish_completion_script method" do
-    generate_elvish_completion_script.size.should be > 0
+  it "has a Noir::Completions::Elvish.script method" do
+    Noir::Completions::Elvish.script.size.should be > 0
   end
 
   describe "Zsh completion" do
     it "includes all output formats" do
-      script = generate_zsh_completion_script
+      script = Noir::Completions::Zsh.script
       script.should contain("sarif")
       script.should contain("html")
       script.should contain("postman")
@@ -30,25 +30,25 @@ describe "Completion Script Generation" do
     end
 
     it "includes passive scan options" do
-      script = generate_zsh_completion_script
+      script = Noir::Completions::Zsh.script
       script.should contain("--passive-scan-severity")
       script.should contain("--passive-scan-auto-update")
       script.should contain("--passive-scan-no-update-check")
     end
 
     it "includes cache options" do
-      script = generate_zsh_completion_script
+      script = Noir::Completions::Zsh.script
       script.should contain("--cache-disable")
       script.should contain("--cache-clear")
     end
 
     it "includes technology options" do
-      script = generate_zsh_completion_script
+      script = Noir::Completions::Zsh.script
       script.should contain("--only-techs")
     end
 
     it "bundles long forms as aliases of short forms" do
-      script = generate_zsh_completion_script
+      script = Noir::Completions::Zsh.script
       # zsh spec form: '(-X --long)'{-X,--long}'[...]'
       script.should contain("(-b --base-path)")
       script.should contain("(-u --url)")
@@ -63,7 +63,7 @@ describe "Completion Script Generation" do
     end
 
     it "includes set-pvalue variants" do
-      script = generate_zsh_completion_script
+      script = Noir::Completions::Zsh.script
       %w[
         --set-pvalue
         --set-pvalue-header --set-pvalue-cookie --set-pvalue-query
@@ -72,7 +72,7 @@ describe "Completion Script Generation" do
     end
 
     it "completes `noir help <cmd>` with subcommand list" do
-      script = generate_zsh_completion_script
+      script = Noir::Completions::Zsh.script
       # The help branch must describe commands at CURRENT == 3
       script.should contain("help)")
       script.should match(/help\)\s+if \(\( CURRENT == 3 \)\); then\s+_describe -t commands/)
@@ -81,7 +81,7 @@ describe "Completion Script Generation" do
 
   describe "Bash completion" do
     it "includes all output formats" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       script.should contain("sarif")
       script.should contain("html")
       script.should contain("postman")
@@ -91,30 +91,30 @@ describe "Completion Script Generation" do
     end
 
     it "includes passive scan options" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       script.should contain("--passive-scan-severity")
       script.should contain("--passive-scan-auto-update")
       script.should contain("--passive-scan-no-update-check")
     end
 
     it "includes cache options" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       script.should contain("--cache-disable")
       script.should contain("--cache-clear")
     end
 
     it "includes passive-scan-severity completion values" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       script.should contain("critical high medium low")
     end
 
     it "includes technology options" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       script.should contain("--only-techs")
     end
 
     it "covers long-form flags in the prev case (file/value completion)" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       # File-completion branch
       script.should contain("--base-path")
       script.should contain("--url")
@@ -131,7 +131,7 @@ describe "Completion Script Generation" do
     end
 
     it "completes `noir help <cmd>` with subcommand list" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       script.should contain("help)")
       script.should contain("compgen -W \"${commands}\"")
     end
@@ -141,25 +141,25 @@ describe "Completion Script Generation" do
     # Fish completions register long flags with `-l name` (without the
     # leading --), so the substring assertions use that bare form.
     it "includes passive scan options" do
-      script = generate_fish_completion_script
+      script = Noir::Completions::Fish.script
       script.should contain("-l passive-scan-severity")
       script.should contain("-l passive-scan-auto-update")
       script.should contain("-l passive-scan-no-update-check")
     end
 
     it "includes cache options" do
-      script = generate_fish_completion_script
+      script = Noir::Completions::Fish.script
       script.should contain("-l cache-disable")
       script.should contain("-l cache-clear")
     end
 
     it "includes technology options" do
-      script = generate_fish_completion_script
+      script = Noir::Completions::Fish.script
       script.should contain("-l only-techs")
     end
 
     it "registers set-pvalue variants" do
-      script = generate_fish_completion_script
+      script = Noir::Completions::Fish.script
       %w[
         set-pvalue set-pvalue-header set-pvalue-cookie set-pvalue-query
         set-pvalue-form set-pvalue-json set-pvalue-path
@@ -167,7 +167,7 @@ describe "Completion Script Generation" do
     end
 
     it "registers legacy include-* flags and status/exclude codes" do
-      script = generate_fish_completion_script
+      script = Noir::Completions::Fish.script
       script.should contain("-l include-path")
       script.should contain("-l include-techs")
       script.should contain("-l include-callee")
@@ -176,7 +176,7 @@ describe "Completion Script Generation" do
     end
 
     it "registers AI agent flags" do
-      script = generate_fish_completion_script
+      script = Noir::Completions::Fish.script
       script.should contain("-l ai-agent")
       script.should contain("-l ai-agent-max-steps")
       script.should contain("-l ai-native-tools-allowlist")
@@ -186,26 +186,26 @@ describe "Completion Script Generation" do
 
   describe "v1 subcommand awareness" do
     it "zsh completion lists every top-level subcommand" do
-      script = generate_zsh_completion_script
+      script = Noir::Completions::Zsh.script
       %w[scan list cache config rules completion version help].each do |verb|
         script.should contain(verb)
       end
     end
 
     it "bash completion lists every top-level subcommand" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       script.should contain("scan list cache config rules completion version help")
     end
 
     it "fish completion registers each top-level subcommand" do
-      script = generate_fish_completion_script
+      script = Noir::Completions::Fish.script
       %w[scan list cache config rules completion version help].each do |verb|
         script.should contain("-a #{verb}")
       end
     end
 
     it "elvish completion registers the noir arg-completer with every verb" do
-      script = generate_elvish_completion_script
+      script = Noir::Completions::Elvish.script
       # Wires into the Elvish completion API
       script.should contain("edit:completion:arg-completer[noir]")
       # Lists each v1 verb as a candidate
@@ -217,17 +217,17 @@ describe "Completion Script Generation" do
 
   describe "Elvish completion shells/actions" do
     it "lists every supported shell, including elvish itself" do
-      script = generate_elvish_completion_script
+      script = Noir::Completions::Elvish.script
       %w[zsh bash fish elvish].each { |shell| script.should contain(shell) }
     end
 
     it "exposes config edit as a sub-action" do
-      script = generate_elvish_completion_script
+      script = Noir::Completions::Elvish.script
       script.should contain("[show edit init path]")
     end
 
     it "includes set-pvalue variants in scan-flags" do
-      script = generate_elvish_completion_script
+      script = Noir::Completions::Elvish.script
       %w[
         --set-pvalue
         --set-pvalue-header --set-pvalue-cookie --set-pvalue-query
@@ -237,7 +237,7 @@ describe "Completion Script Generation" do
     end
 
     it "handles v0 bare-flag invocations (verb starting with -)" do
-      script = generate_elvish_completion_script
+      script = Noir::Completions::Elvish.script
       # The arg-completer must accept a leading flag as implicit scan
       script.should contain("str:has-prefix $verb -")
     end
@@ -248,10 +248,10 @@ describe "Completion Script Generation" do
   # "does the string contain flag X" specs did not cover.
   describe "exploration fixes" do
     it "exposes --tls-skip-verify in every shell (matches `noir scan --help`)" do
-      generate_zsh_completion_script.should contain("--tls-skip-verify")
-      generate_bash_completion_script.should contain("--tls-skip-verify")
-      generate_fish_completion_script.should contain("-l tls-skip-verify")
-      generate_elvish_completion_script.should contain("--tls-skip-verify")
+      Noir::Completions::Zsh.script.should contain("--tls-skip-verify")
+      Noir::Completions::Bash.script.should contain("--tls-skip-verify")
+      Noir::Completions::Fish.script.should contain("-l tls-skip-verify")
+      Noir::Completions::Elvish.script.should contain("--tls-skip-verify")
     end
 
     # Asserted against the vocabulary itself, not a copy of it: the
@@ -260,25 +260,25 @@ describe "Completion Script Generation" do
     # agreed with them instead of catching it.
     it "offers every documented --ai-context bucket, including all" do
       buckets = NoirAIContext::ACCEPTED_FEATURES.join(" ")
-      generate_zsh_completion_script.should contain(buckets)
-      generate_bash_completion_script.should contain(buckets)
-      generate_fish_completion_script.should contain(buckets)
+      Noir::Completions::Zsh.script.should contain(buckets)
+      Noir::Completions::Bash.script.should contain(buckets)
+      Noir::Completions::Fish.script.should contain(buckets)
     end
 
     it "zsh completes scan positional paths (base paths)" do
       # The scan _arguments block must accept `*` positionals as files.
-      generate_zsh_completion_script.should contain("'*:path:_files'")
+      Noir::Completions::Zsh.script.should contain("'*:path:_files'")
     end
 
     it "bash falls back to filesystem completion for non-flag scan args" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       # A leading '-' means a flag; otherwise complete files/dirs.
       script.should contain("if [[ ${cur} == -* ]]; then")
       script.should contain("compgen -f -- \"${cur}\"")
     end
 
     it "bash completes --flag=value (equals) forms for enum flags" do
-      script = generate_bash_completion_script
+      script = Noir::Completions::Bash.script
       script.should contain("if [[ ${prev} == \"=\" ]]; then")
       script.should contain("${COMP_WORDS[COMP_CWORD-2]}")
     end
@@ -286,7 +286,7 @@ describe "Completion Script Generation" do
     it "bash subcommands return unconditionally so scan flags never leak" do
       # `noir cache clear <TAB>` (CWORD != 2) must not fall through to the
       # scan-flag block. Each subcommand case returns after its `if`.
-      collapsed = generate_bash_completion_script.gsub(/\s+/, " ")
+      collapsed = Noir::Completions::Bash.script.gsub(/\s+/, " ")
       %w[
         techs\ taggers\ formats
         info\ clear\ purge
@@ -299,13 +299,13 @@ describe "Completion Script Generation" do
     end
 
     it "fish guards scan flags so they don't leak into subcommands" do
-      script = generate_fish_completion_script
+      script = Noir::Completions::Fish.script
       script.should contain("function __fish_noir_scan_context")
       script.should contain("-n __fish_noir_scan_context")
     end
 
     it "fish completes `noir help <cmd>` with the subcommand list" do
-      generate_fish_completion_script.should contain(
+      Noir::Completions::Fish.script.should contain(
         "-n '__fish_noir_using_command help' -a 'scan list cache config rules completion version help'")
     end
   end

--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -360,15 +360,15 @@ describe "run_options_parser" do
     # apply_ai_context's own vocabulary check to reject with a precise
     # "unknown feature" error, instead of silently being scanned as a bogus
     # base path ("Base path does not exist: bogus,guards").
-    normalize_ai_context_flag(["--ai-context", "bogus,guards"]).should eq(["--ai-context=bogus,guards"])
-    normalize_ai_context_flag(["--ai-context", "guards,sink"]).should eq(["--ai-context=guards,sink"])
+    Noir::OptionsParsing.normalize_ai_context_flag(["--ai-context", "bogus,guards"]).should eq(["--ai-context=bogus,guards"])
+    Noir::OptionsParsing.normalize_ai_context_flag(["--ai-context", "guards,sink"]).should eq(["--ai-context=guards,sink"])
   end
 
   it "normalize_ai_context_flag still treats a single unrecognized word as a positional path" do
     # A bare single word is genuinely ambiguous with a real one-word
     # directory name (`noir scan --ai-context myapp`), so it's left alone
     # rather than folded in as a feature-list value.
-    normalize_ai_context_flag(["--ai-context", "myapp"]).should eq(["--ai-context=", "myapp"])
+    Noir::OptionsParsing.normalize_ai_context_flag(["--ai-context", "myapp"]).should eq(["--ai-context=", "myapp"])
   end
 
   it "legacy --set-pvalue-query alias still appends to set_pvalue_query" do
@@ -420,7 +420,7 @@ describe "extract_legacy_aliases" do
     legacy_to_key.each do |flag, key|
       opts = create_test_options
       args = [flag, "LEGACY_VALUE"]
-      remaining = extract_legacy_aliases(args, opts)
+      remaining = Noir::OptionsParsing.extract_legacy_aliases(args, opts)
       remaining.should be_empty
       opts[key].as_a.map(&.to_s).should eq(["LEGACY_VALUE"])
     end
@@ -435,7 +435,7 @@ describe "extract_legacy_aliases" do
 
     legacy_to_key.each do |flag, key|
       opts = create_test_options
-      remaining = extract_legacy_aliases([flag], opts)
+      remaining = Noir::OptionsParsing.extract_legacy_aliases([flag], opts)
       remaining.should be_empty
       opts[key].should be_true
     end
@@ -443,13 +443,13 @@ describe "extract_legacy_aliases" do
 
   it "leaves unrelated tokens in place for OptionParser" do
     opts = create_test_options
-    remaining = extract_legacy_aliases(["-b", "./app", "--passive", "--include", "path"], opts)
+    remaining = Noir::OptionsParsing.extract_legacy_aliases(["-b", "./app", "--passive", "--include", "path"], opts)
     remaining.should eq(["-b", "./app", "--passive", "--include", "path"])
   end
 
   it "supports repeating the same legacy flag (each occurrence appends)" do
     opts = create_test_options
-    remaining = extract_legacy_aliases(
+    remaining = Noir::OptionsParsing.extract_legacy_aliases(
       ["--set-pvalue-query", "A", "--set-pvalue-query", "B"],
       opts,
     )
@@ -459,7 +459,7 @@ describe "extract_legacy_aliases" do
 
   it "mixes legacy and v1-native tokens cleanly" do
     opts = create_test_options
-    remaining = extract_legacy_aliases(
+    remaining = Noir::OptionsParsing.extract_legacy_aliases(
       ["--include-callee", "-b", "./app", "--set-pvalue-header", "X=1"],
       opts,
     )

--- a/spec/unit_test/output_builder/formats_spec.cr
+++ b/spec/unit_test/output_builder/formats_spec.cr
@@ -52,10 +52,10 @@ describe Noir::OutputFormats do
 
   it "offers every format in every shell completion" do
     scripts = {
-      "zsh"    => generate_zsh_completion_script,
-      "bash"   => generate_bash_completion_script,
-      "fish"   => generate_fish_completion_script,
-      "elvish" => generate_elvish_completion_script,
+      "zsh"    => Noir::Completions::Zsh.script,
+      "bash"   => Noir::Completions::Bash.script,
+      "fish"   => Noir::Completions::Fish.script,
+      "elvish" => Noir::Completions::Elvish.script,
     }
     # Elvish completes `-f` by file, not by an enum list, so only the three
     # shells whose scripts carry the value list are asserted here.

--- a/src/cli/commands/completion.cr
+++ b/src/cli/commands/completion.cr
@@ -36,10 +36,10 @@ module Noir::CLI::CompletionCommand
     end
 
     case parsed.shell
-    when "zsh"    then puts generate_zsh_completion_script
-    when "bash"   then puts generate_bash_completion_script
-    when "fish"   then puts generate_fish_completion_script
-    when "elvish" then puts generate_elvish_completion_script
+    when "zsh"    then puts Noir::Completions::Zsh.script
+    when "bash"   then puts Noir::Completions::Bash.script
+    when "fish"   then puts Noir::Completions::Fish.script
+    when "elvish" then puts Noir::Completions::Elvish.script
     else
       Noir::CLI.die("Unsupported shell: #{parsed.shell}. Valid: #{SHELLS.join(", ")}.")
     end

--- a/src/cli/scan_flags.cr
+++ b/src/cli/scan_flags.cr
@@ -55,7 +55,7 @@ module Noir::CLI::ScanFlags
   end
 
   # Suggested `--include` values. The first three are the vocabulary
-  # (`INCLUDE_TARGETS` in options.cr); the combined forms are there because
+  # (`Noir::OptionsParsing::INCLUDE_TARGETS` in options.cr); the combined forms are there because
   # the flag is comma-separated and those two are what people actually type.
   INCLUDE_CHOICES = ["path", "techs", "callee", "path,techs", "path,techs,callee"]
 

--- a/src/completions/bash.cr
+++ b/src/completions/bash.cr
@@ -101,7 +101,3 @@ module Noir::Completions::Bash
     end.join("\n")
   end
 end
-
-def generate_bash_completion_script
-  Noir::Completions::Bash.script
-end

--- a/src/completions/elvish.cr
+++ b/src/completions/elvish.cr
@@ -82,7 +82,3 @@ module Noir::Completions::Elvish
     Noir::CLI::ScanFlags::NAMES.each_slice(8).map { |chunk| "  #{chunk.join(" ")}" }.join("\n")
   end
 end
-
-def generate_elvish_completion_script
-  Noir::Completions::Elvish.script
-end

--- a/src/completions/fish.cr
+++ b/src/completions/fish.cr
@@ -107,7 +107,3 @@ module Noir::Completions::Fish
     flag.takes_value? && !flag.arg.optional_choice?
   end
 end
-
-def generate_fish_completion_script
-  Noir::Completions::Fish.script
-end

--- a/src/completions/zsh.cr
+++ b/src/completions/zsh.cr
@@ -114,7 +114,3 @@ module Noir::Completions::Zsh
     end
   end
 end
-
-def generate_zsh_completion_script
-  Noir::Completions::Zsh.script
-end

--- a/src/options.cr
+++ b/src/options.cr
@@ -84,136 +84,13 @@ private def process_override_flag(
   end
 end
 
-def extract_hidden_prompt_flags(noir_options : Hash(String, YAML::Any)) : Array(String)
-  args = ARGV.dup
-  filtered = [] of String
-  i = 0
-  override_flags = {
-    "--override-analyze-prompt"        => "override_analyze_prompt",
-    "--override-llm-optimize-prompt"   => "override_llm_optimize_prompt",
-    "--override-bundle-analyze-prompt" => "override_bundle_analyze_prompt",
-    "--override-filter-prompt"         => "override_filter_prompt",
-  }
-
-  while i < args.size
-    arg = args[i]
-    if override_flags.has_key?(arg)
-      i = process_override_flag(arg, override_flags[arg], noir_options, args, i)
-    else
-      filtered << arg
-      i += 1
-    end
-  end
-  filtered = normalize_ai_context_flag(filtered)
-  filtered = extract_legacy_aliases(filtered, noir_options)
-  filtered
-end
-
-# Silently translate v0 flag spellings to their v1 storage. Keeping the
-# work here (instead of `parser.on "--include-path"`) means the legacy
-# names no longer clutter `noir scan -h`, while every v0 script keeps
-# working untouched in v1.x.
-LEGACY_PVALUE_TARGETS = {
-  "--set-pvalue"        => "set_pvalue",
-  "--set-pvalue-header" => "set_pvalue_header",
-  "--set-pvalue-cookie" => "set_pvalue_cookie",
-  "--set-pvalue-query"  => "set_pvalue_query",
-  "--set-pvalue-form"   => "set_pvalue_form",
-  "--set-pvalue-json"   => "set_pvalue_json",
-  "--set-pvalue-path"   => "set_pvalue_path",
-}
-
-LEGACY_INCLUDE_TARGETS = {
-  "--include-path"   => "include_path",
-  "--include-techs"  => "include_techs",
-  "--include-callee" => "include_callee",
-}
-
-def extract_legacy_aliases(args : Array(String), noir_options : Hash(String, YAML::Any)) : Array(String)
-  result = [] of String
-  i = 0
-  while i < args.size
-    arg = args[i]
-    if key = LEGACY_INCLUDE_TARGETS[arg]?
-      noir_options[key] = YAML::Any.new(true)
-      i += 1
-    elsif pvalue_key = LEGACY_PVALUE_TARGETS[arg]?
-      if i + 1 >= args.size
-        STDERR.puts "ERROR: #{arg} requires an argument.".colorize(:red)
-        exit(1)
-      end
-      append_to_yaml_array(noir_options, pvalue_key, args[i + 1])
-      i += 2
-    else
-      result << arg
-      i += 1
-    end
-  end
-  result
-end
-
-# `--ai-context` accepts an optional comma-separated feature list. Crystal's
-# OptionParser cannot express "optional positional value", so we rewrite
-# the few well-defined ambiguous forms upfront:
-#
-#   --ai-context                 → --ai-context=         (bare, all features)
-#   --ai-context=guards,sinks    → unchanged             (explicit value)
-#   --ai-context guards,sinks    → --ai-context=guards,sinks (heuristic)
-#   --ai-context ./app           → --ai-context=         (next token is a path)
-#
-# The heuristic for "is the next token a feature list?": lowercase words
-# joined by commas, where either (a) there's more than one comma-separated
-# word, or (b) the single word matches the fixed vocabulary below exactly.
-# A real filesystem path essentially never contains a literal comma, so
-# any multi-word comma list — typo'd feature names included — is routed
-# to `--ai-context=...` and left for the vocabulary check in
-# `apply_ai_context` to reject with a precise "unknown feature" error,
-# rather than silently falling through to "Base path does not exist:
-# <the typo>". A single bare word still has to match a known feature
-# exactly, since that shape is genuinely ambiguous with a real one-word
-# directory name (`noir scan --ai-context myapp` must keep scanning `myapp`).
-# Both this and the flag's own validator used to spell the vocabulary out
-# by hand, and both omitted `sources`.
-AI_CONTEXT_FEATURES = NoirAIContext::ACCEPTED_FEATURES
-
-def normalize_ai_context_flag(args : Array(String)) : Array(String)
-  result = [] of String
-  i = 0
-  while i < args.size
-    arg = args[i]
-    if arg == "--ai-context"
-      if i + 1 < args.size && ai_context_feature_list?(args[i + 1])
-        # Greedily absorb space-separated continuations of a comma list:
-        # `--ai-context guards, sinks` shell-splits into "guards," + "sinks",
-        # and without this the trailing "sinks" was mistaken for a positional
-        # scan path ("Base path does not exist: sinks").
-        features = [args[i + 1]]
-        j = i + 2
-        while features.last.ends_with?(",") && j < args.size && ai_context_feature_list?(args[j])
-          features << args[j]
-          j += 1
-        end
-        result << "--ai-context=#{features.join.rstrip(",")}"
-        i = j
-      else
-        result << "--ai-context="
-        i += 1
-      end
-    else
-      result << arg
-      i += 1
-    end
-  end
-  result
-end
-
 private def ai_context_feature_list?(token : String) : Bool
   return false if token.starts_with?("-")
   return false unless token.matches?(/\A[a-z,]+\z/)
   tokens = token.split(',').reject(&.empty?)
   return false if tokens.empty?
   return true if tokens.size > 1
-  AI_CONTEXT_FEATURES.includes?(tokens.first)
+  Noir::OptionsParsing::AI_CONTEXT_FEATURES.includes?(tokens.first)
 end
 
 private def base_help : String
@@ -242,6 +119,229 @@ private def base_help : String
     HELP
 end
 
+# CLI option parsing: the legacy-alias rewrites, the `--set-pvalue` /
+# `--include` / `--ai-context` target tables, and the helpers that apply
+# them to the options hash.
+#
+# These were eight top-level `def`s and five SCREAMING constants leaking
+# into every compilation unit — `INCLUDE_TARGETS` and `AI_CONTEXT_FEATURES`
+# under names generic enough to collide. `run_options_parser` stays
+# top-level: it is the CLI's entry point, same as `detect_techs` and
+# `analysis_endpoints` on the scan side.
+module Noir::OptionsParsing
+  extend self
+
+  def extract_hidden_prompt_flags(noir_options : Hash(String, YAML::Any)) : Array(String)
+    args = ARGV.dup
+    filtered = [] of String
+    i = 0
+    override_flags = {
+      "--override-analyze-prompt"        => "override_analyze_prompt",
+      "--override-llm-optimize-prompt"   => "override_llm_optimize_prompt",
+      "--override-bundle-analyze-prompt" => "override_bundle_analyze_prompt",
+      "--override-filter-prompt"         => "override_filter_prompt",
+    }
+
+    while i < args.size
+      arg = args[i]
+      if override_flags.has_key?(arg)
+        i = process_override_flag(arg, override_flags[arg], noir_options, args, i)
+      else
+        filtered << arg
+        i += 1
+      end
+    end
+    filtered = normalize_ai_context_flag(filtered)
+    filtered = extract_legacy_aliases(filtered, noir_options)
+    filtered
+  end
+
+  # Silently translate v0 flag spellings to their v1 storage. Keeping the
+  # work here (instead of `parser.on "--include-path"`) means the legacy
+  # names no longer clutter `noir scan -h`, while every v0 script keeps
+  # working untouched in v1.x.
+  LEGACY_PVALUE_TARGETS = {
+    "--set-pvalue"        => "set_pvalue",
+    "--set-pvalue-header" => "set_pvalue_header",
+    "--set-pvalue-cookie" => "set_pvalue_cookie",
+    "--set-pvalue-query"  => "set_pvalue_query",
+    "--set-pvalue-form"   => "set_pvalue_form",
+    "--set-pvalue-json"   => "set_pvalue_json",
+    "--set-pvalue-path"   => "set_pvalue_path",
+  }
+
+  LEGACY_INCLUDE_TARGETS = {
+    "--include-path"   => "include_path",
+    "--include-techs"  => "include_techs",
+    "--include-callee" => "include_callee",
+  }
+
+  def extract_legacy_aliases(args : Array(String), noir_options : Hash(String, YAML::Any)) : Array(String)
+    result = [] of String
+    i = 0
+    while i < args.size
+      arg = args[i]
+      if key = LEGACY_INCLUDE_TARGETS[arg]?
+        noir_options[key] = YAML::Any.new(true)
+        i += 1
+      elsif pvalue_key = LEGACY_PVALUE_TARGETS[arg]?
+        if i + 1 >= args.size
+          STDERR.puts "ERROR: #{arg} requires an argument.".colorize(:red)
+          exit(1)
+        end
+        append_to_yaml_array(noir_options, pvalue_key, args[i + 1])
+        i += 2
+      else
+        result << arg
+        i += 1
+      end
+    end
+    result
+  end
+
+  # `--ai-context` accepts an optional comma-separated feature list. Crystal's
+  # OptionParser cannot express "optional positional value", so we rewrite
+  # the few well-defined ambiguous forms upfront:
+  #
+  #   --ai-context                 → --ai-context=         (bare, all features)
+  #   --ai-context=guards,sinks    → unchanged             (explicit value)
+  #   --ai-context guards,sinks    → --ai-context=guards,sinks (heuristic)
+  #   --ai-context ./app           → --ai-context=         (next token is a path)
+  #
+  # The heuristic for "is the next token a feature list?": lowercase words
+  # joined by commas, where either (a) there's more than one comma-separated
+  # word, or (b) the single word matches the fixed vocabulary below exactly.
+  # A real filesystem path essentially never contains a literal comma, so
+  # any multi-word comma list — typo'd feature names included — is routed
+  # to `--ai-context=...` and left for the vocabulary check in
+  # `apply_ai_context` to reject with a precise "unknown feature" error,
+  # rather than silently falling through to "Base path does not exist:
+  # <the typo>". A single bare word still has to match a known feature
+  # exactly, since that shape is genuinely ambiguous with a real one-word
+  # directory name (`noir scan --ai-context myapp` must keep scanning `myapp`).
+  # Both this and the flag's own validator used to spell the vocabulary out
+  # by hand, and both omitted `sources`.
+  AI_CONTEXT_FEATURES = NoirAIContext::ACCEPTED_FEATURES
+
+  def normalize_ai_context_flag(args : Array(String)) : Array(String)
+    result = [] of String
+    i = 0
+    while i < args.size
+      arg = args[i]
+      if arg == "--ai-context"
+        if i + 1 < args.size && ai_context_feature_list?(args[i + 1])
+          # Greedily absorb space-separated continuations of a comma list:
+          # `--ai-context guards, sinks` shell-splits into "guards," + "sinks",
+          # and without this the trailing "sinks" was mistaken for a positional
+          # scan path ("Base path does not exist: sinks").
+          features = [args[i + 1]]
+          j = i + 2
+          while features.last.ends_with?(",") && j < args.size && ai_context_feature_list?(args[j])
+            features << args[j]
+            j += 1
+          end
+          result << "--ai-context=#{features.join.rstrip(",")}"
+          i = j
+        else
+          result << "--ai-context="
+          i += 1
+        end
+      else
+        result << arg
+        i += 1
+      end
+    end
+    result
+  end
+
+  # Split `TYPE=VAL` (or bare `VAL` → all-types) and route it into the
+  # right slot in noir_options. `--pvalue` may be repeated to set multiple
+  # values across different types.
+  PVALUE_TYPE_KEYS = {
+    "any"    => "set_pvalue",
+    "all"    => "set_pvalue",
+    "header" => "set_pvalue_header",
+    "cookie" => "set_pvalue_cookie",
+    "query"  => "set_pvalue_query",
+    "form"   => "set_pvalue_form",
+    "json"   => "set_pvalue_json",
+    "path"   => "set_pvalue_path",
+  }
+
+  def handle_pvalue(noir_options : Hash(String, YAML::Any), spec : String)
+    type, value = if idx = spec.index('=')
+                    {spec[0...idx], spec[(idx + 1)..]}
+                  else
+                    # `--pvalue query` (no '=') sets the literal value "query"
+                    # for all types. Since `query` is itself a type name, this
+                    # is almost always a forgotten '=' (meant `query=<value>`).
+                    # Warn but honor the literal so scripted usage still works.
+                    if PVALUE_TYPE_KEYS.has_key?(spec)
+                      STDERR.puts "WARNING: --pvalue #{spec.inspect} has no '=', so #{spec.inspect} is used as a literal value for all param types. Did you mean --pvalue #{spec}=<value>?".colorize(:yellow)
+                    end
+                    {"any", spec}
+                  end
+
+    key = PVALUE_TYPE_KEYS[type]?
+    if key.nil?
+      STDERR.puts "ERROR: --pvalue: unknown type '#{type}'. Valid: #{PVALUE_TYPE_KEYS.keys.join(", ")}.".colorize(:red)
+      exit(1)
+    end
+
+    append_to_yaml_array(noir_options, key, value)
+  end
+
+  INCLUDE_TARGETS = {
+    "path"   => "include_path",
+    "techs"  => "include_techs",
+    "callee" => "include_callee",
+  }
+
+  def apply_include_list(noir_options : Hash(String, YAML::Any), spec : String)
+    spec.split(',').reject(&.empty?).each do |raw|
+      target = raw.strip.downcase
+      key = INCLUDE_TARGETS[target]?
+      if key.nil?
+        STDERR.puts "ERROR: --include: unknown target '#{raw.strip}'. Valid: #{INCLUDE_TARGETS.keys.join(", ")}.".colorize(:red)
+        exit(1)
+      end
+      noir_options[key] = YAML::Any.new(true)
+    end
+  end
+
+  # `--ai-context[=LIST]` always enables AI context output. An empty LIST
+  # means "every category"; a non-empty LIST narrows the output to the
+  # named categories.
+  def apply_ai_context(noir_options : Hash(String, YAML::Any), spec : String)
+    noir_options["ai_context"] = YAML::Any.new(true)
+    validate_ai_context_features(spec, "--ai-context")
+
+    list = spec.split(',').map(&.strip.downcase).reject(&.empty?)
+    # An empty list, or one naming `all`, means every bucket. Write that out
+    # as the empty value instead of returning early: the config file is read
+    # before OptionParser runs, so an early return left a config-file
+    # `ai_context_features: "guards"` in place and `--ai-context=all` (and the
+    # bare flag) — the two spellings that mean "everything" — were the only
+    # ones that could not override it.
+    list.clear if list.includes?(NoirAIContext::FEATURE_ALL)
+
+    noir_options["ai_context_features"] = YAML::Any.new(list.join(","))
+  end
+
+  # Rejects AI-context bucket names outside the accepted vocabulary. `origin`
+  # names the source in the error so a config-file typo doesn't read as a
+  # command-line one.
+  def validate_ai_context_features(spec : String, origin : String)
+    unknown = NoirAIContext.unknown_features(spec)
+    return if unknown.empty?
+
+    # Echo the user's original spelling (not the lowercased form) so a typo
+    # like `Sinkz` reads as it was written.
+    STDERR.puts "ERROR: #{origin}: unknown feature '#{unknown.first}'. Valid: #{NoirAIContext::FEATURES.join(", ")}.".colorize(:red)
+    exit(1)
+  end
+end
+
 def run_options_parser
   # Resolve `--config-file PATH` (if present in ARGV) before
   # ConfigInitializer reads the file, so the user-supplied path
@@ -253,7 +353,7 @@ def run_options_parser
   noir_options = config_init.read_config
   noir_options["config_file"] = YAML::Any.new(override_config_path) if override_config_path
 
-  extracted_args = extract_hidden_prompt_flags(noir_options)
+  extracted_args = Noir::OptionsParsing.extract_hidden_prompt_flags(noir_options)
 
   # Tracks CSV flags whose first CLI occurrence must override (not append to)
   # a config-file value. See append_to_csv_option.
@@ -284,7 +384,7 @@ def run_options_parser
     end
 
     parser.on "--pvalue TYPE=VAL", "Set parameter value (TYPE: any|header|cookie|query|form|json|path; repeatable)" do |v|
-      handle_pvalue(noir_options, v)
+      Noir::OptionsParsing.handle_pvalue(noir_options, v)
     end
 
     parser.on "--status-codes", "Display HTTP status codes" do
@@ -305,7 +405,7 @@ def run_options_parser
       append_to_csv_option(noir_options, "exclude_path", v)
     end
     parser.on "--include LIST", "Enrich plain output (comma-separated: path,techs,callee)" do |v|
-      apply_include_list(noir_options, v)
+      Noir::OptionsParsing.apply_include_list(noir_options, v)
     end
     # Category names come from the one vocabulary so the help can no longer
     # drift from what the validator accepts. It had: it omitted `sources`
@@ -318,7 +418,7 @@ def run_options_parser
         --ai-context guards,sinks
         --ai-context=callee
       DESC
-      apply_ai_context(noir_options, v)
+      Noir::OptionsParsing.apply_ai_context(noir_options, v)
     end
     parser.on "--no-color", "Disable color output" do
       noir_options["color"] = YAML::Any.new(false)
@@ -571,97 +671,10 @@ def run_options_parser
   # run emitted `ai_context: null` for every endpoint with no diagnostic.
   # A CLI flag has already normalized its own value by this point, so this
   # only ever fires on a config-file value that survived unchanged.
-  validate_ai_context_features(
+  Noir::OptionsParsing.validate_ai_context_features(
     noir_options["ai_context_features"]?.try(&.to_s) || "",
     "config ai_context_features"
   )
 
   noir_options
-end
-
-# Split `TYPE=VAL` (or bare `VAL` → all-types) and route it into the
-# right slot in noir_options. `--pvalue` may be repeated to set multiple
-# values across different types.
-PVALUE_TYPE_KEYS = {
-  "any"    => "set_pvalue",
-  "all"    => "set_pvalue",
-  "header" => "set_pvalue_header",
-  "cookie" => "set_pvalue_cookie",
-  "query"  => "set_pvalue_query",
-  "form"   => "set_pvalue_form",
-  "json"   => "set_pvalue_json",
-  "path"   => "set_pvalue_path",
-}
-
-def handle_pvalue(noir_options : Hash(String, YAML::Any), spec : String)
-  type, value = if idx = spec.index('=')
-                  {spec[0...idx], spec[(idx + 1)..]}
-                else
-                  # `--pvalue query` (no '=') sets the literal value "query"
-                  # for all types. Since `query` is itself a type name, this
-                  # is almost always a forgotten '=' (meant `query=<value>`).
-                  # Warn but honor the literal so scripted usage still works.
-                  if PVALUE_TYPE_KEYS.has_key?(spec)
-                    STDERR.puts "WARNING: --pvalue #{spec.inspect} has no '=', so #{spec.inspect} is used as a literal value for all param types. Did you mean --pvalue #{spec}=<value>?".colorize(:yellow)
-                  end
-                  {"any", spec}
-                end
-
-  key = PVALUE_TYPE_KEYS[type]?
-  if key.nil?
-    STDERR.puts "ERROR: --pvalue: unknown type '#{type}'. Valid: #{PVALUE_TYPE_KEYS.keys.join(", ")}.".colorize(:red)
-    exit(1)
-  end
-
-  append_to_yaml_array(noir_options, key, value)
-end
-
-INCLUDE_TARGETS = {
-  "path"   => "include_path",
-  "techs"  => "include_techs",
-  "callee" => "include_callee",
-}
-
-def apply_include_list(noir_options : Hash(String, YAML::Any), spec : String)
-  spec.split(',').reject(&.empty?).each do |raw|
-    target = raw.strip.downcase
-    key = INCLUDE_TARGETS[target]?
-    if key.nil?
-      STDERR.puts "ERROR: --include: unknown target '#{raw.strip}'. Valid: #{INCLUDE_TARGETS.keys.join(", ")}.".colorize(:red)
-      exit(1)
-    end
-    noir_options[key] = YAML::Any.new(true)
-  end
-end
-
-# `--ai-context[=LIST]` always enables AI context output. An empty LIST
-# means "every category"; a non-empty LIST narrows the output to the
-# named categories.
-def apply_ai_context(noir_options : Hash(String, YAML::Any), spec : String)
-  noir_options["ai_context"] = YAML::Any.new(true)
-  validate_ai_context_features(spec, "--ai-context")
-
-  list = spec.split(',').map(&.strip.downcase).reject(&.empty?)
-  # An empty list, or one naming `all`, means every bucket. Write that out
-  # as the empty value instead of returning early: the config file is read
-  # before OptionParser runs, so an early return left a config-file
-  # `ai_context_features: "guards"` in place and `--ai-context=all` (and the
-  # bare flag) — the two spellings that mean "everything" — were the only
-  # ones that could not override it.
-  list.clear if list.includes?(NoirAIContext::FEATURE_ALL)
-
-  noir_options["ai_context_features"] = YAML::Any.new(list.join(","))
-end
-
-# Rejects AI-context bucket names outside the accepted vocabulary. `origin`
-# names the source in the error so a config-file typo doesn't read as a
-# command-line one.
-def validate_ai_context_features(spec : String, origin : String)
-  unknown = NoirAIContext.unknown_features(spec)
-  return if unknown.empty?
-
-  # Echo the user's original spelling (not the lowercased form) so a typo
-  # like `Sinkz` reads as it was written.
-  STDERR.puts "ERROR: #{origin}: unknown feature '#{unknown.first}'. Valid: #{NoirAIContext::FEATURES.join(", ")}.".colorize(:red)
-  exit(1)
 end


### PR DESCRIPTION
Companion to #2505, covering the other cluster of accidental globals. Behaviour-neutral.

## What

`src/options.cr` leaked **eight top-level `def`s and five SCREAMING constants** into every compilation unit: the legacy-alias rewrites, the `--set-pvalue` / `--include` / `--ai-context` target tables, and the helpers that apply them.

`INCLUDE_TARGETS` and `AI_CONTEXT_FEATURES` are generic enough to collide with a future analyzer's constant; `handle_pvalue` and `apply_include_list` read like methods on something. They move to `Noir::OptionsParsing`.

`run_options_parser` stays top-level — it is the CLI's entry point, at the same level as `detect_techs` and `analysis_endpoints`.

## The completion generators didn't need this

Worth writing down, because assuming otherwise is what broke it. `zsh.cr` and its three siblings **already** namespaced their real implementation as `Noir::Completions::Zsh.script`; the top-level `generate_zsh_completion_script` was a four-line delegator left over from before.

Wrapping that delegator in a module of the same name produced:

```crystal
module Noir::Completions::Zsh
  def script
    Noir::Completions::Zsh.script   # ← itself
  end
end
```

The spec suite crashed with a stack overflow **522,628 frames deep**. The delegators are simply deleted and the seven call sites point at the implementation.

## Where the global namespace landed

Across this and #2505: **51 defs and 19 constants → 14 and 7.**

What remains is deliberate: `any_to_bool` (186 call sites), the JSON/YAML predicates, `utils/http_symbols.cr`'s HTTP verb vocabulary (read by analyzer, optimizer, output_builder and deliver alike), and the four phase entry points.

## Verification

Byte-identical against a `main` build:

- all four completion scripts (`noir completion zsh|bash|fish|elvish`)
- `noir -h`
- scans under `--set-pvalue query=FUZZ`, `--include path,techs`, `--ai-context guards` — the three paths whose target tables moved

`crystal spec spec/unit_test` 4723 examples / `spec/functional_test` 22653 examples, 0 failures. Format check clean; ameba clean on the changed files.