### PR TITLE
refactor(tagger): make the per-endpoint shape the FrameworkTagger default

### DIFF
--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -214,4 +214,29 @@ class FrameworkTagger < Tagger
     return true if STATIC_PUBLIC_FILES.includes?(last)
     STATIC_ASSET_EXTENSIONS.any? { |ext| last.ends_with?(ext) }
   end
+
+  # The per-endpoint shape: look at each endpoint, tag in place, hand the
+  # array back. Fifteen framework taggers carried a byte-identical copy of
+  # this; they now declare only `check_endpoint`.
+  #
+  # Not every framework tagger fits it — eleven still override `perform`
+  # because they need a pre-scan over the project (config files, middleware
+  # registration) before the per-endpoint pass, or they group endpoints
+  # first. Those keep their own.
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  # Per-endpoint hook for taggers using the inherited `perform`.
+  #
+  # A no-op rather than `abstract`: `FrameworkTagger` is instantiated
+  # directly by its own spec and by the tagger-registry specs, so the class
+  # cannot be abstract. A tagger that inherits `perform` without defining
+  # this tags nothing — `spec/unit_test/tagger/framework_taggers/` covers
+  # each one, so that shows up as a failing tagger spec rather than silence.
+  protected def check_endpoint(endpoint : Endpoint)
+  end
 end

--- a/src/tagger/framework_taggers/crystal/crystal_auth.cr
+++ b/src/tagger/framework_taggers/crystal/crystal_auth.cr
@@ -39,13 +39,6 @@ class CrystalAuthTagger < FrameworkTagger
     ["crystal_kemal", "crystal_amber", "crystal_lucky", "crystal_grip", "crystal_marten"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/csharp/aspnet_auth.cr
+++ b/src/tagger/framework_taggers/csharp/aspnet_auth.cr
@@ -31,13 +31,6 @@ class AspnetAuthTagger < FrameworkTagger
     ["cs_aspnet_mvc", "cs_aspnet_core_mvc", "cs_aspnet_core_minimal_api", "cs_carter"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/csharp/fastendpoints_auth.cr
+++ b/src/tagger/framework_taggers/csharp/fastendpoints_auth.cr
@@ -14,13 +14,6 @@ class FastEndpointsAuthTagger < FrameworkTagger
     ["cs_fastendpoints"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       content = read_file(path_info.path)

--- a/src/tagger/framework_taggers/java/java_misc_auth.cr
+++ b/src/tagger/framework_taggers/java/java_misc_auth.cr
@@ -37,13 +37,6 @@ class JavaMiscAuthTagger < FrameworkTagger
     ["java_vertx", "java_armeria", "java_jsp"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/javascript/js_misc_auth.cr
+++ b/src/tagger/framework_taggers/javascript/js_misc_auth.cr
@@ -47,13 +47,6 @@ class JsMiscAuthTagger < FrameworkTagger
     ["js_fastify", "js_koa", "js_restify", "js_nuxtjs"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/javascript/nestjs_auth.cr
+++ b/src/tagger/framework_taggers/javascript/nestjs_auth.cr
@@ -52,13 +52,6 @@ class NestjsAuthTagger < FrameworkTagger
     ["js_nestjs", "ts_nestjs"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/php/php_auth.cr
+++ b/src/tagger/framework_taggers/php/php_auth.cr
@@ -82,13 +82,6 @@ class PhpAuthTagger < FrameworkTagger
     ]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/python/django_auth.cr
+++ b/src/tagger/framework_taggers/python/django_auth.cr
@@ -30,14 +30,6 @@ class DjangoAuthTagger < FrameworkTagger
     ["python_django"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     contexts = read_source_context(endpoint)
     return if contexts.empty?

--- a/src/tagger/framework_taggers/python/fastapi_auth.cr
+++ b/src/tagger/framework_taggers/python/fastapi_auth.cr
@@ -35,13 +35,6 @@ class FastAPIAuthTagger < FrameworkTagger
     ["python_fastapi"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/python/flask_auth.cr
+++ b/src/tagger/framework_taggers/python/flask_auth.cr
@@ -28,13 +28,6 @@ class FlaskAuthTagger < FrameworkTagger
     ["python_flask"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/python/python_misc_auth.cr
+++ b/src/tagger/framework_taggers/python/python_misc_auth.cr
@@ -27,13 +27,6 @@ class PythonMiscAuthTagger < FrameworkTagger
     ["python_sanic", "python_tornado"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/ruby/rails_security.cr
+++ b/src/tagger/framework_taggers/ruby/rails_security.cr
@@ -56,13 +56,6 @@ class RailsSecurityTagger < FrameworkTagger
     ["ruby_rails"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/ruby/ruby_auth.cr
+++ b/src/tagger/framework_taggers/ruby/ruby_auth.cr
@@ -83,13 +83,6 @@ class RubyAuthTagger < FrameworkTagger
     ["ruby_rails", "ruby_sinatra", "ruby_hanami", "ruby_grape", "ruby_roda"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/scala/scala_auth.cr
+++ b/src/tagger/framework_taggers/scala/scala_auth.cr
@@ -38,13 +38,6 @@ class ScalaAuthTagger < FrameworkTagger
     ["scala_play", "scala_akka", "scala_scalatra", "java_play"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)

--- a/src/tagger/framework_taggers/swift/swift_auth.cr
+++ b/src/tagger/framework_taggers/swift/swift_auth.cr
@@ -39,13 +39,6 @@ class SwiftAuthTagger < FrameworkTagger
     ["swift_vapor", "swift_kitura", "swift_hummingbird"]
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints.each do |endpoint|
-      check_endpoint(endpoint)
-    end
-    endpoints
-  end
-
   private def check_endpoint(endpoint : Endpoint)
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)


### PR DESCRIPTION
## Summary

Fifteen framework taggers carried a byte-identical `perform`:

```crystal
def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
  endpoints.each { |endpoint| check_endpoint(endpoint) }
  endpoints
end
```

It moves to `FrameworkTagger`, and those fifteen now declare only their `check_endpoint`. **Net −81 lines.**

Eleven of the 27 framework taggers keep their own `perform` — they need a project-wide pre-scan (auth config, middleware registration) before the per-endpoint pass, or they group endpoints first. Overriding works exactly as before.

`check_endpoint` is a **no-op default rather than `abstract`**, because `FrameworkTagger` is instantiated directly by its own spec and by the tagger-registry specs, so the class cannot be made abstract. A tagger that inherited `perform` without defining `check_endpoint` would tag nothing; `spec/unit_test/tagger/framework_taggers/` has a spec per tagger, so that surfaces as a failing tagger spec rather than as silence.

## Verification note — the usual A/B sweep is blind to this change

The standard fixture A/B sweep does **not** pass `-T`, so taggers never run under it and a tagger regression would have compared clean.

This was verified with a tag-aware sweep instead: the same 666 fixture projects scanned with `-T`, comparing every endpoint's tag `name` / `tag` / `description`.

| | tags |
|---|---|
| main | 1,215 |
| this branch | 1,215 — **byte-identical** |

That is also what proves the dispatch works: the subclasses' `check_endpoint` are `private`, and the inherited `perform` calls them.

## Test plan

- Tag-aware A/B sweep, 666 projects with `-T`: byte-identical, 1,215 tags.
- `crystal spec spec/unit_test` — 4,756 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,660 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.