### PR TITLE
test: stop one spec's collection-time read from erasing the whole suite

### DIFF
--- a/spec/unit_test/cli/error_color_spec.cr
+++ b/spec/unit_test/cli/error_color_spec.cr
@@ -3,17 +3,31 @@ require "colorize"
 require "../../../src/cli/common"
 
 describe "early CLI error colors" do
-  source_files = [
-    "src/options.cr",
-    "src/cli_validation.cr",
-    "src/models/output_builder.cr",
-    "src/cli/common.cr",
-  ]
-  error_lines = source_files.flat_map do |path|
-    File.read_lines(path).select(&.includes?(%q(STDERR.puts "ERROR:)))
-  end
-
+  # Read inside the example, not in the `describe` body.
+  #
+  # These are repo-relative paths, so from any working directory other than
+  # the repo root `File.read_lines` raises — and in the `describe` body that
+  # is collection time, which `spec/AGENTS.md` singles out: Crystal installs
+  # its runner with `at_exit` and skips it when the process is already
+  # exiting on an error, so one raise there took down all ~4,750 examples and
+  # reported `0 examples` — no failure, no name, nothing to grep.
+  #
+  # The sibling source-scanning specs (`layering_boundary_spec.cr`,
+  # `detector_coverage_spec.cr`, and five others) are CWD-relative too, but
+  # they all use `Dir.glob`, which returns an empty list rather than raising,
+  # and each carries a "guards the guard" size assertion so a wrong CWD fails
+  # loudly. This one both raised and skipped that discipline.
   it "uses red for every error path" do
+    source_files = [
+      "src/options.cr",
+      "src/cli_validation.cr",
+      "src/models/output_builder.cr",
+      "src/cli/common.cr",
+    ]
+    error_lines = source_files.flat_map do |path|
+      File.read_lines(path).select(&.includes?(%q(STDERR.puts "ERROR:)))
+    end
+
     error_lines.size.should eq(14)
     error_lines.each(&.should contain(".colorize(:red)"))
   end

--- a/spec/unit_test/models/locator_lifecycle_spec.cr
+++ b/spec/unit_test/models/locator_lifecycle_spec.cr
@@ -21,10 +21,13 @@ require "../../../src/models/noir"
 # was added. #2503's message and this comment both named diff mode anyway,
 # which overstated the blast radius.
 #
-# A single-scan fixture sweep cannot see this by construction, which is why
-# it survived long enough to have a comment written about it rather than a
-# fix. This spec is the oracle: it fails with the hand-written clear list
-# put back in place of `LocatorKeys.reset`.
+# The fixture sweep cannot see this — not because it runs a single scan (it
+# does not; see the note on the end-to-end describe below) but because
+# `func_spec.cr`'s `ensure_scanned` calls `clear_all` before every tester's
+# scan, which wipes the carry-over before it can be observed. That is why it
+# survived long enough to have a comment written about it rather than a fix.
+# This spec is the oracle: it fails with the hand-written clear list put back
+# in place of `LocatorKeys.reset`.
 describe "locator scan lifecycle" do
   it "does not carry a previous scan's spec registrations into the next" do
     logger = NoirLogger.new(false, false, false, true)
@@ -106,7 +109,13 @@ end
 #
 # Nothing else in the suite covers this. `--diff-path` cannot reach it —
 # `src/cli/commands/scan.cr` calls `clear_all` between its two halves — and
-# the fixture sweep runs one scan per process.
+# neither can the fixture sweep, though not for the reason this comment used
+# to give. The sweep does NOT run one scan per process: 554 tester files
+# compile into a single binary and `func_spec.cr`'s `ensure_scanned` runs a
+# full detect+analyze per tester against the one `CodeLocator.instance`. What
+# hides the carry-over is the unconditional `clear_all` that `ensure_scanned`
+# does first. The distinction is load-bearing — narrow that clear for speed
+# and the functional suite silently becomes a 554-scan carry-over test.
 describe "locator scan lifecycle, end to end" do
   it "does not carry a previous scan's endpoints into the next" do
     locator = CodeLocator.instance


### PR DESCRIPTION
## Summary

`spec/unit_test/cli/error_color_spec.cr` read four **repo-relative** source files in its `describe` body — i.e. at collection time. From any working directory other than the repo root that raises, and `spec/AGENTS.md` already documents exactly what that costs:

> Crystal installs its spec runner with `at_exit` and skips it entirely when the process is already exiting on an error, so anything that raises during collection takes the whole run down and reports `0 examples` — no failure, no name, nothing to grep.

Reproduced from a scratch directory:

```
Unhandled exception: Error opening file with mode 'r': 'src/options.cr' (File::NotFoundError)
  ... in 'describe' ... in '__crystal_main'
```

— before example 1. One spec file silently erases all ~4,750 unit examples.

| CWD | before | after |
|---|---|---|
| repo root | passes | `3 examples, 0 failures` |
| anywhere else | **whole suite vanishes, `0 examples`** | `3 examples, 1 errors`, failing example named |

The seven sibling specs that scan `src/` are CWD-relative too, and are safe by contrast on purpose: they use `Dir.glob`, which returns an empty list rather than raising, and each carries a "guards the guard" size assertion (`sources.size.should be > 500`) so a wrong CWD fails loudly instead of passing vacuously. This one both raised *and* skipped that discipline. Moving the read into the example puts it back under the same protection.

Low trigger probability today — `just` and CI always run from the root — but it bites an IDE test runner, a `cd spec` habit, or any future harness that changes CWD, and it presents as "the suite printed nothing", which is the worst available diagnostic.

## Also: two comments asserting the wrong process lifetime

`spec/unit_test/models/locator_lifecycle_spec.cr` claimed the fixture sweep "runs one scan per process". It does not: 554 tester files compile into one binary and `func_spec.cr`'s `ensure_scanned` runs a full detect+analyze **per tester** against the single `CodeLocator.instance` — which `func_spec.cr:78-80` states correctly in its own words. Two files in the same suite said contradictory things about process lifetime.

The conclusion those comments draw is still correct, but for a different reason: cross-scan carry-over is hidden by the unconditional `clear_all` in `ensure_scanned`, not by there being a single scan. That distinction is load-bearing — narrow that clear for speed and the functional suite silently becomes a 554-scan carry-over test, while the comment tells the next reader that situation cannot arise.

## Test plan

- Spec-only change; nothing under `src/` is touched, so scan behaviour is unchanged by construction.
- `crystal spec spec/unit_test` — 4,753 examples, 0 failures.
- Wrong-CWD behaviour verified in both directions (table above).
- `crystal tool format`, `ameba` on both files, repo-wide `typos` — clean.