### PR TITLE
docs: correct the tagger registration steps in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,9 @@ When adding a new framework in a language that already has an extractor, extend 
 
 ### Taggers
 1. Create `src/tagger/taggers/{tagger_name}.cr`
-2. Add unit test: `spec/unit_test/tagger/{tagger_name}_spec.cr`
-3. Register in `HasTaggers` in `src/tagger/tagger.cr`
+2. Annotate the class: `@[Noir::TaggerFor(key: "{tagger_name}", name: "{Name} Tagger", desc: "…", order: 180)]`. This is the whole registration — `src/tagger/tagger.cr` derives the registry, the `-T` key, the `noir list taggers` entry and the run dispatch from the annotation. Unlike `analyzer_for`, omitting it is *not* a compile error; `spec/unit_test/techs/registry_integrity_spec.cr` fails and names the class.
+3. `key` is also the tagger's runtime `name` — `Tagger#initialize` reads it back off the annotation, so do not assign `@name` yourself. `order` fixes the sequence plain taggers run in, which is user-visible: they run sequentially, `Endpoint#add_tag` appends, and nothing sorts tags before output. Values are spaced by 10, so append rather than renumber.
+4. Add unit test: `spec/unit_test/tagger/{tagger_name}_spec.cr`
 
 ### Framework Taggers (Auth Taggers)
 Framework taggers detect framework-specific patterns (e.g., auth decorators, middleware, guards) and tag endpoints accordingly. They extend `FrameworkTagger < Tagger` which provides file caching and `read_source_context()`.
@@ -148,9 +149,9 @@ Framework taggers detect framework-specific patterns (e.g., auth decorators, mid
    - Override `self.target_techs` to return matching technology strings (e.g., `["python_django"]`)
    - Override `perform(endpoints)` to check and tag endpoints
    - Use `read_file(path)` (cached) and `read_source_context(endpoint)` helpers
-2. Add unit test: `spec/unit_test/tagger/framework_taggers/{tagger_name}_spec.cr`
-3. Add fixtures: `spec/functional_test/fixtures/{language}/{framework}_auth/`
-4. Register in `HasFrameworkTaggers` in `src/tagger/tagger.cr`
+2. Annotate the class: `@[Noir::TaggerFor(key: "{tagger_name}", name: "{Framework} Auth Tagger", desc: "…", order: 270)]` — same annotation and same rules as plain taggers above. Framework taggers run under a `WaitGroup`, so for them `order` only sequences `noir list taggers`.
+3. Add unit test: `spec/unit_test/tagger/framework_taggers/{tagger_name}_spec.cr`
+4. Add fixtures: `spec/functional_test/fixtures/{language}/{framework}_auth/`
 
 Key design notes:
 - `FrameworkTagger` inherits from `Tagger` — shares `@logger`, `@options`, `@name`, `perform()` interface


### PR DESCRIPTION
Found while reviewing the #2488–#2506 refactoring batch.

`#2494` derived the tagger registry from the classes and deleted `HasTaggers` / `HasFrameworkTaggers`; `#2496` removed the `@name` assignments that went with them. AGENTS.md was not updated, so both tagger sections still closed with:

```
3. Register in `HasTaggers` in `src/tagger/tagger.cr`
4. Register in `HasFrameworkTaggers` in `src/tagger/tagger.cr`
```

Those two lines were the only remaining references to either constant in the repository:

```console
$ grep -rn "HasTaggers\|HasFrameworkTaggers" --exclude-dir=.git .
AGENTS.md:141:3. Register in `HasTaggers` in `src/tagger/tagger.cr`
AGENTS.md:153:4. Register in `HasFrameworkTaggers` in `src/tagger/tagger.cr`
```

Both lists also omitted the step that replaced them. A `Tagger` subclass without `@[Noir::TaggerFor(...)]` is not a compile error the way a missing `analyzer_for` is — it builds, never joins the registry, and fails `registry_integrity_spec.cr`. Following the file as written means looking for a constant that is gone, then shipping a tagger that cannot run.

This is the failure mode `#2488` was written to remove, three commits into the same batch — the section gained **"There are no registration lists to edit."** in that PR and then contradicted itself twelve lines down.

## What changed

The replacement steps follow the shape `#2488` already used for Output Formats, plus the two facts the annotation carries that are not obvious from reading it:

- `key` is read back as the instance's `@name` (`Tagger#initialize`), so assigning `@name` by hand is now redundant rather than required.
- `order` is user-visible for plain taggers — they run sequentially, `Endpoint#add_tag` appends, and nothing sorts tags before output — but only sequences `noir list taggers` for framework taggers, which run under a `WaitGroup`.

Suggested `order:` values (180, 270) are the next free slot in each group; the two groups are numbered independently.

Docs-only. `docs/content/development/` has no tagger-contribution section, so `index.ko.md` is unaffected.