### PR TITLE
refactor(dart): fold the duplicated Dart analyzer helpers into Analyzer::Dart::Helper

### DIFF
--- a/src/analyzer/analyzers/dart/alfred.cr
+++ b/src/analyzer/analyzers/dart/alfred.cr
@@ -150,7 +150,7 @@ module Analyzer::Dart
           open_paren = (m.end(0) || 0) - 1
           close_paren = Helper.find_matching_paren(cleaned, open_paren)
           next unless close_paren
-          args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
+          args = Helper.split_top_level_args(cleaned[(open_paren + 1)...close_paren])
           next if args.empty?
           sub = Helper.extract_string_literal(args[0])
           next unless sub
@@ -204,7 +204,7 @@ module Analyzer::Dart
         open_paren = (m.end(0) || 0) - 1
         close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
-        args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
+        args = Helper.split_top_level_args(cleaned[(open_paren + 1)...close_paren])
         next if args.empty?
         sub = Helper.extract_string_literal(args[0])
         next unless sub
@@ -268,7 +268,7 @@ module Analyzer::Dart
           handle_call(name, cleaned, open_paren, close_paren, prefix, content, path, include_callee, endpoints, seen)
         elsif name == "route" && !cascade
           # `.route('/x')` (chained, not a cascade) deepens the base.
-          inner = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
+          inner = Helper.split_top_level_args(cleaned[(open_paren + 1)...close_paren])
           if sub = (inner.empty? ? nil : Helper.extract_string_literal(inner[0]))
             prefix = alfred_compose(prefix, sub)
           end
@@ -293,7 +293,7 @@ module Analyzer::Dart
                             endpoints : Array(Endpoint),
                             seen : Set({String, String}))
       return if open_paren >= close_paren
-      args = split_top_level_args(source[(open_paren + 1)...close_paren])
+      args = Helper.split_top_level_args(source[(open_paren + 1)...close_paren])
       # A route always carries a handler, so a single-arg call (e.g. a
       # stray `obj.get('key')`) is not a route.
       return if args.size < 2
@@ -310,47 +310,15 @@ module Analyzer::Dart
         # first top-level comma. Pinning the start here (rather than
         # `close_paren - handler.size`) keeps body extraction correct when
         # a trailing `middleware: [...]` argument follows the handler.
-        comma = first_top_level_comma(source, open_paren + 1, close_paren)
-        callees = handler_callees(args[1], content, comma + 1, path, line) if comma
+        comma = Helper.first_top_level_comma(source, open_paren + 1, close_paren)
+        callees = Helper.handler_callees(args[1], content, comma + 1, path, line) if comma
       end
 
       verbs = method == "all" ? ALL_VERBS : [HTTP_METHOD_MAP[method]]
       verbs.each do |verb|
         next unless seen.add?({verb, url})
-        endpoints << build_endpoint(url, verb, path, line, callees)
+        endpoints << Helper.build_endpoint(url, verb, path, line, callees)
       end
