### PR TITLE
refactor: derive the last hand-maintained lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,37 @@ jobs:
           cache-to: type=gha,mode=max,scope=action-ci
       - name: Run entrypoint end-to-end
         run: bash github-action/test-entrypoint.sh noir-action:ci
+  docs-generated:
+    # The supported-technology tables and the headline framework/language
+    # counts are derived from the techs catalog and committed, so they can go
+    # stale the moment a technology is added and nobody runs the generator.
+    # Nothing used to notice.
+    #
+    # Deliberately its own job with no `shards install`: the generator requires
+    # only stdlib and `src/techs/**`, which is exactly why the catalog metadata
+    # is kept independent of the analyzer tree. Keeping this job dependency-free
+    # is what preserves that property — if it ever needs `shards install`,
+    # something has pulled the analyzers into the techs module.
+    name: Generated docs are current
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: 1.21.0
+      - name: Regenerate supported docs and counts
+        run: crystal run scripts/generate_supported_docs.cr -- -q
+      - name: Fail if the committed output is stale
+        # Scoped to what the generator writes, so an unrelated dirty file
+        # cannot masquerade as stale docs.
+        run: |
+          if ! git diff --quiet -- README.md docs/; then
+            echo "::error::Generated docs are out of date. Run 'just docs-supported' and commit the result."
+            git --no-pager diff --stat -- README.md docs/
+            git --no-pager diff -- README.md docs/
+            exit 1
+          fi
+          echo "Generated docs match the catalog."
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ clean:
 docs-serve:
     hwaro serve -i docs --base-url="http://localhost:3000"
 
-# Generate supported technology docs from techs.cr.
+# Generate supported technology docs and headline counts from the techs catalog.
 [group('documents')]
 docs-supported:
     crystal run scripts/generate_supported_docs.cr

--- a/scripts/generate_supported_docs.cr
+++ b/scripts/generate_supported_docs.cr
@@ -9,6 +9,9 @@
 #   - docs/content/usage/supported/specification/*.md
 #   - docs/content/usage/supported/callee_coverage/*.md
 #
+# Also rewrites the headline framework / language counts quoted in prose on
+# README.md, docs/content/_index.md and the CLI page (both locales).
+#
 # Usage:
 #   crystal run scripts/generate_supported_docs.cr -- [options]
 #   just docs-supported
