### PR TITLE
test(media-filter): stop four specs sharing fixed /tmp paths

### DIFF
--- a/spec/unit_test/utils/media_filter_spec.cr
+++ b/spec/unit_test/utils/media_filter_spec.cr
@@ -66,7 +66,7 @@ describe MediaFilter do
 
     it "should check file size against default limit" do
       # Create a temporary small file
-      temp_file = "/tmp/small_test_file.txt"
+      temp_file = File.tempname("noir_media_small", ".txt")
       File.write(temp_file, "small content")
 
       MediaFilter.file_too_large?(temp_file).should be_false
@@ -76,7 +76,7 @@ describe MediaFilter do
 
     it "should check file size against custom limit" do
       # Create a temporary file
-      temp_file = "/tmp/custom_test_file.txt"
+      temp_file = File.tempname("noir_media_custom", ".txt")
       File.write(temp_file, "test content")
 
       # Should be under 1KB limit
@@ -104,7 +104,7 @@ describe MediaFilter do
 
     it "should handle combination of extension and size checks" do
       # Create a temporary source file that's large
-      temp_file = "/tmp/large_source_file.cr"
+      temp_file = File.tempname("noir_media_large", ".cr")
       File.write(temp_file, "# " + "x" * 1000) # Make it large enough
 
       # Should skip due to size even though it's a source file
@@ -131,7 +131,7 @@ describe MediaFilter do
     end
 
     it "should return file size reason for large files" do
-      temp_file = "/tmp/size_test_file.txt"
+      temp_file = File.tempname("noir_media_size", ".txt")
       File.write(temp_file, "x" * 100)
 
       reason = MediaFilter.skip_reason(temp_file, 50)


### PR DESCRIPTION
## Summary

`spec/unit_test/utils/media_filter_spec.cr` wrote to `/tmp/small_test_file.txt`, `/tmp/custom_test_file.txt`, `/tmp/large_source_file.cr` and `/tmp/size_test_file.txt` — **fixed names, no uniquifier**. Two spec runs overlapping in time delete each other's files between the `File.write` and the assertion.

Not hypothetical. Running the pre-fix spec binary twice concurrently:

| pair | run A | run B |
|---|---|---|
| 1 | 22 examples, 0 failures | 22 examples, 0 failures |
| 2 | 22 examples, 0 failures | 22 examples, **1 failures** |
| 3 | 22 examples, **1 failures** | 22 examples, 0 failures |

After the change, **five consecutive concurrent pairs are all green**.

It fired for real: parallel agents each running the suite in their own worktree deleted each other's files, and the failure output cited another worktree's path — a confusing way to learn that these paths are process-global rather than per-checkout. Two CI jobs on one runner, or a developer with specs running in two terminals, reach it the same way.

## The fix was already in the same file

The five binary-signature examples further down use `/tmp/noir-binsig-…-#{Random.rand(1_000_000)}.py`. These four just never adopted it. They now use `File.tempname`, matching what the rest of the suite does (`detector_spec.cr`, `config_initializer_spec.cr`). Cleanup is unchanged — each still deletes its file behind a `File.exists?` guard.

## Test plan

- The concurrent-pair experiment above, before and after.
- `crystal spec spec/unit_test` — 4,756 examples, 0 failures.
- `ameba`, `crystal tool format --check` — clean.
- Spec-only; nothing under `src/` is touched.