### PR TITLE
fix(miniparser): drop the DTO field index between scans

### DIFF
--- a/spec/unit_test/miniparser/dto_index_lifecycle_spec.cr
+++ b/spec/unit_test/miniparser/dto_index_lifecycle_spec.cr
@@ -1,0 +1,85 @@
+require "file_utils"
+require "../../spec_helper"
+require "../../../src/models/noir"
+
+# The Java/Kotlin DTO field indexes are process-wide and keyed by absolute
+# file path. That sharing is what keeps five Java analyzers from each
+# re-parsing every DTO in the tree — but a path is only a stable key
+# *within* one scan. Across scans the same path can hold different content,
+# and neither index was registered with `ExtractionResultCache`, so
+# `clear_all` at the top of `analysis_endpoints` did not reach them.
+#
+# Two scans of one path, in one process, with the DTO edited in between:
+# before the fix the second scan reported the deleted field and missed the
+# added one. The reachable production shape is a long-lived embedder — watch
+# mode, or a CI daemon scanning one checkout across a `git pull`.
+private def scan_param_names(root : String) : Array(String)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(root)])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints.flat_map { |endpoint| endpoint.params.map(&.name) }.sort!.uniq!
+end
+
+private def write_person_dto(root : String, field : String, getter : String)
+  File.write(File.join(root, "src/main/java/com/example/PersonDto.java"), <<-JAVA)
+    package com.example;
+
+    public class PersonDto {
+        private String name;
+        private String #{field};
+
+        public String getName() { return name; }
+        public String get#{getter}() { return #{field}; }
+    }
+    JAVA
+end
+
+describe "DTO index scan lifecycle" do
+  it "re-reads a DTO whose content changed between two scans of one path" do
+    root = File.tempname("noir_dto_lifecycle")
+    Dir.mkdir_p(File.join(root, "src/main/java/com/example"))
+
+    begin
+      File.write(File.join(root, "pom.xml"), <<-XML)
+        <project><modelVersion>4.0.0</modelVersion>
+          <groupId>com.example</groupId><artifactId>demo</artifactId><version>1.0</version>
+          <dependencies><dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+          </dependency></dependencies>
+        </project>
+        XML
+      File.write(File.join(root, "src/main/java/com/example/UserController.java"), <<-JAVA)
+        package com.example;
+
+        import org.springframework.web.bind.annotation.*;
+
+        @RestController
+        public class UserController {
+            @PostMapping("/users")
+            public String create(@RequestBody PersonDto person) {
+                return "ok";
+            }
+        }
+        JAVA
+
+      write_person_dto(root, "email", "Email")
+      first = scan_param_names(root)
+      first.should contain("email")
+
+      # Same path, different content — the shape a `git pull` produces
+      # under a process that scans more than once.
+      write_person_dto(root, "phone", "Phone")
+      CodeLocator.instance.clear_all
+      second = scan_param_names(root)
+
+      second.should contain("phone")
+      second.should_not contain("email")
+    ensure
+      FileUtils.rm_rf(root) if root
+      CodeLocator.instance.clear_all
+    end
+  end
+end

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -1,6 +1,7 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "../models/code_locator"
+require "./extraction_result_cache"
 require "./import_graph"
 require "./java_route_extractor_ts"
 require "../utils/text_file"
@@ -1189,18 +1190,30 @@ module Noir
     # Promoting the cache to class scope means the Nth analyzer
     # picks up the previously-extracted fields for free.
     #
-    # File contents don't change during a noir run, so this is
-    # safe in production. Tests inside the same Crystal process
-    # use unique fixture paths per scenario, so cross-test
-    # contamination doesn't occur in practice; `clear_cache!` is
-    # exposed anyway for any test setup that wants explicit
-    # determinism.
+    # File contents don't change *during* a run, which is what makes the
+    # sharing safe. They do change *between* runs, and the key is a path,
+    # so the entry from the previous scan of that path is what a second
+    # scan reads. That is a scan-lifetime cache wearing a process-lifetime
+    # coat, and it is why the registration below exists.
     @@shared_cache = Hash(String, Index).new
     # Per-file `class -> superclass simple name` map, cached alongside
     # the field index so a file is parsed once for both. Drives the
     # cross-file inheritance merge below.
     @@shared_super_cache = Hash(String, Hash(String, String)).new
     @@shared_cache_mutex = Mutex.new