@@ -296,6 +299,86 @@ def inject_autogen(dir : String, content : String, dry_run : Bool) : Array(Strin
 end
 
 # --------------------
+# Headline counts
+# --------------------
+
+# The framework / language totals quoted in prose on the README and the landing
+# page. They were hand-maintained across nine sites in five files and two
+# locales, with no generator and no test — correct only for as long as whoever
+# added a framework remembered all nine.
+#
+# Each is exactly derivable, so they are rewritten here alongside the tables:
+#
+#   frameworks     techs carrying a `:language` (i.e. everything but the
+#                  specification formats and the mobile manifests)
+#   languages      distinct `:language` values
+#   cli_languages  distinct `:language` among the `*_cli` techs; a different
+#                  denominator, which is why the CLI page quotes its own number
+#
+# Patterns are anchored on the surrounding prose and split into
+# prefix / number / suffix so only the digits are replaced. Each must match
+# exactly once: a reworded sentence makes this script fail loudly rather than
+# silently leave a stale number behind, which is the failure mode it exists to
+# remove.
+COUNT_PATTERNS = [
+  {"README.md", :frameworks, /(across \[)(\d+)( frameworks\])/},
+  {"docs/content/_index.md", :languages, /(across )(\d+)( languages and )/},
+  {"docs/content/_index.md", :frameworks, /( languages and )(\d+)( frameworks)/},
+  {"docs/content/_index.md", :languages, /(<span class="stat-val">)(\d+)(<\/span><span class="stat-key">Languages<\/span>)/},
+  {"docs/content/_index.md", :frameworks, /(<span class="stat-val">)(\d+)(<\/span><span class="stat-key">Frameworks<\/span>)/},
+  {"docs/content/_index.ko.md", :languages, /()(\d+)(개 언어와 )/},
+  {"docs/content/_index.ko.md", :frameworks, /(개 언어와 )(\d+)(개 프레임워크)/},
+  {"docs/content/_index.ko.md", :languages, /(<span class="stat-val">)(\d+)(<\/span><span class="stat-key">언어<\/span>)/},
+  {"docs/content/_index.ko.md", :frameworks, /(<span class="stat-val">)(\d+)(<\/span><span class="stat-key">프레임워크<\/span>)/},
+  {"docs/content/usage/supported/cli/index.md", :cli_languages, /(across )(\d+)( languages\.)/},
+  {"docs/content/usage/supported/cli/index.ko.md", :cli_languages, /()(\d+)(개 언어에 걸쳐)/},
+]
+
+def headline_counts : Hash(Symbol, Int32)
+  with_language = NoirTechs::TECHS.select { |_, info| info.has_key?(:language) }
+  cli = with_language.select { |tech, _| tech.to_s.ends_with?("_cli") }
+
+  {
+    :frameworks    => with_language.size,
+    :languages     => with_language.compact_map { |_, info| info[:language]?.try(&.to_s) }.uniq!.size,
+    :cli_languages => cli.compact_map { |_, info| info[:language]?.try(&.to_s) }.uniq!.size,
+  }
+end
+
+# Rewrites every count site. Returns the paths whose content actually changed,
+# so an unchanged run stays quiet instead of reporting nine no-ops.
+def update_counts(root : String, dry_run : Bool) : Array(String)
+  counts = headline_counts
+  changed = [] of String
+
+  COUNT_PATTERNS.group_by { |site| site[0] }.each do |relative, sites|
+    path = File.join(root, relative)
+    unless File.exists?(path)
+      raise "count site #{relative} does not exist; update COUNT_PATTERNS in #{__FILE__}"
+    end
+
+    original = File.read(path)
+    content = original
+
+    sites.each do |(_, count_key, pattern)|
+      matches = content.scan(pattern).size
+      unless matches == 1
+        raise "#{relative}: expected exactly one match for #{pattern.source.inspect}, found #{matches}. " \
+              "The prose it anchors on was reworded — update COUNT_PATTERNS in #{__FILE__}."
+      end
+      value = counts[count_key]
+      content = content.sub(pattern) { "#{$1}#{value}#{$3}" }
+    end
+
+    next if content == original
+    File.write(path, content) unless dry_run
+    changed << path
+  end
+
+  changed
+end
+
+# --------------------
 # CLI and entry point
 # --------------------
 
@@ -330,6 +413,8 @@ if show_help
   puts "  - docs/content/usage/supported/language_and_frameworks/*.md"
   puts "  - docs/content/usage/supported/specification/*.md"
   puts "  - docs/content/usage/supported/callee_coverage/*.md"
+  puts "  - the framework / language counts in README.md, docs/content/_index.md"
+  puts "    and docs/content/usage/supported/cli/index.md (both locales)"
   puts
   puts "Examples:"
   puts "  crystal run scripts/generate_supported_docs.cr"
@@ -365,4 +450,18 @@ updated = inject_autogen(File.join(docs_dir, "callee_coverage"), callee_table, d
 unless quiet
   prefix = dry_run ? "Would update" : "Updated"
   updated.each { |p| puts "#{prefix}: #{p}" }
+end
+
+# Rewrite the headline framework / language counts quoted in prose.
+updated = update_counts(root, dry_run)
+unless quiet
+  counts = headline_counts
+  puts "Counts: #{counts[:frameworks]} frameworks, #{counts[:languages]} languages, " \
+       "#{counts[:cli_languages]} CLI languages"
+  if updated.empty?
+    puts "Counts already current in all #{COUNT_PATTERNS.map(&.[](0)).uniq!.size} files"
+  else
+    prefix = dry_run ? "Would update" : "Updated"
+    updated.each { |p| puts "#{prefix}: #{p}" }
+  end
 end

--- a/spec/unit_test/cli/scan_command_spec.cr
+++ b/spec/unit_test/cli/scan_command_spec.cr
@@ -1,23 +1,52 @@
 require "../../spec_helper"
 require "../../../src/cli/commands/scan"
 
-describe Noir::CLI::ScanCommand do
-  describe "STRUCTURED_OUTPUT_FORMATS" do
-    # A zero-technology scan only calls the output builder for formats in
-    # this set; every format below already emits a well-formed envelope
-    # (paths: {}, item: [], header-only table, ...) for zero endpoints, so
-    # skipping any of them here regresses to silent zero-byte output (or,
-    # with `-o`, no file at all) on a "no technologies detected" scan.
-    it "includes every envelope-style format so a no-endpoint scan still emits a valid empty document" do
-      %w[json yaml jsonl toml sarif oas2 oas3 postman html mermaid markdown-table].each do |format|
-        Noir::CLI::ScanCommand::STRUCTURED_OUTPUT_FORMATS.includes?(format).should be_true
-      end
+describe "structured output formats" do
+  # A zero-technology scan only calls the output builder for structured
+  # formats; each of them emits a well-formed envelope (`paths: {}`,
+  # `item: []`, a header-only table, …) for zero endpoints, so dropping one
+  # regresses to silent zero-byte output — or, with `-o`, no file at all — on a
+  # "no technologies detected" scan.
+  #
+  # This used to be a hand-maintained `Set` in `Noir::CLI::ScanCommand`: a
+  # subset of the derived format catalog, which is the shape that rots
+  # silently. It is now declared on the builder as `structured: true` and
+  # derived, so the two lists below are the *contract*, not a copy of the
+  # implementation — they pin which formats must and must not be in it,
+  # whatever mechanism produces the answer.
+  it "includes every envelope-style format so a no-endpoint scan still emits a valid empty document" do
+    %w[json yaml jsonl toml sarif oas2 oas3 postman html mermaid markdown-table].each do |format|
+      Noir::OutputFormats.structured?(format).should be_true
     end
+  end
 
-    it "excludes line-list / command formats that have no envelope to render" do
-      %w[plain curl httpie powershell adb simctl only-url only-param only-header only-cookie only-tag].each do |format|
-        Noir::CLI::ScanCommand::STRUCTURED_OUTPUT_FORMATS.includes?(format).should be_false
-      end
+  it "excludes line-list / command formats that have no envelope to render" do
+    %w[plain curl httpie powershell adb simctl only-url only-param only-header only-cookie only-tag].each do |format|
+      Noir::OutputFormats.structured?(format).should be_false
     end
+  end
+
+  # The two lists above name 22 formats, which is every format in the catalog
+  # today. If a format is added and classified as neither, that is a decision
+  # nobody made — and the consequence (empty output on a zero-endpoint scan) is
+  # invisible until a user hits it.
+  it "classifies every format in the catalog as structured or not" do
+    classified = %w[json yaml jsonl toml sarif oas2 oas3 postman html mermaid markdown-table] +
+                 %w[plain curl httpie powershell adb simctl only-url only-param only-header only-cookie only-tag]
+
+    unclassified = Noir::OutputFormats::NAMES - classified
+
+    fail <<-MSG unless unclassified.empty?
+      these formats are in the catalog but neither list above says whether a
+      zero-endpoint scan should still render them: #{unclassified.sort}.
+      Decide, add `structured: true` to the annotation if it emits an
+      envelope, and add the name to the matching list here.
+      MSG
+  end
+
+  # Guards against the annotation being dropped wholesale — an empty set would
+  # make the "excludes" example pass vacuously.
+  it "derives a non-empty structured set" do
+    Noir::OutputFormats::STRUCTURED_NAMES.size.should eq 11
   end
 end

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -25,24 +25,6 @@ module Noir::CLI::ScanCommand
   # rather than a bare magic number.
   WARNING_COLOR = Colorize::Color256.new(208)
 
-  # Output formats whose downstream consumers (jq, SARIF parsers, Swagger/
-  # Postman importers, CI report uploaders/archivers) treat empty or missing
-  # output as a hard error. When a scan finds no endpoints, we still emit a
-  # valid empty document for these formats — `{"endpoints":[],"passive_
-  # results":[]}` for json, a `"paths": {}` OAS document, a header-only
-  # Markdown table, an empty-mindmap Mermaid diagram, a full HTML shell,
-  # etc. Every format below already produces a well-formed document for
-  # zero endpoints (verified), so this is purely about not skipping the
-  # builder call entirely.
-  #
-  # Command-list / line-list formats (curl, httpie, powershell, adb, simctl,
-  # only-*) and `plain` are deliberately excluded: they have no envelope, so
-  # "nothing to render" is the correct empty output for them.
-  STRUCTURED_OUTPUT_FORMATS = Set{
-    "json", "yaml", "jsonl", "toml", "sarif",
-    "oas2", "oas3", "postman", "html", "mermaid", "markdown-table",
-  }
-
   def self.run(argv : Array(String))
     # Stage ARGV through OptionParser (positional path discovery happens
     # inside `run_options_parser`). Dup `argv` upfront because callers
@@ -369,9 +351,11 @@ module Noir::CLI::ScanCommand
         app.report
         exit(0)
       else
-        # See STRUCTURED_OUTPUT_FORMATS above for which formats still get
-        # a report call (and why) when no endpoints were discovered.
-        if STRUCTURED_OUTPUT_FORMATS.includes?(app.options["format"].to_s)
+        # Structured formats still get a report call on an empty scan, so
+        # downstream consumers receive a valid empty document rather than
+        # nothing. Which formats those are is declared on the builder
+        # (`structured: true`) — see `Noir::OutputFormats::STRUCTURED_NAMES`.
+        if Noir::OutputFormats.structured?(app.options["format"].to_s)
           app.report
         end
         exit(0)

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -2,6 +2,7 @@ require "colorize"
 require "yaml"
 require "./tagger/tagger"
 require "./techs/techs"
+require "./llm/acp/targets"
 require "./llm/native_tool_calling"
 require "./output_builder/formats"
 
@@ -88,19 +89,17 @@ module Noir::CliValidation
     raise Error.new("--ai-provider '#{provider}' needs a companion --ai-model. Pass it with --ai-model, e.g. `noir scan ./app --ai-provider #{provider} --ai-model gpt-4 --ai-key …`. (ACP providers like `acp:claude` or `acp:codex` are the exception and don't need --ai-model.)")
   end
 
-  # ACP targets Noir knows how to launch. Kept in sync with
-  # `LLM::ACPClient::KNOWN_TARGETS` (the actual exec sink). Anything else
-  # would be run as an arbitrary local process, so a `--ai-provider "acp:<cmd>"`
-  # from an untrusted config file is refused here — a clean pre-flight error
-  # instead of the sink's mid-scan raise. See issue: acp arbitrary exec.
-  ACP_KNOWN_TARGETS = %w[codex gemini claude claude-code]
-
+  # Pre-flight rejection of an ACP target Noir will not exec, so an untrusted
+  # `--ai-provider "acp:<cmd>"` fails cleanly before a scan starts rather than
+  # raising from the exec sink partway through one. The list itself lives in
+  # `LLM::ACPTargets` and is shared with that sink — it used to be a second
+  # byte-identical literal here, kept in sync by a comment.
   def self.validate_acp_target!(provider : String)
     target = (provider.split(":", 2)[1]?.try(&.strip.downcase)) || ""
-    return if ACP_KNOWN_TARGETS.includes?(target)
+    return if LLM::ACPTargets.known?(target)
     return if ENV["NOIR_ACP_ALLOW_CUSTOM_COMMAND"]? == "1"
 
-    raise Error.new("--ai-provider '#{provider}': unsupported ACP target. Allowed acp: targets are #{ACP_KNOWN_TARGETS.join(", ")}. Running an arbitrary command as an ACP agent is disabled; set NOIR_ACP_ALLOW_CUSTOM_COMMAND=1 to override (only with trusted config).")
+    raise Error.new("--ai-provider '#{provider}': unsupported ACP target. Allowed acp: targets are #{LLM::ACPTargets.join}. Running an arbitrary command as an ACP agent is disabled; set NOIR_ACP_ALLOW_CUSTOM_COMMAND=1 to override (only with trusted config).")
   end
 
   # `--passive-scan-path PATH` accepts multiple entries (repeatable),

--- a/src/llm/acp/client.cr
+++ b/src/llm/acp/client.cr
@@ -2,6 +2,7 @@ require "acp"
 require "json"
 require "log"
 require "../response_cleanup"
+require "./targets"
 
 module LLM
   # ACP-backed client wrapper for communicating with local AI agents.
@@ -26,12 +27,10 @@ module LLM
     GEMINI_ARGS = ["--experimental-acp"]
     CLAUDE_ARGS = ["@zed-industries/claude-agent-acp"]
 
-    # ACP targets Noir knows how to launch. Anything outside this set would
-    # be executed as an arbitrary local process (`--ai-provider "acp:rm -rf /"`
-    # → command "rm", args ["-rf", "/"]), which is a code-execution hole when
-    # the provider string comes from an untrusted config file. Custom targets
-    # are refused unless the operator explicitly opts in.
-    KNOWN_TARGETS = %w[codex gemini claude claude-code]
+    # See `LLM::ACPTargets` for the list and why it is shared rather than
+    # duplicated. Kept as an alias so existing references still read naturally
+    # at the exec sink.
+    KNOWN_TARGETS = ACPTargets::KNOWN
 
     class UnsupportedACPTargetError < Exception; end
 

--- a/src/llm/acp/targets.cr
+++ b/src/llm/acp/targets.cr
@@ -1,0 +1,39 @@
+module LLM
+  # ACP agent targets Noir knows how to launch.
+  #
+  # Anything outside this set would be executed as an arbitrary local process
+  # (`--ai-provider "acp:rm -rf /"` → command `rm`, args `["-rf", "/"]`), which
+  # is a code-execution hole when the provider string comes from an untrusted
+  # config file. Custom targets are refused unless the operator explicitly opts
+  # in via `NOIR_ACP_ALLOW_CUSTOM_COMMAND=1`.
+  #
+  # This lives in its own dependency-free file because two layers need it and
+  # they must not disagree:
+  #
+  #   * `LLM::ACPClient` — the exec sink, which raises mid-scan.
+  #   * `Noir::CliValidation` — the pre-flight check, so a bad `--ai-provider`
+  #     is a clean error before a scan starts rather than a raise partway
+  #     through it.
+  #
+  # The two used to carry byte-identical `%w[...]` literals, with a comment on
+  # one saying it was "kept in sync with" the other. For a list whose whole
+  # purpose is bounding what Noir will exec, "kept in sync by hand" is the
+  # wrong mechanism: the pre-flight check silently narrowing or widening
+  # relative to the sink is exactly the drift that matters.
+  #
+  # Requiring `acp/client.cr` from `cli_validation.cr` would have worked too,
+  # but it pulls the `acp` shard and `log` into the CLI validation path for one
+  # array. Hence this file, which requires nothing.
+  module ACPTargets
+    KNOWN = %w[codex gemini claude claude-code]
+
+    # `codex` / `gemini` / `claude` / `claude-code`
+    def self.known?(target : String) : Bool
+      KNOWN.includes?(target)
+    end
+
+    def self.join : String
+      KNOWN.join(", ")
+    end
+  end
+end

--- a/src/output_builder/formats.cr
+++ b/src/output_builder/formats.cr
@@ -1,26 +1,19 @@
 require "../models/output_builder"
-require "./adb"
-require "./common"
-require "./curl"
-require "./html"
-require "./httpie"
-require "./json"
-require "./jsonl"
-require "./markdown_table"
-require "./mermaid"
-require "./oas2"
-require "./oas3"
-require "./only-cookie"
-require "./only-header"
-require "./only-param"
-require "./only-tag"
-require "./only-url"
-require "./postman"
-require "./powershell"
-require "./sarif"
-require "./simctl"
-require "./toml"
-require "./yaml"
+# Glob rather than a per-format line. This was the last explicit require list
+# in the repo that grew with every contribution — one guaranteed one-line
+# merge conflict per new output format, in a file whose whole purpose is that
+# a format registers itself.
+#
+# Requiring this file from inside the directory it globs is fine: Crystal
+# tracks what it has already required, so the self-reference is a no-op.
+#
+# The glob also picks up the five non-format files here (`diff`,
+# `mobile_launch`, `passive_scan`, `oas_common`, `toml_serializer`). They carry
+# no `Noir::OutputFormat` annotation, so they cannot reach `ENTRIES`, and
+# `src/models/noir.cr` already loads all of them via `require
+# "../output_builder/*"` — the explicit list only ever existed so this file
+# could also be required standalone (from `src/options.cr`).
+require "./*"
 
 # The catalog of `-f/--format` values, derived from the `Noir::OutputFormat`
 # annotation each builder carries.
@@ -31,7 +24,7 @@ require "./yaml"
 # of them by annotating its builder class — the annotation is the only place
 # its name, description and renderer are written down.
 module Noir::OutputFormats
-  record Entry, name : String, description : String
+  record Entry, name : String, description : String, structured : Bool
 
   # Ordered by the annotation's `order:`, so help output and `noir list
   # formats` group related formats (structured → command → spec → only-* →
@@ -43,13 +36,35 @@ module Noir::OutputFormats
                             .select(&.annotation(Noir::OutputFormat))
                             .sort_by { |sub| sub.annotation(Noir::OutputFormat)[:order] } %}
           {% format = builder.annotation(Noir::OutputFormat) %}
-          Entry.new({{ format[:name] }}, {{ format[:description] }}),
+          Entry.new({{ format[:name] }}, {{ format[:description] }}, {{ !!format[:structured] }}),
         {% end %}
       ] of Entry
     {% end %}
   end
 
   NAMES = ENTRIES.map(&.name)
