### PR TITLE
fix(analyzer): catch unreadable files, not just missing ones

### DIFF
--- a/spec/unit_test/analyzer/unreadable_file_isolation_spec.cr
+++ b/spec/unit_test/analyzer/unreadable_file_isolation_spec.cr
@@ -1,0 +1,89 @@
+require "file_utils"
+require "../../spec_helper"
+require "../../../src/utils/string_extension"
+require "../../../src/analyzer/analyzers/go/gin"
+require "../../../src/models/code_locator"
+require "../../../src/models/logger"
+
+# One unreadable source file must cost that file and nothing else.
+#
+# `File::AccessDeniedError` is a **sibling** of `File::NotFoundError` under
+# `File::Error`, not a subclass, so the `rescue File::NotFoundError` that 42
+# read sites carried did not catch an unreadable file. In `GoEngine`'s
+# synchronous pre-phase readers the escaping exception was not caught until
+# the per-analyzer handler in `analysis_endpoints`, which abandons the whole
+# analyzer: measured on a flat 501-file Gin tree, one `chmod 000` file took
+# the analyzer from 501 endpoints to **zero**, reported as a single warning
+# line.
+#
+# This drives the analyzer directly rather than through `detect_techs`,
+# because the detector registers `.go` paths only after reading them — so
+# once the detector's own read fails, the analyzer never sees the file. The
+# reachable-in-production shape is `-t <tech> --only-techs <other>`, where a
+# tech is selected without its detector running: the path is registered
+# content-free and the analyzer is the first thing to open it.
+describe "analyzer file-read isolation" do
+  it "keeps the other files when one is unreadable" do
+    temp_dir = File.tempname("noir_unreadable_analyzer")
+    Dir.mkdir_p(temp_dir)
+    unreadable = File.join(temp_dir, "locked.go")
+
+    begin
+      File.write(File.join(temp_dir, "go.mod"), "module repro\n\ngo 1.21\n")
+      readable = (0...5).map do |i|
+        path = File.join(temp_dir, "route_#{i}.go")
+        File.write(path, <<-GO)
+          package main
+
+          import "github.com/gin-gonic/gin"
+
+          func Register#{i}(r *gin.Engine) {
+            r.GET("/ok#{i}", func(c *gin.Context) {})
+          }
+          GO
+        path
+      end
+
+      File.write(unreadable, <<-GO)
+        package main
+
+        import "github.com/gin-gonic/gin"
+
+        func RegisterLocked(r *gin.Engine) {
+          r.GET("/locked", func(c *gin.Context) {})
+        }
+        GO
+      File.chmod(unreadable, 0o000)
+
+      # Mode bits do not apply to root, and a spec that cannot establish the
+      # condition it tests must say so rather than pass. Probe by reading:
+      # `File::Info#readable?` reports the mode bits, which for root says
+      # "no" about a file root can in fact read.
+      still_readable = begin
+        File.read(unreadable)
+        true
+      rescue File::Error
+        false
+      end
+      pending! "requires a non-root user: mode 000 is not enforced here" if still_readable
+
+      locator = CodeLocator.instance
+      locator.clear_all
+      # Register every path without content, which is what the detector does
+      # for a file no detector is applicable to.
+      (readable + [unreadable]).each { |path| locator.register_path(path) }
+
+      options = create_test_options
+      options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+      endpoints = Analyzer::Go::Gin.new(options).analyze
+
+      urls = endpoints.map(&.url).sort!
+      urls.should eq((0...5).map { |i| "/ok#{i}" })
+      urls.should_not contain("/locked")
+    ensure
+      File.chmod(unreadable, 0o644) if File.exists?(unreadable)
+      FileUtils.rm_rf(temp_dir) if temp_dir
+      CodeLocator.instance.clear_all
+    end
+  end
+end

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -147,8 +147,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -73,7 +73,7 @@ module Analyzer::Go
               package_mounted_functions[dir] << mount_skip_key(target)
             end
           end
