### PR TITLE
ci: cache the build, and stop scanning at spec-collection time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,15 @@ jobs:
       # `crystal spec spec/unit_test --order <seed>` reproduces it exactly.
       - name: Run unit tests in randomized order
         run: crystal spec spec/unit_test --order random
+      # The functional suite passes randomized today, which is worth fencing
+      # even though the property is currently cheap to hold: `FunctionalTester`
+      # runs each scan at *collection* time and the examples only assert over
+      # already-materialized structs, so shuffling examples shuffles no work.
+      # The fence matters for what comes next — moving those scans inside the
+      # examples is what makes ordering load-bearing, and this step is what
+      # will catch it if that change introduces an order dependency.
+      - name: Run functional tests in randomized order
+        run: crystal spec spec/functional_test --order random
   build-snapcraft:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,42 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal-version }}
+      - name: Cache shards
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib
+            .shards.info
+          key: shards-${{ runner.os }}-${{ hashFiles('shard.lock') }}
+      - name: Cache tree-sitter objects
+        id: ts-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/ext/tree_sitter/runtime/lib.o
+            src/ext/tree_sitter/grammars/*/*.o
+          key: treesitter-${{ runner.os }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
+      - name: Refresh restored object mtimes
+        if: steps.ts-cache.outputs.cache-hit == 'true'
+        # `build.sh` decides staleness by mtime (`[ "$SRC" -nt "$OBJ" ]`), and
+        # `actions/checkout` stamps every source with the checkout time while
+        # the cache restores objects with their original, older mtime. Without
+        # this the objects always look stale and the cache buys nothing.
+        # Touching them is correct by construction: the cache key hashes every
+        # tree-sitter source plus build.sh, so a hit means the sources are
+        # byte-identical to when these objects were compiled.
+        run: find src/ext/tree_sitter -name '*.o' -exec touch {} +
+      - name: Cache Crystal compiler cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/crystal
+          # Crystal fingerprints its own cache entries by content, so a
+          # partially-stale restore is safe — it only ever means some entries
+          # get recompiled. Hence the loose restore-keys ladder.
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
+          restore-keys: |
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-
       - name: Install dependencies
         run: shards install
       - name: Build
@@ -104,6 +140,22 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: 1.21.0
+      - name: Cache shards
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib
+            .shards.info
+          key: shards-${{ runner.os }}-${{ hashFiles('shard.lock') }}
+      - name: Cache Crystal compiler cache
+        uses: actions/cache@v4
+        with:
+          # This job compiles Ameba, not noir, so it needs no tree-sitter
+          # objects — and its cache entries are disjoint from the other jobs'.
+          path: ~/.cache/crystal
+          key: crystal-${{ runner.os }}-1.21.0-lint-${{ hashFiles('shard.lock') }}
+          restore-keys: |
+            crystal-${{ runner.os }}-1.21.0-lint-
       - name: Install dependencies
         run: shards install
       - name: Run Ameba linter
@@ -124,6 +176,34 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal-version }}
+      - name: Cache shards
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib
+            .shards.info
+          key: shards-${{ runner.os }}-${{ hashFiles('shard.lock') }}
+      - name: Cache tree-sitter objects
+        id: ts-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/ext/tree_sitter/runtime/lib.o
+            src/ext/tree_sitter/grammars/*/*.o
+          key: treesitter-${{ runner.os }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
+      - name: Refresh restored object mtimes
+        if: steps.ts-cache.outputs.cache-hit == 'true'
+        # See the identical step in build-crystal for why this is needed and
+        # why it is safe.
+        run: find src/ext/tree_sitter -name '*.o' -exec touch {} +
+      - name: Cache Crystal compiler cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/crystal
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-${{ hashFiles('shard.lock', 'src/**/*.cr', 'spec/**/*.cr') }}
+          restore-keys: |
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-
       - name: Install dependencies
         run: shards install
       - name: Run unit tests

--- a/justfile
+++ b/justfile
@@ -93,6 +93,21 @@ test-func:
 test-uncovered:
     crystal spec spec/uncovered_test
 
+# The fastest feedback loop while working on a single analyzer — ~8.5s
+# against ~16.5s for the whole suite. Almost all of that is compiling src/,
+# not running the test (the run itself is ~0.06s), so narrowing further
+# buys nothing.
+#
+# Run one functional tester, e.g. `just test-func-one javascript/hono`.
+[group('development')]
+test-func-one TESTER:
+    crystal spec spec/functional_test/testers/{{TESTER}}_spec.cr
+
+# Run every functional tester for one language: `just test-func-lang python`.
+[group('development')]
+test-func-lang LANG:
+    crystal spec spec/functional_test/testers/{{LANG}}
+
 # Check version consistency across all files.
 [group('development')]
 version-check:

--- a/spec/AGENTS.md
+++ b/spec/AGENTS.md
@@ -72,13 +72,33 @@ Two things worth knowing before you try to make that faster:
   The number of spec files barely matters — 55 python testers compile in about
   the same time as all 576. So narrowing the target below one file, or
   sharding the suite across jobs, buys nothing.
-- **`--example` does not skip work.** `FunctionalTester` runs `detect` and
-  `analyze` in the method body — at spec *collection* time — and the `it`
-  blocks only assert over the already-computed result. So a filter cannot
-  avoid scanning all 576 fixtures:
-  `--example zzz_no_such_example` reports `0 examples` and still costs
-  **~6.8s**, and `--dry-run` (which executes no example bodies) costs ~6.9s.
-  Pass a **path**, not a filter.
+- **`--example` works too, and is cheap.** `FunctionalTester` scans lazily: the
+  first example to run triggers its tester's scan, so a filter only pays for the
+  testers it selects. `--example hono` costs ~0.2s of run time against ~6.9s
+  before the scans moved out of collection time. It still pays the ~8.5s
+  compile, so a path and a filter cost about the same — use whichever names what
+  you want.
+
+### Assertions go inside the example
+
+`FunctionalTester` scans on first use from *inside* an example. So when you
+reach past `perform_tests` for a one-off assertion, do the lookup in the `it`
+block:
+
+```crystal
+it "keeps a single path param" do
+  endpoint = tester.endpoints.find { |ep| ep.url == "/users/:id" }   # scans here
+  ...
+end
+```
+
+Not in the `describe` body, which runs at collection time. Crystal installs its
+spec runner with `at_exit` and skips it entirely when the process is already
+exiting on an error, so anything that raises during collection takes the whole
+run down and reports `0 examples` — no failure, no name, nothing to grep. That
+is what moving the scan into the examples fixed; putting it back reintroduces
+it. `tester.url = ...` is the one pre-scan setter, and it raises if the scan has
+already run.
 
 ## How to Add a Functional Test
 

--- a/spec/AGENTS.md
+++ b/spec/AGENTS.md
@@ -53,6 +53,33 @@ just test-func         # Run functional tests only
 just test-uncovered    # Run uncovered tests only (not in CI)
 ```
 
+### While working on one analyzer
+
+Don't run the whole suite on every edit. Target the one tester:
+
+```bash
+just test-func-one javascript/hono    # crystal spec spec/functional_test/testers/javascript/hono_spec.cr
+just test-func-lang python            # every tester under testers/python/
+```
+
+Measured on this repo: one tester **~8.5s**, one language directory ~10.5s,
+the whole functional suite ~16.5s.
+
+Two things worth knowing before you try to make that faster:
+
+- **Compiling `src/` is essentially the whole cost.** The single-tester run
+  above executes its 78 examples in ~0.06s; the other ~8.5s is the compiler.
+  The number of spec files barely matters — 55 python testers compile in about
+  the same time as all 576. So narrowing the target below one file, or
+  sharding the suite across jobs, buys nothing.
+- **`--example` does not skip work.** `FunctionalTester` runs `detect` and
+  `analyze` in the method body — at spec *collection* time — and the `it`
+  blocks only assert over the already-computed result. So a filter cannot
+  avoid scanning all 576 fixtures:
+  `--example zzz_no_such_example` reports `0 examples` and still costs
+  **~6.8s**, and `--dry-run` (which executes no example bodies) costs ~6.9s.
+  Pass a **path**, not a filter.
+
 ## How to Add a Functional Test
 
 ### 1. Add Fixture Code

--- a/spec/functional_test/func_spec.cr
+++ b/spec/functional_test/func_spec.cr
@@ -9,6 +9,37 @@ module Noir
   {% end %}
 end
 
+# Drives one fixture through a real scan and asserts the endpoints it produced.
+#
+# ## Registration is side-effect free
+#
+# `test_detect` / `test_analyze` used to call `@app.detect` / `@app.analyze` in
+# the method body — at spec *collection* time — and register `it` blocks that
+# only asserted over the already-computed result. Two consequences, both
+# measured:
+#
+#   * `--dry-run`, which executes no example bodies, still cost ~6.9s, and
+#     `--example zzz_no_match` reported `0 examples` and still cost ~6.8s. No
+#     filter could skip the scans, so there was no way to run one analyzer's
+#     tester without running all 576.
+#   * far worse: Crystal's runner is installed via `at_exit` and skips itself
+#     when the process is already exiting on an error (`spec/dsl.cr:186`). A
+#     single analyzer raising during collection therefore reported
+#     `0 examples, 0 failures` and named nothing — 22k examples silently
+#     replaced by a blank screen, which is exactly the failure a contributor
+#     (or an agent) hits on a branch that broke one analyzer.
+#
+# The scan is now lazy: examples are registered from `@expected_endpoints`,
+# which is known at collection time, and the first example to run triggers the
+# scan. A raise surfaces as a normal failing example and every other tester
+# still reports.
+#
+# ## The exception is memoized too
+#
+# `@scan_error` matters as much as `@scanned`. Marking the scan "done" and
+# leaving a half-populated `@app` behind would turn one real error into one real
+# error plus ~40 "expected endpoint not found" red herrings. Re-raising the
+# stored exception makes every example in the tester name the actual cause.
 class FunctionalTester
   # expected_count's symbols are:
   # :techs
@@ -17,6 +48,8 @@ class FunctionalTester
   @expected_endpoints : Array(Endpoint)
   @app : NoirRunner
   @path : String
+  @scanned = false
+  @scan_error : Exception? = nil
 
   def initialize(@path, expected_count, expected_endpoints, option_overrides : Hash(String, YAML::Any)? = nil)
     config_init = ConfigInitializer.new
@@ -40,13 +73,78 @@ class FunctionalTester
     @app = NoirRunner.new noir_options
   end
 
-  def test_detect
-    @app.detect
-    if @expected_count.has_key?(:techs)
-      it "test detect using count check [#{@path}]" do
-        @app.techs.size.should eq @expected_count[:techs]
-      end
+  # Runs the scan once, on first use from inside an example.
+  #
+  # `CodeLocator` is a process-wide singleton, so it is reset here rather than
+  # at registration: whichever tester runs first must not inherit the previous
+  # one's file map. Crystal's spec runner is single-threaded, so no two
+  # `ensure_scanned` calls interleave.
+  private def ensure_scanned
+    if error = @scan_error
+      raise error
     end
+    return if @scanned
+
+    begin
+      CodeLocator.instance.clear_all
+      @app.detect
+      @app.analyze
+    rescue e
+      @scan_error = e
+      raise e
+    ensure
+      @scanned = true
+    end
+  end
+
+  # The scanned runner. Reading it runs the scan; see `url=` for the pre-scan
+  # configuration path, which must not.
+  def app
+    ensure_scanned
+    @app
+  end
+
+  def endpoints : Array(Endpoint)
+    app.endpoints
+  end
+
+  # Pre-scan configuration. Writes straight to `@app.options` — going through
+  # `app` would run the scan and *then* change an option it had already read.
+  #
+  # The guard is the point: silently configuring a scan that already happened is
+  # how a tester ends up asserting against a stale result.
+  def url=(url)
+    raise "FunctionalTester[#{@path}]: options changed after the scan already ran" if @scanned
+    @app.options["url"] = YAML::Any.new(url)
+  end
+
+  # An expected endpoint's actual counterpart. "Not found" is an assertion
+  # failure inside the example rather than a branch taken while registering
+  # examples.
+  #
+  # Every example for a missing endpoint fails with the same greppable line, so
+  # one absent endpoint is noisy (~1 failure per detail checked) but always names
+  # the tester and the endpoint. The previous shape produced exactly one failure
+  # here — and zero for a raising analyzer, which is the trade this makes.
+  private def actual_endpoint(expected : Endpoint) : Endpoint
+    key = "#{expected.method}::#{expected.url}"
+    endpoints.find { |e| e.method == expected.method && e.url == expected.url } ||
+      fail("MISSING ENDPOINT [#{key}] in tester: #{@path}")
+  end
+
+  private def actual_params(expected : Endpoint, name : String) : Array(Param)
+    found = actual_endpoint(expected).params.select { |param| param.name == name }
+    if found.empty?
+      key = "#{expected.method}::#{expected.url}"
+      fail("MISSING PARAM [#{name}] on [#{key}] in tester: #{@path}")
+    end
+    found
+  end
+
+  private def actual_callee(expected : Endpoint, name : String) : Callee
+    key = "#{expected.method}::#{expected.url}"
+    actual_endpoint(expected).callees.find { |callee| callee.name == name } ||
+      fail("MISSING CALLEE [#{name}] on [#{key}] in tester: #{@path}")
   end
 
   def find_endpoint(key)
@@ -59,99 +157,77 @@ class FunctionalTester
     nil
   end
 
-  def find_param(param_name)
-    if @expected_endpoints.params.size > 0
-      @expected_endpoints.params.each do |param|
-        if param.name.to_s == param_name.to_s
-          return param
-        end
-      end
-    end
+  def test_detect
+    return unless @expected_count.has_key?(:techs)
 
-    nil
+    it "test detect using count check [#{@path}]" do
+      app.techs.size.should eq @expected_count[:techs]
+    end
   end
 
   def test_analyze
-    @app.analyze
     if @expected_count.has_key?(:endpoints)
       it "test analyze using count check [#{@path}]" do
-        @app.endpoints.size.should eq @expected_count[:endpoints]
+        endpoints.size.should eq @expected_count[:endpoints]
       end
     end
 
-    if @expected_endpoints.size > 0
-      @expected_endpoints.each do |expected|
-        key = expected.method.to_s + "::" + expected.url.to_s
-        actual = @app.endpoints.find { |e| e.method == expected.method && e.url == expected.url }
-        if actual.nil?
-          it "expected endpoint [#{key}] not found in tester: #{@path}" do
-            false.should be_true
+    @expected_endpoints.each do |expected|
+      key = expected.method.to_s + "::" + expected.url.to_s
+
+      describe "endpoint check [#{key}]" do
+        it "check - url [K: #{key}]" do
+          actual_endpoint(expected).url.should eq expected.url
+        end
+
+        it "check - method [K: #{key}]" do
+          actual_endpoint(expected).method.should eq expected.method
+        end
+
+        if expected.protocol != "http"
+          it "check - protocol [K: #{key}]" do
+            actual_endpoint(expected).protocol.should eq expected.protocol
           end
-        else
-          describe "endpoint check [#{key}]" do
-            it "check - url [K: #{key}]" do
-              actual.url.should eq expected.url
-            end
+        end
 
-            it "check - method [K: #{key}]" do
-              actual.method.should eq expected.method
-            end
+        if expected.params.size > 0
+          describe "check - params" do
+            expected.params.each do |param|
+              it "check '#{param.name}' name " do
+                actual_params(expected, param.name)[0].name.should eq param.name
+              end
 
-            if expected.protocol != "http"
-              it "check - protocol [K: #{key}]" do
-                actual.protocol.should eq expected.protocol
+              it "check '#{param.name}' param_type '#{param.param_type}'" do
+                actual_params(expected, param.name)
+                  .any? { |found| found.param_type == param.param_type }
+                  .should be_true
               end
             end
+          end
+        end
 
-            if expected.params.size > 0
-              describe "check - params" do
-                expected.params.each do |param|
-                  found_params = actual.params.select { |found_p| found_p.name == param.name }
-                  if found_params.size == 0
-                    it "param '#{param.name}' not found for [#{key}] in tester: #{@path}" do
-                      false.should be_true
-                    end
-                  else
-                    it "check '#{param.name}' name " do
-                      param.name.should eq found_params[0].name
-                    end
-                    it "check '#{param.name}' param_type '#{param.param_type}'" do
-                      (found_params.any? { |found_p| found_p.param_type == param.param_type }).should be_true
-                    end
-                  end
+        if expected.callees.size > 0
+          describe "check - callees" do
+            expected.callees.each do |callee|
+              it "check '#{callee.name}' name" do
+                actual_callee(expected, callee.name).name.should eq callee.name
+              end
+
+              # Only compare the line when the spec author set one; most specs
+              # only care about names, but Pyramid-style cases need to verify
+              # def-line threading.
+              if expected_line = callee.line
+                it "check '#{callee.name}' line #{expected_line}" do
+                  actual_callee(expected, callee.name).line.should eq expected_line
                 end
               end
-            end
 
-            if expected.callees.size > 0
-              describe "check - callees" do
-                expected.callees.each do |callee|
-                  found = actual.callees.find { |c| c.name == callee.name }
-                  if found.nil?
-                    it "callee '#{callee.name}' not found for [#{key}] in tester: #{@path}" do
-                      false.should be_true
-                    end
-                  else
-                    it "check '#{callee.name}' name" do
-                      callee.name.should eq found.name
-                    end
-                    # Only compare the line when the spec author set one;
-                    # most specs only care about names, but Pyramid-style
-                    # cases need to verify def-line threading.
-                    if expected_line = callee.line
-                      it "check '#{callee.name}' line #{expected_line}" do
-                        found.line.should eq expected_line
-                      end
-                    end
-                    if expected_path = callee.path
-                      it "check '#{callee.name}' path #{expected_path}" do
-                        actual_path = found.path
-                        actual_path.should_not be_nil
-                        if actual_path
-                          File.expand_path(actual_path).should eq File.expand_path(expected_path)
-                        end
-                      end
-                    end
+              if expected_path = callee.path
+                it "check '#{callee.name}' path #{expected_path}" do
+                  actual_path = actual_callee(expected, callee.name).path
+                  actual_path.should_not be_nil
+                  if actual_path
+                    File.expand_path(actual_path).should eq File.expand_path(expected_path)
                   end
                 end
               end
@@ -163,18 +239,7 @@ class FunctionalTester
   end
 
   def perform_tests
-    # Describe block removed from here
-    locator = CodeLocator.instance
-    locator.clear_all
     test_detect
     test_analyze
-  end
-
-  def app
-    @app
-  end
-
-  def url=(url)
-    @app.options["url"] = YAML::Any.new(url)
   end
 end

--- a/spec/functional_test/testers/etc/file_based_spec.cr
+++ b/spec/functional_test/testers/etc/file_based_spec.cr
@@ -69,7 +69,10 @@ tester = FunctionalTester.new("fixtures/etc/file_based/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints)
 
-tester.app.options["url"] = YAML::Any.new("https://www.hahwul.com")
+# Pre-scan configuration, so it must not go through `tester.app` — reading that
+# runs the scan. `url=` writes the option and guards against being called after
+# the scan already happened.
+tester.url = "https://www.hahwul.com"
 
 # The url-matching FileAnalyzer hooks only run with `-u`, which is set on the
 # runner above — so the assertions have to be kicked off after it, not by the

--- a/spec/functional_test/testers/javascript/cli_spec.cr
+++ b/spec/functional_test/testers/javascript/cli_spec.cr
@@ -124,14 +124,8 @@ describe "command-line-args scoping keeps unrelated fields out" do
     :techs => 1,
   }, [] of Endpoint)
 
-  locator = CodeLocator.instance
-  locator.clear_all
-  tester.app.detect
-  tester.app.analyze
-
-  endpoint = tester.app.endpoints.find { |ep| ep.url == "cli://cladfpdemo" }
-
   it "does not leak the unrelated 'email'/'age' field-schema keys as flags" do
+    endpoint = tester.endpoints.find { |ep| ep.url == "cli://cladfpdemo" }
     endpoint.should_not be_nil
     if endpoint
       bogus = endpoint.params.select { |p| {"email", "age"}.includes?(p.name) }
@@ -178,14 +172,8 @@ describe "bare 'getopts' substring does not grant CLI evidence" do
     :techs => 1,
   }, [] of Endpoint)
 
-  locator = CodeLocator.instance
-  locator.clear_all
-  tester.app.detect
-  tester.app.analyze
-
-  endpoint = tester.app.endpoints.find { |ep| ep.url == "cli://getoptsfpdemo" }
-
   it "does not attach API_TOKEN from the getopts-comment-only file" do
+    endpoint = tester.endpoints.find { |ep| ep.url == "cli://getoptsfpdemo" }
     endpoint.should_not be_nil
     if endpoint
       bogus = endpoint.params.select { |p| p.name == "API_TOKEN" }

--- a/spec/functional_test/testers/typescript/nestjs_param_dedupe_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_param_dedupe_spec.cr
@@ -5,14 +5,11 @@ describe "nestjs param dedupe" do
     :techs => 1,
   }, [] of Endpoint)
 
-  locator = CodeLocator.instance
-  locator.clear_all
-  tester.app.detect
-  tester.app.analyze
-
-  endpoint = tester.app.endpoints.find { |ep| ep.method == "DELETE" && ep.url == "/users/:id" }
-
+  # The lookup lives inside the example: `FunctionalTester` scans lazily on
+  # first use, so driving `detect`/`analyze` out here would put the scan back at
+  # collection time — where a raise takes the whole run down and reports nothing.
   it "keeps a single path param for DELETE /users/:id" do
+    endpoint = tester.endpoints.find { |ep| ep.method == "DELETE" && ep.url == "/users/:id" }
     endpoint.should_not be_nil
     if endpoint
       path_params = endpoint.params.select { |param| param.name == "id" && param.param_type == "path" }

--- a/spec/uncovered_test/func_spec.cr
+++ b/spec/uncovered_test/func_spec.cr
@@ -9,6 +9,42 @@ module Noir
   {% end %}
 end
 
+# Staging area twin of `spec/functional_test/func_spec.cr` — see that file for
+# why the scan is lazy and why the exception is memoized. Kept structurally
+# identical on purpose: this tree is not run in CI (`just test-uncovered` only),
+# so a divergence here fails silently and only when someone remembers to run it.
+#
+# Drives one fixture through a real scan and asserts the endpoints it produced.
+#
+# ## Registration is side-effect free
+#
+# `test_detect` / `test_analyze` used to call `@app.detect` / `@app.analyze` in
+# the method body — at spec *collection* time — and register `it` blocks that
+# only asserted over the already-computed result. Two consequences, both
+# measured:
+#
+#   * `--dry-run`, which executes no example bodies, still cost ~6.9s, and
+#     `--example zzz_no_match` reported `0 examples` and still cost ~6.8s. No
+#     filter could skip the scans, so there was no way to run one analyzer's
+#     tester without running all 576.
+#   * far worse: Crystal's runner is installed via `at_exit` and skips itself
+#     when the process is already exiting on an error (`spec/dsl.cr:186`). A
+#     single analyzer raising during collection therefore reported
+#     `0 examples, 0 failures` and named nothing — 22k examples silently
+#     replaced by a blank screen, which is exactly the failure a contributor
+#     (or an agent) hits on a branch that broke one analyzer.
+#
+# The scan is now lazy: examples are registered from `@expected_endpoints`,
+# which is known at collection time, and the first example to run triggers the
+# scan. A raise surfaces as a normal failing example and every other tester
+# still reports.
+#
+# ## The exception is memoized too
+#
+# `@scan_error` matters as much as `@scanned`. Marking the scan "done" and
+# leaving a half-populated `@app` behind would turn one real error into one real
+# error plus ~40 "expected endpoint not found" red herrings. Re-raising the
+# stored exception makes every example in the tester name the actual cause.
 class UncoveredFunctionalTester
   # expected_count's symbols are:
   # :techs
@@ -17,12 +53,15 @@ class UncoveredFunctionalTester
   @expected_endpoints : Array(Endpoint)
   @app : NoirRunner
   @path : String
+  @scanned = false
+  @scan_error : Exception? = nil
 
-  def initialize(@path, expected_count, expected_endpoints)
+  def initialize(@path, expected_count, expected_endpoints, option_overrides : Hash(String, YAML::Any)? = nil)
     config_init = ConfigInitializer.new
     noir_options = config_init.default_options
     noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/uncovered_test/#{@path}")])
     noir_options["nolog"] = YAML::Any.new(true)
+    option_overrides.try &.each { |k, v| noir_options[k] = v }
 
     if !expected_count.nil?
       @expected_count = expected_count
@@ -39,13 +78,78 @@ class UncoveredFunctionalTester
     @app = NoirRunner.new noir_options
   end
 
-  def test_detect
-    @app.detect
-    if @expected_count.has_key?(:techs)
-      it "test detect using count check [#{@path}]" do
-        @app.techs.size.should eq @expected_count[:techs]
-      end
+  # Runs the scan once, on first use from inside an example.
+  #
+  # `CodeLocator` is a process-wide singleton, so it is reset here rather than
+  # at registration: whichever tester runs first must not inherit the previous
+  # one's file map. Crystal's spec runner is single-threaded, so no two
+  # `ensure_scanned` calls interleave.
+  private def ensure_scanned
+    if error = @scan_error
+      raise error
     end
+    return if @scanned
+
+    begin
+      CodeLocator.instance.clear_all
+      @app.detect
+      @app.analyze
+    rescue e
+      @scan_error = e
+      raise e
+    ensure
+      @scanned = true
+    end
+  end
+
+  # The scanned runner. Reading it runs the scan; see `url=` for the pre-scan
+  # configuration path, which must not.
+  def app
+    ensure_scanned
+    @app
+  end
+
+  def endpoints : Array(Endpoint)
+    app.endpoints
+  end
+
+  # Pre-scan configuration. Writes straight to `@app.options` — going through
+  # `app` would run the scan and *then* change an option it had already read.
+  #
+  # The guard is the point: silently configuring a scan that already happened is
+  # how a tester ends up asserting against a stale result.
+  def url=(url)
+    raise "UncoveredFunctionalTester[#{@path}]: options changed after the scan already ran" if @scanned
+    @app.options["url"] = YAML::Any.new(url)
+  end
+
+  # An expected endpoint's actual counterpart. "Not found" is an assertion
+  # failure inside the example rather than a branch taken while registering
+  # examples.
+  #
+  # Every example for a missing endpoint fails with the same greppable line, so
+  # one absent endpoint is noisy (~1 failure per detail checked) but always names
+  # the tester and the endpoint. The previous shape produced exactly one failure
+  # here — and zero for a raising analyzer, which is the trade this makes.
+  private def actual_endpoint(expected : Endpoint) : Endpoint
+    key = "#{expected.method}::#{expected.url}"
+    endpoints.find { |e| e.method == expected.method && e.url == expected.url } ||
+      fail("MISSING ENDPOINT [#{key}] in tester: #{@path}")
+  end
+
+  private def actual_params(expected : Endpoint, name : String) : Array(Param)
+    found = actual_endpoint(expected).params.select { |param| param.name == name }
+    if found.empty?
+      key = "#{expected.method}::#{expected.url}"
+      fail("MISSING PARAM [#{name}] on [#{key}] in tester: #{@path}")
+    end
+    found
+  end
+
+  private def actual_callee(expected : Endpoint, name : String) : Callee
+    key = "#{expected.method}::#{expected.url}"
+    actual_endpoint(expected).callees.find { |callee| callee.name == name } ||
+      fail("MISSING CALLEE [#{name}] on [#{key}] in tester: #{@path}")
   end
 
   def find_endpoint(key)
@@ -58,59 +162,77 @@ class UncoveredFunctionalTester
     nil
   end
 
-  def find_param(param_name)
-    @expected_endpoints.each do |endpoint|
-      endpoint.params.each do |param|
-        if param.name.to_s == param_name.to_s
-          return param
-        end
-      end
-    end
+  def test_detect
+    return unless @expected_count.has_key?(:techs)
 
-    nil
+    it "test detect using count check [#{@path}]" do
+      app.techs.size.should eq @expected_count[:techs]
+    end
   end
 
   def test_analyze
-    @app.analyze
     if @expected_count.has_key?(:endpoints)
       it "test analyze using count check [#{@path}]" do
-        @app.endpoints.size.should eq @expected_count[:endpoints]
+        endpoints.size.should eq @expected_count[:endpoints]
       end
     end
 
-    if @expected_endpoints.size > 0
-      @expected_endpoints.each do |expected|
-        key = expected.method.to_s + "::" + expected.url.to_s
-        actual = @app.endpoints.find { |e| e.method == expected.method && e.url == expected.url }
-        if actual.nil?
-          it "expected endpoint [#{key}] not found in tester: #{@path}" do
-            false.should be_true
+    @expected_endpoints.each do |expected|
+      key = expected.method.to_s + "::" + expected.url.to_s
+
+      describe "endpoint check [#{key}]" do
+        it "check - url [K: #{key}]" do
+          actual_endpoint(expected).url.should eq expected.url
+        end
+
+        it "check - method [K: #{key}]" do
+          actual_endpoint(expected).method.should eq expected.method
+        end
+
+        if expected.protocol != "http"
+          it "check - protocol [K: #{key}]" do
+            actual_endpoint(expected).protocol.should eq expected.protocol
           end
-        else
-          describe "endpoint check [#{key}]" do
-            it "check - url [K: #{key}]" do
-              actual.url.should eq expected.url
-            end
+        end
 
-            it "check - method [K: #{key}]" do
-              actual.method.should eq expected.method
-            end
+        if expected.params.size > 0
+          describe "check - params" do
+            expected.params.each do |param|
+              it "check '#{param.name}' name " do
+                actual_params(expected, param.name)[0].name.should eq param.name
+              end
 
-            if expected.params.size > 0
-              describe "check - params" do
-                expected.params.each do |param|
-                  found_params = actual.params.select { |found_p| found_p.name == param.name }
-                  if found_params.size == 0
-                    it "param '#{param.name}' not found for [#{key}] in tester: #{@path}" do
-                      false.should be_true
-                    end
-                  else
-                    it "check '#{param.name}' name " do
-                      param.name.should eq found_params[0].name
-                    end
-                    it "check '#{param.name}' param_type '#{param.param_type}'" do
-                      (found_params.any? { |found_p| found_p.param_type == param.param_type }).should be_true
-                    end
+              it "check '#{param.name}' param_type '#{param.param_type}'" do
+                actual_params(expected, param.name)
+                  .any? { |found| found.param_type == param.param_type }
+                  .should be_true
+              end
+            end
+          end
+        end
+
+        if expected.callees.size > 0
+          describe "check - callees" do
+            expected.callees.each do |callee|
+              it "check '#{callee.name}' name" do
+                actual_callee(expected, callee.name).name.should eq callee.name
+              end
+
+              # Only compare the line when the spec author set one; most specs
+              # only care about names, but Pyramid-style cases need to verify
+              # def-line threading.
+              if expected_line = callee.line
+                it "check '#{callee.name}' line #{expected_line}" do
+                  actual_callee(expected, callee.name).line.should eq expected_line
+                end
+              end
+
+              if expected_path = callee.path
+                it "check '#{callee.name}' path #{expected_path}" do
+                  actual_path = actual_callee(expected, callee.name).path
+                  actual_path.should_not be_nil
+                  if actual_path
+                    File.expand_path(actual_path).should eq File.expand_path(expected_path)
                   end
                 end
               end
@@ -122,18 +244,7 @@ class UncoveredFunctionalTester
   end
 
   def perform_tests
-    # Describe block removed from here
-    locator = CodeLocator.instance
-    locator.clear_all
     test_detect
     test_analyze
-  end
-
-  def app
-    @app
-  end
-
-  def url=(url)
-    @app.options["url"] = YAML::Any.new(url)
   end
 end


### PR DESCRIPTION
> Stacked on #2511. Review the [4 commits](https://github.com/owasp-noir/noir/pull/2512/commits).

Four changes to the feedback loop. The last one is the substantive one, and it is
a robustness fix rather than a speed fix — the measurements below say so
explicitly, because the intuitive framing turned out to be wrong.

### CI had no caching at all

`ci.yml` had zero `actions/cache` steps, so build-crystal, lint and tests each
re-ran `shards install` (7 git clones) and a full cold compile on every push and
every PR. Three caches added, keyed so a stale restore is never wrong: `lib` on
`shard.lock`, the tree-sitter objects on a hash of every vendored source plus
`build.sh`, and `~/.cache/crystal` with a restore-keys ladder (Crystal
fingerprints its own entries by content, so a partial restore can only mean some
entries recompile).

The one subtlety is `Refresh restored object mtimes`. `build.sh` decides staleness
by mtime, while `actions/checkout` stamps sources with the checkout time and the
cache restores objects with their original, older mtime — so every restored object
would look stale and get rebuilt, and the cache would cost a download and buy
nothing. Touching them is correct by construction: the key hashes all tree-sitter
sources, so a hit means the sources are byte-identical to when those objects were
compiled.

### `--order random` on the functional suite

Applied to `spec/unit_test` only. The comment explaining why it exists — four
order couplings had accumulated and surfaced as "passes on macOS, fails in CI on
an unrelated PR" — applies at least as strongly to 576 testers sharing one
`CodeLocator` singleton. It was never tried. It passes.

Landed *before* the change below on purpose: that is what makes example order
load-bearing, and this is the fence that catches an order dependency introduced
by it.

### The fast test loop was undocumented

`spec/AGENTS.md` documented only `just test-func` — the whole suite. Passing a
path was always much faster and simply never written down: one tester ~8.5s, one
language directory ~10.5s, whole suite ~16.5s. Added `just test-func-one
javascript/hono` and `just test-func-lang python` so it appears in `just --list`.

Also recorded the two things that stop anyone chasing this further, both measured:
compiling `src/` is essentially the entire cost (the single-tester run executes its
78 examples in 0.06s), and 55 python testers compile in about the same time as all
576 — so neither a narrower target nor sharding across CI jobs would help.

### The scan ran at spec-collection time

`FunctionalTester#test_detect` / `#test_analyze` called `@app.detect` /
`@app.analyze` in the method body, so all 576 scans ran while `crystal spec` was
still *collecting* examples; the `it` blocks only asserted over results computed
before any example ran.

The real cost was not speed. Crystal installs its runner with `at_exit` and skips
it when the process is already exiting on an error, so anything raising during
collection took the entire run down and reported `0 examples, 0 failures` — no
failure, no file name, nothing to grep. Demonstrated by injecting a raise into
`LLMEndpointOptimizer#optimize` (unguarded on the analyze path, unlike an
analyzer's `analyze`, whose exceptions `analysis_endpoints` already contains):

| | before | after |
|---|---|---|
| a raise on the scan path | **no `examples` line at all** | **22653 reported, 22652 naming the cause** |

For a branch that broke one analyzer — the normal case when several people or
agents work in parallel — that is the difference between a named failure and a
blank screen.

`@scan_error` is memoized alongside `@scanned`, which matters as much: marking the
scan done and leaving a half-populated runner behind would turn one real error into
one real error plus ~40 "expected endpoint not found" red herrings.

Three testers drove the scan themselves from inside a `describe` body — also
collection time. A column-anchored grep missed them; they were caught by the
negative test above and then found properly with a block-aware scan.
`spec/uncovered_test/func_spec.cr` is regenerated from the fixed file rather than
patched, so the structural clone cannot drift (that tree is not in CI, so a
divergence there would fail silently).

### Gates, all measured

| gate | before | after |
|---|---|---|
| full suite | 22653 / 0 failures | **22653 / 0 failures** (unchanged) |
| `--dry-run` | 6.9s | **0.15s** |
| `--example zzz_no_match` | 6.8s | **0.13s** |
| `--example hono` | ~6.9s | **0.23s, 22 examples** |
| `--order random` | passed, but proved nothing | **green on 5 seeds, now meaningful** |

`--example hono` is the merge gate: it is the only one that proves *per-tester*
laziness rather than a suite-wide hook.