### PR TITLE
fix(php/laravel): don't register routes nested in a handler body

### DIFF
--- a/spec/functional_test/fixtures/php/laravel_nested_handlers/composer.json
+++ b/spec/functional_test/fixtures/php/laravel_nested_handlers/composer.json
@@ -1,0 +1,1 @@
+{"require":{"laravel/framework":"^10.0"}}

--- a/spec/functional_test/fixtures/php/laravel_nested_handlers/routes/web.php
+++ b/spec/functional_test/fixtures/php/laravel_nested_handlers/routes/web.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+// A `Route::…` call inside a handler body runs when a request hits the outer
+// route, not at boot, so nothing it registers is attack surface. Whether it
+// leaked out used to depend on which scan shape found it first.
+
+// Same scan on both sides — this was already suppressed.
+Route::get('/same-scan', function () {
+    Route::get('/phantom-same-scan', function () { return 'x'; });
+});
+
+// Outer found by the `any` scan, inner by the verb scan — leaked.
+Route::any('/any-outer', function () {
+    Route::get('/phantom-in-any', function () { return 'x'; });
+});
+
+// Outer found by the chained scan, inner by the verb scan — leaked, and
+// without the enclosing `chain/` prefix.
+Route::middleware('auth')->prefix('chain')->post('/chained-outer', function () {
+    Route::get('/phantom-in-chain', function () { return 'x'; });
+    Route::view('/phantom-static', 'v');
+});
+
+// The canonical Laravel nesting. These ARE registered at boot and DO inherit
+// the group prefix — the fix must not touch them.
+Route::prefix('admin')->group(function () {
+    Route::get('/users', 'UserController@index');
+    Route::post('/users', 'UserController@store');
+});

