### PR TITLE
refactor(minilexer): share the masked-span helpers across the three lexers

### DIFF
--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -213,7 +213,7 @@ module Analyzer::Java
           break unless build_idx
           open_idx = code.index('(', build_idx)
           break unless open_idx
-          close_idx = find_matching_delimiter(code, open_idx, '(', ')')
+          close_idx = JavaEngine.find_matching_delimiter(code, open_idx, '(', ')')
           if close_idx
             expressions << code[found..close_idx]
             offset = close_idx + 1
@@ -239,7 +239,7 @@ module Analyzer::Java
         else
           open_idx = code.index('(', found)
           break unless open_idx
-          close_idx = find_matching_delimiter(code, open_idx, '(', ')')
+          close_idx = JavaEngine.find_matching_delimiter(code, open_idx, '(', ')')
           if close_idx
             expressions << code[(open_idx + 1)...close_idx]
             offset = close_idx + 1
@@ -304,7 +304,7 @@ module Analyzer::Java
 
         open_idx = server_codeblock.index('(', found)
         next unless open_idx
-        close_idx = find_matching_delimiter(server_codeblock, open_idx, '(', ')')
+        close_idx = JavaEngine.find_matching_delimiter(server_codeblock, open_idx, '(', ')')
         next unless close_idx
 
         args = split_top_level_args(server_codeblock[(open_idx + 1)...close_idx])
@@ -446,7 +446,7 @@ module Analyzer::Java
     private def strip_wrapping_parentheses(expr : String) : String
       result = expr
       while result.starts_with?('(') && result.ends_with?(')')
-        close_idx = find_matching_delimiter(result, 0, '(', ')')
+        close_idx = JavaEngine.find_matching_delimiter(result, 0, '(', ')')
         break unless close_idx == result.size - 1
         result = result[1...-1].strip
       end
@@ -557,7 +557,7 @@ module Analyzer::Java
         break unless build_idx
         open_idx = code.index('(', build_idx)
         break unless open_idx
-        close_idx = find_matching_delimiter(code, open_idx, '(', ')')
+        close_idx = JavaEngine.find_matching_delimiter(code, open_idx, '(', ')')
         if close_idx
           expressions << code[found..close_idx]
           offset = close_idx + 1
@@ -770,44 +770,6 @@ module Analyzer::Java
         i += 1
       end
       mask
-    end
-
-    private def find_matching_delimiter(code : String,
-                                        open_idx : Int32,
-                                        open_char : Char,
-                                        close_char : Char) : Int32?
-      # Scan by CHARACTER (not byte): open_idx is a char index from String#index
-      # and callers char-slice with the returned index. A byte scan corrupts both
-      # on multi-byte UTF-8. ASCII-identical to the previous byte loop.
-      depth = 1
-      in_string = false
-      quote = '\0'
-      escape = false
-
-      code.each_char_with_index do |ch, i|
-        next if i <= open_idx
-        if in_string
-          if escape
-            escape = false
-          elsif ch == '\\'
-            escape = true
-          elsif ch == quote
-            in_string = false
-          end
-        else
-          if ch == '"' || ch == '\''
-            in_string = true
-            quote = ch
-          elsif ch == open_char
-            depth += 1
-          elsif ch == close_char
-            depth -= 1
-          end
-        end
-        return i if depth == 0
-      end
-
-      nil
     end
 
     # ---- annotation-based service routes ------------------------------

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -375,7 +375,7 @@ module Analyzer::Java
           end
 
           if cursor < content.size && content[cursor] == '('
-            if close_idx = find_matching_delimiter(content, cursor, '(', ')')
+            if close_idx = JavaEngine.find_matching_delimiter(content, cursor, '(', ')')
               end_offset = close_idx + 1
               yield idx, end_offset, content[(cursor + 1)...close_idx]
               offset = end_offset
@@ -444,7 +444,7 @@ module Analyzer::Java
         class_offset = match.end(0) || start_offset
         open_idx = content.index('{', class_offset)
         next unless open_idx
