### PR TITLE
fix(detector): stop one unreadable file from dropping its whole directory

### DIFF
--- a/spec/unit_test/detector/detector_spec.cr
+++ b/spec/unit_test/detector/detector_spec.cr
@@ -214,4 +214,63 @@ describe "detect_techs file walker" do
       end
     end
   end
+
+  # An unreadable file used to take the rest of its directory with it: the
+  # per-file `TextFile.read` sat bare inside `Dir.each_child`, whose only
+  # rescue is the directory-level one, so the raise unwound the whole
+  # listing and every remaining sibling went unregistered — silently, exit 0.
+  # Measured before the fix on a flat 501-file Gin tree: one `chmod 000`
+  # file cut the scan from 501 endpoints to 277.
+  #
+  # Two unreadable files, deliberately: readdir order is not alphabetical
+  # (and is hash-ordered on both APFS and ext4), so a single one could land
+  # last by luck and the regression would not fire.
+  it "loses only the unreadable files, not the rest of their directory" do
+    temp_dir = File.tempname("noir_detector_unreadable")
+    Dir.mkdir_p(temp_dir)
+    # Resolved before the `begin` so `ensure` can restore the modes even if
+    # creating them is what failed.
+    unreadable = ["locked_a.go", "locked_b.go"].map { |name| File.join(temp_dir, name) }
+
+    begin
+      readable = (0...50).map do |i|
+        path = File.join(temp_dir, "handler_#{i}.go")
+        File.write(path, "package main\n\nfunc Handler#{i}() {}\n")
+        path
+      end
+
+      unreadable.each do |path|
+        File.write(path, "package main\n")
+        File.chmod(path, 0o000)
+      end
+
+      # Mode bits do not apply to root, and a spec that cannot establish the
+      # condition it tests must say so rather than pass. Probe by actually
+      # reading: `File::Info#readable?` reports the mode bits, which for root
+      # says "no" about a file root can in fact read.
+      still_readable = unreadable.any? do |path|
+        File.read(path)
+        true
+      rescue File::Error
+        false
+      end
+      pending! "requires a non-root user: mode 000 is not enforced here" if still_readable
+
+      options = create_test_options
+      options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+      logger = NoirLogger.new(false, false, false, true)
+      locator = CodeLocator.instance
+      locator.clear_all
+
+      detect_techs([temp_dir], options, [] of PassiveScan, logger)
+      files = locator.all_files
+
+      readable.each { |path| files.should contain(path) }
+      unreadable.each { |path| files.should_not contain(path) }
+    ensure
+      unreadable.each { |path| File.chmod(path, 0o644) if File.exists?(path) }
+      FileUtils.rm_rf(temp_dir) if temp_dir
+      CodeLocator.instance.clear_all
+    end
+  end
 end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -396,6 +396,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
       skipped_content_reads = 0
       total_files = 0
       skipped_ignored_dirs = 0
+      unreadable_files = 0
 
       # User-supplied --exclude-path patterns (comma-separated globs).
       # Patterns containing "/" are matched against the relative path;
@@ -530,7 +531,30 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
                 next
               end
 
-              content = Noir::TextFile.read(full_path)
+              # Per-file read isolation.
+              #
+              # This read used to sit bare inside `Dir.each_child`, and the
+              # nearest rescue is the *directory*-level one below. So one
+              # unreadable file aborted the whole directory listing and every
+              # remaining sibling went unregistered — no detection, no
+              # analysis, no message, exit 0. Measured on a flat 501-file Gin
+              # project: `chmod 000` on a single `.go` file took the scan from
+              # 501 endpoints to 277. Files deleted mid-walk take the same
+              # path (`File::NotFoundError`), which a live repo hits without
+              # anyone doing anything unusual.
+              #
+              # A file we cannot read must cost only itself.
+              # `IO::Error`, not `File::Error`: it is the supertype
+              # (`File::Error < IO::Error`), so it also covers a read that
+              # fails for a reason the file layer does not name. The point
+              # here is that *nothing* about one file may end the walk.
+              content = begin
+                Noir::TextFile.read(full_path)
+              rescue e : IO::Error
+                logger.debug "Skipping #{full_path}: #{e.message}"
+                unreadable_files += 1
+                next
+              end
               if content.to_slice.includes?(0_u8)
                 logger.debug "Skipping #{full_path}: binary content (file is text-extension but bytes look binary)"
                 skipped_files += 1
@@ -566,14 +590,25 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
               locator.register_file(full_path, content)
             end
           rescue File::NotFoundError | File::AccessDeniedError
-            # Directory vanished or we can't read it — treat the subtree
-            # as empty and move on.
+            # `Dir.each_child` itself failed: the directory vanished between
+            # being pushed on the stack and being popped, or it is not
+            # listable. Treat the subtree as empty and move on.
+            #
+            # Scope note: this is the *directory* handler. Per-file failures
+            # are caught at the read above, so they no longer land here and
+            # take the rest of the listing with them.
           end
         end
       end
 
       if skipped_files > 0
         logger.info "Skipped #{skipped_files} media/large files out of #{total_files} total files"
+      end
+      # Warning, not info: a media/large skip is the filter working as
+      # intended, but an unreadable file is a hole in the scan the user did
+      # not ask for. It was previously invisible at every verbosity.
+      if unreadable_files > 0
+        logger.warning "Skipped #{unreadable_files} unreadable file#{"s" if unreadable_files != 1} (permissions, or removed during the scan)"
       end
       if skipped_ignored_dirs > 0
         logger.debug "Pruned #{skipped_ignored_dirs} ignored directory tree(s)"


### PR DESCRIPTION
## Summary

The detector's per-file content read sits bare inside `Dir.each_child`, and the nearest rescue is the **directory**-level one that exists for "the directory vanished". So a single unreadable file did not cost itself — it unwound the entire listing, and every remaining sibling in that directory went unregistered. No detection, no analysis, no message at any verbosity, exit 0.

Measured on a flat 501-file Gin tree — the only variable is the mode bits on one file:

| tree | endpoints |
|---|---|
| clean | 501 |
| one `chmod 000` `.go` file | **277** |
| one unreadable `.txt` (not read by the walk) | 501 |

The unit spec added here is sharper still: with two unreadable files among 50 readable ones, only **2 of the 50** survived on the parent commit.

This is not an exotic input. Files deleted mid-walk raise `File::NotFoundError` down the same path, which any scan of a live working tree can hit, and permission-restricted or root-owned files are ordinary in vendored trees and CI checkouts.

## What changed

- The read gets its own rescue, so a file we cannot read costs only itself. The directory-level rescue keeps its original job, and each handler's comment now says which failures it owns.
- Unreadable files are counted and reported with `logger.warning`, rather than folded into the existing media/large-file info line. A media skip is the filter working as intended; a hole in the scan the user did not ask for should be visible — and this one was invisible at every verbosity.

## Test plan

- New unit spec `spec/unit_test/detector/detector_spec.cr` — **fails on the parent commit, passes here**. It probes readability by actually reading rather than by mode bits, and marks itself `pending!` under root instead of passing vacuously (`chmod 000` does not stop root, and a spec that cannot establish its own precondition must say so).
- A/B sweep over all 665 fixture projects: **byte-identical**, 5,160 endpoints, comparing method/url/params/tags **and** `code_paths[].line` / `callees[].line`.
- `crystal spec spec/unit_test` — 4,754 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,653 examples, 0 failures.
- `crystal tool format --check`, `ameba` on touched files, repo-wide `typos` — clean.