+
+  # Formats whose output is a document with an envelope, so "no endpoints" must
+  # still render — `{"endpoints":[],"passive_results":[]}`, a `"paths": {}` OAS
+  # document, a header-only Markdown table, a full HTML shell. Downstream
+  # consumers (jq pipelines, Postman importers, CI report uploaders) treat empty
+  # or missing output as a hard error.
+  #
+  # Command-list and line-list formats (curl, httpie, powershell, adb, simctl,
+  # only-*) and `plain` are deliberately *not* structured: they have no
+  # envelope, so emitting nothing is their correct empty output.
+  #
+  # Declared on the builder as `structured: true`. This used to be a
+  # hand-maintained `Set` in `src/cli/commands/scan.cr` — a subset of a derived
+  # list, which is the shape that silently rots: a new structured format that
+  # nobody remembered to add there emitted *nothing at all* on a zero-endpoint
+  # scan, with no error and no failing spec.
+  STRUCTURED_NAMES = ENTRIES.select(&.structured).map(&.name).to_set
+
+  # Whether `name` must still be rendered when a scan found no endpoints.
+  def self.structured?(name : String) : Bool
+    STRUCTURED_NAMES.includes?(name)
+  end
 
   # The format used when `-f` is absent, and the fallback for a value that
   # reached the runner without passing validation (library callers construct

