### PR TITLE
fix(analyzer): close the walk channel in an ensure, and drop a dead mutex

### DIFF
--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -205,10 +205,21 @@ class Analyzer
   def parallel_analyze(files : Array(String), &block : String -> Nil)
     channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
     WaitGroup.wait do |wg|
-      # Producer — tracked by the WaitGroup
+      # Producer — tracked by the WaitGroup.
+      #
+      # `ensure`, not a trailing statement: if the producer ever raises
+      # mid-send, an unclosed channel leaves every worker parked in
+      # `receive?` forever and `WaitGroup.wait` never returns — a silent
+      # hang with no output and no exit code. `detector.cr`'s reader already
+      # closes in an `ensure` for that reason; the analyzer side did not.
+      # Nothing in this body can raise today (pure array iteration), so this
+      # is defence in depth against the next edit, not a live fix.
       wg.spawn do
-        files.each { |file| channel.send(file) }
-        channel.close
+        begin
+          files.each { |file| channel.send(file) }
+        ensure
+          channel.close
+        end
       end
 
       bounded_worker_count.times do
@@ -398,10 +409,14 @@ class FileAnalyzer < Analyzer
     channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
     WaitGroup.wait do |wg|
-      # Producer — tracked by the WaitGroup
+      # Producer — tracked by the WaitGroup. Closes in an `ensure` for the
+      # same reason as the overload above.
       wg.spawn do
-        all_files.each { |file| channel.send(file) }
-        channel.close
+        begin
+          all_files.each { |file| channel.send(file) }
+        ensure
+          channel.close
+        end
       end
 
       worker_count.times do

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -50,7 +50,6 @@ class NoirLogger
     @color_mode = colorize
     @no_log = no_log
     @no_spinner = no_spinner
-    @output_mutex = Mutex.new
     @spinner_active = false
     @stdout_busy = Atomic(Int8).new(0_i8)
   end


### PR DESCRIPTION
## 1. `parallel_analyze`'s producer now closes in an `ensure`

The producer sends every path and then closes; N workers park in `channel.receive?`. If the producer ever dies mid-send **without** closing, those workers stay parked forever and `WaitGroup.wait` never returns.

The failure mode is what makes this worth fixing: `WaitGroup#spawn` runs the block in a fiber, so the exception dies with the fiber and nothing propagates. **No error, no exit code, 0% CPU, forever.**

Reproduced standalone with the same producer/worker shape and a list whose `each` raises part way through:

```
without ensure -> HUNG (killed at 20s)
with ensure    -> RETURNED seen=["first.rb"]
```

Nothing in the current body can raise — it iterates an array already in memory — so this guards the next edit rather than fixing a live defect. It earns its place because `detector.cr`'s reader has always closed in an `ensure`, with a comment explaining why, and the analyzer side simply never picked it up. The first producer that reads the filesystem inline makes the hang real.

**No spec, deliberately.** Forcing the producer to raise requires subclassing `Array(String)`, and doing that inside the suite perturbs Crystal's type inference globally — it broke an unrelated type alias in `crystal_engine.cr` at compile time, with the whole unit suite failing to build. The standalone probe above is the evidence instead.

## 2. `NoirLogger`'s `@output_mutex` is deleted

Assigned in the constructor, referenced nowhere else. Serialization is done entirely by the `@stdout_busy : Atomic(Int8)` protocol. A `Mutex` sitting in the constructor tells a reader that writes are mutex-guarded, which they are not — the misdirection is the whole cost of keeping it.

## Test plan

- Standalone hang reproduction, both directions (above).
- A/B sweep over all 668 fixture projects: **byte-identical**, 5,176 endpoints, including `code_paths[].line` and `callees[].line`.
- `crystal spec spec/unit_test` — 4,759 examples, 0 failures. `crystal spec spec/functional_test` — 22,699 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.