### PR TITLE
fix: two cross-scan state leaks

### DIFF
--- a/spec/unit_test/analyzer/cfml_pure_narrowing_spec.cr
+++ b/spec/unit_test/analyzer/cfml_pure_narrowing_spec.cr
@@ -47,3 +47,55 @@ describe "cfml_components_only?" do
     end
   end
 end
+
+# The narrowing is communicated to `Analyzer::Cfml::Pure` by writing a key
+# into the options hash `analysis_endpoints` was handed — the caller's hash,
+# which nothing clears between passes. `CodeLocator`'s lifecycle resets do not
+# reach it, because it is not a locator key.
+#
+# So the write has to be unconditional. While it was `if narrowing?` /
+# assign-true, a `true` from one pass survived into the next call on the same
+# hash: an embedder scanning a ColdBox app and then a plain-CFML app got the
+# second scan narrowed to components-only and silently lost its entire `.cfm`
+# page surface. Same shape as the scan-lifecycle leak #2503 fixed, in the one
+# remaining channel that carries state between passes.
+describe "apply_cfml_components_only!" do
+  key = Analyzer::Cfml::Pure::COMPONENTS_ONLY_OPTION
+
+  it "sets the flag when a CFML framework owns the routes" do
+    options = create_test_options
+    apply_cfml_components_only!(options, ["cfml_pure", "cfml_coldbox"])
+    any_to_bool(options[key]?).should be_true
+  end
+
+  # The regression this function exists to prevent. The flag is written into
+  # the caller's options hash and nothing clears it, so an embedder reusing
+  # one hash across two scans used to carry the first scan's narrowing into
+  # the second — silently dropping the whole `.cfm` page surface of a
+  # plain-CFML app that happened to be scanned after a ColdBox one.
+  it "clears a previous pass's flag when the next scan does not narrow" do
+    options = create_test_options
+
+    apply_cfml_components_only!(options, ["cfml_pure", "cfml_coldbox"])
+    any_to_bool(options[key]?).should be_true
+
+    apply_cfml_components_only!(options, ["cfml_pure"])
+    any_to_bool(options[key]?).should be_false
+  end
+
+  it "leaves the flag false for a scan with no CFML techs at all" do
+    options = create_test_options
+    apply_cfml_components_only!(options, ["php_laravel"])
+    any_to_bool(options[key]?).should be_false
+  end
+
+  # `Analyzer#option_flag?` reads it through `any_to_bool`, which maps a
+  # missing key and an explicit `false` to the same answer — so writing
+  # `false` is a real clear, not just a different spelling of "absent".
+  it "writes a value the analyzer layer reads as false" do
+    options = create_test_options
+    apply_cfml_components_only!(options, ["cfml_pure"])
+    options.has_key?(key).should be_true
+    any_to_bool(options[key]).should be_false
+  end
+end

