### PR TITLE
fix(dart): blank an unterminated block comment to end of input

### DIFF
--- a/spec/unit_test/analyzer/dart_helper_spec.cr
+++ b/spec/unit_test/analyzer/dart_helper_spec.cr
@@ -35,6 +35,26 @@ describe Analyzer::Dart::Helper do
       stripped.includes?("/* c */").should be_false
       stripped.includes?("a // b").should be_true
     end
+
+    # An unterminated `/*` used to stop one character short: the file's last
+    # character was never blanked and fell through verbatim. A letter leaking
+    # out is harmless; the two that matter are not. A bare `'` opens a string
+    # state for everything the caller scans afterwards, and a `}` is counted
+    # as real by the brace matchers this helper feeds.
+    it "blanks an unterminated block comment to the end of input" do
+      {"final x = 1; /* note x", "final x = 1; /* note '", "final x = 1; /* note }"}.each do |source|
+        stripped = Analyzer::Dart::Helper.strip_comments(source)
+        stripped.size.should eq source.size
+        stripped.should eq "final x = 1; " + " " * (source.size - 13)
+      end
+    end
+
+    it "still consumes a block comment that ends exactly at end of input" do
+      source = "final x = 1; /* note */"
+      stripped = Analyzer::Dart::Helper.strip_comments(source)
+      stripped.size.should eq source.size
+      stripped.should eq "final x = 1; " + " " * (source.size - 13)
+    end
   end
 
   describe ".extract_string_literal" do

--- a/src/analyzer/analyzers/dart/dart_helper.cr
+++ b/src/analyzer/analyzers/dart/dart_helper.cr
@@ -75,7 +75,14 @@ module Analyzer::Dart
         if c == '/' && i + 1 < chars.size && chars[i + 1] == '*'
           result << "  "
           i += 2
-          while i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')
+          # `i < chars.size`, not `i + 1 < chars.size`. The latter stopped one
+          # char early on an unterminated `/*`, so the file's final character
+          # was never blanked — it fell through to the verbatim `result << c`
+          # below and leaked out of the comment. Harmless for a letter, not
+          # harmless for the two that matter here: `/* x '` emitted a bare
+          # quote that opens a string state for everything after it, and
+          # `/* x }` emitted a brace that the brace counters read as real.
+          while i < chars.size && !(i + 1 < chars.size && chars[i] == '*' && chars[i + 1] == '/')
             result << (chars[i] == '\n' ? '\n' : ' ')
             i += 1
           end


### PR DESCRIPTION
## Summary

`Helper.strip_comments` scanned a block comment with `while i + 1 < chars.size`, which stops **one character early** when the comment never terminates. That last character was never blanked — it fell through to the verbatim `result << c` below and escaped the comment.

| input | before | after |
|---|---|---|
| `final x = 1; /* note x` | `final x = 1;         x` | `final x = 1;          ` |
| `final x = 1; /* note '` | `final x = 1;         '` | `final x = 1;          ` |
| `final x = 1; /* note }` | `final x = 1;         }` | `final x = 1;          ` |

A leaked letter is harmless. The other two are the reason this matters: the helper exists to hand the Dart analyzers a string in which only code is visible. A bare `'` opens a string state for everything scanned after it, and a `}` is counted as real by the brace matchers this feeds — including `Helper.find_matching_paren` in the same file.

`serverpod.cr`'s own comment already recorded that its block-comment loop scans to EOF deliberately, for exactly this reason. The shared helper inherited shelf's bound instead when the copies were folded together in #2525. Now they agree.

The guard moves into the terminator test (`i < chars.size && !(i + 1 < chars.size && …)`), so a comment ending exactly at end of input is still consumed, and offsets are still preserved — output length is unchanged in every case, which the spec asserts alongside the content.

## Test plan

- New unit examples in `dart_helper_spec.cr` — **fail on the parent commit** (`got: "final x = 1;         x"`), pass here. They cover the three leak shapes plus a comment terminating exactly at end of input.
- A/B sweep over all 667 fixture projects: **byte-identical**, 5,165 endpoints — no fixture carries an unterminated block comment, which is why this survived.
- `crystal spec spec/unit_test` — 4,759 examples, 0 failures. `crystal spec spec/functional_test` — 22,674 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.