--- a/src/output_builder/html.cr
+++ b/src/output_builder/html.cr
@@ -8,7 +8,7 @@ require "./html_assets/js"
 require "./html_assets/logo"
 require "html"
 
-@[Noir::OutputFormat(name: "html", description: "HTML report", order: 80)]
+@[Noir::OutputFormat(name: "html", description: "HTML report", order: 80, structured: true)]
 class OutputBuilderHtml < OutputBuilder
   def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     html = build_html(endpoints, passive_results)

--- a/src/output_builder/json.cr
+++ b/src/output_builder/json.cr
@@ -1,7 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
-@[Noir::OutputFormat(name: "json", description: "JSON", order: 30)]
+@[Noir::OutputFormat(name: "json", description: "JSON", order: 30, structured: true)]
 class OutputBuilderJson < OutputBuilder
   def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     message = {"endpoints" => endpoints, "passive_results" => passive_results}.to_json

--- a/src/output_builder/jsonl.cr
+++ b/src/output_builder/jsonl.cr
@@ -2,7 +2,7 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "../models/passive_scan"
 
-@[Noir::OutputFormat(name: "jsonl", description: "JSON Lines", order: 40)]
+@[Noir::OutputFormat(name: "jsonl", description: "JSON Lines", order: 40, structured: true)]
 class OutputBuilderJsonl < OutputBuilder
   # Passive findings were dropped from JSONL entirely (only the JSON builder
   # mapped them). Emit each finding on its own line after the endpoints so a