--- a/spec/unit_test/models/locator_ownership_spec.cr
+++ b/spec/unit_test/models/locator_ownership_spec.cr
@@ -1,0 +1,160 @@
+require "../../spec_helper"
+require "../../../src/models/locator_keys"
+
+# `LocatorKey#owner` names the subsystem that writes the slot. Its own doc
+# comment says it is "read by the integrity spec" — and it was, but only to
+# check it was non-blank. Nothing verified that the named subsystem is the one
+# that actually writes the key.
+#
+# So the field that exists to answer "who writes this slot?" could be wrong,
+# and one of them was: `EXPRESS_ROUTER_PREFIX` declared
+# `analyzer/javascript/express` while `javascript/koa.cr` also writes it. The
+# prose above the declaration even said "and by Koa"; the metadata and the
+# comment had drifted apart with nothing in between them.
+#
+# `CodeLocator` is the one channel that carries state across a phase boundary —
+# 63 keys written by the detector pass and drained during analysis — so knowing
+# who writes what is how anyone reasons about it at all. These examples make the
+# ownership metadata true by construction instead of by good intentions.
+#
+# Companion to `locator_keys_spec.cr` (shape and lifecycle) and
+# `registry_integrity_spec.cr` (analyzer/detector/catalog agreement).
+
+# `detector/specification/har` -> `src/detector/detectors/specification/har`
+#
+# The owner is a logical subsystem path, not a literal one: the layer segment is
+# singular (`detector/`) while the directory is plural (`detector/detectors/`).
+private def owner_prefix(owner : String) : String
+  layer, rest = owner.split("/", 2)
+  "src/#{layer}/#{layer}s/#{rest}"
+end
+
+private def source_files : Array(String)
+  Dir.glob("src/**/*.cr").sort!
+end
+
+# path => source with comment lines dropped, read once; every example below
+# scans the whole tree.
+#
+# Comments are stripped because the declarations in `locator_keys.cr` document
+# the very call shapes these examples grep for — a doc comment naming
+# `ExpressConstants.file_key` would otherwise report the declaration site as a
+# writer of its own key.
+private def sources : Hash(String, String)
+  source_files.to_h do |path|
+    stripped = File.read_lines(path).reject(&.lstrip.starts_with?('#')).join('\n')
+    {path, stripped}
+  end
+end
+
+private def declared_keys : Array(Noir::LocatorKey(String) | Noir::LocatorKey(Array(String)))
+  keys = [] of Noir::LocatorKey(String) | Noir::LocatorKey(Array(String))
+  Noir::LocatorKeys::ARRAY_KEYS.each { |key| keys << key }
+  Noir::LocatorKeys::SINGLE_KEYS.each { |key| keys << key }
+  keys
+end
+
+# Constant name for a key, derived from its wire name: `apisix-json` ->
+# `APISIX_JSON`. The table generates the constants from the same string, so this
+# reverses that rather than duplicating the list.
+private def constant_name_for(key_name : String) : String
+  key_name.gsub('-', '_').upcase
+end
+
+describe "locator key ownership" do
+  it "declares an owner whose subsystem exists" do
+    missing = (declared_keys.map(&.owner) + Noir::LocatorKeys::NAMESPACES.map(&.owner))
+      .uniq!
+      .reject { |owner| Dir.exists?(owner_prefix(owner)) || File.exists?("#{owner_prefix(owner)}.cr") }
+
+    fail <<-MSG unless missing.empty?
+      these owners do not resolve to a file or directory under src/: #{missing.sort}
+      MSG
+  end
+
+  # The load-bearing one. Every `push`/`set` of a declared key must come from
+  # the subsystem that claims it.
+  it "is written only by the subsystem that owns it" do
+    all_sources = sources
+    offenders = [] of String
+
+    declared_keys.each do |key|
+      constant = constant_name_for(key.name)
+      prefix = owner_prefix(key.owner)
+      write_call = /\.(?:push|set)\(\s*(?:Noir::)?LocatorKeys::#{Regex.escape(constant)}\b/
+
+      all_sources.each do |path, source|
+        next unless source.matches?(write_call)
+        next if path.starts_with?(prefix)
+        offenders << "#{key.name} (owner #{key.owner}) written by #{path}"
+      end
+    end
+
+    fail <<-MSG unless offenders.empty?
+      a locator key written from outside its declared owner. Either the write
+      belongs in the owning subsystem, or the key is shared and `owner` should
+      name the layer that actually covers both — an owner that excludes a real
+      writer is worse than none, because it is the field everyone trusts to
+      answer "who writes this slot".
+        #{offenders.sort.join("\n  ")}
+      MSG
+  end
+
+  # Every declared key must have at least one writer, or it is a slot that can
+  # only ever read back empty.
+  it "has a writer for every declared key" do
+    all_sources = sources
+    unwritten = declared_keys.reject do |key|
+      constant = constant_name_for(key.name)
+      write_call = /\.(?:push|set)\(\s*(?:Noir::)?LocatorKeys::#{Regex.escape(constant)}\b/
+      all_sources.any? { |_, source| source.matches?(write_call) }
+    end
+
+    fail <<-MSG unless unwritten.empty?
+      these keys are declared but never written, so every read returns empty:
+      #{unwritten.map(&.name).sort!}
+      MSG
+  end
+
+  # The runtime-minted family cannot be found by constant name at the push site:
+  # the key is a local built from the scanned path. What is greppable is the
+  # minting call, centralised in `ExpressConstants`.
+  #
+  # Minting alone is not writing — `Noir::JSRouteExtractor` mints the same keys
+  # to *read* them back, which is the whole point of the namespace. A writer is a
+  # file that mints and then pushes, and a push of a minted key takes a local
+  # variable rather than a `LocatorKeys::` constant. That pair is what identifies
+  # `koa.cr` and `express/router_mount_scanner.cr`, and it is the check the
+  # `analyzer/javascript/express` owner failed.
+  it "writes namespace keys only from the owning subsystem" do
+    namespace = Noir::LocatorKeys::EXPRESS_ROUTER_PREFIX
+    prefix = owner_prefix(namespace.owner)
+    minting = /ExpressConstants\.(?:file|function)_key\b|LocatorKeys::EXPRESS_ROUTER_PREFIX\.key\b/
+    local_push = /\.push\(\s*[a-z_][a-z_0-9]*\s*,/
+
+    writers = sources.select { |_, source| source.matches?(minting) && source.matches?(local_push) }.keys
+    offenders = writers.reject(&.starts_with?(prefix)).sort!
+
+    fail <<-MSG unless offenders.empty?
+      these files write `#{namespace.prefix}` keys from outside the declared
+      owner (#{namespace.owner}):
+        #{offenders.join("\n  ")}
+      MSG
+
+    # Guards this example specifically: if the minting helper is renamed, the
+    # scan would find no writers and pass while checking nothing.
+    writers.size.should eq 2
+  end
+
+  # Guards the guards. Every example above is a source scan, so a broken glob or
+  # a mis-derived constant name would make all of them pass vacuously.
+  it "resolves every declared key to a constant that exists" do
+    declared_keys.size.should eq 63
+    source_files.size.should be > 500
+
+    # The regex used above must actually match something for a key known to be
+    # written, or the ownership check is inspecting nothing.
+    har = sources["src/detector/detectors/specification/har.cr"]
+    har.matches?(/\.push\(\s*Noir::LocatorKeys::HAR_PATH\b/).should be_true
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -65,6 +65,30 @@ def cfml_components_only?(selected_techs : Array(String)) : Bool
     selected_techs.any? { |tech| CFML_FRAMEWORK_TECHS.includes?(tech) }
 end
 
+# Publishes the narrowing decision into the options hash, which is how
+# `Analyzer::Cfml::Pure` receives it.
+#
+# **Assigns on every pass, never only when true.** The key is written into the
+# *caller's* options hash and nothing clears it — `CodeLocator`'s lifecycle
+# resets cannot reach it, because it is not a locator key. Written
+# conditionally (the previous `if cfml_components_only? ... = true` shape), a
+# `true` from one scan survived into the next `analysis_endpoints` call on the
+# same hash: a library embedder that scanned a ColdBox app and then a
+# plain-CFML app got the second scan silently narrowed to components-only and
+# lost its entire `.cfm` page surface. Same shape as the scan-lifecycle leak
+# #2503 fixed, in the one remaining channel that carries state between passes.
+#
+# The CLI never hit it — `cli/commands/scan.cr` dups the hash before the diff
+# scan — so only embedders reusing one hash were affected.
+#
+# Extracted from `analysis_endpoints` for the same reason
+# `cfml_components_only?` was: in place, the only way to exercise it was to
+# run every analyzer.
+def apply_cfml_components_only!(options : Hash(String, YAML::Any), selected_techs : Array(String)) : Nil
+  options[Analyzer::Cfml::Pure::COMPONENTS_ONLY_OPTION] =
+    YAML::Any.new(cfml_components_only?(selected_techs))
+end
+
 # Drops techs that another detected tech supersedes. The rules live on the
 # superseding tech's catalog entry as `:supersedes`; see the doc on
 # `NoirTechs::SUPERSEDES` for what belongs there and — more importantly —
@@ -116,9 +140,7 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   # Run tech analyzers concurrently to avoid long stalls from a single analyzer
   selected_techs = filter_redundant_generic_techs(techs).select { |t| analyzer.has_key?(t) }
 
-  if cfml_components_only?(selected_techs)
-    options[Analyzer::Cfml::Pure::COMPONENTS_ONLY_OPTION] = YAML::Any.new(true)
-  end
+  apply_cfml_components_only!(options, selected_techs)
 
   mutex = Mutex.new
 

--- a/src/models/locator_keys.cr
+++ b/src/models/locator_keys.cr
@@ -104,12 +104,26 @@ module Noir::LocatorKeys
   {% end %}
 
   # Runtime-minted key family: `express_router_prefix:<file>[:<function>]`.
-  # Written during analysis by the Express router-mount scanner and by Koa,
-  # read by the shared JS route extractor.
+  #
+  # The prose above this declaration always said "written by the Express
+  # router-mount scanner **and by Koa**", but the `owner` field said
+  # `analyzer/javascript/express` — which covers `express.cr` and
+  # `express/router_mount_scanner.cr` and excludes `koa.cr`. The comment and the
+  # metadata disagreed, and nothing checked the metadata beyond it being
+  # non-blank, so the field that exists to answer "who writes this slot" was the
+  # one place in the typed-key registry that was wrong.
+  #
+  # The owner is the JavaScript analyzer family, which is what both writers
+  # actually are. They mint through `ExpressConstants.file_key` /
+  # `.function_key`, and `Noir::JSRouteExtractor` reads it — two analyzers and a
+  # shared extractor, none of which is "express" specifically.
+  #
+  # `spec/unit_test/models/locator_ownership_spec.cr` now verifies this against
+  # the source rather than trusting it.
   EXPRESS_ROUTER_PREFIX = ::Noir::LocatorKeyNamespace.new(
     "express_router_prefix",
     ::Noir::LocatorKey::Lifecycle::AnalyzeScoped,
-    "analyzer/javascript/express")
+    "analyzer/javascript")
 
   NAMESPACES = [EXPRESS_ROUTER_PREFIX]
 


### PR DESCRIPTION
Two real defects, both in the channels that carry state between phases or
between scans. No refactoring — just the fixes and their regression tests.

### 1. The CFML narrowing flag never got cleared

`analysis_endpoints` told `Analyzer::Cfml::Pure` to narrow to components-only
mode by writing a key into the options hash it was handed, and only ever wrote
it when the answer was `true`. That hash belongs to the caller and nothing
clears the key — `CodeLocator`'s lifecycle resets cannot reach it, because it is
not a locator key.

So a `true` from one pass survived into the next `analysis_endpoints` call on the
same hash. A library embedder scanning a ColdBox app and then a plain-CFML app
got the second scan silently narrowed, losing its entire `.cfm` page surface:
every endpoint outside the `access="remote"` methods simply did not appear, with
no error. Same shape as the scan-lifecycle leak #2503 fixed.

The CLI never hit it — `cli/commands/scan.cr` dups the hash before the diff scan
— so only embedders reusing one hash were affected.

The write is now unconditional, so the flag is `true` or `false` per pass and
cannot be sticky. Moved into `apply_cfml_components_only!` for the same reason
`cfml_components_only?` was extracted in 2c06e0eb: in place, the only way to
exercise it was to run every analyzer.

### 2. `EXPRESS_ROUTER_PREFIX` named the wrong owner

`LocatorKey#owner` names the subsystem that writes a slot, and its doc comment
claims it is "read by the integrity spec". It was — but only to check it was
non-blank. Nothing verified the named subsystem is the one that actually writes
the key.

`EXPRESS_ROUTER_PREFIX` declared `analyzer/javascript/express`, which excludes
`javascript/koa.cr` — which also writes it. The prose directly above the
declaration even said "and by Koa": the comment and the metadata had drifted
apart with nothing in between them. The owner is now `analyzer/javascript`.

`spec/unit_test/models/locator_ownership_spec.cr` makes it checked rather than
trusted: every `push`/`set` of a declared key must come from its declared owner,
every declared key must have a writer, every owner must resolve to a real path,
and the runtime-minted namespace is checked through its minting helper (minting
alone is not writing — the shared JS extractor mints the same keys to *read*
them, so a writer is a file that mints *and* pushes a local).

### Verification

Each fix was verified by reverting it and confirming the new spec fails:
restoring the conditional CFML write fails 2 examples; restoring the old owner
fails and names `koa.cr`; adding a `HAR_PATH` write to an unrelated detector
fails and names that file. Every example carries a guard against passing
vacuously.

Unit 4734, functional 22653, format and ameba all green.