-    end
-
-    # Matches a bare handler reference (`_createUser`, `auth.handler`)
-    # passed as a route's handler argument.
-    HANDLER_REFERENCE_REGEX = /\A[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*\z/
-
-    private def handler_callees(handler_arg : String,
-                                content : String,
-                                handler_start : Int32,
-                                path : String,
-                                line : Int32) : Array(Noir::DartCalleeExtractor::Entry)
-      stripped = handler_arg.strip
-
-      # A plain function reference (`_createUser`, `auth.handler`) can't be
-      # resolved cross-file yet, so record the reference itself as the callee.
-      unless stripped.starts_with?('(')
-        return [] of Noir::DartCalleeExtractor::Entry unless stripped.matches?(HANDLER_REFERENCE_REGEX)
-        return [{stripped, path, line}] of Noir::DartCalleeExtractor::Entry
-      end
-
-      # handler_start is a CHAR index into the source; extract_body_after
-      # scans by BYTE offset. `extract_body_after` skips past the leading
-      # `(req, res)` lambda params to the `=>`/`{` body, so a trailing
-      # `middleware:` argument after the body is naturally excluded.
-      start_b = content.char_index_to_byte_index(handler_start)
-      return [] of Noir::DartCalleeExtractor::Entry unless start_b
-      body_info = Noir::DartCalleeExtractor.extract_body_after(content, start_b)
-      return [] of Noir::DartCalleeExtractor::Entry unless body_info
-
-      body, body_start, _ = body_info
-      start_line = Noir::DartCalleeExtractor.line_number_for(content, body_start)
-      Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
     end
 
     # Ensure a leading slash and translate Express-style `:id` / `:id:int`
@@ -371,20 +339,6 @@ module Analyzer::Dart
       else
         first + second
       end
-    end
-
-    private def build_endpoint(url : String,
-                               verb : String,
-                               path : String,
-                               line : Int32,
-                               callees : Array(Noir::DartCalleeExtractor::Entry)) : Endpoint
-      endpoint = Endpoint.new(url, verb)
-      endpoint.details = Details.new(PathInfo.new(path, line))
-      url.scan(/\{(\w+)\}/) do |match|
-        endpoint.push_param(Param.new(match[1], "", "path"))
-      end
-      Noir::DartCalleeExtractor.attach_to(endpoint, callees)
-      endpoint
     end
 
     # ---------- Source-string utilities ----------
@@ -427,105 +381,6 @@ module Analyzer::Dart
         i += 1
       end
       chars.size
-    end
-
-    # Char index of the first comma at paren/brace/bracket depth zero
-    # between `start` and `limit`, or nil when the call has a single
-    # argument.
-    private def first_top_level_comma(text : String, start : Int32, limit : Int32) : Int32?
-      chars = text.chars
-      depth = 0
-      i = start
-      in_string = false
-      string_quote = '\0'
-
-      while i < limit
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '(', '{', '['
-          depth += 1
-        when ')', '}', ']'
-          depth -= 1 if depth > 0
-        when ','
-          return i if depth == 0
-        else
-          # ignore
-        end
-        i += 1
-      end
-
-      nil
-    end
-
-    private def split_top_level_args(text : String) : Array(String)
-      result = [] of String
-      chars = text.chars
-      depth_paren = 0
-      depth_brace = 0
-      depth_bracket = 0
-      depth_angle = 0
-      start = 0
-      i = 0
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth_paren += 1
-        when ')'
-          depth_paren -= 1 if depth_paren > 0
-        when '{'
-          depth_brace += 1
-        when '}'
-          depth_brace -= 1 if depth_brace > 0
-        when '['
-          depth_bracket += 1
-        when ']'
-          depth_bracket -= 1 if depth_bracket > 0
-        when '<'
-          depth_angle += 1
-        when '>'
-          depth_angle -= 1 if depth_angle > 0
-        when ','
-          if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << chars[start...i].join
-            start = i + 1
-          end
-        else
-          # ignore
-        end
-        i += 1
-      end
-      result << chars[start..].join if start <= chars.size
-      result
     end
   end
 end

--- a/src/analyzer/analyzers/dart/angel3.cr
+++ b/src/analyzer/analyzers/dart/angel3.cr
@@ -181,7 +181,7 @@ module Analyzer::Dart
         next unless call
         close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
-        args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
+        args = Helper.split_top_level_args(cleaned[(open_paren + 1)...close_paren])
         next if args.size < 2
 
         literal = Helper.extract_string_literal(args[0])
@@ -189,7 +189,7 @@ module Analyzer::Dart
         param = closure_param(args[1])
         next unless param
 
-        comma = first_top_level_comma(cleaned, open_paren + 1, close_paren)
+        comma = Helper.first_top_level_comma(cleaned, open_paren + 1, close_paren)
         next unless comma
         raw << {own: normalize_path(literal), param: param, range_start: comma + 1, range_end: close_paren, call: call}
       end
@@ -254,7 +254,7 @@ module Analyzer::Dart
                             endpoints : Array(Endpoint),
                             seen : Set({String, String}))
       return if open_paren >= close_paren
