### PR TITLE
refactor(rust): hoist the seven copied tree-sitter helpers onto RustEngine

### DIFF
--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -891,18 +891,6 @@ module Analyzer::Rust
       LibTreeSitter.ts_node_start_byte(node).to_i
     end
 
-    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
-      index = {} of String => LibTreeSitter::TSNode
-      walk(root) do |node|
-        next unless Noir::TreeSitter.node_type(node) == "function_item"
-        name_node = Noir::TreeSitter.field(node, "name")
-        next unless name_node
-        name = Noir::TreeSitter.node_text(name_node, source)
-        index[name] = node unless index.has_key?(name)
-      end
-      index
-    end
-
     private def attach_builder_handler_context(endpoint : Endpoint,
                                                handler_name : String,
                                                function_index : Hash(String, LibTreeSitter::TSNode),
@@ -1257,40 +1245,6 @@ module Analyzer::Rust
       end
     end
 
-    private def attach_handler_callees(function : LibTreeSitter::TSNode,
-                                       source : String,
-                                       path : String,
-                                       endpoint : Endpoint)
-      body = Noir::TreeSitter.field(function, "body")
-      return unless body
-      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
-      attach_rust_callees(endpoint, entries)
-    end
-
-    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
-      fn_node = Noir::TreeSitter.field(call, "function")
-      return unless fn_node
-      Noir::TreeSitter.node_text(fn_node, source)
-    end
-
-    # Walk `node`'s children at every depth and yield `(attribute_item,
-    # function_item)` pairs where the attribute immediately precedes
-    # the function (skipping intermediate attribute_items and doc
-    # comments). This matches how `#[get(...)] async fn handler` is
-    # laid out in the AST — both are top-level siblings, not parent /
-    # child.
-    private def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
-      named = [] of LibTreeSitter::TSNode
-      Noir::TreeSitter.each_named_child(node) { |c| named << c }
-      named.each_with_index do |child, idx|
-        if Noir::TreeSitter.node_type(child) == "attribute_item"
-          pair_function = find_paired_function(named, idx + 1)
-          block.call(child, pair_function) if pair_function
-        end
-        each_routing_pair(child, &block)
-      end
-    end
-
     private def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
       (start...named.size).each do |i|
         next_node = named[i]
@@ -1315,20 +1269,6 @@ module Analyzer::Rust
         result = string_content_of(child, source)
       end
       result
-    end
-
-    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
-      Noir::TreeSitter.each_named_child(node) do |child|
-        return child if Noir::TreeSitter.node_type(child) == type
-      end
-      nil
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
     end
   end
 end

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -1594,13 +1594,6 @@ module Analyzer::Rust
       end
     end
 
-    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
-      Noir::TreeSitter.each_named_child(node) do |child|
-        return child if Noir::TreeSitter.node_type(child) == type
-      end
-      nil
-    end
-
     # Walk `node`'s children pairing each `attribute_item` with the
     # `function_item` it decorates (skipping doc comments / other attrs).
     private def each_attribute_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
@@ -1622,13 +1615,6 @@ module Analyzer::Rust
           end
         end
         each_attribute_pair(child, &block)
-      end
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
       end
     end
   end

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -372,22 +372,6 @@ module Analyzer::Rust
       end
     end
 
-    private def attach_handler_callees(function : LibTreeSitter::TSNode,
-                                       source : String,
-                                       path : String,
-                                       endpoint : Endpoint)
-      body = Noir::TreeSitter.field(function, "body")
-      return unless body
-      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
-      attach_rust_callees(endpoint, entries)
-    end
-
-    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
-      fn_node = Noir::TreeSitter.field(call, "function")
-      return unless fn_node
-      Noir::TreeSitter.node_text(fn_node, source)
-    end
-
     private def first_identifier_argument(call : LibTreeSitter::TSNode, source : String) : String?
       args = Noir::TreeSitter.field(call, "arguments")
       return unless args
@@ -400,18 +384,6 @@ module Analyzer::Rust
         end
       end
       nil
-    end
-
-    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
-      index = {} of String => LibTreeSitter::TSNode
-      walk(root) do |node|
-        next unless Noir::TreeSitter.node_type(node) == "function_item"
-        name_node = Noir::TreeSitter.field(node, "name")
-        next unless name_node
-        name = Noir::TreeSitter.node_text(name_node, source)
-        index[name] = node unless index.has_key?(name)
-      end
-      index
     end
 
     private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
@@ -429,13 +401,6 @@ module Analyzer::Rust
         end
       end
       result
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
     end
   end
 end

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -217,18 +217,6 @@ module Analyzer::Rust
       nil
     end
 
-    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
-      index = {} of String => LibTreeSitter::TSNode
-      walk(root) do |node|
-        next unless Noir::TreeSitter.node_type(node) == "function_item"
-        name_node = Noir::TreeSitter.field(node, "name")
-        next unless name_node
-        name = Noir::TreeSitter.node_text(name_node, source)
-        index[name] = node unless index.has_key?(name)
-      end
-      index
-    end
-
     # Loco analysers are scoped to `pub async fn` items only — the
     # legacy regex `pub\s+async\s+fn\s+(\w+)` enforced both modifiers.
     # tree-sitter exposes them as children of the `function_item`'s
@@ -390,22 +378,6 @@ module Analyzer::Rust
       name.includes?("-") || name.in?(%w[Authorization Content-Type Accept])
     end
 
-    private def attach_handler_callees(function : LibTreeSitter::TSNode,
-                                       source : String,
-                                       path : String,
-                                       endpoint : Endpoint)
-      body = Noir::TreeSitter.field(function, "body")
-      return unless body
-      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
-      attach_rust_callees(endpoint, entries)
-    end
-
-    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
-      fn_node = Noir::TreeSitter.field(call, "function")
-      return unless fn_node
-      Noir::TreeSitter.node_text(fn_node, source)
-    end
-
     private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
       return unless node
       result : String? = nil
@@ -421,13 +393,6 @@ module Analyzer::Rust
         end
       end
       result
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
     end
   end
 end

--- a/src/analyzer/analyzers/rust/poem.cr
+++ b/src/analyzer/analyzers/rust/poem.cr
@@ -277,22 +277,6 @@ module Analyzer::Rust
       end
     end
 
-    private def attach_handler_callees(function : LibTreeSitter::TSNode,
-                                       source : String,
-                                       path : String,
-                                       endpoint : Endpoint)
-      body = Noir::TreeSitter.field(function, "body")
-      return unless body
-      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
-      attach_rust_callees(endpoint, entries)
-    end
-
-    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
-      fn_node = Noir::TreeSitter.field(call, "function")
-      return unless fn_node
-      Noir::TreeSitter.node_text(fn_node, source)
-    end
-
     private def first_identifier_argument(call : LibTreeSitter::TSNode, source : String) : String?
       args = Noir::TreeSitter.field(call, "arguments")
       return unless args
@@ -322,18 +306,6 @@ module Analyzer::Rust
       return unless named.size == 1
       return unless Noir::TreeSitter.node_type(named[0]) == "string_literal"
       string_content(named[0], source)
-    end
-
-    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
-      index = {} of String => LibTreeSitter::TSNode
-      walk(root) do |node|
-        next unless Noir::TreeSitter.node_type(node) == "function_item"
-        name_node = Noir::TreeSitter.field(node, "name")
-        next unless name_node
-        name = Noir::TreeSitter.node_text(name_node, source)
-        index[name] = node unless index.has_key?(name)
-      end
-      index
     end
 
     # ── poem-openapi nest prefix composition ─────────────────────────
@@ -468,33 +440,6 @@ module Analyzer::Rust
       suffix.empty? ? pfx : "#{pfx}/#{suffix}"
     end
 
-    private def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
-      named = [] of LibTreeSitter::TSNode
-      Noir::TreeSitter.each_named_child(node) { |c| named << c }
-      named.each_with_index do |child, idx|
-        if Noir::TreeSitter.node_type(child) == "attribute_item"
-          pair_function = find_paired_function(named, idx + 1)
-          block.call(child, pair_function) if pair_function
-        end
-        each_routing_pair(child, &block)
-      end
-    end
-
-    private def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
-      (start...named.size).each do |i|
-        next_node = named[i]
-        case Noir::TreeSitter.node_type(next_node)
-        when "function_item"
-          return next_node
-        when "attribute_item", "line_comment", "block_comment"
-          next
-        else
-          return
-        end
-      end
-      nil
-    end
-
     private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
       return unless node
       result : String? = nil
@@ -505,27 +450,6 @@ module Analyzer::Rust
         end
       end
       result
-    end
-
-    private def string_content(string_literal : LibTreeSitter::TSNode, source : String) : String?
-      Noir::TreeSitter.each_named_child(string_literal) do |grand|
-        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
-      end
-      nil
-    end
-
-    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
-      Noir::TreeSitter.each_named_child(node) do |child|
-        return child if Noir::TreeSitter.node_type(child) == type
-      end
-      nil
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
     end
   end
 end

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -572,49 +572,6 @@ module Analyzer::Rust
       end
     end
 
-    private def attach_handler_callees(function : LibTreeSitter::TSNode,
-                                       source : String,
-                                       path : String,
-                                       endpoint : Endpoint)
-      body = Noir::TreeSitter.field(function, "body")
-      return unless body
-      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
-      attach_rust_callees(endpoint, entries)
-    end
-
-    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
-      fn_node = Noir::TreeSitter.field(call, "function")
-      return unless fn_node
-      Noir::TreeSitter.node_text(fn_node, source)
-    end
-
-    private def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
-      named = [] of LibTreeSitter::TSNode
-      Noir::TreeSitter.each_named_child(node) { |c| named << c }
-      named.each_with_index do |child, idx|
-        if Noir::TreeSitter.node_type(child) == "attribute_item"
-          pair_function = find_paired_function(named, idx + 1)
-          block.call(child, pair_function) if pair_function
-        end
-        each_routing_pair(child, &block)
-      end
-    end
-
-    private def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
-      (start...named.size).each do |i|
-        next_node = named[i]
-        case Noir::TreeSitter.node_type(next_node)
-        when "function_item"
-          return next_node
-        when "attribute_item", "line_comment", "block_comment"
-          next
-        else
-          return
-        end
-      end
-      nil
-    end
-
     private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
       return unless node
       result : String? = nil
@@ -625,27 +582,6 @@ module Analyzer::Rust
         end
       end
       result
-    end
-
-    private def string_content(string_literal : LibTreeSitter::TSNode, source : String) : String?
-      Noir::TreeSitter.each_named_child(string_literal) do |grand|
-        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
-      end
-      nil
-    end
-
-    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
-      Noir::TreeSitter.each_named_child(node) do |child|
-        return child if Noir::TreeSitter.node_type(child) == type
-      end
-      nil
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
     end
   end
 end

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -456,12 +456,5 @@ module Analyzer::Rust
       end
       result
     end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
-    end
   end
 end

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -564,22 +564,6 @@ module Analyzer::Rust
       end
     end
 
-    private def attach_handler_callees(function : LibTreeSitter::TSNode,
-                                       source : String,
-                                       path : String,
-                                       endpoint : Endpoint)
-      body = Noir::TreeSitter.field(function, "body")
-      return unless body
-      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
-      attach_rust_callees(endpoint, entries)
-    end
-
-    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
-      fn_node = Noir::TreeSitter.field(call, "function")
-      return unless fn_node
-      Noir::TreeSitter.node_text(fn_node, source)
-    end
-
     # First identifier / scoped-path argument of a call, used as the
     # handler name. `get(create_user)` → `create_user`,
     # `get(html::pages::login)` → `html::pages::login`.
@@ -618,18 +602,6 @@ module Analyzer::Rust
         fragments << {"fn __noir_salvo_wf() { let __noir_x = #{text}; }", Noir::TreeSitter.node_start_row(tt)}
       end
       fragments
-    end
-
-    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
-      index = {} of String => LibTreeSitter::TSNode
-      walk(root) do |node|
-        next unless Noir::TreeSitter.node_type(node) == "function_item"
-        name_node = Noir::TreeSitter.field(node, "name")
-        next unless name_node
-        name = Noir::TreeSitter.node_text(name_node, source)
-        index[name] = node unless index.has_key?(name)
-      end
-      index
     end
 
     # ── cross-fn external prefix resolution ───────────────────────────
@@ -818,33 +790,6 @@ module Analyzer::Rust
       final
     end
 
-    private def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
-      named = [] of LibTreeSitter::TSNode
-      Noir::TreeSitter.each_named_child(node) { |c| named << c }
-      named.each_with_index do |child, idx|
-        if Noir::TreeSitter.node_type(child) == "attribute_item"
-          pair_function = find_paired_function(named, idx + 1)
-          block.call(child, pair_function) if pair_function
-        end
-        each_routing_pair(child, &block)
-      end
-    end
-
-    private def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
-      (start...named.size).each do |i|
-        next_node = named[i]
-        case Noir::TreeSitter.node_type(next_node)
-        when "function_item"
-          return next_node
-        when "attribute_item", "line_comment", "block_comment"
-          next
-        else
-          return
-        end
-      end
-      nil
-    end
-
     # Collect `const NAME: &str = "..."` / `static NAME: &str = "..."` string
     # constants across the project (regex over source; these are simple
     # top-level declarations). Used to resolve concatenated path prefixes.
@@ -915,27 +860,6 @@ module Analyzer::Rust
         end
       end
       result
-    end
-
-    private def string_content(string_literal : LibTreeSitter::TSNode, source : String) : String?
-      Noir::TreeSitter.each_named_child(string_literal) do |grand|
-        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
-      end
-      nil
-    end
-
-    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
-      Noir::TreeSitter.each_named_child(node) do |child|
-        return child if Noir::TreeSitter.node_type(child) == type
-      end
-      nil
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
     end
   end
 end

--- a/src/analyzer/analyzers/rust/tide.cr
+++ b/src/analyzer/analyzers/rust/tide.cr
@@ -324,22 +324,6 @@ module Analyzer::Rust
       end
     end
 
-    private def attach_handler_callees(function : LibTreeSitter::TSNode,
-                                       source : String,
-                                       path : String,
-                                       endpoint : Endpoint)
-      body = Noir::TreeSitter.field(function, "body")
-      return unless body
-      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
-      attach_rust_callees(endpoint, entries)
-    end
-
-    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
-      fn_node = Noir::TreeSitter.field(call, "function")
-      return unless fn_node
-      Noir::TreeSitter.node_text(fn_node, source)
-    end
-
     private def first_named_argument(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
       args = Noir::TreeSitter.field(call, "arguments")
       return unless args
@@ -347,18 +331,6 @@ module Analyzer::Rust
         return child
       end
       nil
-    end
-
-    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
-      index = {} of String => LibTreeSitter::TSNode
-      walk(root) do |node|
-        next unless Noir::TreeSitter.node_type(node) == "function_item"
-        name_node = Noir::TreeSitter.field(node, "name")
-        next unless name_node
-        name = Noir::TreeSitter.node_text(name_node, source)
-        index[name] = node unless index.has_key?(name)
-      end
-      index
     end
 
     private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
@@ -376,13 +348,6 @@ module Analyzer::Rust
         end
       end
       result
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
     end
   end
 end

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -492,16 +492,6 @@ module Analyzer::Rust
       index[handler_name]? || index[leaf]?
     end
 
-    private def attach_handler_callees(function : LibTreeSitter::TSNode,
-                                       source : String,
-                                       path : String,
-                                       endpoint : Endpoint)
-      body = Noir::TreeSitter.field(function, "body")
-      return unless body
-      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
-      attach_rust_callees(endpoint, entries)
-    end
-
     private def attach_external_handler_callees(handler_name : String,
                                                 current_path : String,
                                                 endpoint : Endpoint)
@@ -640,18 +630,6 @@ module Analyzer::Rust
       result
     end
 
-    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
-      index = {} of String => LibTreeSitter::TSNode
-      walk(root) do |node|
-        next unless Noir::TreeSitter.node_type(node) == "function_item"
-        name_node = Noir::TreeSitter.field(node, "name")
-        next unless name_node
-        name = Noir::TreeSitter.node_text(name_node, source)
-        index[name] = node unless index.has_key?(name)
-      end
-      index
-    end
-
     private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
       return unless node
       result : String? = nil
@@ -667,13 +645,6 @@ module Analyzer::Rust
         end
       end
       result
-    end
-
-    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
-      block.call(node)
-      Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, &block)
-      end
     end
   end
 end

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -1,6 +1,8 @@
 require "../../models/analyzer"
 require "./file_scan_engine"
 require "../../miniparsers/rust_callee_extractor"
+require "../../miniparsers/rust_callee_extractor_ts"
+require "../../ext/tree_sitter/tree_sitter"
 
 module Analyzer::Rust
   abstract class RustEngine < FileScanEngine
@@ -370,6 +372,121 @@ module Analyzer::Rust
       return unless found_opening_brace
 
       {body_lines.join("\n"), body_start_line, lines.size - 1}
+    end
+
+    # ---- Shared tree-sitter walking helpers -----------------------------
+    #
+    # These were 47 byte-identical private copies across the ten Rust
+    # framework adapters. They are `protected`, so an adapter that needs
+    # different behaviour still overrides — and three do, deliberately:
+    #
+    #   * `warp#call_function_text` returns text only for a
+    #     `scoped_identifier`, nil otherwise.
+    #   * `axum#build_function_index` is an overload pair that tracks
+    #     module scope while descending.
+    #   * `actix_web#find_paired_function` differs from the shape below.
+    #
+    # Those three keep their own versions; Crystal dispatches to the
+    # subclass, so the helpers here that call them (`each_routing_pair` →
+    # `find_paired_function`, `build_function_index` → `walk`) still get
+    # the adapter's behaviour.
+
+    # Yield `node` and every named descendant, depth-first.
+    protected def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, &block)
+      end
+    end
+
+    # The first named child of `node` whose type is `type`.
+    protected def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        return child if Noir::TreeSitter.node_type(child) == type
+      end
+      nil
+    end
+
+    # `function_name => function_item` over the whole tree, first
+    # definition winning.
+    protected def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
+      index = {} of String => LibTreeSitter::TSNode
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "function_item"
+        name_node = Noir::TreeSitter.field(node, "name")
+        next unless name_node
+        name = Noir::TreeSitter.node_text(name_node, source)
+        index[name] = node unless index.has_key?(name)
+      end
+      index
+    end
+
+    # The callee text of a `call_expression` (`foo`, `Bar::baz`, …).
+    protected def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node
+      Noir::TreeSitter.node_text(fn_node, source)
+    end
+
+    # Walk `node`'s children at every depth and yield `(attribute_item,
+    # function_item)` pairs where the attribute immediately precedes
+    # the function (skipping intermediate attribute_items and doc
+    # comments). This matches how `#[get(...)] async fn handler` is
+    # laid out in the AST — both are top-level siblings, not parent /
+    # child.
+    protected def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(node) { |c| named << c }
+      named.each_with_index do |child, idx|
+        if Noir::TreeSitter.node_type(child) == "attribute_item"
+          pair_function = find_paired_function(named, idx + 1)
+          block.call(child, pair_function) if pair_function
+        end
+        each_routing_pair(child, &block)
+      end
+    end
+
+    # The `function_item` that `named[start...]` leads to, skipping further
+    # attributes and comments. Anything else means the attribute does not
+    # decorate a function, so there is no pair.
+    protected def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
+      (start...named.size).each do |i|
+        next_node = named[i]
+        case Noir::TreeSitter.node_type(next_node)
+        when "function_item"
+          return next_node
+        when "attribute_item", "line_comment", "block_comment"
+          next
+        else
+          return
+        end
+      end
+      nil
+    end
+
+    # The first `string_content` child of a `string_literal`.
+    #
+    # NOTE: tree-sitter-rust splits a literal at each escape, so this
+    # truncates a path carrying one (`"/page-{id:\d+}"` → `/page-{id:`).
+    # `actix_web#string_content_of` concatenates the `escape_sequence`
+    # children and is the correct form; folding these together is a
+    # behaviour change and belongs in its own commit.
+    protected def string_content(string_literal : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(string_literal) do |grand|
+        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
+      end
+      nil
+    end
+
+    # Attach the 1-hop callees of `function`'s body to `endpoint`.
+    protected def attach_handler_callees(function : LibTreeSitter::TSNode,
+                                         source : String,
+                                         path : String,
+                                         endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
+      attach_rust_callees(endpoint, entries)
     end
   end
 end


### PR DESCRIPTION
## Summary

**47 byte-identical private copies** across the ten Rust framework adapters, all of which already inherit `RustEngine`. **Net −314 lines**, no behaviour change.

| helper | copies | | helper | copies |
|---|---|---|---|---|
| `walk` | 10 | | `find_named_child` | 5 |
| `attach_handler_callees` | 8 | | `each_routing_pair` | 4 |
| `build_function_index` | 7 | | `find_paired_function` | 3 |
| `call_function_text` | 7 | | `string_content` | 3 |

## Identity was established by body, not by name — and that mattered

Hashing whitespace-normalised bodies found the copies; matching on the method name alone would have deleted three methods that are **not** copies. Each keeps its own version:

- **`warp#call_function_text`** returns text only for a `scoped_identifier` and nil otherwise, where the shared one returns any function node's text. Deleting it would have changed warp's output.
- **`axum#build_function_index`** is an overload pair that threads module scope while descending.
- **`actix_web#find_paired_function`** differs from the shared shape.

The hoisted helpers are `protected`, so Crystal dispatches to those overrides — `each_routing_pair` → `find_paired_function` and `build_function_index` → `walk` still get the adapter's behaviour inside the adapter.

## Two families deliberately left alone

- **`first_string_literal_text`** — the five-copy version reads only the first `string_content` child, but tree-sitter-rust splits a literal at every escape, so it **truncates** a path carrying one (`"/page-{id:\d+}"` → `/page-{id:`). actix_web and axum carry the correct escape-concatenating form, documented as such in their own comments. Folding these is a *bug fix*, not a de-duplication, and belongs in its own commit with a fixture. `string_content` shares the flaw and now carries a note pointing at it, so the eventual fix has one place to land.
- **`extract_path_params`** — identical in gotham/rwf/tide, but it parses `:name`, while salvo's same-named method parses `<name>` / `{name}`. That is framework route syntax, not a shared utility; hoisting one dialect under that name would mislead.

## Test plan

- A/B sweep over all 666 fixture projects: **byte-identical**, 5,162 endpoints, including `code_paths[].line` and `callees[].line`.
- `crystal spec spec/unit_test` — 4,756 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,660 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.