### PR TITLE
fix(rust): stop truncating route paths at a string escape

### DIFF
--- a/spec/functional_test/fixtures/rust/tide_escaped_paths/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/tide_escaped_paths/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tide-escaped-paths"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tide = "0.16"

--- a/spec/functional_test/fixtures/rust/tide_escaped_paths/src/main.rs
+++ b/spec/functional_test/fixtures/rust/tide_escaped_paths/src/main.rs
@@ -1,0 +1,22 @@
+use tide::Request;
+
+async fn show(_req: Request<()>) -> tide::Result<String> {
+    Ok("ok".to_string())
+}
+
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    let mut app = tide::new();
+
+    // tree-sitter-rust splits a string literal at every escape, so a route
+    // whose path carries one used to be truncated at the first escape.
+    app.at("/page-{id:\\d+}").get(show);
+    app.at("/file-{name:.*\\.json}").get(show);
+
+    // Unescaped neighbours: these were always read correctly, and must stay
+    // that way.
+    app.at("/plain/{name}").get(show);
+
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
+}

--- a/spec/functional_test/testers/rust/tide_escaped_paths_spec.cr
+++ b/spec/functional_test/testers/rust/tide_escaped_paths_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+# A route path containing a Rust string escape must survive intact.
+#
+# tree-sitter-rust splits a string literal at every escape, so
+# `"/page-{id:\d+}"` parses as string_content `/page-{id:`, escape_sequence
+# `\d`, string_content `+}`. Eight of the ten Rust adapters read only the
+# first `string_content` child, which truncated the path to `/page-{id:` —
+# a URL that matches nothing, with the param lost.
+#
+# Regex-constrained path params are ordinary in tide, actix and rocket, so
+# this is not an exotic shape. No pre-existing Rust fixture carried one,
+# which is exactly why the truncation survived: the whole fixture sweep
+# compared clean either way.
+expected_endpoints = [
+  Endpoint.new("/page-{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/file-{name}", "GET", [
+    Param.new("name", "", "path"),
+  ]),
+  Endpoint.new("/plain/{name}", "GET", [
+    Param.new("name", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/rust/tide_escaped_paths/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -1127,7 +1127,7 @@ module Analyzer::Rust
           saw_method = Noir::TreeSitter.node_text(child, source) == "method"
         when "string_literal"
           if saw_method
-            if v = string_content_of(child, source)
+            if v = string_content(child, source)
               methods << v.upcase
             end
             saw_method = false
@@ -1137,31 +1137,13 @@ module Analyzer::Rust
       methods.uniq
     end
 
-    # Full text of a string literal, concatenating every
-    # `string_content` and `escape_sequence` child. tree-sitter-rust
-    # splits a literal at each escape (`"/page-{id:\d+}"` → content
-    # `/page-{id:`, escape `\d`, content `+}`), so reading only the
-    # first `string_content` truncates paths that carry an escape (e.g.
-    # a regex-constrained param). Returns nil for a literal with no
-    # content children (genuinely empty `""`).
-    private def string_content_of(string_literal : LibTreeSitter::TSNode, source : String) : String?
-      parts = [] of String
-      Noir::TreeSitter.each_named_child(string_literal) do |grand|
-        case Noir::TreeSitter.node_type(grand)
-        when "string_content", "escape_sequence"
-          parts << Noir::TreeSitter.node_text(grand, source)
-        end
-      end
-      parts.empty? ? nil : parts.join
-    end
-
     # The route-path argument of a `.route(path, ...)` call. A bare
     # string literal yields its content, an empty literal `""` yields
     # "" (actix's "register at the scope root" form), and anything that
     # isn't a string literal yields nil so the route is skipped.
     private def path_arg_text(node : LibTreeSitter::TSNode, source : String) : String?
       return unless Noir::TreeSitter.node_type(node) == "string_literal"
-      string_content_of(node, source) || ""
+      string_content(node, source) || ""
     end
 
     # Walk every node (named children, any depth) and yield each.
@@ -1258,17 +1240,6 @@ module Analyzer::Rust
         end
       end
       nil
-    end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        next unless Noir::TreeSitter.node_type(child) == "string_literal"
-        result = string_content_of(child, source)
-      end
-      result
     end
   end
 end

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -352,7 +352,7 @@ module Analyzer::Rust
       return unless name && NEST_NAMES.includes?(name)
       args = named_arguments(call)
       return unless args.size >= 2
-      prefix = string_literal_text(args[0], source)
+      prefix = string_literal_content(args[0], source)
       return unless prefix
       {prefix, args[1]}
     end
@@ -556,7 +556,7 @@ module Analyzer::Rust
         return unless args
         named = named_children(args)
         return if named.size < 2
-        path = string_literal_text(named[0], source)
+        path = string_literal_content(named[0], source)
         return unless path
         {path, decode_handler(named[1], source)}
       when "route_service"
@@ -564,7 +564,7 @@ module Analyzer::Rust
         return unless args
         named = named_children(args)
         return if named.size < 1
-        path = string_literal_text(named[0], source)
+        path = string_literal_content(named[0], source)
         return unless path
         {path, [{SERVICE_METHOD, nil.as(String?)}]}
       when "nest_service"
@@ -572,7 +572,7 @@ module Analyzer::Rust
         return unless args
         named = named_children(args)
         return if named.size < 1
-        prefix = string_literal_text(named[0], source)
+        prefix = string_literal_content(named[0], source)
         return unless prefix
         {nest_join(prefix, "/*"), [{SERVICE_METHOD, nil.as(String?)}]}
       when "fallback", "fallback_service"
@@ -598,7 +598,7 @@ module Analyzer::Rust
       named = named_arguments(call)
       return if named.size < 2
 
-      path = string_literal_text(named[0], source)
+      path = string_literal_content(named[0], source)
       return unless path
 
       handler = callable_text(named[1], source)
@@ -814,33 +814,6 @@ module Analyzer::Rust
     private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
       function = Noir::TreeSitter.field(call, "function")
       function ? Noir::TreeSitter.node_text(function, source) : nil
-    end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      return string_literal_text(node, source) if Noir::TreeSitter.node_type(node) == "string_literal"
-
-      Noir::TreeSitter.each_named_child(node) do |child|
-        if text = first_string_literal_text(child, source)
-          return text
-        end
-      end
-      nil
-    end
-
-    private def string_literal_text(node : LibTreeSitter::TSNode, source : String) : String?
-      return unless Noir::TreeSitter.node_type(node) == "string_literal"
-      # tree-sitter-rust splits a literal with escapes into multiple children
-      # ("/a\tb" -> string_content "/a", escape_sequence "\t", string_content "b").
-      # Concatenate every segment instead of keeping only the last one.
-      parts = [] of String
-      Noir::TreeSitter.each_named_child(node) do |child|
-        case Noir::TreeSitter.node_type(child)
-        when "string_content", "escape_sequence"
-          parts << Noir::TreeSitter.node_text(child, source)
-        end
-      end
-      parts.empty? ? nil : parts.join
     end
 
     private def build_router_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
@@ -1195,7 +1168,7 @@ module Analyzer::Rust
               next unless name && NEST_NAMES.includes?(name)
               args = named_arguments(node)
               next unless args.size >= 2
-              prefix = string_literal_text(args[0], src)
+              prefix = string_literal_content(args[0], src)
               next unless prefix
               call = resolve_router_call(args[1], src, let_calls)
               next unless call
@@ -1255,7 +1228,7 @@ module Analyzer::Rust
             next unless NEST_NAMES.includes?(field)
             args = named_arguments(call)
             next unless args.size >= 2
-            prefix = string_literal_text(args[0], source)
+            prefix = string_literal_content(args[0], source)
             next unless prefix
             child = resolve_router_call(args[1], source, let_calls)
             next unless child
@@ -1498,7 +1471,7 @@ module Analyzer::Rust
             named = [] of LibTreeSitter::TSNode
             Noir::TreeSitter.each_named_child(args) { |a| named << a }
             next if named.size < 2
-            prefix = string_literal_text(named[0], source)
+            prefix = string_literal_content(named[0], source)
             next unless prefix
             child_key = nest_child_key(named[1], source, base, file_mod)
             next unless child_key

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -385,22 +385,5 @@ module Analyzer::Rust
       end
       nil
     end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        if Noir::TreeSitter.node_type(child) == "string_literal"
-          Noir::TreeSitter.each_named_child(child) do |grand|
-            if Noir::TreeSitter.node_type(grand) == "string_content"
-              result = Noir::TreeSitter.node_text(grand, source)
-              break
-            end
-          end
-        end
-      end
-      result
-    end
   end
 end

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -377,22 +377,5 @@ module Analyzer::Rust
     private def header_name?(name : String) : Bool
       name.includes?("-") || name.in?(%w[Authorization Content-Type Accept])
     end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        if Noir::TreeSitter.node_type(child) == "string_literal"
-          Noir::TreeSitter.each_named_child(child) do |grand|
-            if Noir::TreeSitter.node_type(grand) == "string_content"
-              result = Noir::TreeSitter.node_text(grand, source)
-              break
-            end
-          end
-        end
-      end
-      result
-    end
   end
 end

--- a/src/analyzer/analyzers/rust/poem.cr
+++ b/src/analyzer/analyzers/rust/poem.cr
@@ -439,17 +439,5 @@ module Analyzer::Rust
       suffix = path.lstrip("/")
       suffix.empty? ? pfx : "#{pfx}/#{suffix}"
     end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        if Noir::TreeSitter.node_type(child) == "string_literal"
-          result = string_content(child, source)
-        end
-      end
-      result
-    end
   end
 end

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -571,17 +571,5 @@ module Analyzer::Rust
         end
       end
     end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        if Noir::TreeSitter.node_type(child) == "string_literal"
-          result = string_content(child, source)
-        end
-      end
-      result
-    end
   end
 end

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -439,22 +439,5 @@ module Analyzer::Rust
       return unless field
       Noir::TreeSitter.node_text(field, source)
     end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        if Noir::TreeSitter.node_type(child) == "string_literal"
-          Noir::TreeSitter.each_named_child(child) do |grand|
-            if Noir::TreeSitter.node_type(grand) == "string_content"
-              result = Noir::TreeSitter.node_text(grand, source)
-              break
-            end
-          end
-        end
-      end
-      result
-    end
   end
 end

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -845,21 +845,5 @@ module Analyzer::Rust
         @str_consts.try { |consts| consts[{base, Noir::TreeSitter.node_text(node, source).split("::").last}]? }
       end
     end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        case Noir::TreeSitter.node_type(child)
-        when "string_literal", "raw_string_literal"
-          # Salvo regex-constrained params live in raw strings:
-          # `Router::with_path(r"delete/{id|[0-9a-fA-F]{8}}")`. Those are
-          # `raw_string_literal` nodes, not `string_literal`.
-          result = string_content(child, source)
-        end
-      end
-      result
-    end
   end
 end

--- a/src/analyzer/analyzers/rust/tide.cr
+++ b/src/analyzer/analyzers/rust/tide.cr
@@ -332,22 +332,5 @@ module Analyzer::Rust
       end
       nil
     end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        if Noir::TreeSitter.node_type(child) == "string_literal"
-          Noir::TreeSitter.each_named_child(child) do |grand|
-            if Noir::TreeSitter.node_type(grand) == "string_content"
-              result = Noir::TreeSitter.node_text(grand, source)
-              break
-            end
-          end
-        end
-      end
-      result
-    end
   end
 end

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -423,7 +423,7 @@ module Analyzer::Rust
       Noir::TreeSitter.each_named_child(token_tree) do |child|
         case Noir::TreeSitter.node_type(child)
         when "string_literal"
-          seg = string_content_text(child, source)
+          seg = string_content(child, source)
           if seg && !seg.empty?
             path_parts << seg
             count += 1
@@ -443,13 +443,6 @@ module Analyzer::Rust
         end
       end
       count
-    end
-
-    private def string_content_text(string_literal : LibTreeSitter::TSNode, source : String) : String?
-      Noir::TreeSitter.each_named_child(string_literal) do |grand|
-        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
-      end
-      nil
     end
 
     # `.map(handler)` / `.and_then(handler)` / `.then(handler)` — pull
@@ -625,23 +618,6 @@ module Analyzer::Rust
           result = Noir::TreeSitter.node_text(child, source)
         when "scoped_type_identifier"
           result = Noir::TreeSitter.node_text(child, source).split("::").last
-        end
-      end
-      result
-    end
-
-    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless node
-      result : String? = nil
-      walk(node) do |child|
-        next if result
-        if Noir::TreeSitter.node_type(child) == "string_literal"
-          Noir::TreeSitter.each_named_child(child) do |grand|
-            if Noir::TreeSitter.node_type(grand) == "string_content"
-              result = Noir::TreeSitter.node_text(grand, source)
-              break
-            end
-          end
         end
       end
       result

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -464,18 +464,55 @@ module Analyzer::Rust
       nil
     end
 
-    # The first `string_content` child of a `string_literal`.
+    # The full text of a `string_literal`, concatenating every
+    # `string_content` and `escape_sequence` child.
     #
-    # NOTE: tree-sitter-rust splits a literal at each escape, so this
-    # truncates a path carrying one (`"/page-{id:\d+}"` → `/page-{id:`).
-    # `actix_web#string_content_of` concatenates the `escape_sequence`
-    # children and is the correct form; folding these together is a
-    # behaviour change and belongs in its own commit.
+    # tree-sitter-rust splits a literal at each escape — `"/page-{id:\d+}"`
+    # parses as string_content `/page-{id:`, escape_sequence `\d`,
+    # string_content `+}` — so reading only the first `string_content`
+    # truncates any path carrying one. That is what this method used to do,
+    # and it is why a route registered as `.at("/page-{id:\d+}")` was
+    # reported as `/page-{id:`.
+    #
+    # Returns nil for a literal with no content children (a genuinely empty
+    # `""`), which is what every caller's `|| ""` fallback expects.
     protected def string_content(string_literal : LibTreeSitter::TSNode, source : String) : String?
-      Noir::TreeSitter.each_named_child(string_literal) do |grand|
-        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
+      parts = [] of String
+      Noir::TreeSitter.each_named_child(string_literal) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "string_content", "escape_sequence"
+          parts << Noir::TreeSitter.node_text(child, source)
+        end
       end
-      nil
+      parts.empty? ? nil : parts.join
+    end
+
+    # `string_content` with a type guard, for callers that hand over an
+    # arbitrary argument node and want nil when it is not a literal (an
+    # identifier, a macro call, a method chain). Keeping this separate
+    # preserves the guard that `axum#string_literal_text` carried — its
+    # callers pass `args[0]` / `named[0]` straight from a call expression.
+    protected def string_literal_content(node : LibTreeSitter::TSNode, source : String) : String?
+      return unless Noir::TreeSitter.node_type(node) == "string_literal"
+      string_content(node, source)
+    end
+
+    # The first string literal anywhere under `node`, depth-first.
+    #
+    # Ten adapters carried their own copy of this walk. Eight read only the
+    # first `string_content` child and truncated at escapes; actix_web and
+    # axum had each independently found that bug and written their own
+    # escape-aware reader, complete with a comment explaining it — the
+    # knowledge existed twice in the tree and never reached the other eight.
+    protected def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
+      return unless node
+      result : String? = nil
+      walk(node) do |child|
+        next if result
+        next unless Noir::TreeSitter.node_type(child) == "string_literal"
+        result = string_content(child, source)
+      end
+      result
     end
 
     # Attach the 1-hop callees of `function`'s body to `endpoint`.


### PR DESCRIPTION
## Summary

tree-sitter-rust splits a string literal at every escape, so `"/page-{id:\d+}"` parses as **three** children — string_content `/page-{id:`, escape_sequence `\d`, string_content `+}`. Eight of the ten Rust adapters read only the first `string_content`, which truncated the path:

```rust
app.at("/page-{id:\d+}").get(show)
```

| | reported |
|---|---|
| before | `GET /page-{id:` — param lost, URL matches nothing |
| after | `GET /page-{id}` |

Regex-constrained path params are ordinary in tide, actix and rocket. This is not an exotic input.

## The knowledge already existed in the tree — twice

`actix_web#string_content_of` and `axum#string_literal_text` each concatenate the escape segments, and **each carries a comment explaining exactly this parse shape**. Neither ever reached the other eight adapters.

So this is one fix and one de-duplication in the same edit: `RustEngine#string_content` becomes the escape-aware reader, a shared `first_string_literal_text` joins it, and **thirteen adapter-level readers across ten files are deleted**. Net −92 lines.

`string_literal_content` is added alongside, guarded on node type, because `axum#string_literal_text` carried that guard and its callers pass `args[0]` / `named[0]` straight from a call expression — dropping it would have read the children of a non-literal node. The two unguarded call sites (actix_web, warp) already sit inside a `when "string_literal"` branch, so they take the unguarded form.

## Test plan

- **New fixture `rust/tide_escaped_paths`** — and it is necessary: the A/B sweep over all 666 *existing* fixture projects is **byte-identical** (5,162 endpoints), because not one of them had an escape in a route path. That is precisely why the truncation survived. The fixture covers a numeric constraint (`{id:\d+}`), one with a literal dot (`{name:.*\.json}`), and an unescaped neighbour that must stay unchanged.
- `crystal spec spec/unit_test` — 4,756 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,674 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.