### PR TITLE
fix(ruby/rails): stop controller_to_endpoint building its result in @result

### DIFF
--- a/spec/unit_test/analyzer/rails_result_isolation_spec.cr
+++ b/spec/unit_test/analyzer/rails_result_isolation_spec.cr
@@ -1,0 +1,33 @@
+require "../../spec_helper"
+require "../../../src/models/code_locator"
+require "../../../src/analyzer/analyzers/ruby/rails"
+
+# `controller_to_endpoint` must not build its return value in `@result`.
+#
+# It used to open with `@result = [] of Endpoint`, i.e. it wiped the
+# analyzer's accumulated endpoints and handed back its own fresh array. Its
+# one caller compensated with `@result += controller_to_endpoint(...)`, which
+# is correct only because Crystal evaluates the `+` receiver before the
+# argument: the old array is read, then the call replaces `@result`, then the
+# sum is assigned back.
+#
+# That made an ordinary-looking edit destructive. Rewriting the call site as
+# `@result.concat(...)` — the form anyone would reach for, and the one that
+# avoids an intermediate array — discarded every endpoint collected so far,
+# silently. This example pins the method to a local so the caller is free to
+# use either form.
+describe "Analyzer::Ruby::Rails#controller_to_endpoint" do
+  it "leaves already-collected endpoints alone" do
+    options = create_test_options
+    analyzer = Analyzer::Ruby::Rails.new(options)
+
+    analyzer.result << Endpoint.new("/collected-earlier", "GET")
+
+    # A path no file backs: the method returns early, which is the shortest
+    # route to the assignment that used to do the damage.
+    returned = analyzer.controller_to_endpoint("/nonexistent/controller.rb", "", "widgets")
+
+    returned.should be_empty
+    analyzer.result.map(&.url).should eq(["/collected-earlier"])
+  end
+end

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -1091,13 +1091,18 @@ module Analyzer::Ruby
 
       existing_controller_path = candidates.find { |c| known_file?(c) }
       candidates.each do |ctrl_path|
-        @result += controller_to_endpoint(
+        # `concat`, not `+=`. `controller_to_endpoint` used to build its
+        # return value in `@result` — reassigning it to a fresh array on
+        # entry — so this line only worked because Crystal evaluates the
+        # `+` receiver before the argument. It now uses a local, which is
+        # what makes `concat` safe here.
+        @result.concat(controller_to_endpoint(
           ctrl_path, @url, url_segment,
           path_prefix: path_prefix,
           only: only_list,
           except: except_list,
           singular: singular,
-        )
+        ))
       end
 
       existing_controller_path
@@ -1285,9 +1290,9 @@ module Analyzer::Ruby
       except : Array(String) = [] of String,
       singular : Bool = false,
     )
-      @result = [] of Endpoint
+      endpoints = [] of Endpoint
 
-      return @result unless known_file?(path)
+      return endpoints unless known_file?(path)
 
       data = extract_controller_data(path)
       defined_actions = data.defined_actions
@@ -1321,35 +1326,35 @@ module Analyzer::Ruby
           details = Details.new(PathInfo.new(path, data.action_lines["index"]?))
           endpoint = Endpoint.new(index_url, "GET", last_params, details)
           attach_callees_for_action(endpoint, data, "index")
-          @result << endpoint
+          endpoints << endpoint
         when "GET/SHOW"
           last_params = promote_identifier_to_path(action_params(data, "show", "GET"))
           details = Details.new(PathInfo.new(path, data.action_lines["show"]?))
           endpoint = Endpoint.new(member_url, "GET", last_params, details)
           attach_callees_for_action(endpoint, data, "show")
-          @result << endpoint
+          endpoints << endpoint
         when "POST"
           last_params = action_params(data, "create", method)
           details = Details.new(PathInfo.new(path, data.action_lines["create"]?))
           endpoint = Endpoint.new(index_url, method, last_params, details)
           attach_callees_for_action(endpoint, data, "create")
-          @result << endpoint
+          endpoints << endpoint
         when "DELETE"
           last_params = promote_identifier_to_path(action_params(data, "destroy", method))
           details = Details.new(PathInfo.new(path, data.action_lines["destroy"]?))
           endpoint = Endpoint.new(member_url, method, last_params, details)
           attach_callees_for_action(endpoint, data, "destroy")
-          @result << endpoint
+          endpoints << endpoint
         else
           last_params = promote_identifier_to_path(action_params(data, "update", method))
           details = Details.new(PathInfo.new(path, data.action_lines["update"]?))
           endpoint = Endpoint.new(member_url, method, last_params, details)
           attach_callees_for_action(endpoint, data, "update")
-          @result << endpoint
+          endpoints << endpoint
         end
       end
 
-      @result
+      endpoints
     end
 
     # Scans a controller file once, collecting per-method params (headers/cookies)


### PR DESCRIPTION
## Summary

`controller_to_endpoint` opened with `@result = [] of Endpoint` — it **wiped the analyzer's accumulated endpoints** and handed back its own fresh array.

Its one caller compensated with:

```crystal
@result += controller_to_endpoint(...)
```

which is correct *only* because Crystal evaluates the `+` receiver before the argument: the old array is read, then the call replaces `@result`, then the sum is assigned back.

That made an ordinary-looking edit destructive. Rewriting the call site as `@result.concat(...)` — the form anyone would reach for, and the one that avoids an intermediate array — **silently discarded every endpoint collected so far**. Nothing in the code said so.

The method now builds a local and returns it; the caller uses `concat`. Its body only calls `attach_callees_for_action`, which mutates the endpoint rather than the result array, so the change is contained.

## The guard

`spec/unit_test/analyzer/rails_result_isolation_spec.cr` seeds `analyzer.result` with an endpoint, calls `controller_to_endpoint` on a path no file backs — the shortest route to the assignment that did the damage — and asserts the seeded endpoint survives.

On the parent commit it reports `got: []`.

## Test plan

- New spec **fails on the parent commit**, passes here.
- A/B sweep over all 667 fixture projects: **byte-identical**, 5,165 endpoints, including `code_paths[].line` and `callees[].line`.
- `crystal spec spec/unit_test` — 4,758 examples, 0 failures. `crystal spec spec/functional_test` — 22,674 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.