-        rescue File::NotFoundError
+        rescue IO::Error
           # skip
         end
       end
@@ -263,8 +263,8 @@ module Analyzer::Go
                     extract_params(line, state, last_endpoint)
                   end
                 end
-              rescue File::NotFoundError
-                logger.debug "File not found: #{path}"
+              rescue e : IO::Error
+                logger.debug "Skipping #{path}: #{e.message}"
               end
             end
           end
@@ -431,7 +431,7 @@ module Analyzer::Go
           (file_contents_cache.try &.[search_path]?) ||
             begin
               read_file_content(search_path)
-            rescue File::NotFoundError
+            rescue IO::Error
               next
             end
 

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -134,8 +134,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -33,7 +33,7 @@ module Analyzer::Go
           next if GoEngine.go_test_file?(base_relative_path(fp))
           begin
             file_contents[fp] = read_file_content(fp)
-          rescue File::NotFoundError
+          rescue IO::Error
             # skip
           end
         end

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -136,8 +136,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -126,8 +126,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -201,8 +201,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/go_restful.cr
+++ b/src/analyzer/analyzers/go/go_restful.cr
@@ -79,8 +79,8 @@ module Analyzer::Go
 
                     result << endpoint
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -119,8 +119,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -137,8 +137,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -34,7 +34,7 @@ module Analyzer::Go
         next if File.directory?(fp)
         begin
           file_contents[fp] = read_file_content(fp)
-        rescue File::NotFoundError
+        rescue IO::Error
           # skip
         end
       end
@@ -125,8 +125,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -74,7 +74,7 @@ module Analyzer::Go
           package_files[dir] ||= [] of String
           package_files[dir] << scan_path
           file_contents_cache[scan_path] = read_file_content(scan_path)
-        rescue File::NotFoundError
+        rescue IO::Error
           # skip
         end
       end
@@ -121,8 +121,8 @@ module Analyzer::Go
                   mutex.synchronize do
                     endpoints.each { |ep| result << ep }
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -111,8 +111,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/go/pocketbase.cr
+++ b/src/analyzer/analyzers/go/pocketbase.cr
@@ -71,8 +71,8 @@ module Analyzer::Go
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -98,8 +98,8 @@ module Analyzer::Java
                       collect_builder_routes(server_codeblock, resolved_constants, details, mask, start)
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end
@@ -475,8 +475,8 @@ module Analyzer::Java
 
           registrations[{base, service_class}] << prefix
         end
-      rescue File::NotFoundError
-        logger.debug "File not found: #{path}"
+      rescue e : IO::Error
+        logger.debug "Skipping #{path}: #{e.message}"
       end
 
       registrations.each_value(&.uniq!)
@@ -505,8 +505,8 @@ module Analyzer::Java
             index[{base, class_name}] = routes unless routes.empty?
           end
         end
-      rescue File::NotFoundError
-        logger.debug "File not found: #{path}"
+      rescue e : IO::Error
+        logger.debug "Skipping #{path}: #{e.message}"
       end
 
       index

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -211,7 +211,7 @@ module Analyzer::Java
             body = file == path ? content : read_file_content(file)
             Noir::TreeSitterJaxRsExtractor.extract_bean_fields(body)
           end
-        rescue File::NotFoundError
+        rescue IO::Error
           {} of String => Array(Param)
         end
 
@@ -233,7 +233,7 @@ module Analyzer::Java
       Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
         body = cache[file] ||= begin
           file == path ? content : read_file_content(file)
-        rescue File::NotFoundError
+        rescue IO::Error
           ""
         end
         next if body.empty?

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -366,7 +366,7 @@ module Analyzer::Java
             body = file == path ? content : read_file_content(file)
             Noir::TreeSitterJaxRsExtractor.extract_bean_fields(body)
           end
