### PR TITLE
fix(javascript): report the right line on multi-byte source

### DIFF
--- a/spec/functional_test/fixtures/javascript/sveltekit_nonascii/src/routes/api/users/+server.ts
+++ b/spec/functional_test/fixtures/javascript/sveltekit_nonascii/src/routes/api/users/+server.ts
@@ -1,0 +1,11 @@
+// 사용자 API 엔드포인트 — 한국어 주석으로 멀티바이트 문자를 포함합니다.
+// これは日本語のコメントです。マルチバイト文字が含まれています。
+// Emoji también cuentan: 🚀🔥 — los acentos y símbolos ocupan más de un byte.
+
+export async function GET({ url }) {
+  return new Response("list");
+}
+
+export async function POST({ request }) {
+  return new Response("create");
+}

--- a/spec/functional_test/fixtures/javascript/sveltekit_nonascii/svelte.config.js
+++ b/spec/functional_test/fixtures/javascript/sveltekit_nonascii/svelte.config.js
@@ -1,0 +1,1 @@
+export default { kit: {} };

--- a/spec/functional_test/testers/javascript/sveltekit_nonascii_spec.cr
+++ b/spec/functional_test/testers/javascript/sveltekit_nonascii_spec.cr
@@ -1,0 +1,45 @@
+require "../../func_spec.cr"
+
+# Line numbers must survive multi-byte source.
+#
+# `MatchData#begin` returns a CHAR index. Four JS analyzers fed it straight
+# into `content.to_slice[0, index]`, which reads it as a BYTE length — so
+# every non-ASCII character before the match shortened the slice, fewer
+# newlines were counted, and the reported line came out too low. Three lines
+# of Korean/Japanese/Spanish comments were enough to move a route from line 5
+# to line 2.
+#
+# The fixture is deliberately mixed-script: Hangul (3 bytes/char), Kana
+# (3 bytes), emoji (4 bytes) and Latin-1 accents (2 bytes), so a fix that
+# only handles one width does not pass.
+expected_endpoints = [
+  Endpoint.new("/api/users", "GET"),
+  Endpoint.new("/api/users", "POST"),
+]
+
+FunctionalTester.new("fixtures/javascript/sveltekit_nonascii/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests
+
+describe "SvelteKit line numbers with multi-byte source" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "reports the line the route is actually on" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/sveltekit_nonascii/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    get = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/users" }
+    get.details.code_paths.first.line.should eq(5)
+
+    post = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/users" }
+    post.details.code_paths.first.line.should eq(9)
+  end
+end

--- a/src/analyzer/analyzers/javascript/astro.cr
+++ b/src/analyzer/analyzers/javascript/astro.cr
@@ -185,9 +185,13 @@ module Analyzer::Javascript
       end
     end
 
+    # `MatchData#begin` is a CHAR index; the inherited helper is the one
+    # that converts it to a byte offset before counting newlines. This used
+    # to slice `content.to_slice[0, start]` with the char index directly,
+    # which undercounts on any source with non-ASCII before the match — the
+    # sibling `express.cr#line_for_pos` carries the same warning.
     private def line_for_match(content : String, match : Regex::MatchData) : Int32
-      start = match.begin(0) || 0
-      content.to_slice[0, start].count('\n'.ord.to_u8) + 1
+      line_number_for_index(content, match.begin(0) || 0)
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/nextjs.cr
+++ b/src/analyzer/analyzers/javascript/nextjs.cr
@@ -344,8 +344,14 @@ module Analyzer::Javascript
       path.ends_with?(".ts") || path.ends_with?(".tsx")
     end
 
+    # Both call sites pass a CHAR index (`MatchData#begin` at :218,
+    # `String#index` at :332); the inherited helper converts to a byte
+    # offset before counting newlines. The previous body sliced
+    # `content.to_slice[0, index]` with the char index directly, so any
+    # source with non-ASCII before the match reported a line number that
+    # was too low.
     private def line_for_index(content : String, index : Int32) : Int32
-      content.to_slice[0, index].count('\n'.ord.to_u8) + 1
+      line_number_for_index(content, index)
     end
 
     private def detect_pages_router_methods(content : String) : Array(String)

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -264,9 +264,13 @@ module Analyzer::Javascript
       end
     end
 
+    # `MatchData#begin` is a CHAR index; the inherited helper is the one
+    # that converts it to a byte offset before counting newlines. This used
+    # to slice `content.to_slice[0, start]` with the char index directly,
+    # which undercounts on any source with non-ASCII before the match — the
+    # sibling `express.cr#line_for_pos` carries the same warning.
     private def line_for_match(content : String, match : Regex::MatchData) : Int32
-      start = match.begin(0) || 0
-      content.to_slice[0, start].count('\n'.ord.to_u8) + 1
+      line_number_for_index(content, match.begin(0) || 0)
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/sveltekit.cr
+++ b/src/analyzer/analyzers/javascript/sveltekit.cr
@@ -227,9 +227,13 @@ module Analyzer::Javascript
       end
     end
 
+    # `MatchData#begin` is a CHAR index; the inherited helper is the one
+    # that converts it to a byte offset before counting newlines. This used
+    # to slice `content.to_slice[0, start]` with the char index directly,
+    # which undercounts on any source with non-ASCII before the match — the
+    # sibling `express.cr#line_for_pos` carries the same warning.
     private def line_for_match(content : String, match : Regex::MatchData) : Int32
-      start = match.begin(0) || 0
-      content.to_slice[0, start].count('\n'.ord.to_u8) + 1
+      line_number_for_index(content, match.begin(0) || 0)
     end
 
     private def attach_callees(endpoint : Endpoint, path : String, content : String, verb : String)


### PR DESCRIPTION
## Summary

`Regex::MatchData#begin` returns a **char** index. Four JS analyzers fed it straight into `content.to_slice[0, index]`, which reads its argument as a **byte** length. Every non-ASCII character before the match shortened the slice, so fewer newlines were counted and the reported line came out too low.

This is not hypothetical, and not confined to unusual input — **two fixtures already in this repo were being reported wrong**, both because of an em dash the project itself wrote into a comment:

| file | symbol | reported | actually on |
|---|---|---|---|
| `remix_escape_segments/contacts.$contactId_.edit.tsx` | `loader` | 5 | **6** |
| `remix_escape_segments/contacts.$contactId_.edit.tsx` | `action` | 8 | **10** |
| `remix_escape_segments/jokes[.]rss.tsx` | `loader` | 4 | **5** |
| `sveltekit_form_actions/login/+page.server.ts` | `actions` | 3 | **4** |

Seven wrong line numbers across two fixtures, and nothing caught them — no tester asserted on those particular lines, so the A/B fixture sweep is what surfaced them.

`details.code_paths[].line` is what a user clicks to jump to a route, and what every output format and the AI context carry. A line that is quietly two off is a real defect for any codebase whose comments are not pure ASCII — which is most of them outside English.

## Fix

All four delegate to the inherited `Analyzer#line_number_for_index`, which does the `char_index_to_byte_index` conversion.

**The correct form already existed twice in this same directory.** `express.cr#line_for_pos` does the conversion and carries a comment warning about exactly this hazard, and the base helper has done it since it was written. These four were simply never folded in — so the fix and the de-duplication are the same edit.

## Test plan

- New fixture + tester `spec/functional_test/testers/javascript/sveltekit_nonascii_spec.cr`. Deliberately mixed-script — Hangul and Kana (3 bytes/char), emoji (4), Latin-1 accents (2) — so a fix handling only one width does not pass. **Fails on the parent commit with `Expected: 5, got: 2`.**
- A/B sweep over all fixture projects: changes **exactly** the seven line numbers in the table above and nothing else. Every other endpoint, param, tag, code_path and callee is byte-identical. Each new value was checked against the source file by hand.
- `crystal spec spec/unit_test` — 4,753 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,660 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.