--- a/src/output_builder/markdown_table.cr
+++ b/src/output_builder/markdown_table.cr
@@ -1,7 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
-@[Noir::OutputFormat(name: "markdown-table", description: "Markdown table", order: 60)]
+@[Noir::OutputFormat(name: "markdown-table", description: "Markdown table", order: 60, structured: true)]
 class OutputBuilderMarkdownTable < OutputBuilder
   def print(endpoints : Array(Endpoint))
     ob_puts "| Endpoint | Protocol | Params |"

--- a/src/output_builder/mermaid.cr
+++ b/src/output_builder/mermaid.cr
@@ -2,7 +2,7 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "../models/passive_scan"
 
-@[Noir::OutputFormat(name: "mermaid", description: "Mermaid diagram", order: 220)]
+@[Noir::OutputFormat(name: "mermaid", description: "Mermaid diagram", order: 220, structured: true)]
 class OutputBuilderMermaid < OutputBuilder
   # CLI inputs get a plural label; the bucket key is the singular param type.
   CLI_PARAM_LABELS = {"flag" => "flags", "argument" => "arguments", "env" => "env"}

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -3,7 +3,7 @@ require "../models/endpoint"
 require "./oas_common"
 require "json"
 
-@[Noir::OutputFormat(name: "oas2", description: "OpenAPI 2.0 (Swagger)", order: 140)]
+@[Noir::OutputFormat(name: "oas2", description: "OpenAPI 2.0 (Swagger)", order: 140, structured: true)]
 class OutputBuilderOas2 < OutputBuilder
   include OutputBuilderOasCommon
 

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -3,7 +3,7 @@ require "../models/endpoint"
 require "./oas_common"
 require "json"
 