+
+    # Filesystem-derived memos must not survive into a second scan in the
+    # same process (library use, watch mode, a CI daemon scanning one
+    # checkout across a `git pull`). Same reasoning, same mechanism as
+    # `ImportGraph`'s registration — this cache was simply never wired up,
+    # so `ExtractionResultCache.clear_all` at the top of `analysis_endpoints`
+    # did not reach it.
+    #
+    # The observable failure: scan a Spring app whose `PersonDto` has
+    # `{name, email}`, change it to `{name, phone}`, scan the same path
+    # again in the same process, and every endpoint taking that DTO as a
+    # body still reports the deleted `email` and omits the added `phone`.
+    Noir::ExtractionResultCache.register_clearer { clear_cache! }
 
     def self.clear_cache!
       @@shared_cache_mutex.synchronize do

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -1,6 +1,7 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "../models/code_locator"
+require "./extraction_result_cache"
 require "./import_graph"
 require "../utils/text_file"
 
@@ -1304,6 +1305,11 @@ module Noir
     # cross-file inheritance merge below (mirrors TreeSitterJavaDtoIndex).
     @@shared_super_cache = Hash(String, Hash(String, String)).new
     @@shared_cache_mutex = Mutex.new
+
+    # Path-keyed, so it must not survive into a second scan in the same
+    # process. See the twin registration in `TreeSitterJavaDtoIndex` for the
+    # failure this prevents.
+    Noir::ExtractionResultCache.register_clearer { clear_cache! }
 
     # Backstop against pathological supertype graphs — far above any real
     # DTO hierarchy depth/fan-out.


### PR DESCRIPTION
## Summary

The Java and Kotlin DTO field indexes (`TreeSitterJavaDtoIndex`, `TreeSitterKotlinDtoIndex`) are process-wide and keyed by **absolute file path**. That sharing is load-bearing — it is what stops five Java analyzers from each re-parsing every DTO in the tree — but a path is only a stable key *within* one scan. Across scans the same path can hold different content, and neither index was registered with `ExtractionResultCache`, so the `clear_all` at the top of `analysis_endpoints` never reached them. `clear_cache!` existed on both classes and had **no production caller**.

Reproduced with two scans of one path in one process, the DTO edited in between:

| | `PersonDto` on disk | params reported |
|---|---|---|
| scan A | `{name, email}` | `email, name` |
| scan B (before) | `{name, phone}` | `email, name` ← **stale** |
| scan B (after) | `{name, phone}` | `name, phone` |

Every endpoint taking that DTO as a body reported the **deleted** field and omitted the **added** one, silently.

## Who can hit it

Not the CLI: one scan per process, and `--diff-path` scans two different paths, which a path-keyed cache does not collide on. What reaches it is a long-lived embedder — watch mode, or a CI daemon scanning one checkout across a `git pull`.

`ImportGraph` already registers its filesystem-derived memos for exactly this reason, with a comment saying so (`import_graph.cr:46-48`). These two were simply never wired up. Registering them also bounds their growth, which was otherwise unlimited in a long-running process.

The old comment claimed *"File contents don't change during a noir run, so this is safe in production."* The premise is true and the conclusion did not follow — the problem was never *within* a run. Rewritten to say which lifetime the cache actually has.

## Test plan

- New spec `spec/unit_test/miniparser/dto_index_lifecycle_spec.cr` — **fails on the parent commit** (`Expected: ["email", "name"] to include: "phone"`), passes here.
- A/B sweep over all 665 fixture projects: **byte-identical**, 5,160 endpoints, including `code_paths[].line` and `callees[].line`. Expected — the sweep runs one scan per fixture, so nothing there exercises the second-scan path.
- `crystal spec spec/unit_test` — 4,755 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,653 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.