--- a/spec/functional_test/testers/php/laravel_nested_handlers_spec.cr
+++ b/spec/functional_test/testers/php/laravel_nested_handlers_spec.cr
@@ -1,0 +1,59 @@
+require "../../func_spec.cr"
+
+# A `Route::…` call inside another route's handler body is not a route
+# registration: the closure runs when a request hits the outer route, not at
+# boot, so nothing it registers is attack surface.
+#
+# The scan that owned the outer route already skipped its body, but each of the
+# six scans started at offset 0 and knew nothing about the others' skips — so
+# whether a nested call leaked out depended on which scan shape happened to
+# find it first. `Route::get` inside `Route::get` was suppressed; the same call
+# inside a `Route::any` or behind a fluent `->post(...)` was emitted at top
+# level, and without the enclosing prefix.
+#
+# The four `/phantom-*` paths in the fixture are the ones that used to leak.
+# They are asserted absent by the endpoint-count check plus the explicit
+# examples below.
+expected_endpoints = [
+  Endpoint.new("/same-scan", "GET"),
+  Endpoint.new("/any-outer", "GET"),
+  Endpoint.new("/any-outer", "POST"),
+  Endpoint.new("/any-outer", "PUT"),
+  Endpoint.new("/any-outer", "PATCH"),
+  Endpoint.new("/any-outer", "DELETE"),
+  Endpoint.new("/any-outer", "OPTIONS"),
+  Endpoint.new("/any-outer", "HEAD"),
+  Endpoint.new("/chain/chained-outer", "POST"),
+  # The canonical `Route::group` nesting still resolves, prefix and all.
+  Endpoint.new("/admin/users", "GET"),
+  Endpoint.new("/admin/users", "POST"),
+]
+
+FunctionalTester.new("fixtures/php/laravel_nested_handlers/", {
+  :techs     => 2,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests
+
+describe "Laravel routes nested in a handler body" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "registers none of them, whichever scan would have found them" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/php/laravel_nested_handlers/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    urls = app.endpoints.map(&.url)
+    urls.should_not contain("/phantom-same-scan")
+    urls.should_not contain("/phantom-in-any")
+    urls.should_not contain("/phantom-in-chain")
+    urls.should_not contain("/phantom-static")
+    # …and not under the enclosing prefix either, which is how they surfaced.
+    urls.should_not contain("/chain/phantom-in-chain")
+  end
+end

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -33,7 +33,7 @@ module Analyzer::Php
     # recursive pass. Bundled so the shared scan helpers below take the body
     # once instead of threading eight arguments through every call.
     private struct RouteScanContext
-      getter content, file_path, include_callee, base_line, lexer, imports, route_groups, skip_ranges
+      getter content, file_path, include_callee, base_line, lexer, imports, route_groups, skip_ranges, handler_bodies
 
       def initialize(@content : String,
                      @file_path : String,
@@ -42,7 +42,8 @@ module Analyzer::Php
                      @lexer : Noir::PhpLexer,
                      @imports : Hash(String, String),
                      @route_groups : Array(RouteGroup),
-                     @skip_ranges : Array(Range(Int32, Int32)))
+                     @skip_ranges : Array(Range(Int32, Int32)),
+                     @handler_bodies : Array(Range(Int32, Int32)))
       end
     end
 
@@ -166,6 +167,11 @@ module Analyzer::Php
     # capture 2 the (unread) static verb, capture 3 the path.
     CHAINED_STATIC_ROUTE_REGEX = /Route::((?:\w+\s*\([^;]*?\)\s*->\s*)+)(view|redirect|permanentRedirect)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
 
+    # Any `Route::…('path', …` registration, whatever verb or chain precedes
+    # it. Used only to locate handler-closure bodies up front; the six scans
+    # above are what actually decide which registrations become endpoints.
+    ROUTE_REGISTRATION_RE = /Route::(?:\w+\s*\([^;]*?\)\s*->\s*)*\w+\s*\(\s*(?:\[[^\]]*\]\s*,\s*)?['"][^'"]*['"]\s*,/mi
+
     # Methods a single `Route::any` registration stands for.
     ANY_ROUTE_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
 
@@ -190,7 +196,7 @@ module Analyzer::Php
       # `"Try Route::get(...)"` string, or a `<<<SQL … SQL` heredoc doesn't
       # surface as a real endpoint.
       skip_ranges = lexer.skip_ranges
-      ctx = RouteScanContext.new(content, file_path, include_callee, base_line, lexer, imports, route_groups, skip_ranges)
+      ctx = RouteScanContext.new(content, file_path, include_callee, base_line, lexer, imports, route_groups, skip_ranges, collect_handler_bodies(content, base_line, lexer))
 
       # 1. Verb routes. Every scan below walks the body the same way, with the
       # same guards — `each_laravel_route` holds that walk once. What differs
@@ -290,12 +296,59 @@ module Analyzer::Php
 
       while route_match = content.match(regex, pos)
         pos = if inside_laravel_group_body?(route_match.begin(0), ctx.route_groups) ||
-                 inside_php_skip_range?(route_match.begin(0), ctx.skip_ranges)
+                 inside_php_skip_range?(route_match.begin(0), ctx.skip_ranges) ||
+                 inside_handler_body?(route_match.begin(0), ctx.handler_bodies)
                 route_match.end(0)
               else
                 yield route_match
               end
       end
+    end
+
+    # Whether `offset` falls inside some route handler's closure body.
+    private def inside_handler_body?(offset : Int32, bodies : Array(Range(Int32, Int32))) : Bool
+      bodies.any?(&.includes?(offset))
+    end
+
+    # Byte ranges of every inline route-handler closure body in `content`.
+    #
+    # A `Route::…` call inside a handler body is not a route registration:
+    # the closure runs when a request hits the outer route, not at boot, so
+    # nothing it registers is part of the attack surface.
+    #
+    # The scan that *owns* the outer route already skipped its body —
+    # `emit_handler_route` returns a position past it. But each of the six
+    # scans starts at 0 and knew nothing about the others' skips, so whether a
+    # nested call leaked out depended on which scan shape happened to find it:
+    #
+    #   Route::get('/a', function () { Route::get('/nested', …); });
+    #     -> suppressed (both found by the same verb scan)
+    #
+    #   Route::any('/a', function () { Route::get('/nested', …); });
+    #   Route::middleware('x')->prefix('p')->post('/a', function () { Route::get('/nested', …); });
+    #     -> `/nested` emitted, at top level and WITHOUT the enclosing prefix,
+    #        because the verb scan reached it before/independently of the scan
+    #        that owns the outer route
+    #
+    # Collecting the ranges once, up front, makes the skip a property of the
+    # content rather than of scan ordering — the same shape `skip_ranges`
+    # already uses for strings, comments and heredocs.
+    private def collect_handler_bodies(content : String, base_line : Int32, lexer : Noir::PhpLexer) : Array(Range(Int32, Int32))
+      bodies = [] of Range(Int32, Int32)
+      pos = 0
+
+      while route_match = content.match(ROUTE_REGISTRATION_RE, pos)
+        action_pos = route_match.end(0)
+        if lexer.in_code?(route_match.begin(0))
+          _body, next_pos, _line = extract_inline_closure_body(content, action_pos, base_line, lexer)
+          bodies << (action_pos...next_pos) if next_pos > action_pos
+          pos = action_pos
+        else
+          pos = route_match.end(0)
+        end
+      end
+
+      bodies
     end
 
     # Append one endpoint per HTTP method for a route that has a handler — an


### PR DESCRIPTION
## Summary

A `Route::…` call inside another route's handler body is **not** a route registration. The closure runs when a request hits the outer route, not at boot, so nothing it registers is attack surface.

The scan that *owned* the outer route already skipped its body — `emit_handler_route` returns a position past it. But each of the six scans starts at offset 0 and knew nothing about the others' skips, so whether a nested call leaked out depended on **which scan shape happened to find it first**:

```php
Route::get('/a', function () { Route::get('/nested', …); });
  -> suppressed; both sides belong to the verb scan

Route::any('/a', function () { Route::get('/nested', …); });
Route::middleware('x')->prefix('p')->post('/a', function () { Route::get('/nested', …); });
  -> `/nested` emitted, at top level and WITHOUT the enclosing prefix
```

Collecting the handler-body ranges once, up front, makes the skip a property of the content rather than of scan ordering — the same shape `skip_ranges` already uses for strings, comments and heredocs.

**The canonical `Route::group(…, function () { … })` nesting is untouched.** Those routes *are* registered at boot and *do* inherit the group prefix; `extract_route_groups` handles them and the new fixture pins that.

## Not done — and the reason is the deliverable

The audit that surfaced this also flagged `CHAINED_VERB_REGEX` / `CHAINED_STATIC_ROUTE_REGEX` for using `(?:\w+\s*\([^;]*?\)\s*->\s*)+` — a nested quantifier over a lazy class — where the sibling `extract_route_groups` deliberately uses `[^;()]*` and carries a ReDoS comment saying why.

I could not reproduce a blow-up on it (measured up to 20 chain links, with and without semicolons, both forms at 0.0ms). More importantly, **switching to `[^;()]*` is not safe here** — that form cannot cross a nested paren:

| input | current | `[^;()]*` |
|---|---|---|
| `Route::middleware('auth')->get(…)` | ✅ | ✅ |
| `Route::middleware(['auth','verified'])->get(…)` | ✅ | ✅ |
| `Route::middleware([Auth::class, config('x')])->get(…)` | ✅ | ❌ **route lost** |
| `Route::prefix(config('app.prefix'))->middleware('auth')->get(…)` | ✅ | ❌ **route lost** |

`Route::prefix(config('…'))` is ordinary Laravel. The sibling can afford the stricter class because it only has to find `group(`. Leaving these regexes as they are is the correct call, not an oversight — recorded in the source so the next reader doesn't "fix" it.

## Test plan

- **New fixture** `php/laravel_nested_handlers` + tester, covering all three nesting shapes plus a real `Route::group`. **Fails on the parent commit with 2 failures**, passes here.
- A/B sweep over all 667 *existing* fixture projects: **byte-identical**, 5,165 endpoints — no fixture had a route nested inside a handler, which is why this survived.
- `crystal spec spec/unit_test` — 4,756 examples, 0 failures. `crystal spec spec/functional_test` — 22,699 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.