-@[Noir::OutputFormat(name: "oas3", description: "OpenAPI 3.0", order: 150)]
+@[Noir::OutputFormat(name: "oas3", description: "OpenAPI 3.0", order: 150, structured: true)]
 class OutputBuilderOas3 < OutputBuilder
   include OutputBuilderOasCommon
 

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -4,7 +4,7 @@ require "../utils/http_symbols"
 require "uri"
 require "json"
 
-@[Noir::OutputFormat(name: "postman", description: "Postman collection", order: 160)]
+@[Noir::OutputFormat(name: "postman", description: "Postman collection", order: 160, structured: true)]
 class OutputBuilderPostman < OutputBuilder
   def print(endpoints : Array(Endpoint))
     items = [] of Hash(String, JSON::Any)

--- a/src/output_builder/sarif.cr
+++ b/src/output_builder/sarif.cr
@@ -2,7 +2,7 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "sarif"
 
-@[Noir::OutputFormat(name: "sarif", description: "SARIF format", order: 70)]
+@[Noir::OutputFormat(name: "sarif", description: "SARIF format", order: 70, structured: true)]
 class OutputBuilderSarif < OutputBuilder
   def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     message = build_sarif(endpoints, passive_results)

--- a/src/output_builder/toml.cr
+++ b/src/output_builder/toml.cr
@@ -2,7 +2,7 @@ require "../models/output_builder"
 require "../models/endpoint"
 require "./toml_serializer"
 