-        rescue File::NotFoundError
+        rescue IO::Error
           {} of String => Array(Param)
         end
 
@@ -388,7 +388,7 @@ module Analyzer::Java
       Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
         body = cache[file] ||= begin
           file == path ? content : read_file_content(file)
-        rescue File::NotFoundError
+        rescue IO::Error
           ""
         end
         next if body.empty?

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -75,8 +75,8 @@ module Analyzer::Java
                       result << endpoint
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end
@@ -125,8 +125,8 @@ module Analyzer::Java
             servlet_methods[{base_path, "#{package_name}.#{class_name}"}] = methods
           end
         end
-      rescue File::NotFoundError
-        logger.debug "File not found: #{path}"
+      rescue e : IO::Error
+        logger.debug "Skipping #{path}: #{e.message}"
       end
 
       servlet_methods
@@ -316,8 +316,8 @@ module Analyzer::Java
           add_endpoint(endpoints, "/", "GET", params, details)
           matched = true
           break
-        rescue File::NotFoundError
-          logger.debug "File not found: #{jsp_path}"
+        rescue e : IO::Error
+          logger.debug "Skipping #{jsp_path}: #{e.message}"
         end
 
         break if matched
@@ -344,8 +344,8 @@ module Analyzer::Java
         content = read_file_content(path)
         methods = extract_servlet_http_methods(content)
         return methods unless methods.empty?
-      rescue File::NotFoundError
-        logger.debug "File not found: #{path}"
+      rescue e : IO::Error
+        logger.debug "Skipping #{path}: #{e.message}"
       end
     end
 

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -710,7 +710,7 @@ module Analyzer::Java
             body = file == path ? content : read_file_content(file)
             Noir::TreeSitterJaxRsExtractor.extract_bean_fields(body)
           end
-        rescue File::NotFoundError
+        rescue IO::Error
           {} of String => Array(Param)
         end
 
@@ -732,7 +732,7 @@ module Analyzer::Java
       Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
         body = cache[file] ||= begin
           file == path ? content : read_file_content(file)
-        rescue File::NotFoundError
+        rescue IO::Error
           ""
         end
         next if body.empty?

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -119,8 +119,8 @@ module Analyzer::Java
                       end
                     end
                   end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                rescue e : IO::Error
+                  logger.debug "Skipping #{path}: #{e.message}"
                 end
               end
             end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -231,8 +231,8 @@ module Analyzer::Python
                     end
                   end
                 end
-              rescue File::NotFoundError
-                logger.debug "File not found: #{file}"
+              rescue e : IO::Error
+                logger.debug "Skipping #{file}: #{e.message}"
               end
             end
           end

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -35,7 +35,7 @@ module Analyzer::Specification
       CodeLocator.instance.files_by_extension(".proto").each do |proto_file|
         begin
           content = read_file_content(proto_file)
-        rescue File::NotFoundError
+        rescue IO::Error
           next
         end
         clean = strip_comments(content)

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -147,7 +147,7 @@ module Analyzer::Go
         paths.each do |path|
           begin
             file_contents[path] = read_file_content(path)
-          rescue File::NotFoundError
+          rescue IO::Error
             # skip
           end
         end
@@ -431,7 +431,7 @@ module Analyzer::Go
         next if GoEngine.go_test_file?(base_relative_path(path))
         begin
           file_contents[path] = read_file_content(path)
-        rescue File::NotFoundError
+        rescue IO::Error
           # skip
         end
       end
@@ -562,7 +562,7 @@ module Analyzer::Go
 
         begin
           content = read_file_content(path)
-        rescue File::NotFoundError
+        rescue IO::Error
           next
         end
 

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -97,7 +97,7 @@ module Analyzer::Javascript
         elsif base == "package.json"
           begin
             content = read_file_content(file)
