### PR TITLE
docs(locator): correct the blast radius #2503 claimed

### DIFF
--- a/spec/unit_test/models/locator_lifecycle_spec.cr
+++ b/spec/unit_test/models/locator_lifecycle_spec.cr
@@ -7,15 +7,23 @@ require "../../../src/models/locator_keys"
 #
 # `detect_techs` used to clear six of the 64 locator keys by hand — the file
 # registry and the five mobile ones. Every specification key survived into
-# the next scan, so a long-lived process (diff mode, or noir used as a
-# library) drained the *previous* codebase's spec files. The only thing
-# masking it was the `File.exists?` guard in
+# the next scan, so a process that runs two detect passes without a
+# `clear_all` between them drained the *previous* codebase's spec files. The
+# only thing masking it was the `File.exists?` guard in
 # `SpecificationEngine#each_spec_file`, which passes whenever the first
 # tree's files are still on disk — i.e. always, in the case that matters.
 #
+# That case is a library caller driving `detect_techs` / `analysis_endpoints`
+# directly. The CLI never reached it: `--diff-path` is the only way to get
+# two detect passes out of one `noir` process, and `src/cli/commands/scan.cr`
+# has called `CodeLocator#clear_all` between the two halves since the flag
+# was added. #2503's message and this comment both named diff mode anyway,
+# which overstated the blast radius.
+#
 # A single-scan fixture sweep cannot see this by construction, which is why
 # it survived long enough to have a comment written about it rather than a
-# fix. This spec is the oracle; it fails on main.
+# fix. This spec is the oracle: it fails with the hand-written clear list
+# put back in place of `LocatorKeys.reset`.
 describe "locator scan lifecycle" do
   it "does not carry a previous scan's spec registrations into the next" do
     logger = NoirLogger.new(false, false, false, true)


### PR DESCRIPTION
Second finding from the #2488–#2506 review. Companion to #2507.

`spec/unit_test/models/locator_lifecycle_spec.cr`'s header names diff mode as a case the uncleared-locator-keys bug reached:

> so a long-lived process (diff mode, or noir used as a library) drained the *previous* codebase's spec files

**It did not reach diff mode.** `--diff-path` is the only way to get two detect passes out of one `noir` process — `src/cli/commands/scan.cr` holds the only two `NoirRunner#detect` call sites — and it has called `CodeLocator#clear_all` between the two halves since the flag was added:

```console
$ git show 33d7c568^:src/cli/commands/scan.cr | grep -A3 'Diffing base'
      app.logger.info "Diffing base and diff codebases."
      locator = CodeLocator.instance
      locator.clear_all
      app_diff.detect

$ git log --oneline -S "locator.clear_all" -- src/cli/commands/scan.cr
27c9951d Release v1 (#1745)
0efca165 Add codes for --diff-path
```

`clear_all` empties `@a_map` outright, so every specification key was already gone before the second `detect_techs` ran.

Confirmed empirically while reviewing the batch: `--diff-path` output is byte-identical between a build of #2503's parent (`30e724e0`) and one of its merge, over four fixture pairs spanning the specification analyzers this bug was about.

The genuinely affected case is the other half of that parenthesis — a library caller driving `detect_techs` / `analysis_endpoints` directly, which gets no `clear_all` and, by #2503's own design, no automatic reset of `Process`-lifetime keys. **The fix and the spec are both right; only the stated reach was wrong.**

## Why correct it rather than leave it

#2503's own reasoning. It rewrote the `File.exists?` comment in `specification_engine.cr` precisely because "a comment asserting a removed invariant is worse than none — the next reader deletes the guard on its authority." A reader who trusts this header and then finds `clear_all` already covering diff mode learns to distrust the surrounding paragraph too, which is the part that matters.

Also drops "it fails on main" — untrue the moment #2503 merged — for the reproduction that stays true: put the hand-written clear list back in place of `LocatorKeys.reset`.

## Not changed

`src/analyzer/engines/specification_engine.cr` needs no edit. Its rewritten comment says "a second scan in the same process", which is accurate for the library case and never names diff mode.

Comment-only; no executable line touched. `crystal tool format --check` clean, the spec's 2 examples pass.