### PR TITLE
refactor(php): hoist the three copied helpers onto PhpEngine

### DIFF
--- a/src/analyzer/analyzers/php/hyperf.cr
+++ b/src/analyzer/analyzers/php/hyperf.cr
@@ -374,18 +374,5 @@ module Analyzer::Php
 
       params
     end
-
-    private def dedup_params(params : Array(Param)) : Array(Param)
-      seen = Set(String).new
-      params.select do |param|
-        key = "#{param.param_type}\0#{param.name}"
-        if seen.includes?(key)
-          false
-        else
-          seen.add(key)
-          true
-        end
-      end
-    end
   end
 end

--- a/src/analyzer/analyzers/php/laminas.cr
+++ b/src/analyzer/analyzers/php/laminas.cr
@@ -285,7 +285,7 @@ module Analyzer::Php
       body_end = find_matching_delimiter(content, brace_pos)
       return {nil, pos, nil} unless body_end
 
-      body_start_line = php_line_number_for_index(content, brace_pos)
+      body_start_line = line_number_for_index(content, brace_pos)
       {content[(brace_pos + 1)...body_end], body_end + 1, body_start_line}
     end
 
@@ -771,19 +771,6 @@ module Analyzer::Php
 
     private def array_entry(entries : Array(PhpArrayEntry), key : String) : String?
       entries.find { |entry| entry.key == key }.try(&.array_body)
-    end
-
-    private def dedup_params(params : Array(Param)) : Array(Param)
-      seen = Set(String).new
-      params.select do |param|
-        key = "#{param.param_type}\0#{param.name}"
-        if seen.includes?(key)
-          false
-        else
-          seen.add(key)
-          true
-        end
-      end
     end
 
     private def dedup_endpoints(endpoints : Array(Endpoint)) : Array(Endpoint)

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -501,12 +501,6 @@ module Analyzer::Php
       {content[body_start...body_end], body_end, body_start_line}
     end
 
-    private def newline_count_before(content : String, pos : Int32) : Int32
-      return 0 if pos <= 0
-
-      content[0...pos].count('\n')
-    end
-
     # True when `pos` falls inside any skip range (PHP comment, string
     # literal or heredoc/nowdoc body — see `PhpLexer#skip_ranges`). Cheap on
     # the ~few-hundred-range count seen in real Laravel routes files.

--- a/src/analyzer/analyzers/php/lumen.cr
+++ b/src/analyzer/analyzers/php/lumen.cr
@@ -263,12 +263,6 @@ module Analyzer::Php
       attach_php_callees(endpoint, callees)
     end
 
-    private def newline_count_before(content : String, pos : Int32) : Int32
-      return 0 if pos <= 0
-
-      content[0...pos].count('\n')
-    end
-
     private def extract_methods_from_array(methods_str : String) : Array(String)
       methods = [] of String
       methods_str.scan(/['"]([^'"]+)['"]/).each do |match|
@@ -296,19 +290,6 @@ module Analyzer::Php
         end
       end
       params
-    end
-
-    private def dedup_params(params : Array(Param)) : Array(Param)
-      seen = Set(String).new
-      params.select do |param|
-        key = "#{param.param_type}\0#{param.name}"
-        if seen.includes?(key)
-          false
-        else
-          seen.add(key)
-          true
-        end
-      end
     end
   end
 end

--- a/src/analyzer/analyzers/php/slim.cr
+++ b/src/analyzer/analyzers/php/slim.cr
@@ -174,19 +174,6 @@ module Analyzer::Php
       attach_php_callees(endpoint, callees)
     end
 
-    private def dedup_params(params : Array(Param)) : Array(Param)
-      seen = Set(String).new
-      params.select do |param|
-        key = "#{param.param_type}\0#{param.name}"
-        if seen.includes?(key)
-          false
-        else
-          seen.add(key)
-          true
-        end
-      end
-    end
-
     # Locate the first `$var->group("/prefix", function(...) { ... })` call
     # in the given content and return its span + extracted prefix.
     private def find_group_call(content : String) : Tuple(Int32, Int32, Int32, Int32, String)?
@@ -241,12 +228,6 @@ module Analyzer::Php
 
       body_start_line = base_line + newline_count_before(content, brace_pos)
       {content[(brace_pos + 1)...body_end], body_end + 1, body_start_line}
-    end
-
-    private def newline_count_before(content : String, pos : Int32) : Int32
-      return 0 if pos <= 0
-
-      content[0...pos].count('\n')
     end
 
     # Byte-level scan for O(1) positional access instead of the previous

--- a/src/analyzer/analyzers/php/thinkphp.cr
+++ b/src/analyzer/analyzers/php/thinkphp.cr
@@ -246,11 +246,6 @@ module Analyzer::Php
       pos
     end
 
-    private def newline_count_before(content : String, pos : Int32) : Int32
-      return 0 if pos <= 0
-      content[0...pos].count('\n')
-    end
-
     private def normalize_route(route : String) : String
       normalized = route.gsub(/\[:(\w+)\]/) { ":#{$1}" }
       normalized = normalized.gsub(/:(\w+)/) { "{#{$1}}" }
@@ -648,19 +643,6 @@ module Analyzer::Php
       attach_php_callees(endpoint, callees)
     end
 
