### PR TITLE
test(locator): cover the scan-lifecycle leak at the endpoint level

### DIFF
--- a/spec/unit_test/models/locator_lifecycle_spec.cr
+++ b/spec/unit_test/models/locator_lifecycle_spec.cr
@@ -2,6 +2,7 @@ require "../../spec_helper"
 require "../../../src/detector/detector"
 require "../../../src/models/analyzer"
 require "../../../src/models/locator_keys"
+require "../../../src/models/noir"
 
 # Two detect passes in one process, over two different trees.
 #
@@ -74,5 +75,62 @@ describe "locator lifecycle reset" do
     locator.all(express.key("/app.js")).should be_empty
   ensure
     CodeLocator.instance.clear_all
+  end
+end
+
+# Run the full detect→analyze pipeline over `root` and deliberately leave the
+# locator populated. `scan_base_path_spec.cr`'s helper clears on the way out,
+# which would mask the carry-over these examples exist to catch.
+private def scan_leaving_state(root : String) : Array(String)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints.map { |endpoint| "#{endpoint.method} #{endpoint.url}" }.sort!
+end
+
+# The endpoint-level companion to the two examples above.
+#
+# Those assert the locator *registration* is gone. This asserts what an
+# embedder actually receives, which is the part that was user-visible: #2503's
+# leak did not stop at the blackboard, it put the previous codebase's
+# endpoints in the next scan's results.
+#
+# Both scans must detect the same tech or the example is vacuous. With
+# oas3-then-har the second scan never runs the OAS3 analyzer at all, so the
+# stale registrations go unread and it passes with or without the fix — two
+# distinct OAS3 subtrees is what makes it bite. Verified against a build of
+# #2503's parent, where the second scan returns 8 endpoints instead of 4, the
+# extra four being scan 1's `/gems_json` and `/gems_yml`.
+#
+# Nothing else in the suite covers this. `--diff-path` cannot reach it —
+# `src/cli/commands/scan.cr` calls `clear_all` between its two halves — and
+# the fixture sweep runs one scan per process.
+describe "locator scan lifecycle, end to end" do
+  it "does not carry a previous scan's endpoints into the next" do
+    locator = CodeLocator.instance
+    # `clear_all` does not reset the scan roots, and this drives `NoirRunner`,
+    # which publishes them. Restoring them is what keeps the example from
+    # reintroducing the cross-file coupling #2492 removed.
+    previous_bases = locator.scan_base_paths
+    oas3 = File.expand_path("#{__DIR__}/../../functional_test/fixtures/specification/oas3")
+
+    begin
+      first = scan_leaving_state("#{oas3}/param_in_path")
+      second = scan_leaving_state("#{oas3}/security_schemes")
+
+      # What a fresh process reports for the same second tree.
+      locator.clear_all
+      locator.scan_base_paths = previous_bases
+      expected = scan_leaving_state("#{oas3}/security_schemes")
+
+      first.should_not be_empty
+      expected.should_not be_empty
+      second.should eq expected
+    ensure
+      locator.clear_all
+      locator.scan_base_paths = previous_bases
+    end
   end
 end


### PR DESCRIPTION
Third and last item from the #2488–#2506 review. Follows #2507 and #2508.

`locator_lifecycle_spec.cr` proves #2503's fix at the blackboard: after a second `detect_techs`, `locator.all(OAS3_JSON)` is empty. That is the *mechanism*, not the *symptom*. Nothing asserted what an embedder actually receives — and the symptom turned out to be worse than the commit described. The leak did not stop at the locator; it put the previous codebase's **endpoints** in the next scan's results.

With #2503 reverted in the working tree, the new example fails like this:

```
Expected: ["GET /items", "GET /public", "GET /search", "POST /items"]
     got: ["GET /gems_json", "GET /gems_yml", "GET /items",
           "GET /public", "GET /search", "POST /gems_json",
           "POST /items", "PUT /gems_yml"]
```

Four endpoints from the first tree, served under the second tree's scan.

## The part that took two attempts

**Both scans have to detect the same tech, or the example is vacuous.** The obvious pairing — oas3 then har, mirroring the existing example — passes with *or without* the fix: the second scan never detects OAS3, so the OAS3 analyzer never runs and the stale registrations go unread. I wrote that version first and it passed against a build of #2503's parent, which is what exposed it as a non-test. Two distinct OAS3 subtrees is what makes it bite.

## Why nothing else covers this

`--diff-path` is the only CLI path with two detect passes in one process, and `src/cli/commands/scan.cr` calls `clear_all` between its halves. The 665-directory fixture sweep runs one scan per process. So this is reachable only by a library caller driving `NoirRunner` directly — exactly the surface #2503 fixed, and the one no A/B sweep can see.

## Order-independence

The example restores `scan_base_paths` explicitly. `clear_all` does not reset it and this drives `NoirRunner`, which publishes it; leaving it set is how `wordpress_detector_spec.cr` came to depend on another file's leftovers before #2492. Verified against the default order plus seeds `11111` / `22222` / `33333` and a random seed — 4725 examples, 0 failures each. `crystal tool format --check` and `ameba` clean.

Test-only; no `src/` change.