### PR TITLE
refactor(python): one delimiter-delta helper, and fold the spec $ref resolvers

### DIFF
--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -833,36 +833,6 @@ module Analyzer::Python
       ranges
     end
 
-    private def python_bracket_delta(line : ::String) : Int32
-      depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      line.each_char do |ch|
-        if in_quote
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-        when '['
-          depth += 1
-        when ']'
-          depth -= 1
-        end
-      end
-
-      depth
-    end
-
     private def prefixes_for_add_routes_call(line : ::String,
                                              app_prefixes : Hash(::String, Array(::String)),
                                              route_list_prefixes : Hash(Int32, Array(::String)),

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -751,36 +751,6 @@ module Analyzer::Python
       nil
     end
 
-    private def python_bracket_delta(line : ::String) : Int32
-      depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      line.each_char do |ch|
-        if in_quote
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-        when '['
-          depth += 1
-        when ']'
-          depth -= 1
-        end
-      end
-
-      depth
-    end
-
     private def extract_route_mappings(content : ::String) : Array(Tuple(::String, ::String))
       mappings = [] of Tuple(::String, ::String)
       lines = content.split("\n")

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -1405,37 +1405,6 @@ module Analyzer::Python
       pieces.join(' ')
     end
 
-    # Net `(` − `)` paren count for `line`, ignoring parens inside
-    # single- or double-quoted strings. Sufficient for FastAPI
-    # decorator headers, which don't carry triple-quoted strings or
-    # raw f-strings on the call line itself.
-    private def python_paren_delta(line : ::String) : Int32
-      depth = 0
-      in_quote = nil
-      escaped = false
-      line.each_char do |ch|
-        if in_quote
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-        case ch
-        when '\'', '"'
-          in_quote = ch
-        when '('
-          depth += 1
-        when ')'
-          depth -= 1
-        end
-      end
-      depth
-    end
-
     # Whether `line`'s paren count is balanced (delta == 0). Used to
     # short-circuit the multi-line join when the call already closes
     # on the same line.

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -1099,36 +1099,6 @@ module Analyzer::Python
       pieces.join(" ")
     end
 
-    private def python_bracket_delta(line : ::String) : Int32
-      depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      line.each_char do |ch|
-        if in_quote
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-        when '['
-          depth += 1
-        when ']'
-          depth -= 1
-        end
-      end
-
-      depth
-    end
-
     # Locate `class <name>(...):` in a file's lines (-1 when absent).
     private def find_python_class_def(class_lines : Array(::String), class_name : ::String) : Int32
       class_prefix = "class #{class_name}"

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -615,36 +615,6 @@ module Analyzer::Python
       pieces.join(" ")
     end
 
-    private def python_bracket_delta(line : ::String) : Int32
-      depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      line.each_char do |ch|
-        if in_quote
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-        when '['
-          depth += 1
-        when ']'
-          depth -= 1
-        end
-      end
-
-      depth
-    end
-
     private def find_method_def(lines : Array(::String), class_def_index : Int32, class_indent : Int32, method_name : ::String) : Int32
       # Compile once per call; an interpolated literal inside the loop
       # would be recompiled on every line.

--- a/src/analyzer/analyzers/specification/asyncapi.cr
+++ b/src/analyzer/analyzers/specification/asyncapi.cr
@@ -162,18 +162,6 @@ module Analyzer::Specification
       end
     end
 
-    private def resolve_ref_json(root : JSON::Any, ref : String) : JSON::Any?
-      return unless ref.starts_with?("#/")
-      node = root
-      ref[2..].split('/').each do |segment|
-        decoded = segment.gsub("~1", "/").gsub("~0", "~")
-        return unless hash = node.as_h?
-        return unless next_node = hash[decoded]?
-        node = next_node
-      end
-      node
-    end
-
     # --- YAML path ------------------------------------------------------
 
     private def process_yaml(root : YAML::Any, details : Details, source : String)
@@ -321,18 +309,6 @@ module Analyzer::Specification
           all_of.each { |s| collect_schema_props_yaml(root, s, param_type, params, seen) }
         end
       end
-    end
-
-    private def resolve_ref_yaml(root : YAML::Any, ref : String) : YAML::Any?
-      return unless ref.starts_with?("#/")
-      node = root
-      ref[2..].split('/').each do |segment|
-        decoded = segment.gsub("~1", "/").gsub("~0", "~")
-        return unless hash = node.as_h?
-        return unless next_node = hash[YAML::Any.new(decoded)]?
-        node = next_node
-      end
-      node
     end
 
     # --- shared ---------------------------------------------------------

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -7,38 +7,6 @@ module Analyzer::Specification
 
     HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
 
-    # Resolves a `#/definitions/Name` pointer against the spec root.
-    # Returns the referenced node, or nil when the ref cannot be followed.
-    private def resolve_ref_json(root : JSON::Any, ref : String) : JSON::Any?
-      return unless ref.starts_with?("#/")
-      node = root
-      ref[2..].split('/').each do |segment|
-        decoded = segment.gsub("~1", "/").gsub("~0", "~")
-        return unless hash = node.as_h?
-        return unless next_node = hash[decoded]?
-        node = next_node
-      end
-      node
-    end
-
-    private def resolve_ref_yaml(root : YAML::Any, ref : String) : YAML::Any?
-      return unless ref.starts_with?("#/")
-      node = root
-      ref[2..].split('/').each do |segment|
-        decoded = segment.gsub("~1", "/").gsub("~0", "~")
-        return unless hash = node.as_h?
-        return unless next_node = hash[YAML::Any.new(decoded)]?
-        node = next_node
-      end
-      node
-    end
-
-    private def add_param(params : Array(Param), name : String, param_type : String)
-      return if name.empty?
-      param = Param.new(name, "", param_type)
-      params << param unless params.includes?(param)
-    end
-
     # Walks a body schema and emits a Param per top-level property.
     private def collect_body_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
       if ref = schema["$ref"]?.try(&.as_s?)

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -33,37 +33,6 @@ module Analyzer::Specification
       end
     end
 
-    # Resolves `#/components/schemas/Name` etc. against the spec root.
-    private def resolve_ref_json(root : JSON::Any, ref : String) : JSON::Any?
-      return unless ref.starts_with?("#/")
-      node = root
-      ref[2..].split('/').each do |segment|
-        decoded = segment.gsub("~1", "/").gsub("~0", "~")
-        return unless hash = node.as_h?
-        return unless next_node = hash[decoded]?
-        node = next_node
-      end
-      node
-    end
-
-    private def resolve_ref_yaml(root : YAML::Any, ref : String) : YAML::Any?
-      return unless ref.starts_with?("#/")
-      node = root
-      ref[2..].split('/').each do |segment|
-        decoded = segment.gsub("~1", "/").gsub("~0", "~")
-        return unless hash = node.as_h?
-        return unless next_node = hash[YAML::Any.new(decoded)]?
-        node = next_node
-      end
-      node
-    end
-
-    private def add_param(params : Array(Param), name : String, param_type : String)
-      return if name.empty?
-      param = Param.new(name, "", param_type)
-      params << param unless params.includes?(param)
-    end
-
     private def server_url_json(server_obj : JSON::Any) : String
       url = server_obj["url"]?.try(&.as_s?) || ""
       if variables = server_obj["variables"]?.try(&.as_h?)

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -663,19 +663,28 @@ module Analyzer::Python
       end
     end
 
-    # Net `(` − `)` count on a single Python source line, ignoring
-    # parens that fall inside single- or double-quoted strings on the
-    # same line. Sufficient for decorator / function-call headers,
-    # which never carry triple-quoted strings on the call line.
+    # Net `open_char` − `close_char` count on a single Python source
+    # line, ignoring delimiters that fall inside single- or
+    # double-quoted strings on the same line — a `"("` inside a route
+    # pattern or a `"["` inside a regex must not move the depth.
+    # Backslash escapes are tracked inside a quoted run so that `\'`
+    # / `\"` do not close it early.
     #
-    # Used by analyzers that walk source line-by-line and need to
-    # join continuation lines into one logical call (e.g. multi-line
-    # decorators in FastAPI / Litestar / Sanic / Bottle, multi-line
-    # `Route(...)` entries in Starlette).
-    def python_paren_delta(line : ::String) : Int32
+    # Only same-line quoting is modelled: `in_quote` resets on every
+    # call, so a triple-quoted string spanning lines is not tracked.
+    # That is sufficient for the shapes the callers care about —
+    # decorator / call headers and collection literals never open a
+    # triple-quoted string on the line being counted.
+    #
+    # Unbalanced input is reported as-is (negative when the line
+    # closes more than it opens); callers decide what to do with it.
+    private def python_delimiter_delta(line : ::String,
+                                       open_char : Char,
+                                       close_char : Char) : Int32
       depth = 0
-      in_quote = nil
+      in_quote : Char? = nil
       escaped = false
+
       line.each_char do |ch|
         if in_quote
           if escaped
@@ -687,16 +696,39 @@ module Analyzer::Python
           end
           next
         end
+
         case ch
         when '\'', '"'
           in_quote = ch
-        when '('
+        when open_char
           depth += 1
-        when ')'
+        when close_char
           depth -= 1
         end
       end
+
       depth
+    end
+
+    # Net `(` − `)` count on a single Python source line.
+    #
+    # Used by analyzers that walk source line-by-line and need to
+    # join continuation lines into one logical call (e.g. multi-line
+    # decorators in FastAPI / Litestar / Sanic / Bottle, multi-line
+    # `Route(...)` entries in Starlette).
+    def python_paren_delta(line : ::String) : Int32
+      python_delimiter_delta(line, '(', ')')
+    end
+
+    # Net `[` − `]` count on a single Python source line.
+    #
+    # Used where the construct being followed is a collection literal
+    # rather than a call: Django's `urlpatterns = [...]` / inline
+    # `include([...])`, aiohttp's route-table lists, and the
+    # Flask / Quart collection assignments that add both deltas
+    # together to follow a mixed `[... (...) ...]` continuation.
+    def python_bracket_delta(line : ::String) : Int32
+      python_delimiter_delta(line, '[', ']')
     end
 
     # Given a 0-based `index` into `lines` whose content `line` is

--- a/src/analyzer/engines/specification_engine.cr
+++ b/src/analyzer/engines/specification_engine.cr
@@ -1,6 +1,8 @@
 require "../../models/analyzer"
 require "../../models/code_locator"
 require "uri"
+require "json"
+require "yaml"
 require "../../models/locator_keys"
 
 module Analyzer::Specification
@@ -164,6 +166,62 @@ module Analyzer::Specification
       else
         @url + path
       end
+    end
+
+    # Follows a local JSON Pointer — OAS2's `#/definitions/Name`, OAS3's
+    # `#/components/schemas/Name`, AsyncAPI's `#/components/messages/Name`
+    # — against the document root.
+    #
+    # Only same-document refs are resolved: a ref that does not start with
+    # `#/` points at another file (or an external URL) that the analyzer
+    # never loaded, so it returns nil rather than guessing.
+    #
+    # `~1` and `~0` are unescaped per RFC 6901, in that order — `~0` must be
+    # decoded last or a literal `~1` in a key would be corrupted by the `~`
+    # produced from `~0`.
+    #
+    # Returns nil at the first segment that is not a mapping or is absent,
+    # which is what lets callers treat a dangling ref as "no schema" instead
+    # of raising mid-walk.
+    protected def resolve_ref_json(root : JSON::Any, ref : String) : JSON::Any?
+      return unless ref.starts_with?("#/")
+      node = root
+      ref[2..].split('/').each do |segment|
+        decoded = segment.gsub("~1", "/").gsub("~0", "~")
+        return unless hash = node.as_h?
+        return unless next_node = hash[decoded]?
+        node = next_node
+      end
+      node
+    end
+
+    # `resolve_ref_json` for the YAML parse of the same formats. Kept
+    # separate rather than generic because the two `Any` types are
+    # unrelated and their hashes are keyed differently — YAML mappings are
+    # keyed by `YAML::Any`, not by `String`.
+    protected def resolve_ref_yaml(root : YAML::Any, ref : String) : YAML::Any?
+      return unless ref.starts_with?("#/")
+      node = root
+      ref[2..].split('/').each do |segment|
+        decoded = segment.gsub("~1", "/").gsub("~0", "~")
+        return unless hash = node.as_h?
+        return unless next_node = hash[YAML::Any.new(decoded)]?
+        node = next_node
+      end
+      node
+    end
+
+    # Appends a valueless `Param` unless an equal one is already present.
+    #
+    # Schema walks reach the same property twice whenever a document
+    # composes schemas (`allOf`, a `$ref` pulled in from two places), so the
+    # dedupe is load-bearing, not defensive. Equality is full `Param`
+    # equality; the value is always `""` here, so it reduces to name +
+    # param_type.
+    protected def add_param(params : Array(Param), name : String, param_type : String)
+      return if name.empty?
+      param = Param.new(name, "", param_type)
+      params << param unless params.includes?(param)
     end
   end
 end


### PR DESCRIPTION
## Summary

`python_bracket_delta` (4 copies) and `PythonEngine#python_paren_delta` are the same 29-line algorithm differing only in the delimiter pair. They collapse to one parameterised helper. **+102 / −250, net −148 lines.**

| group | occurrences | fate |
|---|---|---|
| `python_bracket_delta` | 4 — `python/{aiohttp,django,flask,quart}.cr` | deleted |
| `python_paren_delta` | 2 — `engines/python_engine.cr`, **`python/fastapi.cr:1412`** | fastapi copy deleted |
| `resolve_ref_json` | 3 — `specification/{asyncapi,oas2,oas3}.cr` | folded onto `SpecificationEngine` |
| `resolve_ref_yaml` | 3 — same three | folded onto `SpecificationEngine` |
| `add_param` | 2 — `specification/{oas2,oas3}.cr` | folded onto `SpecificationEngine` |

**The "differs only in the delimiter" claim was almost right.** Hashing the bodies with `[`/`]` folded onto `(`/`)` still did not match, on one character: `in_quote = nil` versus `in_quote : Char? = nil`. Crystal infers `Char?` for the unannotated one, so it is semantically identical; the explicit annotation is kept in the shared helper. Everything else — quote tracking, backslash escapes, `when` ordering, no clamp, unbalanced input returned as-is — is character-for-character the same.

**FastAPI carried a fifth copy** that was not in the brief: a `private def python_paren_delta` byte-identical to the inherited public one, shadowing it to no effect. Deleted.

Both original names are kept as thin wrappers rather than updating ~60 call sites across 14 files — `python_paren_delta(line) + python_bracket_delta(line)` reads better than the same thing spelled with two char arguments.

Three rationales that **no copy carried** are now documented on the shared implementations: the RFC 6901 `~1`-before-`~0` unescape order (decoding `~0` first corrupts a literal `~1`), why only same-line quoting is modelled, and why the schema-walk dedupe is load-bearing rather than defensive (`allOf`/`$ref` composition reaches the same property twice).

## Excluded, with the blocking difference

- **`add_param` in `specification/{http_file,insomnia}.cr`** — a *second* identical pair, deliberately left. It takes 4 args (carries `value`), strips the name, and dedupes on name+param_type only, where the folded 3-arg version dedupes on full `Param` equality. Putting two dedupe rules behind one identifier as arity overloads would be worse than the duplication.
- **`collect_python_collection_assignment`** (flask/quart) is another identical pair adjacent to the deleted code and foldable, but out of scope for this diff.

## Test plan

- **A/B sweep over all 667 fixture projects: byte-identical**, 5,165 endpoints, including `code_paths[].line` and `callees[].line`.
- Per-fixture diff against an unmodified-tree baseline: `python/` 62/62 byte-identical (492 endpoints, callees matching); `specification/` 57/57 byte-identical.
- **Release-build timing** on the python fixture tree, since the delimiters are now runtime arguments on a per-line hot path: 0.09 s/scan on both main and this branch — the arguments inline away.
- `crystal spec spec/unit_test` — 4,757 examples, 0 failures. `crystal spec spec/functional_test` — 22,674 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.