-    private def dedup_params(params : Array(Param)) : Array(Param)
-      seen = Set(String).new
-      params.select do |param|
-        key = "#{param.param_type}\0#{param.name}"
-        if seen.includes?(key)
-          false
-        else
-          seen.add(key)
-          true
-        end
-      end
-    end
-
     private def analyze_annotation_routes(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
 
@@ -674,7 +656,7 @@ module Analyzer::Php
 
         pattern = route_match[1]
         normalized_path = normalize_route(pattern)
-        route_line = php_line_number_for_index(content, route_match.begin(0))
+        route_line = line_number_for_index(content, route_match.begin(0))
 
         methods = ["GET"]
         if method_str = route_match[2]?

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -125,25 +125,38 @@ module Analyzer::Php
       return unless method_end
       return if method_end <= brace_start + 1
 
-      body_start_line = php_line_number_for_index(content, brace_start)
+      body_start_line = line_number_for_index(content, brace_start)
       {content[(brace_start + 1)...method_end], body_start_line}
     end
 
-    protected def php_line_number_for_index(content : String, index : Int32) : Int32
-      return 1 if index <= 0
+    # Newlines strictly before `pos`, a CHAR offset — i.e. the 0-based line
+    # index where `line_number_for_index` gives the 1-based number.
+    #
+    # Four analyzers (laravel, lumen, slim, thinkphp) each carried a
+    # byte-identical `content[0...pos].count('\n')` copy of this. That form
+    # allocates a prefix substring per call; routing through the inherited
+    # helper drops the allocation and keeps one definition of "which line is
+    # this offset on" for the whole engine.
+    protected def newline_count_before(content : String, pos : Int32) : Int32
+      line_number_for_index(content, pos) - 1
+    end
 
-      # Count newlines without allocating `content[0...index]` (O(n)
-      # copy per call). Byte scan is correct because `\n` is ASCII and
-      # never appears inside a UTF-8 multi-byte sequence.
-      bytes = content.to_slice
-      byte_end = content.char_index_to_byte_index(index) || bytes.size
-      count = 1
-      i = 0
-      while i < byte_end
-        count += 1 if bytes[i] == BYTE_NEWLINE
-        i += 1
+    # Drop repeat `(param_type, name)` pairs, keeping the first.
+    #
+    # Was five byte-identical private copies (hyperf, laminas, lumen, slim,
+    # thinkphp). The NUL separator matters: it cannot occur in either field,
+    # so `("query", "a\0b")` and `("query\0a", "b")` cannot collide.
+    protected def dedup_params(params : Array(Param)) : Array(Param)
+      seen = Set(String).new
+      params.select do |param|
+        key = "#{param.param_type}\0#{param.name}"
+        if seen.includes?(key)
+          false
+        else
+          seen.add(key)
+          true
+        end
       end
-      count
     end
 
     # ASCII byte values for the structural delimiters scanned below.

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -327,8 +327,9 @@ class Analyzer
   # is correct because `\n` is ASCII and never appears inside a UTF-8
   # multi-byte sequence.
   #
-  # `PhpEngine#php_line_number_for_index` predates this and is identical;
-  # it should fold into this helper when PHP is next touched.
+  # Takes a CHAR offset. Feeding it a byte offset silently reports a line
+  # that is too low on non-ASCII input — the defect four JS analyzers
+  # carried until they were folded in here.
   def line_number_for_index(content : String, char_index : Int32) : Int32
     return 1 if char_index <= 0
 


### PR DESCRIPTION
## Summary

Nine byte-identical private copies across six analyzers that **already share `PhpEngine`**, plus one engine method that duplicated an inherited one. **Net −74 lines**, no behaviour change.

| helper | copies | where |
|---|---|---|
| `dedup_params` | 5 | hyperf, laminas, lumen, slim, thinkphp |
| `newline_count_before` | 4 | laravel, lumen, slim, thinkphp |
| `php_line_number_for_index` | 1 (engine) | duplicated `Analyzer#line_number_for_index` |

### Why each is safe

- **`dedup_params`** — byte-identical in all five.
- **`newline_count_before`** — byte-identical in all four, and exactly `line_number_for_index(content, pos) - 1`. Both take a **CHAR** offset, so the equivalence holds on non-ASCII too, and the boundary agrees (`pos <= 0` yields `0` from one and `1` from the other). The old body allocated a prefix substring per call; the inherited helper scans bytes without copying.
- **`php_line_number_for_index`** — line-for-line identical to `Analyzer#line_number_for_index`, down to `BYTE_NEWLINE` being the same constant the base inlines. `src/models/analyzer.cr` has carried a comment since that helper was written saying this one *"predates this and is identical; it should fold into this helper when PHP is next touched."* This is that. Its three call sites now use the inherited method.

That stale comment is replaced with the thing actually worth knowing: the helper takes a **CHAR** offset, and feeding it a byte offset silently reports a line that is too low on non-ASCII input — the defect four JS analyzers carried until #2519.

## Test plan

- A/B sweep over all 666 fixture projects: **byte-identical**, 5,162 endpoints, including `code_paths[].line` and `callees[].line`.
- `crystal spec spec/unit_test` — 4,756 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,660 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.