-          rescue File::NotFoundError
+          rescue IO::Error
             next
           end
           add_project_root(roots, File.dirname(file)) if package_markers.any? { |marker| content.includes?(marker) }

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -1288,7 +1288,7 @@ module Noir
         @@shared_super_cache[file] ||= supertypes
         {@@shared_cache[file], @@shared_super_cache[file]}
       end
-    rescue File::NotFoundError
+    rescue IO::Error
       {Index.new, Hash(String, String).new}
     end
 
@@ -1403,7 +1403,7 @@ module Noir
         imports = TreeSitterJavaParameterExtractor.extract_imports_from(root, body)
       end
       {package_name, imports}
-    rescue File::NotFoundError
+    rescue IO::Error
       {"", [] of Noir::ImportGraph::ImportRef}
     end
 

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -1383,7 +1383,7 @@ module Noir
         @@shared_super_cache[file] ||= supertypes
         {@@shared_cache[file], @@shared_super_cache[file]}
       end
-    rescue File::NotFoundError
+    rescue IO::Error
       {Index.new, Hash(String, String).new}
     end
 
@@ -1486,7 +1486,7 @@ module Noir
         imports = TreeSitterKotlinParameterExtractor.extract_imports_from(root, body)
       end
       {package_name, imports}
-    rescue File::NotFoundError
+    rescue IO::Error
       {"", [] of Noir::ImportGraph::ImportRef}
     end
 


### PR DESCRIPTION
## Summary

`File::AccessDeniedError` is a **sibling** of `File::NotFoundError` under `File::Error`, not a subclass:

```
File::Error < IO::Error                        # true
File::AccessDeniedError < File::Error          # true
File::AccessDeniedError < File::NotFoundError  # false   <-- the hole
```

So `rescue File::NotFoundError` around a file read — the shape 42 sites used — does not catch a file the process cannot read, and the exception escapes.

**Where it escapes to decides how much is lost.** In `GoEngine`'s synchronous pre-phase readers (`go_engine.cr:150/434/565`) there is no handler between the read and the per-analyzer rescue in `analysis_endpoints`, which abandons the analyzer whole. Measured on a flat 501-file Gin tree, using `-t go_gin --only-techs oas3` so the path is registered without the detector reading it first:

| tree | before | after |
|---|---|---|
| one `chmod 000` `.go` file | **0 endpoints** | 500 |
| same tree, file readable | 501 | 501 |

Zero endpoints from one unreadable file, surfaced as a single `warning` line.

## What changed

- All **42** naked sites widened to `IO::Error` — the supertype (`File::Error < IO::Error`), so a read failing for a reason the file layer does not name is covered too.
- **Every one of the 42 rescue bodies was read before changing it.** They are all "skip this file" (`# skip`, `next`), "return an empty index" (`{Index.new, ...}`, `{} of String => Array(Param)`, `""`), or "log and continue". Not one distinguishes missing from unreadable, so none loses a distinction it was making.
- **Four sites deliberately keep `rescue File::NotFoundError`**: `models/analyzer.cr:221`, `detector/detector.cr:660`, and both in `go/connect_rpc.cr`. Each is already followed by a broader `rescue`, so `AccessDeniedError` was handled there all along.
- The 22 sites that logged `"File not found: #{path}"` now log `"Skipping #{path}: #{e.message}"` — after widening the old wording would be wrong for exactly the case this fixes. No spec asserts on that string.

## Test plan

- New spec `spec/unit_test/analyzer/unreadable_file_isolation_spec.cr` — **errors on the parent commit, passes here**. It marks itself `pending!` under root rather than passing vacuously.
- A/B sweep over all 665 fixture projects: **byte-identical**, 5,160 endpoints, including `code_paths[].line` and `callees[].line`. Expected — the change only widens which exception types are caught, and no fixture file is unreadable.
- `crystal spec spec/unit_test` — 4,754 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,653 examples, 0 failures.
- `ameba` over 2,132 files, `crystal tool format --check`, repo-wide `typos` — clean.