-        close_idx = find_matching_delimiter(content, open_idx, '{', '}') || open_idx
+        close_idx = JavaEngine.find_matching_delimiter(content, open_idx, '{', '}') || open_idx
         base_path = reactive_annotation_path(match[1]? || "") || ""
         bases << ReactiveRouteBase.new(start_offset, close_idx, normalize_route_path(base_path))
       end
@@ -562,7 +562,7 @@ module Analyzer::Java
     private def route_method_signature_after(content : String, offset : Int32) : String
       open_idx = content.index('(', offset)
       return "" unless open_idx
-      close_idx = find_matching_delimiter(content, open_idx, '(', ')')
+      close_idx = JavaEngine.find_matching_delimiter(content, open_idx, '(', ')')
       return "" unless close_idx
 
       content[(open_idx + 1)...close_idx]
@@ -654,44 +654,6 @@ module Analyzer::Java
     end
 
     HTTP_METHOD_NAMES = Set{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE"}
-
-    private def find_matching_delimiter(code : String,
-                                        open_idx : Int32,
-                                        open_char : Char,
-                                        close_char : Char) : Int32?
-      # Scan by CHARACTER (not byte): open_idx is a char index from String#index
-      # and callers char-slice with / range-compare the returned index. A byte
-      # scan corrupts both on multi-byte UTF-8. ASCII-identical.
-      depth = 1
-      in_string = false
-      quote = '\0'
-      escape = false
-
-      code.each_char_with_index do |ch, i|
-        next if i <= open_idx
-        if in_string
-          if escape
-            escape = false
-          elsif ch == '\\'
-            escape = true
-          elsif ch == quote
-            in_string = false
-          end
-        else
-          if ch == '"' || ch == '\''
-            in_string = true
-            quote = ch
-          elsif ch == open_char
-            depth += 1
-          elsif ch == close_char
-            depth -= 1
-          end
-        end
-        return i if depth == 0
-      end
-
-      nil
-    end
 
     private def bean_index_for(path : String,
                                content : String,

--- a/src/analyzer/engines/java_engine.cr
+++ b/src/analyzer/engines/java_engine.cr
@@ -31,5 +31,48 @@ module Analyzer::Java
       return true if relative_path.includes?("/src/it/")
       false
     end
+
+    # Index of the delimiter closing the `open_char` at `open_idx`, or nil when
+    # the source runs out first. String and char literals are skipped, so a
+    # `)`/`}` inside `"…"` or `'…'` cannot close the block early.
+    #
+    # Scan by CHARACTER (not byte): `open_idx` is a char index from
+    # `String#index` and callers char-slice with — or range-compare — the
+    # returned index. A byte scan corrupts both on multi-byte UTF-8.
+    # ASCII-identical to the previous byte loop.
+    def self.find_matching_delimiter(code : String,
+                                     open_idx : Int32,
+                                     open_char : Char,
+                                     close_char : Char) : Int32?
+      depth = 1
+      in_string = false
+      quote = '\0'
+      escape = false
+
+      code.each_char_with_index do |ch, i|
+        next if i <= open_idx
+        if in_string
+          if escape
+            escape = false
+          elsif ch == '\\'
+            escape = true
+          elsif ch == quote
+            in_string = false
+          end
+        else
+          if ch == '"' || ch == '\''
+            in_string = true
+            quote = ch
+          elsif ch == open_char
+            depth += 1
+          elsif ch == close_char
+            depth -= 1
+          end
+        end
+        return i if depth == 0
+      end
+
+      nil
+    end
   end
 end

--- a/src/minilexers/csharp_lexer.cr
+++ b/src/minilexers/csharp_lexer.cr
@@ -1,3 +1,5 @@
+require "./masked_lexer"
+
 module Noir
   # A single token produced by `CSharpLexer#tokens`. `start`/`end` are
   # character indices into the original source (`end` exclusive); `line` is
@@ -35,17 +37,17 @@ module Noir
   #   * comments    `//…` and `/* … */`
   #
   # Every literal is masked to spaces (newlines preserved, length unchanged), so
-  # the structural helpers below are plain depth counters over `@masked`. The
-  # source is materialised once into an `Array(Char)` for O(1) indexing, keeping
-  # the scan O(n) on multi-byte (e.g. CJK-commented) source.
+  # the structural helpers in `Noir::MaskedLexer` are plain depth counters over
+  # `@masked`. The source is materialised once into an `Array(Char)` for O(1)
+  # indexing, keeping the scan O(n) on multi-byte (e.g. CJK-commented) source.
   class CSharpLexer
-    getter masked : Array(Char)
+    # Supplies `@masked`/`@size`/`@spans`/`@skip_ranges` plus the shared
+    # `matching_delimiter`, `statement_end`, `skip_ranges`, `in_code?` and
+    # identifier predicates.
+    include MaskedLexer
 
     @chars : Array(Char)
-    @size : Int32
-    @spans : Array(Tuple(Symbol, Int32, Int32))
     @tokens : Array(CSharpToken)?
-    @skip_ranges : Array(Range(Int32, Int32))?
     @masked_lines : Array(String)?
     @code_lines : Array(String)?
     @code_source : String?
@@ -61,14 +63,6 @@ module Noir
       @code_lines = nil
       @code_source = nil
       scan
-    end
-
-    private def ident_char?(c : Char) : Bool
-      c == '_' || c.ascii_alphanumeric? || c.ord >= 0x80
-    end
-
-    private def ident_start?(c : Char) : Bool
-      c == '_' || c.ascii_letter? || c.ord >= 0x80
     end
 
     private def scan
@@ -358,62 +352,9 @@ module Noir
     end
 
     # ---- structural helpers (character indices) ----------------------------
-
-    def matching_delimiter(open_pos : Int32) : Int32?
-      return unless 0 <= open_pos && open_pos < @size
-      open = @masked[open_pos]
-      close = case open
-              when '(' then ')'
-              when '[' then ']'
-              when '{' then '}'
-              else          return
-              end
-      depth = 0
-      i = open_pos
-      while i < @size
-        c = @masked[i]
-        if c == open
-          depth += 1
-        elsif c == close
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-      nil
-    end
-
-    # Index just after the top-level `;` at or after `start_pos`, or the source
-    # size when none is found.
-    def statement_end(start_pos : Int32) : Int32
-      paren = 0
-      bracket = 0
-      brace = 0
-      i = start_pos < 0 ? 0 : start_pos
-      while i < @size
-        case @masked[i]
-        when '(' then paren += 1
-        when ')' then paren -= 1 if paren > 0
-        when '[' then bracket += 1
-        when ']' then bracket -= 1 if bracket > 0
-        when '{' then brace += 1
-        when '}' then brace -= 1 if brace > 0
-        when ';'
-          return i + 1 if paren == 0 && bracket == 0 && brace == 0
-        end
-        i += 1
-      end
-      @size
-    end
-
-    def skip_ranges : Array(Range(Int32, Int32))
-      @skip_ranges ||= @spans.map { |(_, s, e)| (s..e - 1) }
-    end
-
-    def in_code?(pos : Int32) : Bool
-      return false unless 0 <= pos && pos < @size
-      @spans.none? { |(_, s, e)| s <= pos && pos < e }
-    end
+    #
+    # `matching_delimiter`, `statement_end`, `skip_ranges` and `in_code?` come
+    # from `Noir::MaskedLexer`. Only the C#-specific views live here.
 
     # The masked source split into lines, parallel to `source.lines`. Strings,
     # comments and char literals are blanked, so the C# analyzers can run their

--- a/src/minilexers/masked_lexer.cr
+++ b/src/minilexers/masked_lexer.cr
@@ -1,0 +1,117 @@
+module Noir
+  # Structural helpers shared by the hand-rolled masking lexers
+  # (`Noir::PhpLexer`, `Noir::CSharpLexer`, `Noir::ScalaLexer`).
+  #
+  # Each of those lexers exists for the same reason: the analyzers they feed
+  # used to count `{`/`}`/`(`/`)`/`;` per line with no string awareness, so a
+  # single delimiter inside a string literal, a comment or a heredoc body
+  # truncated a method block (dropping callees), made a signature run away
+  # (dropping parameters), or leaked route-shaped text as a phantom endpoint.
+  # Each lexer therefore makes ONE linear pass that blanks every non-code region
+  # to spaces — newlines preserved, character length unchanged — into `@masked`,
+  # and records each blanked region in `@spans`.
+  #
+  # The language-specific part is that masking pass (PHP heredocs and `#[…]`
+  # attributes, the C# string zoo, Scala's nested block comments and
+  # triple-quoted strings). Everything below is what is left once masking is
+  # done: plain depth counters and span lookups over `@masked`/`@spans` with no
+  # string-state bookkeeping of their own, and therefore language-agnostic.
+  #
+  # An includer must declare `@masked`, `@size`, `@spans` and `@skip_ranges`.
+  # They are declared here so the contract is enforced at compile time rather
+  # than restated (and potentially drifting) in each lexer.
+  module MaskedLexer
+    # Code with strings, comments and any other non-code region (PHP heredoc
+    # bodies, Scala triple-quoted strings, …) blanked to spaces. Same character
+    # length as the source and newlines preserved, so line/offset math against
+    # the original content stays valid.
+    getter masked : Array(Char)
+
+    # Source length in characters. The source is materialised once into an
+    # `Array(Char)` for O(1) indexing, so scanning stays O(n) on multi-byte
+    # (e.g. CJK-commented) input instead of the O(n^2) that `String#[](Int)`
+    # would cost.
+    @size : Int32
+
+    # Recorded non-code regions as {kind, start, end_exclusive}. Used for
+    # `skip_ranges`, `in_code?`, and to splice string/comment spans into each
+    # lexer's token stream.
+    @spans : Array(Tuple(Symbol, Int32, Int32))
+
+    # Memo for `skip_ranges`.
+    @skip_ranges : Array(Range(Int32, Int32))?
+
+    # Index of the delimiter that closes the `(`/`[`/`{` at `open_pos`, or nil.
+    # Counts only the matching pair type, which is correct for balanced code and
+    # mirrors the per-analyzer scanners this replaces (e.g. PHP's
+    # `find_matching_php_close_brace`).
+    def matching_delimiter(open_pos : Int32) : Int32?
+      return unless 0 <= open_pos && open_pos < @size
+      open = @masked[open_pos]
+      close = case open
+              when '(' then ')'
+              when '[' then ']'
+              when '{' then '}'
+              else          return
+              end
+      depth = 0
+      i = open_pos
+      while i < @size
+        c = @masked[i]
+        if c == open
+          depth += 1
+        elsif c == close
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+      nil
+    end
+
+    # Index just after the top-level `;` at or after `start_pos`, or the source
+    # size when none is found. Mirrors PHP's `find_php_statement_end`.
+    def statement_end(start_pos : Int32) : Int32
+      paren = 0
+      bracket = 0
+      brace = 0
+      i = start_pos < 0 ? 0 : start_pos
+      while i < @size
+        case @masked[i]
+        when '(' then paren += 1
+        when ')' then paren -= 1 if paren > 0
+        when '[' then bracket += 1
+        when ']' then bracket -= 1 if bracket > 0
+        when '{' then brace += 1
+        when '}' then brace -= 1 if brace > 0
+        when ';'
+          return i + 1 if paren == 0 && bracket == 0 && brace == 0
+        end
+        i += 1
+      end
+      @size
+    end
+
+    # Character ranges occupied by the non-code regions: strings, comments and
+    # whatever else the includer masks (PHP heredoc/nowdoc bodies, …).
+    def skip_ranges : Array(Range(Int32, Int32))
+      @skip_ranges ||= @spans.map { |(_, s, e)| (s..e - 1) }
+    end
+
+    def in_code?(pos : Int32) : Bool
+      return false unless 0 <= pos && pos < @size
+      @spans.none? { |(_, s, e)| s <= pos && pos < e }
+    end
+
+    # Identifier classification is deliberately permissive about >= 0x80: every
+    # one of these languages allows non-ASCII identifiers, and the lexers must
+    # not split a CJK or accented name into fragments.
+    private def ident_char?(c : Char) : Bool
+      c == '_' || c.ascii_alphanumeric? || c.ord >= 0x80
+    end
+
+    private def ident_start?(c : Char) : Bool
+      c == '_' || c.ascii_letter? || c.ord >= 0x80
+    end
+  end
+end

--- a/src/minilexers/php_lexer.cr
+++ b/src/minilexers/php_lexer.cr
@@ -1,3 +1,5 @@
+require "./masked_lexer"
+
 module Noir
   # A single token produced by `PhpLexer#tokens`. `start`/`end` are
   # character indices into the original source (`end` exclusive); `line`
@@ -33,21 +35,16 @@ module Noir
   #
   # The lexer masks every non-code region (strings, comments, heredoc/nowdoc
   # bodies) into spaces in `@masked` while preserving newlines and overall
-  # length, so the structural helpers below are plain depth counters over
-  # `@masked` with no string-state bookkeeping of their own.
+  # length, so the structural helpers in `Noir::MaskedLexer` are plain depth
+  # counters over `@masked` with no string-state bookkeeping of their own.
   class PhpLexer
-    # Code with strings/comments/heredoc bodies blanked to spaces. Same
-    # character length as the source; newlines preserved so line/offset math
-    # against the original content stays valid.
-    getter masked : Array(Char)
+    # Supplies `@masked`/`@size`/`@spans`/`@skip_ranges` plus the shared
+    # `matching_delimiter`, `statement_end`, `skip_ranges`, `in_code?` and
+    # identifier predicates.
+    include MaskedLexer
 
     @chars : Array(Char)
-    @size : Int32
-    # Recorded non-code regions as {kind, start, end_exclusive}. Used for
-    # `skip_ranges` and to splice string/comment tokens into `tokens`.
-    @spans : Array(Tuple(Symbol, Int32, Int32))
     @tokens : Array(PhpToken)?
-    @skip_ranges : Array(Range(Int32, Int32))?
 
     def initialize(source : String)
       @chars = source.chars
@@ -57,14 +54,6 @@ module Noir
       @tokens = nil
       @skip_ranges = nil
       scan
-    end
-
-    private def ident_char?(c : Char) : Bool
-      c == '_' || c.ascii_alphanumeric? || c.ord >= 0x80
-    end
-
-    private def ident_start?(c : Char) : Bool
-      c == '_' || c.ascii_letter? || c.ord >= 0x80
     end
 
     # Single masking pass. Walks the character array once, copying code
@@ -255,56 +244,9 @@ module Noir
     end
 
     # ---- structural helpers (character indices) ----------------------------
-
-    # Index of the delimiter that closes the `(`/`[`/`{` at `open_pos`, or nil.
-    # Counts only the matching pair type, which is correct for balanced code
-    # and mirrors the engine's `find_matching_php_close_brace`.
-    def matching_delimiter(open_pos : Int32) : Int32?
-      return unless 0 <= open_pos && open_pos < @size
-      open = @masked[open_pos]
-      close = case open
-              when '(' then ')'
-              when '[' then ']'
-              when '{' then '}'
-              else          return
-              end
-      depth = 0
-      i = open_pos
-      while i < @size
-        c = @masked[i]
-        if c == open
-          depth += 1
-        elsif c == close
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-      nil
-    end
-
-    # Index just after the top-level `;` at or after `start_pos`, or the source
-    # size when none is found. Mirrors `find_php_statement_end`.
-    def statement_end(start_pos : Int32) : Int32
-      paren = 0
-      bracket = 0
-      brace = 0
-      i = start_pos < 0 ? 0 : start_pos
-      while i < @size
-        case @masked[i]
-        when '(' then paren += 1
-        when ')' then paren -= 1 if paren > 0
-        when '[' then bracket += 1
-        when ']' then bracket -= 1 if bracket > 0
-        when '{' then brace += 1
-        when '}' then brace -= 1 if brace > 0
-        when ';'
-          return i + 1 if paren == 0 && bracket == 0 && brace == 0
-        end
-        i += 1
-      end
-      @size
-    end
+    #
+    # `matching_delimiter`, `statement_end`, `skip_ranges` and `in_code?` come
+    # from `Noir::MaskedLexer`. Only the PHP-specific one lives here.
 
     # Index of the first top-level expression terminator (`,` `;` or a closing
     # `) ] }` that would pop above the starting level) at or after `start_pos`.
@@ -337,16 +279,6 @@ module Noir
         i += 1
       end
       @size
-    end
-
-    # Character ranges occupied by strings, comments and heredoc/nowdoc bodies.
-    def skip_ranges : Array(Range(Int32, Int32))
-      @skip_ranges ||= @spans.map { |(_, s, e)| (s..e - 1) }
-    end
-
-    def in_code?(pos : Int32) : Bool
-      return false unless 0 <= pos && pos < @size
-      @spans.none? { |(_, s, e)| s <= pos && pos < e }
     end
 
     # ---- token stream ------------------------------------------------------

--- a/src/minilexers/scala_lexer.cr
+++ b/src/minilexers/scala_lexer.cr
@@ -1,3 +1,5 @@
+require "./masked_lexer"
+
 module Noir
   # A single token produced by `ScalaLexer#tokens`. `start`/`end` are
   # character indices into the original source (`end` exclusive); `line` is
@@ -37,14 +39,15 @@ module Noir
   # raw strings spanning lines, regular strings with `\` escapes, and `'x'` /
   # `'\n'` char literals (left as code when it is actually a `'sym` symbol).
   class ScalaLexer
-    getter masked : Array(Char)
+    # Supplies `@masked`/`@size`/`@spans`/`@skip_ranges` plus the shared
+    # `matching_delimiter`, `statement_end`, `skip_ranges`, `in_code?` and
+    # identifier predicates.
+    include MaskedLexer
+
     getter code : Array(Char)
 
     @chars : Array(Char)
-    @size : Int32
-    @spans : Array(Tuple(Symbol, Int32, Int32))
     @tokens : Array(ScalaToken)?
-    @skip_ranges : Array(Range(Int32, Int32))?
     @masked_lines : Array(String)?
     @code_lines : Array(String)?
 
@@ -59,14 +62,6 @@ module Noir
       @masked_lines = nil
       @code_lines = nil
       scan
-    end
-
-    private def ident_char?(c : Char) : Bool
-      c == '_' || c.ascii_alphanumeric? || c.ord >= 0x80
-    end
-
-    private def ident_start?(c : Char) : Bool
-      c == '_' || c.ascii_letter? || c.ord >= 0x80
     end
 
     # Emit one source character to both views.
@@ -205,60 +200,9 @@ module Noir
     end
 
     # ---- structural helpers (character indices, over the structural view) ---
-
-    def matching_delimiter(open_pos : Int32) : Int32?
-      return unless 0 <= open_pos && open_pos < @size
-      open = @masked[open_pos]
-      close = case open
-              when '(' then ')'
-              when '[' then ']'
-              when '{' then '}'
-              else          return
-              end
-      depth = 0
-      i = open_pos
-      while i < @size
-        c = @masked[i]
-        if c == open
-          depth += 1
-        elsif c == close
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-      nil
-    end
-
-    def statement_end(start_pos : Int32) : Int32
-      paren = 0
-      bracket = 0
-      brace = 0
-      i = start_pos < 0 ? 0 : start_pos
-      while i < @size
-        case @masked[i]
-        when '(' then paren += 1
-        when ')' then paren -= 1 if paren > 0
-        when '[' then bracket += 1
-        when ']' then bracket -= 1 if bracket > 0
-        when '{' then brace += 1
-        when '}' then brace -= 1 if brace > 0
-        when ';'
-          return i + 1 if paren == 0 && bracket == 0 && brace == 0
-        end
-        i += 1
-      end
-      @size
-    end
-
-    def skip_ranges : Array(Range(Int32, Int32))
-      @skip_ranges ||= @spans.map { |(_, s, e)| (s..e - 1) }
-    end
-
-    def in_code?(pos : Int32) : Bool
-      return false unless 0 <= pos && pos < @size
-      @spans.none? { |(_, s, e)| s <= pos && pos < e }
-    end
+    #
+    # `matching_delimiter`, `statement_end`, `skip_ranges` and `in_code?` come
+    # from `Noir::MaskedLexer`. Only the Scala-specific views live here.
 
     # Structural masked source split into lines (1:1 with `String#lines`).
     def masked_lines : Array(String)


### PR DESCRIPTION
## Summary

`csharp_lexer.cr`, `php_lexer.cr` and `scala_lexer.cr` each carried the same six span/delimiter helpers. They move to a new `Noir::MaskedLexer` mixin. **Net −99 lines.**

| method | lines | sites |
|---|---|---|
| `matching_delimiter` | 23 | csharp:362, php:262, scala:209 |
| `statement_end` | 20 | csharp:388, php:288, scala:233 |
| `in_code?` | 4 | csharp:413, php:347, scala:258 |
| `skip_ranges` | 3 | csharp:409, php:343, scala:254 |
| `ident_char?` | 3 | csharp:66, php:62, scala:64 |
| `ident_start?` | 3 | csharp:70, php:66, scala:68 |

Identity came from hashing whitespace-normalised bodies twice — comments included and comments stripped — and only groups identical under both were folded.

The four backing ivars are declared **in the module**, so the contract the three lexers share is now compile-checked instead of restated three times and free to drift:

```crystal
getter masked : Array(Char)
@size        : Int32
@spans       : Array(Tuple(Symbol, Int32, Int32))
@skip_ranges : Array(Range(Int32, Int32))?
```

Class-specific state (`@chars`, each lexer's token array, `@masked_lines`, `@code_lines`, Scala's `code`) stays put. Nothing that is a per-language optimisation was touched — PHP's heredoc masking, C#'s raw/interpolated/verbatim string handling, Scala's nested block comments and dual `masked`/`code` views, and all three token streams never entered a group.

Also folds `find_matching_delimiter` from `java/armeria.cr:775` and `java/quarkus.cr:658` onto `JavaEngine` (8 call sites). It references no constant, so it is clear of the `JAVA_EXTENSION` hazard that keeps `read_properties` and friends unfoldable.

## Corrections to the audit that prompted this

- **`miniparsers/java_route_extractor_ts.cr:885 find_matching_delimiter` is NOT a third copy.** The audit called it byte-identical to armeria/quarkus; it is not. The block variable is `char` rather than `ch`, and it terminates via `result = i; break` instead of `return i`. Behaviourally equivalent, textually distinct — and folding it would point a miniparser at an analyzer module, backwards through the layering the repo enforces. Left alone.
- **`masked_lines`** is identical but only in 2 of 3 lexers (`PhpLexer` has no `@masked_lines`). A second single-purpose mixin would cost more boilerplate than the 7 lines it saves.
- **The three token structs' `initialize`/`to_s`** are 3-way identical (~20 lines). A `getter` mixin would work but hides the field list of three public struct types at their definition sites and puts `Struct`'s ivar-derived `==`/`hash` behind an include. Reported, not done.

## Test plan

- **A/B sweep over all 667 fixture projects: byte-identical**, 5,165 endpoints, including `code_paths[].line` and `callees[].line`.
- Per-fixture `-f json --include-callee` diff over all 68 `{php,csharp,scala}` fixture dirs, against a baseline from the unmodified tree: byte-identical.
- `crystal spec spec/unit_test` — 4,757 examples, 0 failures. `crystal spec spec/functional_test` — 22,674 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.