-@[Noir::OutputFormat(name: "toml", description: "TOML", order: 50)]
+@[Noir::OutputFormat(name: "toml", description: "TOML", order: 50, structured: true)]
 class OutputBuilderToml < OutputBuilder
   include OutputBuilderTomlSerializer
 

--- a/src/output_builder/yaml.cr
+++ b/src/output_builder/yaml.cr
@@ -1,7 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 
-@[Noir::OutputFormat(name: "yaml", description: "YAML", order: 20)]
+@[Noir::OutputFormat(name: "yaml", description: "YAML", order: 20, structured: true)]
 class OutputBuilderYaml < OutputBuilder
   def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
     message = {"endpoints" => endpoints, "passive_results" => passive_results}.to_yaml


### PR DESCRIPTION
> Stacked on #2512. Review the [5 commits](https://github.com/owasp-noir/noir/pull/2513/commits).

Five small lists that were maintained by hand and could be derived. Each is a
place where "remember to also update X" was the only thing keeping the tree
correct.

### The last explicit require list

`src/output_builder/formats.cr` opened with 22 `require "./<format>"` lines — the
only require list left that grows with every contribution, i.e. one guaranteed
one-line merge conflict per new output format, in the file whose entire purpose is
that a format registers itself by annotating its class.

The apparent blocker was that `formats.cr` lives inside the directory it would
glob, so `require "./*"` self-references — but Crystal tracks what it has already
required, so that is a no-op. The glob also picks up the five non-format files
there; none carries the annotation, and `src/models/noir.cr` already loads all of
them anyway.