-      args = split_top_level_args(source[(open_paren + 1)...close_paren])
+      args = Helper.split_top_level_args(source[(open_paren + 1)...close_paren])
       return if args.size < 2
 
       literal = Helper.extract_string_literal(args[0])
@@ -265,39 +265,15 @@ module Analyzer::Dart
 
       callees = [] of Noir::DartCalleeExtractor::Entry
       if include_callee
-        comma = first_top_level_comma(source, open_paren + 1, close_paren)
-        callees = handler_callees(args[1], content, comma + 1, path, line) if comma
+        comma = Helper.first_top_level_comma(source, open_paren + 1, close_paren)
+        callees = Helper.handler_callees(args[1], content, comma + 1, path, line) if comma
       end
 
       verbs = method == "all" ? ALL_VERBS : [HTTP_METHOD_MAP[method]]
       verbs.each do |verb|
         next unless seen.add?({verb, url})
-        endpoints << build_endpoint(url, verb, path, line, callees)
+        endpoints << Helper.build_endpoint(url, verb, path, line, callees)
       end
-    end
-
-    HANDLER_REFERENCE_REGEX = /\A[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*\z/
-
-    private def handler_callees(handler_arg : String,
-                                content : String,
-                                handler_start : Int32,
-                                path : String,
-                                line : Int32) : Array(Noir::DartCalleeExtractor::Entry)
-      stripped = handler_arg.strip
-
-      unless stripped.starts_with?('(')
-        return [] of Noir::DartCalleeExtractor::Entry unless stripped.matches?(HANDLER_REFERENCE_REGEX)
-        return [{stripped, path, line}] of Noir::DartCalleeExtractor::Entry
-      end
-
-      start_b = content.char_index_to_byte_index(handler_start)
-      return [] of Noir::DartCalleeExtractor::Entry unless start_b
-      body_info = Noir::DartCalleeExtractor.extract_body_after(content, start_b)
-      return [] of Noir::DartCalleeExtractor::Entry unless body_info
-
-      body, body_start, _ = body_info
-      start_line = Noir::DartCalleeExtractor.line_number_for(content, body_start)
-      Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
     end
 
     # Ensure a leading slash and translate Express-style `:id` captures
@@ -313,118 +289,6 @@ module Analyzer::Dart
       right = sub.starts_with?('/') ? sub : "/#{sub}"
       result = "#{left}#{right}"
       result.empty? ? "/" : result
-    end
-
-    private def build_endpoint(url : String,
-                               verb : String,
-                               path : String,
-                               line : Int32,
-                               callees : Array(Noir::DartCalleeExtractor::Entry)) : Endpoint
-      endpoint = Endpoint.new(url, verb)
-      endpoint.details = Details.new(PathInfo.new(path, line))
-      url.scan(/\{(\w+)\}/) do |match|
-        endpoint.push_param(Param.new(match[1], "", "path"))
-      end
-      Noir::DartCalleeExtractor.attach_to(endpoint, callees)
-      endpoint
-    end
-
-    # ---------- source-string utilities ----------
-
-    private def first_top_level_comma(text : String, start : Int32, limit : Int32) : Int32?
-      chars = text.chars
-      depth = 0
-      i = start
-      in_string = false
-      string_quote = '\0'
-
-      while i < limit
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '(', '{', '['
-          depth += 1
-        when ')', '}', ']'
-          depth -= 1 if depth > 0
-        when ','
-          return i if depth == 0
-        else
-          # ignore
-        end
-        i += 1
-      end
-
-      nil
-    end
-
-    private def split_top_level_args(text : String) : Array(String)
-      result = [] of String
-      chars = text.chars
-      depth_paren = 0
-      depth_brace = 0
-      depth_bracket = 0
-      depth_angle = 0
-      start = 0
-      i = 0
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth_paren += 1
-        when ')'
-          depth_paren -= 1 if depth_paren > 0
-        when '{'
-          depth_brace += 1
-        when '}'
-          depth_brace -= 1 if depth_brace > 0
-        when '['
-          depth_bracket += 1
-        when ']'
-          depth_bracket -= 1 if depth_bracket > 0
-        when '<'
-          depth_angle += 1
-        when '>'
-          depth_angle -= 1 if depth_angle > 0
-        when ','
-          if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << chars[start...i].join
-            start = i + 1
-          end
-        else
-          # ignore
-        end
-        i += 1
-      end
-      result << chars[start..].join if start <= chars.size
-      result
     end
   end
 end

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -162,11 +162,9 @@ module Analyzer::Dart
       [] of Noir::DartCalleeExtractor::Entry
     end
 
-    # A bare (possibly dotted) handler reference assigned to `onRequest`.
-    HANDLER_REFERENCE_REGEX = /\A[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*\z/
-
     private def assignment_callees(rhs : String, path : String, line : Int32) : Array(Noir::DartCalleeExtractor::Entry)
-      return [{rhs, path, line}] of Noir::DartCalleeExtractor::Entry if rhs.matches?(HANDLER_REFERENCE_REGEX)
+      # A bare (possibly dotted) handler reference assigned to `onRequest`.
+      return [{rhs, path, line}] of Noir::DartCalleeExtractor::Entry if rhs.matches?(Helper::HANDLER_REFERENCE_REGEX)
       Noir::DartCalleeExtractor.callees_for_body(rhs, path, line)
     end
 

--- a/src/analyzer/analyzers/dart/dart_helper.cr
+++ b/src/analyzer/analyzers/dart/dart_helper.cr
@@ -1,4 +1,5 @@
 require "../../../utils/path_scope"
+require "../../../miniparsers/dart_callee_extractor"
 
 module Analyzer::Dart
   # Shared helpers for the Dart framework analyzers (Dart Frog, Shelf,
@@ -160,6 +161,175 @@ module Analyzer::Dart
       end
 
       nil
+    end
+
+    # Char index of the first comma at paren/brace/bracket depth zero
+    # between `start` and `limit`, or nil when the call has a single
+    # argument.
+    def first_top_level_comma(text : String, start : Int32, limit : Int32) : Int32?
+      chars = text.chars
+      depth = 0
+      i = start
+      in_string = false
+      string_quote = '\0'
+
+      while i < limit
+        c = chars[i]
+        if in_string
+          if c == '\\' && i + 1 < chars.size
+            i += 2
+            next
+          end
+          in_string = false if c == string_quote
+          i += 1
+          next
+        end
+
+        case c
+        when '"', '\''
+          in_string = true
+          string_quote = c
+        when '(', '{', '['
+          depth += 1
+        when ')', '}', ']'
+          depth -= 1 if depth > 0
+        when ','
+          return i if depth == 0
+        else
+          # ignore
+        end
+        i += 1
+      end
+
+      nil
+    end
+
+    # Split a call's argument list on top-level commas. Each bracket kind
+    # (`()`, `{}`, `[]`, `<>`) gets its own counter so a generic argument
+    # (`Map<String, int>`) and a collection literal (`[a, b]`) both keep
+    # their inner commas, and string literals are skipped so a comma inside
+    # `'a,b'` never splits. The trailing segment is always emitted, so a
+    # single-argument call yields a one-element array.
+    #
+    # Note: `Serverpod#split_top_level_commas` is deliberately NOT this
+    # method — it tracks only `<`/`(` on one shared counter and is not
+    # string-aware, matching the narrower shapes it parses.
+    def split_top_level_args(text : String) : Array(String)
+      result = [] of String
+      chars = text.chars
+      depth_paren = 0
+      depth_brace = 0
+      depth_bracket = 0
+      depth_angle = 0
+      start = 0
+      i = 0
+      in_string = false
+      string_quote = '\0'
+
+      while i < chars.size
+        c = chars[i]
+        if in_string
+          if c == '\\' && i + 1 < chars.size
+            i += 2
+            next
+          end
+          in_string = false if c == string_quote
+          i += 1
+          next
+        end
+
+        case c
+        when '"', '\''
+          in_string = true
+          string_quote = c
+        when '('
+          depth_paren += 1
+        when ')'
+          depth_paren -= 1 if depth_paren > 0
+        when '{'
+          depth_brace += 1
+        when '}'
+          depth_brace -= 1 if depth_brace > 0
+        when '['
+          depth_bracket += 1
+        when ']'
+          depth_bracket -= 1 if depth_bracket > 0
+        when '<'
+          depth_angle += 1
+        when '>'
+          depth_angle -= 1 if depth_angle > 0
+        when ','
+          if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
+            result << chars[start...i].join
+            start = i + 1
+          end
+        else
+          # ignore
+        end
+        i += 1
+      end
+      result << chars[start..].join if start <= chars.size
+      result
+    end
+
+    # Matches a bare handler reference (`_createUser`, `auth.handler`)
+    # passed as a route's handler argument.
+    HANDLER_REFERENCE_REGEX = /\A[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*\z/
+
+    # Callees for a route's handler argument, where `handler_start` is the
+    # CHAR index at which the handler expression begins (typically the
+    # char just past the first top-level comma).
+    #
+    # A plain function reference (`_createUser`, `auth.handler`) can't be
+    # resolved cross-file yet, so the reference itself is recorded as the
+    # callee.
+    #
+    # `extract_body_after` scans by BYTE offset, hence the char-to-byte
+    # conversion. It skips past the leading `(req, res)` lambda params to
+    # the `=>`/`{` body, so a trailing `middleware:` argument after the
+    # body is naturally excluded.
+    #
+    # Shelf keeps its own variant: it derives the handler start from the
+    # call's closing paren instead of a comma index, so the two are not
+    # interchangeable.
+    def handler_callees(handler_arg : String,
+                        content : String,
+                        handler_start : Int32,
+                        path : String,
+                        line : Int32) : Array(Noir::DartCalleeExtractor::Entry)
+      stripped = handler_arg.strip
+
+      unless stripped.starts_with?('(')
+        return [] of Noir::DartCalleeExtractor::Entry unless stripped.matches?(HANDLER_REFERENCE_REGEX)
+        return [{stripped, path, line}] of Noir::DartCalleeExtractor::Entry
+      end
+
+      start_b = content.char_index_to_byte_index(handler_start)
+      return [] of Noir::DartCalleeExtractor::Entry unless start_b
+      body_info = Noir::DartCalleeExtractor.extract_body_after(content, start_b)
+      return [] of Noir::DartCalleeExtractor::Entry unless body_info
+
+      body, body_start, _ = body_info
+      start_line = Noir::DartCalleeExtractor.line_number_for(content, body_start)
+      Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    # Build an endpoint from an already-normalized URL, promoting every
+    # `{name}` capture in it to a path param and attaching the callees.
+    # Analyzers whose endpoints carry extra state (Dart Frog's websocket
+    # flag, `dart:io` HttpServer's inherited params) keep their own.
+    def build_endpoint(url : String,
+                       verb : String,
+                       path : String,
+                       line : Int32,
+                       callees : Array(Noir::DartCalleeExtractor::Entry)) : Endpoint
+      endpoint = Endpoint.new(url, verb)
+      endpoint.details = Details.new(PathInfo.new(path, line))
+      url.scan(/\{(\w+)\}/) do |match|
+        endpoint.push_param(Param.new(match[1], "", "path"))
+      end
+      Noir::DartCalleeExtractor.attach_to(endpoint, callees)
+      endpoint
     end
 
     private def relative_for_match(path : String, base_path : String?) : String

--- a/src/analyzer/analyzers/dart/get_server.cr
+++ b/src/analyzer/analyzers/dart/get_server.cr
@@ -186,7 +186,7 @@ module Analyzer::Dart
 
         verbs.each do |verb|
           next unless seen.add?({verb, url, page[:file]})
-          result << build_endpoint(url, verb, page[:file], page[:line], callees)
+          result << Helper.build_endpoint(url, verb, page[:file], page[:line], callees)
         end
       end
 
@@ -236,26 +236,12 @@ module Analyzer::Dart
       base.gsub(/:([A-Za-z_]\w*)/) { "{#{$~[1]}}" }
     end
 
-    private def build_endpoint(url : String,
-                               verb : String,
-                               path : String,
-                               line : Int32,
-                               callees : Array(Noir::DartCalleeExtractor::Entry)) : Endpoint
-      endpoint = Endpoint.new(url, verb)
-      endpoint.details = Details.new(PathInfo.new(path, line))
-      url.scan(/\{(\w+)\}/) do |match|
-        endpoint.push_param(Param.new(match[1], "", "path"))
-      end
-      Noir::DartCalleeExtractor.attach_to(endpoint, callees)
-      endpoint
-    end
-
     # ---------- source-string utilities ----------
 
     # Split a call's argument list into a `name: value` map at top level.
     private def named_args(text : String) : Hash(String, String)
       result = {} of String => String
-      split_top_level_args(text).each do |raw|
+      Helper.split_top_level_args(text).each do |raw|
         arg = raw.strip
         next if arg.empty?
         colon = top_level_colon(arg)
@@ -305,64 +291,6 @@ module Analyzer::Dart
         i += 1
       end
       nil
-    end
-
-    private def split_top_level_args(text : String) : Array(String)
-      result = [] of String
-      chars = text.chars
-      depth_paren = 0
-      depth_brace = 0
-      depth_bracket = 0
-      depth_angle = 0
-      start = 0
-      i = 0
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth_paren += 1
-        when ')'
-          depth_paren -= 1 if depth_paren > 0
-        when '{'
-          depth_brace += 1
-        when '}'
-          depth_brace -= 1 if depth_brace > 0
-        when '['
-          depth_bracket += 1
-        when ']'
-          depth_bracket -= 1 if depth_bracket > 0
-        when '<'
-          depth_angle += 1
-        when '>'
-          depth_angle -= 1 if depth_angle > 0
-        when ','
-          if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << chars[start...i].join
-            start = i + 1
-          end
-        else
-          # ignore
-        end
-        i += 1
-      end
-      result << chars[start..].join if start <= chars.size
-      result
     end
   end
 end

--- a/src/analyzer/analyzers/dart/shelf.cr
+++ b/src/analyzer/analyzers/dart/shelf.cr
@@ -200,13 +200,13 @@ module Analyzer::Dart
         close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
 
-        args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
+        args = Helper.split_top_level_args(cleaned[(open_paren + 1)...close_paren])
         next if args.empty?
 
         verbs, path_arg = annotation_verbs_and_path(m[1]?, args)
         next if verbs.empty? || path_arg.nil?
 
-        literal = extract_string_literal(path_arg)
+        literal = Helper.extract_string_literal(path_arg)
         next unless literal
 
         owner = enclosing_class(classes, match_begin)
@@ -236,9 +236,9 @@ module Analyzer::Dart
         next unless match_begin && open_paren
         close_paren = Helper.find_matching_paren(cleaned, open_paren)
         next unless close_paren
-        args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
+        args = Helper.split_top_level_args(cleaned[(open_paren + 1)...close_paren])
         next if args.empty?
-        literal = extract_string_literal(args[0])
+        literal = Helper.extract_string_literal(args[0])
         next unless literal
         # `@RoutePrefix` sits *above* the `class` keyword, so it isn't
         # bracketed by any class body — attribute it to the class whose
@@ -275,7 +275,7 @@ module Analyzer::Dart
 
       # `@Route('GET', '/path')` — verb is the first string argument.
       return {[] of String, nil} if args.size < 2
-      verb_lit = extract_string_literal(args[0])
+      verb_lit = Helper.extract_string_literal(args[0])
       return {[] of String, nil} unless verb_lit
       verb = verb_lit.downcase
       return {ALL_VERBS.dup, args[1]} if verb == "all"
@@ -415,10 +415,10 @@ module Analyzer::Dart
                             mounts : Array(Mount))
       return if open_paren >= close_paren
       args_text = source[(open_paren + 1)...close_paren]
-      args = split_top_level_args(args_text)
+      args = Helper.split_top_level_args(args_text)
       return if args.empty?
 
-      literal = extract_string_literal(args[0])
+      literal = Helper.extract_string_literal(args[0])
       return unless literal
 
       line = line_number_for_index(file_content, open_paren)
@@ -442,10 +442,6 @@ module Analyzer::Dart
       end
     end
 
-    # Matches a bare handler reference (`getNotes`, `_echo`,
-    # `health_check.handler`) passed as the second argument to a route.
-    HANDLER_REFERENCE_REGEX = /\A[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*\z/
-
     # Best-effort callee extraction for the route handler. Inline lambdas
     # have their body scanned for callees; a plain function reference
     # (Dart can't resolve these cross-file yet) is itself recorded as the
@@ -458,7 +454,7 @@ module Analyzer::Dart
       stripped = handler_arg.strip
 
       unless stripped.starts_with?('(')
-        return [] of Noir::DartCalleeExtractor::Entry unless stripped.matches?(HANDLER_REFERENCE_REGEX)
+        return [] of Noir::DartCalleeExtractor::Entry unless stripped.matches?(Helper::HANDLER_REFERENCE_REGEX)
         return [{stripped, path, line}] of Noir::DartCalleeExtractor::Entry
       end
 
@@ -481,24 +477,6 @@ module Analyzer::Dart
       return if cleaned.empty?
       return unless cleaned.matches?(/\A[A-Za-z_]\w*\z/)
       cleaned
-    end
-
-    private def extract_string_literal(text : String) : String?
-      stripped = text.strip
-      return if stripped.empty?
-      first = stripped[0]
-      return unless first == '"' || first == '\''
-      i = 1
-      while i < stripped.size
-        c = stripped[i]
-        if c == '\\' && i + 1 < stripped.size
-          i += 2
-          next
-        end
-        return stripped[1...i] if c == first
-        i += 1
-      end
-      nil
     end
 
     # `<id>` → `{id}` ; `<id|[0-9]+>` → `{id}` ; keep slashes.
@@ -541,7 +519,7 @@ module Analyzer::Dart
       if info
         info[:routes].each do |route|
           full_path = mount_join(prefix, route[:path])
-          endpoints << build_endpoint(full_path, route[:verb], route[:file], route[:line], route[:callees])
+          endpoints << Helper.build_endpoint(full_path, route[:verb], route[:file], route[:line], route[:callees])
         end
         info[:mounts].each do |mnt|
           child_prefix = mount_join(prefix, mnt[:prefix])
@@ -556,20 +534,6 @@ module Analyzer::Dart
       right = sub.starts_with?('/') ? sub : "/#{sub}"
       result = "#{left}#{right}"
       result.empty? ? "/" : result
-    end
-
-    private def build_endpoint(url : String,
-                               verb : String,
-                               path : String,
-                               line : Int32,
-                               callees : Array(Noir::DartCalleeExtractor::Entry)) : Endpoint
-      endpoint = Endpoint.new(url, verb)
-      endpoint.details = Details.new(PathInfo.new(path, line))
-      url.scan(/\{(\w+)\}/) do |match|
-        endpoint.push_param(Param.new(match[1], "", "path"))
-      end
-      Noir::DartCalleeExtractor.attach_to(endpoint, callees)
-      endpoint
     end
 
     # ---------- Source-string utilities ----------
@@ -621,64 +585,6 @@ module Analyzer::Dart
         i += 1
       end
       chars.size
-    end
-
-    private def split_top_level_args(text : String) : Array(String)
-      result = [] of String
-      chars = text.chars
-      depth_paren = 0
-      depth_brace = 0
-      depth_bracket = 0
-      depth_angle = 0
-      start = 0
-      i = 0
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth_paren += 1
-        when ')'
-          depth_paren -= 1 if depth_paren > 0
-        when '{'
-          depth_brace += 1
-        when '}'
-          depth_brace -= 1 if depth_brace > 0
-        when '['
-          depth_bracket += 1
-        when ']'
-          depth_bracket -= 1 if depth_bracket > 0
-        when '<'
-          depth_angle += 1
-        when '>'
-          depth_angle -= 1 if depth_angle > 0
-        when ','
-          if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << chars[start...i].join
-            start = i + 1
-          end
-        else
-          # ignore
-        end
-        i += 1
-      end
-      result << chars[start..].join if start <= chars.size
-      result
     end
 
     private def strip_dart_comments(text : String) : String


### PR DESCRIPTION
## Summary

Twelve duplicated helper copies across the four Dart analyzers fold into `Analyzer::Dart::Helper`, which already existed for exactly this and which all four files already `require`. **Net −279 lines** (475 removed / 196 added).

| helper | copies | locations |
|---|---|---|
| `split_top_level_args` (57 ln) | ×4 byte-identical | alfred, angel3, get_server, shelf |
| `build_endpoint` (13 ln) | ×4 byte-identical | alfred, angel3, get_server, shelf |
| `first_top_level_comma` (37 ln) | ×2 byte-identical | alfred, angel3 |
| `handler_callees` | ×2 | alfred, angel3 |
| `extract_string_literal` | ×2 | dart_helper, shelf |
| `HANDLER_REFERENCE_REGEX` | ×4 identical | alfred, angel3, shelf, dart_frog |

All folds follow the file's existing `Helper.foo(...)` namespace convention; nothing is `include`d.

## Identity was established by body hash, not by name

Name matching would have been wrong here in both directions: `build_endpoint` has **6** same-named definitions but only **4** identical bodies, and `normalize_path` has **5** same-named definitions and **5** distinct bodies.

Two cosmetic-drift calls, made explicitly rather than silently:
- **`handler_callees`** — the bodies differ *only* in comments. alfred carries two explanatory blocks (why a bare reference is recorded as its own callee; the char→byte offset contract) that angel3 lacks. Same behaviour; both docs are folded into the helper rather than dropped.
- **`extract_string_literal`** — shelf's copy differs from the helper's in one local variable name (`first` vs `quote`) and nothing else.

## Excluded, with the blocking difference named

- **`Serverpod#split_top_level_commas`** — one shared depth over `<`/`(` only, no `{}`/`[]`, not string-literal aware, and it pushes the tail unconditionally.
- **`Shelf#find_statement_end`** — three independent counters requiring all-zero, where alfred uses one shared clamped counter. They disagree on unbalanced source.
- **`Shelf#handler_callees`** — back-computes the offset from `close_paren`; alfred/angel3 take a post-comma `handler_start`.
- **`strip_dart_comments`** (serverpod/shelf) — serverpod's block-comment loop scans to EOF; shelf's `i + 1 < chars.size` leaves the final char un-blanked on an unterminated `/*`.
- **`relevant_method?`** — byte-identical one-liner, but it resolves the *enclosing class's* `HTTP_METHOD_MAP`.
- **`pop_contexts` / `pop_route_contexts` / `pop_switches`** in `http.cr` — identical one-line bodies over four distinct alias types. That is Crystal overload dispatch, not copy-paste.
- **`normalize_path` ×5, `mount_join` ×2** — per-framework capture syntax (`:id:int`, `:id?`, `<id|re>`).

A re-run of the identity script after the fold shows the only remaining multi-location groups are exactly those intentional exclusions.

## Follow-up noted, not done here

`Helper.strip_comments` carries shelf's `i + 1 < chars.size` bound, i.e. the same un-blanked-final-char behaviour that serverpod's inline comment describes as a bug. Fixing it is a behaviour change and belongs in its own commit with a fixture.

## Test plan

- A/B sweep over all 666 fixture projects: **byte-identical**, 5,162 endpoints, including `code_paths[].line` and `callees[].line`.
- `crystal spec spec/unit_test` — 4,756 examples, 0 failures.
- `crystal spec spec/functional_test` — 22,660 examples, 0 failures. All four touched analyzers have fixture-backed functional testers, so endpoint output is behaviourally pinned.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.