### `STRUCTURED_OUTPUT_FORMATS`

A hand-maintained `Set` of 11 names in `ScanCommand` — a *subset* of the derived
format catalog. That shape rots in one direction only, and silently: a new
envelope-style format nobody remembered to add there emits **nothing at all** on a
zero-endpoint scan (or writes no file with `-o`), with no error and no failing
spec. The consumers this exists for — jq pipelines, SARIF parsers, Swagger and
Postman importers — treat missing output as a hard error.

Now `structured: true` on the annotation, alongside the name, description and order
the builder already declares. The derived set matches the old literal exactly.
The spec is rewritten to pin the contract rather than the constant, and gains a
completeness example so a new format cannot slip in unclassified.

### The ACP target allowlist existed twice

`LLM::ACPClient::KNOWN_TARGETS` (the exec sink) and
`Noir::CliValidation::ACP_KNOWN_TARGETS` (the pre-flight check) were byte-identical,
with a comment on the latter saying it was "kept in sync with" the former. For a
list whose job is bounding what Noir will exec, that is the wrong mechanism: if
they drift, either a target passes validation and dies mid-scan, or the pre-flight
refuses something the sink would happily run. Neither shows up as a test failure.

Both now read `LLM::ACPTargets::KNOWN`, in its own dependency-free file — requiring
`acp/client.cr` from `cli_validation.cr` would pull the `acp` shard and `log` into
the CLI validation path for one array.

### The headline counts

README and the landing page quote "193 frameworks", "29 languages" and — against a
different denominator — "21 languages". Nine sites in five files, not the four you
find by grepping for `193`: the landing page carries the numbers twice, and every
page has a Korean twin that `check_i18n_docs.cr` requires but nothing keeps
numerically in sync. They happen to be correct today, which is what made this cheap
to land.

`generate_supported_docs.cr` now rewrites them. Each pattern is anchored on its
surrounding prose, split prefix/number/suffix so only digits are touched, and
asserted to match **exactly once** — rewording a sentence fails the script loudly
instead of silently leaving a stale number, which is the failure mode being removed
and so must not be reintroduced by the fix.

### …and a CI check, because deriving them made the drift worse

Adding the counts put README and the landing page into the set of files a framework
PR is expected to regenerate. A generator nobody is required to run is a generator
that drifts. New `docs-generated` job: regenerate, fail if anything under
`README.md` or `docs/` changed, print the diff, name the command.

It deliberately runs no `shards install`. The generator requires only stdlib and
`src/techs/**` — that independence from the analyzer tree is what makes generating
docs a two-second operation, and keeping this job dependency-free turns it into
something CI enforces.

### Verification

Format catalog dumped before and after (22 entries, names, descriptions, order):
identical. Derived structured set matched the old literal name by name. Count
rewriter verified both ways — setting README to "999 frameworks" and the Korean page
to "7개 언어와 42개 프레임워크" restores both; renaming `across` to `covering` raises
with the file, the pattern and what to do. ACP checked end to end: `acp:rm -rf /`
still refused pre-flight, `acp:claude` still passes.

Unit 4747, functional 22653, format and ameba green.