### PR TITLE
refactor(go): route the 16 analyzers through the shared parallel walk

### DIFF
--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -40,122 +40,96 @@ module Analyzer::Go
       # 1-hop callees walked even though the call doesn't pass it as an
       # argument. Empty unless callees are requested.
       package_controller_method_bodies = collect_package_controller_method_bodies(file_contents)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = read_file_content(path)
+        next unless content_matches?(content, IMPORT_MARKER_RE)
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+        # Functional `web.Get("/x", h)` verb routes plus
+        # controller-style `web.Router("/x", &Ctrl{}, "get:M")`
+        # registrations — the latter is Beego's dominant idiom.
+        controller_methods = ts_controller_methods_for_directory(package_controller_methods, File.dirname(path))
+        beego_routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(content, controller_methods)
+        # Track which lines are `web.Router` registrations so the
+        # controller-method callee fallback below only fires for
+        # them — never for a `web.Get` verb route whose handler
+        # text happens to collide with a method name.
+        beego_router_lines = Set(Int32).new
+        beego_routes.each { |r| beego_router_lines << r.line }
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content) + beego_routes
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = read_file_content(path)
-                    next unless content_matches?(content, IMPORT_MARKER_RE)
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        # Resolve 1-hop callees for every route (see Gin).
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+        controller_method_bodies = ts_controller_method_bodies_for_directory(package_controller_method_bodies, File.dirname(path))
 
-                    # Functional `web.Get("/x", h)` verb routes plus
-                    # controller-style `web.Router("/x", &Ctrl{}, "get:M")`
-                    # registrations — the latter is Beego's dominant idiom.
-                    controller_methods = ts_controller_methods_for_directory(package_controller_methods, File.dirname(path))
-                    beego_routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(content, controller_methods)
-                    # Track which lines are `web.Router` registrations so the
-                    # controller-method callee fallback below only fires for
-                    # them — never for a `web.Get` verb route whose handler
-                    # text happens to collide with a method name.
-                    beego_router_lines = Set(Int32).new
-                    beego_routes.each { |r| beego_router_lines << r.line }
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content) + beego_routes
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    # Resolve 1-hop callees for every route (see Gin).
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
-                    controller_method_bodies = ts_controller_method_bodies_for_directory(package_controller_method_bodies, File.dirname(path))
-
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                            new_endpoint = Endpoint.new(route.path, verb, details)
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            elsif callees_needed? && beego_router_lines.includes?(route.line) &&
-                                  !route.handler.empty? &&
-                                  (bodies = controller_method_bodies[route.handler]?) && bodies.size == 1
-                              # `web.Router` routes carry the controller
-                              # method name in `handler`; the registration
-                              # call doesn't pass it as an argument, so walk
-                              # the method body here. Only when exactly one
-                              # controller in the package defines the name
-                              # (avoids mis-attributing an ambiguous method).
-                              Noir::GoCalleeExtractor.callees_in_body(bodies.first, external_fns).each do |name, callee_path, callee_line|
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-                          end
-                        end
-                      end
-
-                      CONTEXT_GETTER_PATTERNS.each do |pattern, getter_regex|
-                        # Quote-bounded + scan so two accessor calls on one line
-                        # each yield their own param (greedy `(.*)` captured across
-                        # both, producing one garbage name).
-                        next unless line.includes?(pattern)
-                        line.scan(getter_regex) do |m|
-                          last_endpoint.params << Param.new(m[1], "", "query")
-                        end
-                      end
-
-                      if line.includes?("GetCookie(")
-                        match = line.match(/GetCookie\(\"([^"]*)\"\)/)
-                        if match
-                          cookie_name = match[1]
-                          last_endpoint.params << Param.new(cookie_name, "", "cookie")
-                        end
-                      end
-
-                      if line.includes?("GetSecureCookie(")
-                        match = line.match(/GetSecureCookie\(\"([^"]*)\"\)/)
-                        if match
-                          cookie_name = match[1]
-                          last_endpoint.params << Param.new(cookie_name, "", "cookie")
-                        end
-                      end
-                    end
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                new_endpoint = Endpoint.new(route.path, verb, details)
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                   end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
+                elsif callees_needed? && beego_router_lines.includes?(route.line) &&
+                      !route.handler.empty? &&
+                      (bodies = controller_method_bodies[route.handler]?) && bodies.size == 1
+                  # `web.Router` routes carry the controller
+                  # method name in `handler`; the registration
+                  # call doesn't pass it as an argument, so walk
+                  # the method body here. Only when exactly one
+                  # controller in the package defines the name
+                  # (avoids mis-attributing an ambiguous method).
+                  Noir::GoCalleeExtractor.callees_in_body(bodies.first, external_fns).each do |name, callee_path, callee_line|
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                  end
                 end
+                result << new_endpoint
+                last_endpoint = new_endpoint
               end
             end
           end
+
+          CONTEXT_GETTER_PATTERNS.each do |pattern, getter_regex|
+            # Quote-bounded + scan so two accessor calls on one line
+            # each yield their own param (greedy `(.*)` captured across
+            # both, producing one garbage name).
+            next unless line.includes?(pattern)
+            line.scan(getter_regex) do |m|
+              last_endpoint.params << Param.new(m[1], "", "query")
+            end
+          end
+
+          if line.includes?("GetCookie(")
+            match = line.match(/GetCookie\(\"([^"]*)\"\)/)
+            if match
+              cookie_name = match[1]
+              last_endpoint.params << Param.new(cookie_name, "", "cookie")
+            end
+          end
+
+          if line.includes?("GetSecureCookie(")
+            match = line.match(/GetSecureCookie\(\"([^"]*)\"\)/)
+            if match
+              cookie_name = match[1]
+              last_endpoint.params << Param.new(cookie_name, "", "cookie")
+            end
+          end
         end
-      rescue e
-        logger.debug e
       end
 
       resolve_public_dirs_with_glob(public_dirs)

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -119,158 +119,135 @@ module Analyzer::Go
         package_string_values[dir] = merged unless merged.empty?
       end
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents_cache[path]? || read_file_content(path)
+        next unless content_matches?(content, IMPORT_MARKER_RE)
+        lines = file_lines_cache[path]? || content.lines
+
+        dir = File.dirname(path)
+        mounted_functions = package_mounted_functions.fetch(dir, Set(String).new)
+
+        # Tree-sitter pre-pass: every `r.Get(...)` / `r.Route(...)`
+        # / `r.Group(...)` resolved with the correct prefix, skipping
+        # bodies of functions that are expanded via Mount (those
+        # are handled below to get their `/admin` prefix).
+        ts_routes = Noir::TreeSitterGoRouteExtractor
+          .extract_chi_routes(content, mounted_functions,
+            package_string_values[dir]? || Hash(String, String).new)
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
+
+        # Resolve 1-hop callees for every route in this file.
+        # Inline-closure handlers (the common Chi shape inside
+        # `r.Route("/x", func(r chi.Router){ r.Get(...) })`)
+        # walk in place; bare identifier handlers fall through
+        # to sibling-file function bodies via the per-directory map.
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, dir)
+        external_methods = Noir::GoCalleeExtractor.method_bodies_for_directory(package_method_bodies, dir)
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
+
+        state = ChiRouteState.new
+        last_endpoint = Endpoint.new("", "")
+        in_mounted_func = false
+        mounted_func_brace_count = 0
+
+        lines.each_with_index do |line, index|
+          # Skip bodies of mounted router functions so parameter
+          # extraction only attributes them to the Mount-expanded
+          # endpoints, not the free-floating verb calls we now
+          # skip in the TS pass.
+          if in_mounted_func
+            mounted_func_brace_count += line.count("{")
+            mounted_func_brace_count -= line.count("}")
+            if mounted_func_brace_count <= 0
+              in_mounted_func = false
+            end
+            next
           end
-
-          worker_count.times do
-            wg.spawn do
-              loop do
-                path = channel.receive?
-                break if path.nil?
-                next if File.directory?(path)
-                next if GoEngine.go_test_file?(base_relative_path(path))
-                if File.exists?(path)
-                  content = file_contents_cache[path]? || read_file_content(path)
-                  next unless content_matches?(content, IMPORT_MARKER_RE)
-                  lines = file_lines_cache[path]? || content.lines
-
-                  dir = File.dirname(path)
-                  mounted_functions = package_mounted_functions.fetch(dir, Set(String).new)
-
-                  # Tree-sitter pre-pass: every `r.Get(...)` / `r.Route(...)`
-                  # / `r.Group(...)` resolved with the correct prefix, skipping
-                  # bodies of functions that are expanded via Mount (those
-                  # are handled below to get their `/admin` prefix).
-                  ts_routes = Noir::TreeSitterGoRouteExtractor
-                    .extract_chi_routes(content, mounted_functions,
-                      package_string_values[dir]? || Hash(String, String).new)
-                  routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                  ts_routes.each do |r|
-                    routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                    routes_by_line[r.line] << r
-                  end
-
-                  # Resolve 1-hop callees for every route in this file.
-                  # Inline-closure handlers (the common Chi shape inside
-                  # `r.Route("/x", func(r chi.Router){ r.Get(...) })`)
-                  # walk in place; bare identifier handlers fall through
-                  # to sibling-file function bodies via the per-directory map.
-                  route_rows = Set(Int32).new
-                  routes_by_line.each_key { |row| route_rows << row }
-                  external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, dir)
-                  external_methods = Noir::GoCalleeExtractor.method_bodies_for_directory(package_method_bodies, dir)
-                  callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
-
-                  state = ChiRouteState.new
-                  last_endpoint = Endpoint.new("", "")
-                  in_mounted_func = false
-                  mounted_func_brace_count = 0
-
-                  lines.each_with_index do |line, index|
-                    # Skip bodies of mounted router functions so parameter
-                    # extraction only attributes them to the Mount-expanded
-                    # endpoints, not the free-floating verb calls we now
-                    # skip in the TS pass.
-                    if in_mounted_func
-                      mounted_func_brace_count += line.count("{")
-                      mounted_func_brace_count -= line.count("}")
-                      if mounted_func_brace_count <= 0
-                        in_mounted_func = false
-                      end
-                      next
-                    end
-                    if !mounted_functions.empty? && line.strip.starts_with?("func ")
-                      # Match both plain functions (`func adminRouter(`) and
-                      # methods (`func (rs todosResource) Routes(`); either
-                      # can be a mount target whose body must be skipped so
-                      # its routes are attributed only to the Mount-expanded
-                      # (prefixed) endpoints, never the free-floating pass.
-                      # Methods are keyed by `Receiver.Method` so an
-                      # unmounted same-named method (e.g. a top-level
-                      # `func (s server) Routes()` used directly) keeps its
-                      # routes — and the `.Mount(...)` calls inside it.
-                      decl_name = nil
-                      if func_match = line.match(/func\s+\(\s*\w+\s+\*?([\w.]+)\)\s+([a-zA-Z_]\w*)\s*\(/)
-                        decl_name = "#{func_match[1].split('.').last}.#{func_match[2]}"
-                      elsif func_match = line.match(/func\s+([a-zA-Z_]\w*)\s*\(/)
-                        decl_name = func_match[1]
-                      end
-                      if decl_name && mounted_functions.includes?(decl_name)
-                        in_mounted_func = true
-                        mounted_func_brace_count = line.count("{") - line.count("}")
-                        if mounted_func_brace_count <= 0
-                          in_mounted_func = false
-                        end
-                        next
-                      end
-                    end
-
-                    details = Details.new(PathInfo.new(path, index + 1))
-
-                    if line.includes?(".Mount(")
-                      if target = parse_mount_target(line)
-                        endpoints = analyze_router_function(path, target[:func_name], package_files, file_contents_cache, file_lines_cache, target[:recv_type])
-                        endpoints.each do |ep|
-                          ep.url = target[:prefix] + ep.url
-                          result << ep
-                        end
-                      end
-                      next
-                    end
-
-                    # Emit any route whose declaration begins on this line,
-                    # and seed inline-handler tracking so the param extractor
-                    # below only attributes params to the enclosing route.
-                    if ts_hits = routes_by_line[index]?
-                      ts_hits.each do |route|
-                        Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                          endpoint = Endpoint.new(route.path, verb, details)
-                          if entries = callees_by_route[route.line]?
-                            entries.each do |entry|
-                              name, callee_path, callee_line = entry
-                              endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                            end
-                          end
-                          result << endpoint
-                          last_endpoint = endpoint
-                        end
-                      end
-                      if line.includes?("func(")
-                        state.in_inline_handler = true
-                        state.handler_brace_count = line.count("{") - line.count("}")
-                        if state.handler_brace_count <= 0
-                          state.in_inline_handler = false
-                          state.handler_brace_count = 0
-                        end
-                      end
-                    elsif state.in_inline_handler?
-                      # Normal line inside an inline handler — tally braces
-                      # so we know when it closes.
-                      state.handler_brace_count += line.count("{")
-                      state.handler_brace_count -= line.count("}")
-                      if state.handler_brace_count <= 0
-                        state.in_inline_handler = false
-                        state.handler_brace_count = 0
-                      end
-                    end
-
-                    extract_params(line, state, last_endpoint)
-                  end
-                end
-              rescue e : IO::Error
-                logger.debug "Skipping #{path}: #{e.message}"
+          if !mounted_functions.empty? && line.strip.starts_with?("func ")
+            # Match both plain functions (`func adminRouter(`) and
+            # methods (`func (rs todosResource) Routes(`); either
+            # can be a mount target whose body must be skipped so
+            # its routes are attributed only to the Mount-expanded
+            # (prefixed) endpoints, never the free-floating pass.
+            # Methods are keyed by `Receiver.Method` so an
+            # unmounted same-named method (e.g. a top-level
+            # `func (s server) Routes()` used directly) keeps its
+            # routes — and the `.Mount(...)` calls inside it.
+            decl_name = nil
+            if func_match = line.match(/func\s+\(\s*\w+\s+\*?([\w.]+)\)\s+([a-zA-Z_]\w*)\s*\(/)
+              decl_name = "#{func_match[1].split('.').last}.#{func_match[2]}"
+            elsif func_match = line.match(/func\s+([a-zA-Z_]\w*)\s*\(/)
+              decl_name = func_match[1]
+            end
+            if decl_name && mounted_functions.includes?(decl_name)
+              in_mounted_func = true
+              mounted_func_brace_count = line.count("{") - line.count("}")
+              if mounted_func_brace_count <= 0
+                in_mounted_func = false
               end
+              next
             end
           end
+
+          details = Details.new(PathInfo.new(path, index + 1))
+
+          if line.includes?(".Mount(")
+            if target = parse_mount_target(line)
+              endpoints = analyze_router_function(path, target[:func_name], package_files, file_contents_cache, file_lines_cache, target[:recv_type])
+              endpoints.each do |ep|
+                ep.url = target[:prefix] + ep.url
+                result << ep
+              end
+            end
+            next
+          end
+
+          # Emit any route whose declaration begins on this line,
+          # and seed inline-handler tracking so the param extractor
+          # below only attributes params to the enclosing route.
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                endpoint = Endpoint.new(route.path, verb, details)
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                  end
+                end
+                result << endpoint
+                last_endpoint = endpoint
+              end
+            end
+            if line.includes?("func(")
+              state.in_inline_handler = true
+              state.handler_brace_count = line.count("{") - line.count("}")
+              if state.handler_brace_count <= 0
+                state.in_inline_handler = false
+                state.handler_brace_count = 0
+              end
+            end
+          elsif state.in_inline_handler?
+            # Normal line inside an inline handler — tally braces
+            # so we know when it closes.
+            state.handler_brace_count += line.count("{")
+            state.handler_brace_count -= line.count("}")
+            if state.handler_brace_count <= 0
+              state.in_inline_handler = false
+              state.handler_brace_count = 0
+            end
+          end
+
+          extract_params(line, state, last_endpoint)
         end
-      rescue e
-        logger.debug e
       end
       result
     end

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -17,132 +17,106 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       import_path_function_bodies = collect_import_path_function_bodies(package_function_bodies)
       framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents[path]? || read_file_content(path)
+        dir = File.dirname(path)
+        next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Add", "Static", "File"])
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+        # Tree-sitter pre-pass: every Echo verb route
+        # (`e.GET`, `g.POST`, …) with its group prefix applied.
+        cross_file_groups = ts_groups_for_directory(package_groups, dir)
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Add")
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = file_contents[path]? || read_file_content(path)
-                    dir = File.dirname(path)
-                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Add", "Static", "File"])
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        # Resolve 1-hop callees for every route in this file.
+        # Inline-closure handlers walk in place; bare
+        # identifier handlers fall through to sibling-file
+        # function bodies via the per-directory map.
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(
+          callees_needed?,
+          content,
+          path,
+          route_rows,
+          external_fns,
+          imported_functions: import_path_function_bodies
+        )
 
-                    # Tree-sitter pre-pass: every Echo verb route
-                    # (`e.GET`, `g.POST`, …) with its group prefix applied.
-                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Add")
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        # `e.Static("/url", "./dir")` — same shape as Gin/Fiber/etc.
+        Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
+          public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
+        end
 
-                    # Resolve 1-hop callees for every route in this file.
-                    # Inline-closure handlers walk in place; bare
-                    # identifier handlers fall through to sibling-file
-                    # function bodies via the per-directory map.
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(
-                      callees_needed?,
-                      content,
-                      path,
-                      route_rows,
-                      external_fns,
-                      imported_functions: import_path_function_bodies
-                    )
+        # `e.File("/url", "disk/path")` — single-file static route.
+        Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content, method_name: "File").each do |sp|
+          public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
+        end
 
-                    # `e.Static("/url", "./dir")` — same shape as Gin/Fiber/etc.
-                    Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
-                      public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
-                    end
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    # `e.File("/url", "disk/path")` — single-file static route.
-                    Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content, method_name: "File").each do |sp|
-                      public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
-                    end
-
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          # Echo's `e.Any` registers a route for every HTTP
-                          # method — fan out so downstream formats see a real
-                          # verb per endpoint instead of "ANY".
-                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                            new_endpoint = Endpoint.new(route.path, verb, details)
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-                          end
-                        end
-                      end
-
-                      if line.includes?("Param(") || line.includes?("FormValue(")
-                        add_param_to_endpoint(get_param(line), last_endpoint)
-                      end
-
-                      # `c.Bind(&v)` / `c.BindBody(...)` populate the
-                      # request body. Echo also exposes `BindJSON`-style
-                      # helpers via the echo-contrib package. Emit a
-                      # single "body" indicator without trying to decode
-                      # the bound struct's shape (would need static-type
-                      # resolution we don't have).
-                      if line.matches?(/\.Bind(?:Body|JSON|XML|YAML|Headers|Query|Path)?\s*\(/) &&
-                         !line.includes?("// ")
-                        add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
-                      end
-
-                      if line.includes?("Request().Header.Get(")
-                        match = line.match(/Request\(\)\.Header\.Get\(\"(.*)\"\)/)
-                        if match
-                          header_name = match[1]
-                          last_endpoint.params << Param.new(header_name, "", "header")
-                        end
-                      end
-
-                      if line.includes?("Cookie(") &&
-                         !line.includes?("Header.Get") && !line.includes?("Query().Get") &&
-                         !line.includes?("Request().Header.Get")
-                        match = line.match(/Cookie\(\"(.*)\"\)/)
-                        if match
-                          cookie_name = match[1]
-                          last_endpoint.params << Param.new(cookie_name, "", "cookie")
-                        end
-                      end
-                    end
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              # Echo's `e.Any` registers a route for every HTTP
+              # method — fan out so downstream formats see a real
+              # verb per endpoint instead of "ANY".
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                new_endpoint = Endpoint.new(route.path, verb, details)
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                   end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
                 end
+                result << new_endpoint
+                last_endpoint = new_endpoint
               end
             end
           end
+
+          if line.includes?("Param(") || line.includes?("FormValue(")
+            add_param_to_endpoint(get_param(line), last_endpoint)
+          end
+
+          # `c.Bind(&v)` / `c.BindBody(...)` populate the
+          # request body. Echo also exposes `BindJSON`-style
+          # helpers via the echo-contrib package. Emit a
+          # single "body" indicator without trying to decode
+          # the bound struct's shape (would need static-type
+          # resolution we don't have).
+          if line.matches?(/\.Bind(?:Body|JSON|XML|YAML|Headers|Query|Path)?\s*\(/) &&
+             !line.includes?("// ")
+            add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
+          end
+
+          if line.includes?("Request().Header.Get(")
+            match = line.match(/Request\(\)\.Header\.Get\(\"(.*)\"\)/)
+            if match
+              header_name = match[1]
+              last_endpoint.params << Param.new(header_name, "", "header")
+            end
+          end
+
+          if line.includes?("Cookie(") &&
+             !line.includes?("Header.Get") && !line.includes?("Query().Get") &&
+             !line.includes?("Request().Header.Get")
+            match = line.match(/Cookie\(\"(.*)\"\)/)
+            if match
+              cookie_name = match[1]
+              last_endpoint.params << Param.new(cookie_name, "", "cookie")
+            end
+          end
         end
-      rescue e
-        logger.debug e
       end
 
       resolve_public_dirs(public_dirs)

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -16,135 +16,109 @@ module Analyzer::Go
       import_path_function_bodies = collect_import_path_function_bodies(package_function_bodies)
       import_path_method_bodies = collect_import_path_method_bodies(package_method_bodies)
       framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents[path]? || read_file_content(path)
+        dir = File.dirname(path)
+        next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Add", "Static"])
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+        # Tree-sitter pre-pass for Fiber's verb-method routes.
+        # websocket.New(...) detection stays on the raw line text
+        # because it's a sibling expression, not part of the route
+        # argument list.
+        cross_file_groups = ts_groups_for_directory(package_groups, dir)
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Add")
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = file_contents[path]? || read_file_content(path)
-                    dir = File.dirname(path)
-                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Add", "Static"])
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        # Resolve 1-hop callees for every route (see Gin).
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
+        external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, dir)
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(
+          callees_needed?,
+          content,
+          path,
+          route_rows,
+          external_fns,
+          external_methods,
+          imported_functions: import_path_function_bodies,
+          imported_methods: import_path_method_bodies
+        )
 
-                    # Tree-sitter pre-pass for Fiber's verb-method routes.
-                    # websocket.New(...) detection stays on the raw line text
-                    # because it's a sibling expression, not part of the route
-                    # argument list.
-                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Add")
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        # `app.Static("/url", "./dir")`.
+        Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
+          public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
+        end
 
-                    # Resolve 1-hop callees for every route (see Gin).
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
-                    external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, dir)
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(
-                      callees_needed?,
-                      content,
-                      path,
-                      route_rows,
-                      external_fns,
-                      external_methods,
-                      imported_functions: import_path_function_bodies,
-                      imported_methods: import_path_method_bodies
-                    )
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    # `app.Static("/url", "./dir")`.
-                    Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
-                      public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
-                    end
-
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                            new_endpoint = Endpoint.new(route.path, verb, details)
-                            new_endpoint.protocol = "ws" if route.handler.includes?("websocket.New(")
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-                          end
-                        end
-                      end
-
-                      if line.includes?(".Query(") || line.includes?(".FormValue(") ||
-                         line.includes?(".Params(") || line.includes?(".ParamsInt(")
-                        add_param_to_endpoint(get_param(line), last_endpoint)
-                      end
-
-                      # Fiber's body-binding helpers: `c.BodyParser(&v)`
-                      # for arbitrary content negotiation, plus the
-                      # explicit `c.QueryParser` / `c.ReqHeaderParser`
-                      # /`c.CookieParser` /`c.ParamsParser` variants that
-                      # parse into a struct. `BodyParser` is the one
-                      # that signals a request body is expected; the
-                      # others duplicate accessors we already surface.
-                      if line.includes?(".BodyParser(")
-                        add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
-                      end
-
-                      if line.includes?("GetRespHeader(")
-                        match = line.match(/GetRespHeader\(\"(.*)\"\)/)
-                        if match
-                          header_name = match[1]
-                          last_endpoint.params << Param.new(header_name, "", "header")
-                        end
-                      end
-
-                      if line.includes?("Vary(")
-                        match = line.match(/Vary\(\"(.*)\"\)/)
-                        if match
-                          header_value = match[1]
-                          last_endpoint.params << Param.new("Vary", header_value, "header")
-                        end
-                      end
-
-                      if line.includes?("Cookies(") &&
-                         !line.includes?("Header.Get") && !line.includes?("Cookie.Get")
-                        match = line.match(/Cookies\(\"(.*)\"\)/)
-                        if match
-                          cookie_name = match[1]
-                          last_endpoint.params << Param.new(cookie_name, "", "cookie")
-                        end
-                      end
-                    end
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                new_endpoint = Endpoint.new(route.path, verb, details)
+                new_endpoint.protocol = "ws" if route.handler.includes?("websocket.New(")
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                   end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
                 end
+                result << new_endpoint
+                last_endpoint = new_endpoint
               end
             end
           end
+
+          if line.includes?(".Query(") || line.includes?(".FormValue(") ||
+             line.includes?(".Params(") || line.includes?(".ParamsInt(")
+            add_param_to_endpoint(get_param(line), last_endpoint)
+          end
+
+          # Fiber's body-binding helpers: `c.BodyParser(&v)`
+          # for arbitrary content negotiation, plus the
+          # explicit `c.QueryParser` / `c.ReqHeaderParser`
+          # /`c.CookieParser` /`c.ParamsParser` variants that
+          # parse into a struct. `BodyParser` is the one
+          # that signals a request body is expected; the
+          # others duplicate accessors we already surface.
+          if line.includes?(".BodyParser(")
+            add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
+          end
+
+          if line.includes?("GetRespHeader(")
+            match = line.match(/GetRespHeader\(\"(.*)\"\)/)
+            if match
+              header_name = match[1]
+              last_endpoint.params << Param.new(header_name, "", "header")
+            end
+          end
+
+          if line.includes?("Vary(")
+            match = line.match(/Vary\(\"(.*)\"\)/)
+            if match
+              header_value = match[1]
+              last_endpoint.params << Param.new("Vary", header_value, "header")
+            end
+          end
+
+          if line.includes?("Cookies(") &&
+             !line.includes?("Header.Get") && !line.includes?("Cookie.Get")
+            match = line.match(/Cookies\(\"(.*)\"\)/)
+            if match
+              cookie_name = match[1]
+              last_endpoint.params << Param.new(cookie_name, "", "cookie")
+            end
+          end
         end
-      rescue e
-        logger.debug e
       end
 
       resolve_public_dirs(public_dirs)

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -23,118 +23,93 @@ module Analyzer::Go
       # build the file_contents hash via a dedicated helper.
       file_contents = read_package_file_contents
       package_function_bodies = collect_package_function_bodies(file_contents)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = read_file_content(path)
+        next unless content_matches?(content, IMPORT_MARKER_RE)
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = read_file_content(path)
-                    next unless content_matches?(content, IMPORT_MARKER_RE)
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
-
-                    # GoFrame standardized routing: request structs embed
-                    # `g.Meta` with `path:`/`method:` tags that fully
-                    # define the route. These live in dedicated API
-                    # definition files (no verb-call registration), so
-                    # they're emitted directly here rather than through
-                    # the closure-scoped walker. Gated on the `g.Meta`
-                    # marker so files without it skip the tree-sitter
-                    # parse entirely.
-                    if content.includes?("g.Meta") && content.includes?("path:")
-                      Noir::TreeSitterGoRouteExtractor.extract_gf_meta_routes(content).each do |mr|
-                        mr_details = Details.new(PathInfo.new(path, mr.line + 1))
-                        # A `method:"all"`/method-less route (verb "ALL")
-                        # responds to every HTTP method; fan it out the
-                        # same way Gin's `r.Any` is, so it isn't dropped by
-                        # the optimizer's allowed-method filter.
-                        verbs = mr.methods.flat_map { |m| Noir::TreeSitterGoRouteExtractor.fan_out_verbs(m) }.uniq!
-                        verbs.each do |verb|
-                          meta_ep = Endpoint.new(mr.path, verb, mr_details)
-                          ptype = (verb == "GET" || verb == "HEAD" || verb == "DELETE") ? "query" : "json"
-                          mr.params.each do |pname|
-                            param = Param.new(pname, "", ptype)
-                            meta_ep.params << param unless meta_ep.params.includes?(param)
-                          end
-                          result << meta_ep
-                        end
-                      end
-                    end
-
-                    # Tree-sitter pre-pass covers gf's three route shapes
-                    # in one walk: closure groups `.Group("/x", func(){...})`,
-                    # chained `s.Group("/multi").GET(...)`, and
-                    # `.BindHandler("/x", h)` method-agnostic registrations.
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_gf_routes(content)
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
-
-                    # Resolve 1-hop callees for every route (see Gin).
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
-
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          # BindHandler/BindMiddleware accept any method;
-                          # fixtures expect GET, so fold "ALL" down.
-                          verb = route.verb == "ALL" ? "GET" : route.verb
-                          new_endpoint = Endpoint.new(route.path, verb, details)
-                          if entries = callees_by_route[route.line]?
-                            entries.each do |entry|
-                              name, callee_path, callee_line = entry
-                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                            end
-                          end
-                          result << new_endpoint
-                          last_endpoint = new_endpoint
-                        end
-                      end
-
-                      ["Get", "GetQuery", "GetForm", "GetHeader", "GetUploadFile"].each do |pattern|
-                        if line.includes?("#{pattern}(") && !line.includes?("Cookie.Get")
-                          add_param_to_endpoint(get_param(line), last_endpoint)
-                        end
-                      end
-
-                      if line.includes?("Cookie.Get(")
-                        match = line.match(/Cookie\.Get\(\"(.*)\"\)/)
-                        if match
-                          cookie_name = match[1]
-                          last_endpoint.params << Param.new(cookie_name, "", "cookie")
-                        end
-                      end
-                    end
-                  end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
-                end
+        # GoFrame standardized routing: request structs embed
+        # `g.Meta` with `path:`/`method:` tags that fully
+        # define the route. These live in dedicated API
+        # definition files (no verb-call registration), so
+        # they're emitted directly here rather than through
+        # the closure-scoped walker. Gated on the `g.Meta`
+        # marker so files without it skip the tree-sitter
+        # parse entirely.
+        if content.includes?("g.Meta") && content.includes?("path:")
+          Noir::TreeSitterGoRouteExtractor.extract_gf_meta_routes(content).each do |mr|
+            mr_details = Details.new(PathInfo.new(path, mr.line + 1))
+            # A `method:"all"`/method-less route (verb "ALL")
+            # responds to every HTTP method; fan it out the
+            # same way Gin's `r.Any` is, so it isn't dropped by
+            # the optimizer's allowed-method filter.
+            verbs = mr.methods.flat_map { |m| Noir::TreeSitterGoRouteExtractor.fan_out_verbs(m) }.uniq!
+            verbs.each do |verb|
+              meta_ep = Endpoint.new(mr.path, verb, mr_details)
+              ptype = (verb == "GET" || verb == "HEAD" || verb == "DELETE") ? "query" : "json"
+              mr.params.each do |pname|
+                param = Param.new(pname, "", ptype)
+                meta_ep.params << param unless meta_ep.params.includes?(param)
               end
+              result << meta_ep
             end
           end
         end
-      rescue e
-        logger.debug e
+
+        # Tree-sitter pre-pass covers gf's three route shapes
+        # in one walk: closure groups `.Group("/x", func(){...})`,
+        # chained `s.Group("/multi").GET(...)`, and
+        # `.BindHandler("/x", h)` method-agnostic registrations.
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_gf_routes(content)
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
+
+        # Resolve 1-hop callees for every route (see Gin).
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
+
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              # BindHandler/BindMiddleware accept any method;
+              # fixtures expect GET, so fold "ALL" down.
+              verb = route.verb == "ALL" ? "GET" : route.verb
+              new_endpoint = Endpoint.new(route.path, verb, details)
+              if entries = callees_by_route[route.line]?
+                entries.each do |entry|
+                  name, callee_path, callee_line = entry
+                  new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                end
+              end
+              result << new_endpoint
+              last_endpoint = new_endpoint
+            end
+          end
+
+          ["Get", "GetQuery", "GetForm", "GetHeader", "GetUploadFile"].each do |pattern|
+            if line.includes?("#{pattern}(") && !line.includes?("Cookie.Get")
+              add_param_to_endpoint(get_param(line), last_endpoint)
+            end
+          end
+
+          if line.includes?("Cookie.Get(")
+            match = line.match(/Cookie\.Get\(\"(.*)\"\)/)
+            if match
+              cookie_name = match[1]
+              last_endpoint.params << Param.new(cookie_name, "", "cookie")
+            end
+          end
+        end
       end
 
       resolve_public_dirs(public_dirs)

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -28,188 +28,163 @@ module Analyzer::Go
       # must be grafted onto the helper's routes.
       builder_prefixes_by_dir = resolve_router_builder_prefixes(file_contents, package_groups)
       framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents[path]? || read_file_content(path)
+        dir = File.dirname(path)
+        next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Handle", "Static"])
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
+
+        # Tree-sitter pre-pass: harvest every verb route with its
+        # group-resolved path in one go. Indexed by line so the
+        # line loop below can attribute body params (Query/PostForm
+        # /GetHeader/Cookie) to the most recently declared route —
+        # matching the legacy `last_endpoint` semantics.
+        cross_file_groups = ts_groups_for_directory(package_groups, dir)
+
+        # Router-builder expansion: graft call-site prefixes onto
+        # the routes of `func addXRoutes(rg *gin.RouterGroup)`
+        # helpers DEFINED in this file. Only "case b" helpers are
+        # expanded — those whose group parameter name is NOT
+        # already a key in the package group map. ("Case a" helpers
+        # whose parameter name happens to match a caller's group
+        # variable, e.g. both named `v1`, are already resolved by
+        # the whole-file pass below, so they're left untouched to
+        # keep their params/callees.) Expanded helpers' bodies are
+        # suppressed in the whole-file pass to avoid emitting the
+        # prefix-less variant alongside the corrected one.
+        dir_builder_prefixes = builder_prefixes_by_dir[dir]? || EMPTY_BUILDER_PREFIXES
+        expand_builders = [] of Tuple(String, Noir::TreeSitterGoRouteExtractor::RouterBuilder, Set(String))
+        suppress_ranges = [] of Range(Int32, Int32)
+        if content.includes?("*gin.RouterGroup")
+          Noir::TreeSitterGoRouteExtractor.collect_router_group_builders(content).each do |fn, rb|
+            pset = dir_builder_prefixes[fn]?
+            next if pset.nil? || pset.empty?
+            next if cross_file_groups.has_key?(rb.param)
+            suppress_ranges << (rb.start_row..rb.end_row)
+            expand_builders << {fn, rb, pset}
           end
+        end
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = file_contents[path]? || read_file_content(path)
-                    dir = File.dirname(path)
-                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Handle", "Static"])
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        # Gin also accepts `r.Handle(method, path, handler)`
+        # alongside the verb shortcuts (`r.GET`, etc.),
+        # so opt into the method-first decoder so those
+        # registrations surface as endpoints too.
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Handle")
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-                    # Tree-sitter pre-pass: harvest every verb route with its
-                    # group-resolved path in one go. Indexed by line so the
-                    # line loop below can attribute body params (Query/PostForm
-                    # /GetHeader/Cookie) to the most recently declared route —
-                    # matching the legacy `last_endpoint` semantics.
-                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
+        # Resolve 1-hop callees for every route in this file.
+        # Inline-closure handlers walk in place; bare
+        # identifier handlers fall through to sibling-file
+        # function bodies via the per-directory map.
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(
+          callees_needed?,
+          content,
+          path,
+          route_rows,
+          external_fns,
+          imported_functions: import_path_function_bodies
+        )
 
-                    # Router-builder expansion: graft call-site prefixes onto
-                    # the routes of `func addXRoutes(rg *gin.RouterGroup)`
-                    # helpers DEFINED in this file. Only "case b" helpers are
-                    # expanded — those whose group parameter name is NOT
-                    # already a key in the package group map. ("Case a" helpers
-                    # whose parameter name happens to match a caller's group
-                    # variable, e.g. both named `v1`, are already resolved by
-                    # the whole-file pass below, so they're left untouched to
-                    # keep their params/callees.) Expanded helpers' bodies are
-                    # suppressed in the whole-file pass to avoid emitting the
-                    # prefix-less variant alongside the corrected one.
-                    dir_builder_prefixes = builder_prefixes_by_dir[dir]? || EMPTY_BUILDER_PREFIXES
-                    expand_builders = [] of Tuple(String, Noir::TreeSitterGoRouteExtractor::RouterBuilder, Set(String))
-                    suppress_ranges = [] of Range(Int32, Int32)
-                    if content.includes?("*gin.RouterGroup")
-                      Noir::TreeSitterGoRouteExtractor.collect_router_group_builders(content).each do |fn, rb|
-                        pset = dir_builder_prefixes[fn]?
-                        next if pset.nil? || pset.empty?
-                        next if cross_file_groups.has_key?(rb.param)
-                        suppress_ranges << (rb.start_row..rb.end_row)
-                        expand_builders << {fn, rb, pset}
-                      end
-                    end
+        # Gin uses `r.Static("/url", "./dir")`. Pick these up
+        # in a single tree-sitter pass up front; downstream
+        # `resolve_public_dirs` still expects the legacy hash
+        # shape, so we convert here.
+        Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
+          public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
+        end
 
-                    # Gin also accepts `r.Handle(method, path, handler)`
-                    # alongside the verb shortcuts (`r.GET`, etc.),
-                    # so opt into the method-first decoder so those
-                    # registrations surface as endpoints too.
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Handle")
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        # StaticFile / StaticFileFS register a single file URL —
+        # emit the route directly. Do not feed them through
+        # resolve_public_dirs (directory glob), which drops "/"
+        # prefixes and skips common media extensions like .ico.
+        ["StaticFile", "StaticFileFS"].each do |mn|
+          Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content, method_name: mn).each do |sp|
+            sf_details = Details.new(PathInfo.new(path, sp.line + 1))
+            result << Endpoint.new(sp.url_prefix, "GET", sf_details)
+          end
+        end
 
-                    # Resolve 1-hop callees for every route in this file.
-                    # Inline-closure handlers walk in place; bare
-                    # identifier handlers fall through to sibling-file
-                    # function bodies via the per-directory map.
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(
-                      callees_needed?,
-                      content,
-                      path,
-                      route_rows,
-                      external_fns,
-                      imported_functions: import_path_function_bodies
-                    )
+        lines.each_with_index do |line, index|
+          # Skip lines inside an expanded router-builder body — its
+          # routes (and any params) are emitted, with the call-site
+          # prefix applied, by the expansion pass below.
+          next if suppress_ranges.any?(&.includes?(index))
 
-                    # Gin uses `r.Static("/url", "./dir")`. Pick these up
-                    # in a single tree-sitter pass up front; downstream
-                    # `resolve_public_dirs` still expects the legacy hash
-                    # shape, so we convert here.
-                    Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
-                      public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
-                    end
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    # StaticFile / StaticFileFS register a single file URL —
-                    # emit the route directly. Do not feed them through
-                    # resolve_public_dirs (directory glob), which drops "/"
-                    # prefixes and skips common media extensions like .ico.
-                    ["StaticFile", "StaticFileFS"].each do |mn|
-                      Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content, method_name: mn).each do |sp|
-                        sf_details = Details.new(PathInfo.new(path, sp.line + 1))
-                        result << Endpoint.new(sp.url_prefix, "GET", sf_details)
-                      end
-                    end
-
-                    lines.each_with_index do |line, index|
-                      # Skip lines inside an expanded router-builder body — its
-                      # routes (and any params) are emitted, with the call-site
-                      # prefix applied, by the expansion pass below.
-                      next if suppress_ranges.any?(&.includes?(index))
-
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      # Emit endpoints for any verb route that begins on this
-                      # line. Gin allows the same verb method name upper/lower
-                      # (`r.GET` vs `r.Get`); both are covered by the TS
-                      # extractor's HTTP_VERB_METHODS set.
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          # `r.Any(...)` / `r.All(...)` register one route under
-                          # every HTTP method. Fan out so downstream formats
-                          # (SARIF / Postman / openapi) get a usable verb per
-                          # endpoint instead of a non-HTTP "ANY" string they
-                          # can't ingest.
-                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                            new_endpoint = Endpoint.new(route.path, verb, details)
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-                          end
-                        end
-                      end
-
-                      add_gin_param_patterns(line, last_endpoint)
-                    end
-
-                    # Expansion pass: emit each suppressed router-builder's
-                    # routes once per resolved call-site prefix, with the
-                    # group parameter bound to that prefix. (A helper called
-                    # from two versioned groups — `addPingRoutes(v1)` and
-                    # `addPingRoutes(v2)` — yields both `/v1/ping` and
-                    # `/v2/ping`.)
-                    expand_builders.each do |fn, rb, pset|
-                      builder_emitted = [] of Endpoint
-                      pset.each do |prefix|
-                        Noir::TreeSitterGoRouteExtractor.extract_routes_from_function(
-                          content, fn, {rb.param => prefix}, handle_method: "Handle"
-                        ).each do |route|
-                          rdetails = Details.new(PathInfo.new(path, route.line + 1))
-                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                            ep = Endpoint.new(route.path, verb, rdetails)
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                ep.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            result << ep
-                            builder_emitted << ep
-                          end
-                        end
-                      end
-                      # Attach any Gin params (Query/Bind/Cookie/Param) and callees
-                      # from the builder function body to the expanded endpoints.
-                      # Mirrors chi's attach_router_function_params for Mount-expanded
-                      # routes (callees were attached in the emit above using the
-                      # precomputed callees_by_route; params via the dedicated attach).
-                      if !builder_emitted.empty?
-                        attach_gin_builder_params(builder_emitted, content, rb.start_row, rb.end_row)
-                      end
-                    end
+          # Emit endpoints for any verb route that begins on this
+          # line. Gin allows the same verb method name upper/lower
+          # (`r.GET` vs `r.Get`); both are covered by the TS
+          # extractor's HTTP_VERB_METHODS set.
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              # `r.Any(...)` / `r.All(...)` register one route under
+              # every HTTP method. Fan out so downstream formats
+              # (SARIF / Postman / openapi) get a usable verb per
+              # endpoint instead of a non-HTTP "ANY" string they
+              # can't ingest.
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                new_endpoint = Endpoint.new(route.path, verb, details)
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                   end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
                 end
+                result << new_endpoint
+                last_endpoint = new_endpoint
               end
             end
           end
+
+          add_gin_param_patterns(line, last_endpoint)
         end
-      rescue e
-        logger.debug e
+
+        # Expansion pass: emit each suppressed router-builder's
+        # routes once per resolved call-site prefix, with the
+        # group parameter bound to that prefix. (A helper called
+        # from two versioned groups — `addPingRoutes(v1)` and
+        # `addPingRoutes(v2)` — yields both `/v1/ping` and
+        # `/v2/ping`.)
+        expand_builders.each do |fn, rb, pset|
+          builder_emitted = [] of Endpoint
+          pset.each do |prefix|
+            Noir::TreeSitterGoRouteExtractor.extract_routes_from_function(
+              content, fn, {rb.param => prefix}, handle_method: "Handle"
+            ).each do |route|
+              rdetails = Details.new(PathInfo.new(path, route.line + 1))
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                ep = Endpoint.new(route.path, verb, rdetails)
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    ep.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                  end
+                end
+                result << ep
+                builder_emitted << ep
+              end
+            end
+          end
+          # Attach any Gin params (Query/Bind/Cookie/Param) and callees
+          # from the builder function body to the expanded endpoints.
+          # Mirrors chi's attach_router_function_params for Mount-expanded
+          # routes (callees were attached in the emit above using the
+          # precomputed callees_by_route; params via the dedicated attach).
+          if !builder_emitted.empty?
+            attach_gin_builder_params(builder_emitted, content, rb.start_row, rb.end_row)
+          end
+        end
       end
 
       resolve_public_dirs(public_dirs)

--- a/src/analyzer/analyzers/go/go_restful.cr
+++ b/src/analyzer/analyzers/go/go_restful.cr
@@ -30,64 +30,39 @@ module Analyzer::Go
     def analyze
       file_contents = read_package_file_contents
       package_function_bodies = collect_package_function_bodies(file_contents)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
 
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
+        content = file_contents[path]? || read_file_content(path)
+        next unless content_matches?(content, IMPORT_MARKER_RE)
+
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_go_restful_routes(content)
+        next if ts_routes.empty?
+
+        route_rows = Set(Int32).new
+        ts_routes.each { |r| route_rows << r.line }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+
+        ts_routes.each do |route|
+          details = Details.new(PathInfo.new(path, route.line + 1))
+          endpoint = Endpoint.new(normalize_restful_path(route.path), route.verb, details)
+
+          route.params.each do |name, param_in|
+            param = Param.new(name, "", param_in)
+            endpoint.params << param unless endpoint.params.includes?(param)
           end
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  next unless File.exists?(path)
-
-                  content = file_contents[path]? || read_file_content(path)
-                  next unless content_matches?(content, IMPORT_MARKER_RE)
-
-                  ts_routes = Noir::TreeSitterGoRouteExtractor.extract_go_restful_routes(content)
-                  next if ts_routes.empty?
-
-                  route_rows = Set(Int32).new
-                  ts_routes.each { |r| route_rows << r.line }
-                  external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                  callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
-
-                  ts_routes.each do |route|
-                    details = Details.new(PathInfo.new(path, route.line + 1))
-                    endpoint = Endpoint.new(normalize_restful_path(route.path), route.verb, details)
-
-                    route.params.each do |name, param_in|
-                      param = Param.new(name, "", param_in)
-                      endpoint.params << param unless endpoint.params.includes?(param)
-                    end
-
-                    if entries = callees_by_route[route.line]?
-                      entries.each do |entry|
-                        callee_name, callee_path, callee_line = entry
-                        endpoint.push_callee(Callee.new(callee_name, path: callee_path, line: callee_line))
-                      end
-                    end
-
-                    result << endpoint
-                  end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
-                end
-              end
+          if entries = callees_by_route[route.line]?
+            entries.each do |entry|
+              callee_name, callee_path, callee_line = entry
+              endpoint.push_callee(Callee.new(callee_name, path: callee_path, line: callee_line))
             end
           end
+
+          result << endpoint
         end
-      rescue e
-        logger.debug e
       end
 
       result

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -27,107 +27,81 @@ module Analyzer::Go
       # `ctrl.Show`); resolve them to their method bodies so callees and
       # ai-context aren't empty.
       package_method_bodies = collect_package_controller_method_bodies(file_contents)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = read_file_content(path)
+        next unless content_matches?(content, IMPORT_MARKER_RE)
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+        # Goyave uses `router.Subrouter("/api")` (single-arg) for
+        # prefix groups and `v1 := api.Group()` (zero-arg) as an
+        # alias that inherits the parent's prefix. The TS
+        # extractor models both via `group_method: "Subrouter"`
+        # plus `group_aliases: ["Group"]`.
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(
+          content,
+          group_method: "Subrouter",
+          group_aliases: ["Group"],
+          extra_verbs: ["Route"],
+        )
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = read_file_content(path)
-                    next unless content_matches?(content, IMPORT_MARKER_RE)
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        # Resolve 1-hop callees for every route (see Gin).
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+        external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, File.dirname(path))
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
 
-                    # Goyave uses `router.Subrouter("/api")` (single-arg) for
-                    # prefix groups and `v1 := api.Group()` (zero-arg) as an
-                    # alias that inherits the parent's prefix. The TS
-                    # extractor models both via `group_method: "Subrouter"`
-                    # plus `group_aliases: ["Group"]`.
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(
-                      content,
-                      group_method: "Subrouter",
-                      group_aliases: ["Group"],
-                      extra_verbs: ["Route"],
-                    )
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        # `router.Static(&fs, "/prefix", false)` — the first
+        # `/`-prefixed string arg is both URL prefix and (with
+        # leading slash stripped) disk path.
+        Noir::TreeSitterGoRouteExtractor.extract_goyave_statics(content).each do |sp|
+          public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
+        end
 
-                    # Resolve 1-hop callees for every route (see Gin).
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
+        lines.each_index do |index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    # `router.Static(&fs, "/prefix", false)` — the first
-                    # `/`-prefixed string arg is both URL prefix and (with
-                    # leading slash stripped) disk path.
-                    Noir::TreeSitterGoRouteExtractor.extract_goyave_statics(content).each do |sp|
-                      public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
-                    end
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              # Goyave's `.Route(...)` decorator accepts any
+              # method; treat it as the "any verb" wildcard
+              # so `fan_out_verbs` expands into one endpoint
+              # per HTTP method instead of a non-HTTP "ANY"
+              # string.
+              raw_verb = route.verb == "ROUTE" ? "ANY" : route.verb
+              # Strip type patterns from path params for the
+              # URL (e.g. `/product/{id:[0-9]+}` -> `/product/{id}`).
+              clean_path = route.path.gsub(/\{([a-zA-Z0-9_]+):[^}]+\}/, "{\\1}")
 
-                    lines.each_index do |index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          # Goyave's `.Route(...)` decorator accepts any
-                          # method; treat it as the "any verb" wildcard
-                          # so `fan_out_verbs` expands into one endpoint
-                          # per HTTP method instead of a non-HTTP "ANY"
-                          # string.
-                          raw_verb = route.verb == "ROUTE" ? "ANY" : route.verb
-                          # Strip type patterns from path params for the
-                          # URL (e.g. `/product/{id:[0-9]+}` -> `/product/{id}`).
-                          clean_path = route.path.gsub(/\{([a-zA-Z0-9_]+):[^}]+\}/, "{\\1}")
-
-                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(raw_verb).each do |verb|
-                            new_endpoint = Endpoint.new(clean_path, verb, details)
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-
-                            route.path.scan(/\{([a-zA-Z0-9_]+)(?::[^}]+)?\}/) do |match_data|
-                              # The `value` field holds an example value, not a
-                              # route regex constraint — leave it empty (matches
-                              # fasthttp/other Go analyzers).
-                              last_endpoint.params << Param.new(match_data[1], "", "path")
-                            end
-                          end
-                        end
-                      end
-                    end
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(raw_verb).each do |verb|
+                new_endpoint = Endpoint.new(clean_path, verb, details)
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                   end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
+                end
+                result << new_endpoint
+                last_endpoint = new_endpoint
+
+                route.path.scan(/\{([a-zA-Z0-9_]+)(?::[^}]+)?\}/) do |match_data|
+                  # The `value` field holds an example value, not a
+                  # route regex constraint — leave it empty (matches
+                  # fasthttp/other Go analyzers).
+                  last_endpoint.params << Param.new(match_data[1], "", "path")
                 end
               end
             end
           end
         end
-      rescue e
-        logger.debug e
       end
 
       resolve_public_dirs_with_glob(public_dirs)

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -33,163 +33,138 @@ module Analyzer::Go
       # function-body map naturally skips `.api`.
       file_contents = read_package_file_contents
       package_function_bodies = collect_package_function_bodies(file_contents)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            [".go", ".api"].each do |ext|
-              get_files_by_extension(ext).each { |file| channel.send(file) }
-            end
-            channel.close
+      # Both `.go` files and gozero's `.api` DSL files. The per-path
+      # `File.extname` re-check the inlined walk carried is redundant:
+      # `get_files_by_extensions` resolves the same `File.extname` index,
+      # so every path here already has one of those two extensions.
+      parallel_analyze(get_files_by_extensions([".go", ".api"])) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+
+        content = read_file_content(path)
+        # `.api` files are gozero's DSL (no Go imports);
+        # only gate `.go` files on the import marker.
+        next if File.extname(path) == ".go" && !content_matches?(content, IMPORT_MARKER_RE)
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
+
+        # Go files: tree-sitter pre-pass (same verb-on-identifier
+        # pattern Gin uses, no groups in gozero's common idioms).
+        # .api files use a non-Go DSL — keep the legacy regex.
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        callees_by_route = Hash(Int32, Array(Tuple(String, String, Int32))).new
+        if File.extname(path) == ".go"
+          Noir::TreeSitterGoRouteExtractor.extract_routes(content).each do |r|
+            next unless r.raw_path.starts_with?("/")
+            routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+            routes_by_line[r.line] << r
+          end
+          Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
+            public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
           end
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
+          # Resolve 1-hop callees for every verb-style .go
+          # route. (Done before AddRoutes routes are folded in
+          # below: their handlers are cross-package wrapper
+          # refs, so directory-scoped body resolution can't
+          # reach them — they carry no 1-hop callees.)
+          route_rows = Set(Int32).new
+          routes_by_line.each_key { |row| route_rows << row }
+          external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+          callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
-                  # Handle both .go files and .api files
-                  if File.exists?(path) && (File.extname(path) == ".go" || File.extname(path) == ".api")
-                    content = read_file_content(path)
-                    # `.api` files are gozero's DSL (no Go imports);
-                    # only gate `.go` files on the import marker.
-                    next if File.extname(path) == ".go" && !content_matches?(content, IMPORT_MARKER_RE)
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+          # go-zero's canonical generated `routes.go`:
+          # `server.AddRoutes([]rest.Route{ {Method, Path,
+          # Handler}, ... }, rest.WithPrefix("/p"))`. These are
+          # struct literals, not verb calls, so the generic
+          # extractor misses them. Fold them into the same
+          # per-line map for emission with full mounted paths.
+          Noir::TreeSitterGoRouteExtractor.extract_gozero_routes(content).each do |r|
+            routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+            routes_by_line[r.line] << r
+          end
+        end
 
-                    # Go files: tree-sitter pre-pass (same verb-on-identifier
-                    # pattern Gin uses, no groups in gozero's common idioms).
-                    # .api files use a non-Go DSL — keep the legacy regex.
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    callees_by_route = Hash(Int32, Array(Tuple(String, String, Int32))).new
-                    if File.extname(path) == ".go"
-                      Noir::TreeSitterGoRouteExtractor.extract_routes(content).each do |r|
-                        next unless r.raw_path.starts_with?("/")
-                        routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                        routes_by_line[r.line] << r
-                      end
-                      Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
-                        public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
-                      end
+        # `.api` route paths are relative to the `@server`
+        # block's `prefix:` (and go-zero mounts them under
+        # it). Track the active prefix as we scan so each
+        # `post /user/login` resolves to its full mounted
+        # path (`/usercenter/v1/user/login`) — matching what
+        # the generated `routes.go` registers via
+        # `rest.WithPrefix(...)`, so the two representations
+        # dedupe instead of producing half-paths.
+        api_prefix = ""
+        in_server_block = false
 
-                      # Resolve 1-hop callees for every verb-style .go
-                      # route. (Done before AddRoutes routes are folded in
-                      # below: their handlers are cross-package wrapper
-                      # refs, so directory-scoped body resolution can't
-                      # reach them — they carry no 1-hop callees.)
-                      route_rows = Set(Int32).new
-                      routes_by_line.each_key { |row| route_rows << row }
-                      external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                      callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                      # go-zero's canonical generated `routes.go`:
-                      # `server.AddRoutes([]rest.Route{ {Method, Path,
-                      # Handler}, ... }, rest.WithPrefix("/p"))`. These are
-                      # struct literals, not verb calls, so the generic
-                      # extractor misses them. Fold them into the same
-                      # per-line map for emission with full mounted paths.
-                      Noir::TreeSitterGoRouteExtractor.extract_gozero_routes(content).each do |r|
-                        routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                        routes_by_line[r.line] << r
-                      end
-                    end
+          # Handle .api files (go-zero API definition files)
+          if File.extname(path) == ".api"
+            stripped = line.strip
+            if stripped.starts_with?("@server")
+              in_server_block = true
+              api_prefix = ""
+            elsif in_server_block && (pm = stripped.match(/^prefix:\s*"?([^"\s]+)"?/))
+              pfx = pm[1].strip
+              api_prefix = if pfx.empty?
+                             ""
+                           else
+                             pfx.starts_with?("/") ? pfx : "/#{pfx}"
+                           end
+            elsif in_server_block && stripped.starts_with?(")")
+              in_server_block = false
+            end
 
-                    # `.api` route paths are relative to the `@server`
-                    # block's `prefix:` (and go-zero mounts them under
-                    # it). Track the active prefix as we scan so each
-                    # `post /user/login` resolves to its full mounted
-                    # path (`/usercenter/v1/user/login`) — matching what
-                    # the generated `routes.go` registers via
-                    # `rest.WithPrefix(...)`, so the two representations
-                    # dedupe instead of producing half-paths.
-                    api_prefix = ""
-                    in_server_block = false
-
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      # Handle .api files (go-zero API definition files)
-                      if File.extname(path) == ".api"
-                        stripped = line.strip
-                        if stripped.starts_with?("@server")
-                          in_server_block = true
-                          api_prefix = ""
-                        elsif in_server_block && (pm = stripped.match(/^prefix:\s*"?([^"\s]+)"?/))
-                          pfx = pm[1].strip
-                          api_prefix = if pfx.empty?
-                                         ""
-                                       else
-                                         pfx.starts_with?("/") ? pfx : "/#{pfx}"
-                                       end
-                        elsif in_server_block && stripped.starts_with?(")")
-                          in_server_block = false
-                        end
-
-                        if match = line.match(/^\s*(get|post|put|delete|patch|head|options)\s+([^\s\(]+)/)
-                          method = match[1].upcase
-                          route_path = match[2]
-                          full_path = if api_prefix.empty?
-                                        route_path
-                                      else
-                                        rel = route_path.starts_with?("/") ? route_path : "/#{route_path}"
-                                        "#{api_prefix}#{rel}"
-                                      end
-                          new_endpoint = Endpoint.new(full_path, method, details)
-                          result << new_endpoint
-                          last_endpoint = new_endpoint
-                        end
-                      end
-
-                      # Handle .go files
-                      if File.extname(path) == ".go"
-                        if ts_hits = routes_by_line[index]?
-                          ts_hits.each do |route|
-                            Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                              new_endpoint = Endpoint.new(route.path, verb, details)
-                              if entries = callees_by_route[route.line]?
-                                entries.each do |entry|
-                                  name, callee_path, callee_line = entry
-                                  new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                                end
-                              end
-                              result << new_endpoint
-                              last_endpoint = new_endpoint
-                            end
+            if match = line.match(/^\s*(get|post|put|delete|patch|head|options)\s+([^\s\(]+)/)
+              method = match[1].upcase
+              route_path = match[2]
+              full_path = if api_prefix.empty?
+                            route_path
+                          else
+                            rel = route_path.starts_with?("/") ? route_path : "/#{route_path}"
+                            "#{api_prefix}#{rel}"
                           end
-                        end
+              new_endpoint = Endpoint.new(full_path, method, details)
+              result << new_endpoint
+              last_endpoint = new_endpoint
+            end
+          end
 
-                        ["Query", "PostForm", "GetHeader", "PathParam", "FormValue"].each do |pattern|
-                          if line.includes?("#{pattern}(")
-                            add_param_to_endpoint(get_param(line, pattern), last_endpoint)
-                          end
-                        end
-
-                        # gozero's canonical body-binding entrypoint is
-                        # `httpx.Parse(r, &req)` / `httpx.ParseJsonBody`;
-                        # both populate the request body. `json.NewDecoder`
-                        # is also common in raw handlers.
-                        if line.includes?("httpx.Parse(") || line.includes?("httpx.ParseJsonBody(") ||
-                           line.includes?("httpx.ParseForm(") || line.matches?(/json\.NewDecoder\(.+\.Body\)/)
-                          add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
-                        end
-                      end
+          # Handle .go files
+          if File.extname(path) == ".go"
+            if ts_hits = routes_by_line[index]?
+              ts_hits.each do |route|
+                Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                  new_endpoint = Endpoint.new(route.path, verb, details)
+                  if entries = callees_by_route[route.line]?
+                    entries.each do |entry|
+                      name, callee_path, callee_line = entry
+                      new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                     end
                   end
-                rescue
-                  # Skip problematic files
-                  next
+                  result << new_endpoint
+                  last_endpoint = new_endpoint
                 end
               end
             end
+
+            ["Query", "PostForm", "GetHeader", "PathParam", "FormValue"].each do |pattern|
+              if line.includes?("#{pattern}(")
+                add_param_to_endpoint(get_param(line, pattern), last_endpoint)
+              end
+            end
+
+            # gozero's canonical body-binding entrypoint is
+            # `httpx.Parse(r, &req)` / `httpx.ParseJsonBody`;
+            # both populate the request body. `json.NewDecoder`
+            # is also common in raw handlers.
+            if line.includes?("httpx.Parse(") || line.includes?("httpx.ParseJsonBody(") ||
+               line.includes?("httpx.ParseForm(") || line.matches?(/json\.NewDecoder\(.+\.Body\)/)
+              add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
+            end
           end
         end
-      rescue
-        # Handle channel errors
       end
 
       resolve_public_dirs_with_glob(public_dirs)

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -22,130 +22,105 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       import_path_function_bodies = collect_import_path_function_bodies(package_function_bodies)
       framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents[path]? || read_file_content(path)
+        dir = File.dirname(path)
+        next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Handle", "Static"])
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = file_contents[path]? || read_file_content(path)
-                    dir = File.dirname(path)
-                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Handle", "Static"])
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        # Tree-sitter pre-pass. Hertz's `.Any("/path", ...)`
+        # comes through as verb="ANY" and we fan it out to
+        # every HTTP method below — matching the legacy
+        # behaviour.
+        cross_file_groups = ts_groups_for_directory(package_groups, dir)
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Handle")
+          .select { |route| HTTP_METHODS_ALLOWED.includes?(route.verb) }
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-                    # Tree-sitter pre-pass. Hertz's `.Any("/path", ...)`
-                    # comes through as verb="ANY" and we fan it out to
-                    # every HTTP method below — matching the legacy
-                    # behaviour.
-                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Handle")
-                      .select { |route| HTTP_METHODS_ALLOWED.includes?(route.verb) }
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        # Resolve 1-hop callees for every route (see Gin).
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(
+          callees_needed?,
+          content,
+          path,
+          route_rows,
+          external_fns,
+          imported_functions: import_path_function_bodies
+        )
 
-                    # Resolve 1-hop callees for every route (see Gin).
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(
-                      callees_needed?,
-                      content,
-                      path,
-                      route_rows,
-                      external_fns,
-                      imported_functions: import_path_function_bodies
-                    )
+        # `h.Static("/url", "./dir")`.
+        Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
+          public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
+        end
 
-                    # `h.Static("/url", "./dir")`.
-                    Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
-                      public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
-                    end
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          callee_entries = callees_by_route[route.line]?
-                          if route.verb == "ANY"
-                            HTTP_METHODS_EXPANDED.each do |m|
-                              new_endpoint = Endpoint.new(route.path, m, details)
-                              callee_entries.try &.each do |entry|
-                                name, callee_path, callee_line = entry
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                              result << new_endpoint
-                              last_endpoint = new_endpoint
-                            end
-                          else
-                            new_endpoint = Endpoint.new(route.path, route.verb, details)
-                            callee_entries.try &.each do |entry|
-                              name, callee_path, callee_line = entry
-                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                            end
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-                          end
-                        end
-                      end
-
-                      # Bind* helpers already contribute a single generic body
-                      # param below. Skip the accessor loop on those lines so
-                      # `BindQuery(&input)` does not also fabricate a bogus
-                      # query param named "&input" via the `Query(` substring.
-                      is_bind_line = line.matches?(/\.Bind(?:JSON|Query|Header|Form|Protobuf|And\w+)?\s*\(/)
-
-                      unless is_bind_line
-                        ["Query", "PostForm", "GetHeader", "Param", "FormValue"].each do |pattern|
-                          if line.includes?("#{pattern}(")
-                            add_param_to_endpoint(get_param(line), last_endpoint)
-                          end
-                        end
-                      end
-
-                      # Read cookies via `ctx.Cookie("name")`. The leading `\.` avoids matching
-                      # `SetCookie(...)` (which is for *writing* cookies, not extracting params).
-                      if line.includes?("Cookie(")
-                        if cookie_match = line.match(/\.Cookie\s*\(\s*"([^"]+)"/)
-                          add_param_to_endpoint(Param.new(cookie_match[1], "", "cookie"), last_endpoint)
-                        end
-                      end
-
-                      # Hertz body-binding helpers populate the request
-                      # body from JSON/form/etc. Surface a single "body"
-                      # indicator — the bound struct's fields are not
-                      # statically resolvable here. `And\w+` catches
-                      # `BindAndValidate`.
-                      if is_bind_line
-                        add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
-                      end
-                    end
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              callee_entries = callees_by_route[route.line]?
+              if route.verb == "ANY"
+                HTTP_METHODS_EXPANDED.each do |m|
+                  new_endpoint = Endpoint.new(route.path, m, details)
+                  callee_entries.try &.each do |entry|
+                    name, callee_path, callee_line = entry
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                   end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
+                  result << new_endpoint
+                  last_endpoint = new_endpoint
                 end
+              else
+                new_endpoint = Endpoint.new(route.path, route.verb, details)
+                callee_entries.try &.each do |entry|
+                  name, callee_path, callee_line = entry
+                  new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                end
+                result << new_endpoint
+                last_endpoint = new_endpoint
               end
             end
           end
+
+          # Bind* helpers already contribute a single generic body
+          # param below. Skip the accessor loop on those lines so
+          # `BindQuery(&input)` does not also fabricate a bogus
+          # query param named "&input" via the `Query(` substring.
+          is_bind_line = line.matches?(/\.Bind(?:JSON|Query|Header|Form|Protobuf|And\w+)?\s*\(/)
+
+          unless is_bind_line
+            ["Query", "PostForm", "GetHeader", "Param", "FormValue"].each do |pattern|
+              if line.includes?("#{pattern}(")
+                add_param_to_endpoint(get_param(line), last_endpoint)
+              end
+            end
+          end
+
+          # Read cookies via `ctx.Cookie("name")`. The leading `\.` avoids matching
+          # `SetCookie(...)` (which is for *writing* cookies, not extracting params).
+          if line.includes?("Cookie(")
+            if cookie_match = line.match(/\.Cookie\s*\(\s*"([^"]+)"/)
+              add_param_to_endpoint(Param.new(cookie_match[1], "", "cookie"), last_endpoint)
+            end
+          end
+
+          # Hertz body-binding helpers populate the request
+          # body from JSON/form/etc. Surface a single "body"
+          # indicator — the bound struct's fields are not
+          # statically resolvable here. `And\w+` catches
+          # `BindAndValidate`.
+          if is_bind_line
+            add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
+          end
         end
-      rescue e
-        logger.debug e
       end
 
       resolve_public_dirs(public_dirs)

--- a/src/analyzer/analyzers/go/http.cr
+++ b/src/analyzer/analyzers/go/http.cr
@@ -39,120 +39,94 @@ module Analyzer::Go
       end
       request_function_bodies = Noir::GoRequestParamExtractor.package_function_bodies_for_dirs(file_contents, route_dirs)
       request_method_bodies = Noir::GoRequestParamExtractor.package_method_bodies_for_dirs(file_contents, route_dirs)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents[path]? || read_file_content(path)
+        dir = File.dirname(path)
+        next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["HandleFunc", "Handle"])
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = file_contents[path]? || read_file_content(path)
-                    dir = File.dirname(path)
-                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["HandleFunc", "Handle"])
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_net_http_routes(content)
+        # With no route in the file the line loop below is a
+        # no-op by construction: it only ever appends to
+        # `last_endpoint`, and `add_param_to_endpoint` (plus
+        # the body-param branch) require a non-empty URL,
+        # which the seed endpoint never has. Bail before
+        # splitting the file into lines.
+        next if ts_routes.empty?
 
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_net_http_routes(content)
-                    # With no route in the file the line loop below is a
-                    # no-op by construction: it only ever appends to
-                    # `last_endpoint`, and `add_param_to_endpoint` (plus
-                    # the body-param branch) require a non-empty URL,
-                    # which the seed endpoint never has. Bail before
-                    # splitting the file into lines.
-                    next if ts_routes.empty?
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        # Resolve 1-hop callees for every route (see Gin/Mux).
+        route_rows = Set(Int32).new
+        route_methods_by_row = Hash(Int32, String).new
+        routes_by_line.each do |row, routes|
+          route_rows << row
+          route_methods_by_row[row] = routes.first.verb
+        end
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
+        external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, dir)
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
+        request_fns = Noir::GoRequestParamExtractor.function_bodies_for_directory(request_function_bodies, dir)
+        request_methods = Noir::GoRequestParamExtractor.method_bodies_for_directory(request_method_bodies, dir)
+        params_by_route = Noir::GoRequestParamExtractor.params_for_routes(content, route_rows, route_methods_by_row, request_fns, request_methods)
 
-                    # Resolve 1-hop callees for every route (see Gin/Mux).
-                    route_rows = Set(Int32).new
-                    route_methods_by_row = Hash(Int32, String).new
-                    routes_by_line.each do |row, routes|
-                      route_rows << row
-                      route_methods_by_row[row] = routes.first.verb
-                    end
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
-                    external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, dir)
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
-                    request_fns = Noir::GoRequestParamExtractor.function_bodies_for_directory(request_function_bodies, dir)
-                    request_methods = Noir::GoRequestParamExtractor.method_bodies_for_directory(request_method_bodies, dir)
-                    params_by_route = Noir::GoRequestParamExtractor.params_for_routes(content, route_rows, route_methods_by_row, request_fns, request_methods)
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          verbs = if route.verb.upcase == "ANY" || route.verb.upcase == "ALL"
-                                    Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb)
-                                  else
-                                    [route.verb]
-                                  end
-                          verbs.each do |verb|
-                            new_endpoint = Endpoint.new(route.path, verb, details)
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            if params = params_by_route[route.line]?
-                              params.each { |param| add_param_to_endpoint(param, new_endpoint) }
-                            end
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-                          end
-                        end
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              verbs = if route.verb.upcase == "ANY" || route.verb.upcase == "ALL"
+                        Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb)
+                      else
+                        [route.verb]
                       end
-
-                      # Handle parameter extraction patterns in Go (identical to mux / stdlib Request usage).
-                      # Order: more specific first.
-                      if line.includes?("Query().Get(")
-                        add_param_to_endpoint(get_param(line, "Query"), last_endpoint)
-                      elsif line.includes?("PostFormValue(")
-                        add_param_to_endpoint(get_param(line, "PostFormValue", last_endpoint), last_endpoint)
-                      elsif line.includes?("FormValue(")
-                        add_param_to_endpoint(get_param(line, "FormValue", last_endpoint), last_endpoint)
-                      elsif line.includes?("Header.Get(")
-                        add_param_to_endpoint(get_param(line, "Header"), last_endpoint)
-                      elsif line.includes?("Cookie(")
-                        add_param_to_endpoint(get_param(line, "Cookie"), last_endpoint)
-                      end
-
-                      # Stdlib-style body reads (json or raw) — same heuristic used by mux analyzer.
-                      if !last_endpoint.url.empty? &&
-                         (line.matches?(/json\.NewDecoder\([^)]*\.Body\)\s*\.\s*Decode/) ||
-                         line.matches?(/(?:io|ioutil)\.ReadAll\([^)]*\.Body\)/))
-                        body_param = Param.new("body", "", "json")
-                        last_endpoint.params << body_param unless last_endpoint.params.includes?(body_param)
-                      end
-                    end
+              verbs.each do |verb|
+                new_endpoint = Endpoint.new(route.path, verb, details)
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                   end
-                rescue
-                  # Skip problematic files
-                  next
                 end
+                if params = params_by_route[route.line]?
+                  params.each { |param| add_param_to_endpoint(param, new_endpoint) }
+                end
+                result << new_endpoint
+                last_endpoint = new_endpoint
               end
             end
           end
+
+          # Handle parameter extraction patterns in Go (identical to mux / stdlib Request usage).
+          # Order: more specific first.
+          if line.includes?("Query().Get(")
+            add_param_to_endpoint(get_param(line, "Query"), last_endpoint)
+          elsif line.includes?("PostFormValue(")
+            add_param_to_endpoint(get_param(line, "PostFormValue", last_endpoint), last_endpoint)
+          elsif line.includes?("FormValue(")
+            add_param_to_endpoint(get_param(line, "FormValue", last_endpoint), last_endpoint)
+          elsif line.includes?("Header.Get(")
+            add_param_to_endpoint(get_param(line, "Header"), last_endpoint)
+          elsif line.includes?("Cookie(")
+            add_param_to_endpoint(get_param(line, "Cookie"), last_endpoint)
+          end
+
+          # Stdlib-style body reads (json or raw) — same heuristic used by mux analyzer.
+          if !last_endpoint.url.empty? &&
+             (line.matches?(/json\.NewDecoder\([^)]*\.Body\)\s*\.\s*Decode/) ||
+             line.matches?(/(?:io|ioutil)\.ReadAll\([^)]*\.Body\)/))
+            body_param = Param.new("body", "", "json")
+            last_endpoint.params << body_param unless last_endpoint.params.includes?(body_param)
+          end
         end
-      rescue e
-        logger.debug e
       end
 
       result

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -40,100 +40,75 @@ module Analyzer::Go
       end
       package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies_if(callees_needed?, file_contents)
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = read_file_content(path)
+        next unless content_matches?(content, IMPORT_MARKER_RE)
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = read_file_content(path)
-                    next unless content_matches?(content, IMPORT_MARKER_RE)
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        # Tree-sitter pre-pass: httprouter exposes HTTP verbs as
+        # methods on the router AND a `Handle("METHOD", "/path",
+        # handler)` shape where the method is the first argument.
+        # Pass `handle_method: "Handle"` so both shapes resolve in
+        # a single parse. httprouter has no groups, so we don't
+        # pass any cross-file group map.
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(
+          content, handle_method: "Handle")
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-                    # Tree-sitter pre-pass: httprouter exposes HTTP verbs as
-                    # methods on the router AND a `Handle("METHOD", "/path",
-                    # handler)` shape where the method is the first argument.
-                    # Pass `handle_method: "Handle"` so both shapes resolve in
-                    # a single parse. httprouter has no groups, so we don't
-                    # pass any cross-file group map.
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(
-                      content, handle_method: "Handle")
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        # Resolve 1-hop callees for every route. `find_handler_arg`
+        # in `GoCalleeExtractor` picks the first non-string
+        # positional arg after the path string, which works
+        # for httprouter's both shapes: `r.GET("/x", h)` (path
+        # then handler) and `r.Handle("METHOD", "/x", h)` (two
+        # leading strings then handler).
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, File.dirname(path))
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
-                    # Resolve 1-hop callees for every route. `find_handler_arg`
-                    # in `GoCalleeExtractor` picks the first non-string
-                    # positional arg after the path string, which works
-                    # for httprouter's both shapes: `r.GET("/x", h)` (path
-                    # then handler) and `r.Handle("METHOD", "/x", h)` (two
-                    # leading strings then handler).
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          last_endpoint = add_endpoint(route.path, route.verb, details)
-                          if entries = callees_by_route[route.line]?
-                            entries.each do |entry|
-                              name, callee_path, callee_line = entry
-                              last_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                            end
-                          end
-                        end
-                      end
-
-                      # FormValue must be checked separately to avoid matching PostFormValue
-                      if line.includes?("FormValue(") && !line.includes?("PostFormValue(")
-                        extract_param(line, /(?<!Post)FormValue\s*\(\s*[\"']([^\"']+)[\"']\s*\)/, "query", last_endpoint)
-                      end
-
-                      PARAM_PATTERNS.each do |includes_check, regex, param_type|
-                        if line.includes?(includes_check)
-                          extract_param(line, regex, param_type, last_endpoint)
-                        end
-                      end
-
-                      # Stdlib body-decoding idioms used by raw httprouter
-                      # handlers. Captures both the JSON-decoder pattern
-                      # and `io.ReadAll(r.Body)` raw-byte access.
-                      if !last_endpoint.url.empty? &&
-                         (line.matches?(/json\.NewDecoder\([^)]*\.Body\)\s*\.\s*Decode/) ||
-                         line.matches?(/(?:io|ioutil)\.ReadAll\([^)]*\.Body\)/))
-                        body_param = Param.new("body", "", "json")
-                        last_endpoint.params << body_param unless last_endpoint.params.includes?(body_param)
-                      end
-                    end
-                  end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              last_endpoint = add_endpoint(route.path, route.verb, details)
+              if entries = callees_by_route[route.line]?
+                entries.each do |entry|
+                  name, callee_path, callee_line = entry
+                  last_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                 end
               end
             end
           end
+
+          # FormValue must be checked separately to avoid matching PostFormValue
+          if line.includes?("FormValue(") && !line.includes?("PostFormValue(")
+            extract_param(line, /(?<!Post)FormValue\s*\(\s*[\"']([^\"']+)[\"']\s*\)/, "query", last_endpoint)
+          end
+
+          PARAM_PATTERNS.each do |includes_check, regex, param_type|
+            if line.includes?(includes_check)
+              extract_param(line, regex, param_type, last_endpoint)
+            end
+          end
+
+          # Stdlib body-decoding idioms used by raw httprouter
+          # handlers. Captures both the JSON-decoder pattern
+          # and `io.ReadAll(r.Body)` raw-byte access.
+          if !last_endpoint.url.empty? &&
+             (line.matches?(/json\.NewDecoder\([^)]*\.Body\)\s*\.\s*Decode/) ||
+             line.matches?(/(?:io|ioutil)\.ReadAll\([^)]*\.Body\)/))
+            body_param = Param.new("body", "", "json")
+            last_endpoint.params << body_param unless last_endpoint.params.includes?(body_param)
+          end
         end
-      rescue e
-        logger.debug e
       end
 
       result

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -89,47 +89,23 @@ module Analyzer::Go
         end
       end
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        mutex = Mutex.new
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+      mutex = Mutex.new
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  next unless File.exists?(path)
+        content = file_contents_cache[path]? || read_file_content(path)
+        next unless content_matches?(content, IMPORT_MARKER_RE)
 
-                  content = file_contents_cache[path]? || read_file_content(path)
-                  next unless content_matches?(content, IMPORT_MARKER_RE)
+        dir = File.dirname(path)
+        structs = package_structs[dir]? || Hash(String, Array(StructField)).new
 
-                  dir = File.dirname(path)
-                  structs = package_structs[dir]? || Hash(String, Array(StructField)).new
+        endpoints = extract_huma_endpoints(content, path, structs)
+        next if endpoints.empty?
 
-                  endpoints = extract_huma_endpoints(content, path, structs)
-                  next if endpoints.empty?
-
-                  mutex.synchronize do
-                    endpoints.each { |ep| result << ep }
-                  end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
-                end
-              end
-            end
-          end
+        mutex.synchronize do
+          endpoints.each { |ep| result << ep }
         end
-      rescue e
-        logger.debug e
       end
 
       result

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -20,107 +20,80 @@ module Analyzer::Go
       package_groups, file_contents = collect_package_groups_ts("Party")
       # Pre-pass for cross-file identifier-handler resolution (see Gin).
       package_function_bodies = collect_package_function_bodies(file_contents)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents[path]? || read_file_content(path)
+        next unless content_matches?(content, IMPORT_MARKER_RE)
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+        cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(
+          content, cross_file_groups, group_method: "Party",
+          # `app.Handle("GET", "/x", h)` is Iris's method-first
+          # registration; `app.HandleMany("GET POST", "/x", h)`
+          # lists several verbs at once. `PartyFunc("/x",
+          # func(p){...})` (and the closure form of `Party`) is
+          # Iris's idiomatic closure-scoped group.
+          handle_method: "Handle",
+          handle_many_method: "HandleMany",
+          closure_group_methods: ["Party", "PartyFunc"]
+        )
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = file_contents[path]? || read_file_content(path)
-                    next unless content_matches?(content, IMPORT_MARKER_RE)
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        # Resolve 1-hop callees for every route (see Gin).
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
-                    cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(
-                      content, cross_file_groups, group_method: "Party",
-                      # `app.Handle("GET", "/x", h)` is Iris's method-first
-                      # registration; `app.HandleMany("GET POST", "/x", h)`
-                      # lists several verbs at once. `PartyFunc("/x",
-                      # func(p){...})` (and the closure form of `Party`) is
-                      # Iris's idiomatic closure-scoped group.
-                      handle_method: "Handle",
-                      handle_many_method: "HandleMany",
-                      closure_group_methods: ["Party", "PartyFunc"]
-                    )
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    # Resolve 1-hop callees for every route (see Gin).
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
-
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          # `app.Party("admin.")` is an Iris *subdomain*,
-                          # not a path segment — peel it so the path is
-                          # clean (`/settings`, not `/admin./settings`) and
-                          # preserve the host on a `subdomain` tag.
-                          subdomain, clean = split_iris_subdomain(route.path)
-                          normalized = normalize_iris_path(clean)
-                          callee_entries = callees_by_route[route.line]?
-                          verbs = route.verb == "ANY" ? HTTP_METHODS : [route.verb]
-                          verbs.each do |m|
-                            new_endpoint = Endpoint.new(normalized, m, details)
-                            callee_entries.try &.each do |entry|
-                              name, callee_path, callee_line = entry
-                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                            end
-                            new_endpoint.add_tag(Tag.new("subdomain", subdomain, "iris_analyzer")) if subdomain
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-                          end
-                        end
-                      end
-
-                      ["URLParam", "URLParamDefault", "URLParamTrim",
-                       "PostValue", "FormValue",
-                       "GetHeader", "GetCookie"].each do |pattern|
-                        if line.includes?("#{pattern}(")
-                          add_param_to_endpoint(get_param(line, pattern), last_endpoint)
-                        end
-                      end
-
-                      # Iris exposes a family of body readers — JSON is
-                      # most common, but the framework also accepts XML,
-                      # YAML, MsgPack, Protobuf, plain Body, and Form
-                      # readers. All consume the request body.
-                      if line.matches?(/\.Read(?:JSON|XML|YAML|MsgPack|Protobuf|Body|Form)\s*\(/)
-                        add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
-                      end
-                    end
-                  end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              # `app.Party("admin.")` is an Iris *subdomain*,
+              # not a path segment — peel it so the path is
+              # clean (`/settings`, not `/admin./settings`) and
+              # preserve the host on a `subdomain` tag.
+              subdomain, clean = split_iris_subdomain(route.path)
+              normalized = normalize_iris_path(clean)
+              callee_entries = callees_by_route[route.line]?
+              verbs = route.verb == "ANY" ? HTTP_METHODS : [route.verb]
+              verbs.each do |m|
+                new_endpoint = Endpoint.new(normalized, m, details)
+                callee_entries.try &.each do |entry|
+                  name, callee_path, callee_line = entry
+                  new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                 end
+                new_endpoint.add_tag(Tag.new("subdomain", subdomain, "iris_analyzer")) if subdomain
+                result << new_endpoint
+                last_endpoint = new_endpoint
               end
             end
           end
+
+          ["URLParam", "URLParamDefault", "URLParamTrim",
+           "PostValue", "FormValue",
+           "GetHeader", "GetCookie"].each do |pattern|
+            if line.includes?("#{pattern}(")
+              add_param_to_endpoint(get_param(line, pattern), last_endpoint)
+            end
+          end
+
+          # Iris exposes a family of body readers — JSON is
+          # most common, but the framework also accepts XML,
+          # YAML, MsgPack, Protobuf, plain Body, and Form
+          # readers. All consume the request body.
+          if line.matches?(/\.Read(?:JSON|XML|YAML|MsgPack|Protobuf|Body|Form)\s*\(/)
+            add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
+          end
         end
-      rescue e
-        logger.error "Iris analyzer failed: #{e.message}"
-        logger.debug e
       end
 
       result

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -24,116 +24,90 @@ module Analyzer::Go
       # their method bodies so callees/ai-context aren't empty.
       package_method_bodies = collect_package_controller_method_bodies(file_contents)
       framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents[path]? || read_file_content(path)
+        dir = File.dirname(path)
+        next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Handle", "HandleFunc", "Path", "PathPrefix", "Methods", "Queries"])
+        lines = content.lines
+        last_endpoint = Endpoint.new("", "")
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = file_contents[path]? || read_file_content(path)
-                    dir = File.dirname(path)
-                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Handle", "HandleFunc", "Path", "PathPrefix", "Methods", "Queries"])
-                    lines = content.lines
-                    last_endpoint = Endpoint.new("", "")
+        cross_file_groups = ts_groups_for_directory(package_groups, dir)
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(
+          content, cross_file_groups,
+          group_method: "Subrouter",
+          handlefunc_methods: true,
+        )
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(
-                      content, cross_file_groups,
-                      group_method: "Subrouter",
-                      handlefunc_methods: true,
-                    )
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        # Resolve 1-hop callees for every route (see Gin).
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
+        external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, dir)
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
 
-                    # Resolve 1-hop callees for every route (see Gin).
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
-                    external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, dir)
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
+        # Mux static-file: `r.PathPrefix("/x/").Handler(... http.Dir("./x/") ...)`
+        Noir::TreeSitterGoRouteExtractor.extract_mux_statics(content).each do |sp|
+          public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
+        end
 
-                    # Mux static-file: `r.PathPrefix("/x/").Handler(... http.Dir("./x/") ...)`
-                    Noir::TreeSitterGoRouteExtractor.extract_mux_statics(content).each do |sp|
-                      public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
-                    end
+        lines.each_with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                    lines.each_with_index do |line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                            new_endpoint = Endpoint.new(route.path, verb, details)
-                            # mux's `.Queries("type", "{type}", ...)` declares
-                            # required query params; bind them to the endpoint.
-                            route.query_params.each do |qp|
-                              new_endpoint.params << Param.new(qp, "", "query")
-                            end
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            result << new_endpoint
-                            last_endpoint = new_endpoint
-                          end
-                        end
-                      end
-
-                      # Handle parameter extraction patterns in Go (order matters - check more specific patterns first)
-                      if line.includes?("Vars(")
-                        add_param_to_endpoint(get_param(line, "Vars"), last_endpoint)
-                      elsif line.includes?("Query().Get(")
-                        add_param_to_endpoint(get_param(line, "Query"), last_endpoint)
-                      elsif line.includes?("PostFormValue(")
-                        add_param_to_endpoint(get_param(line, "PostFormValue", last_endpoint), last_endpoint)
-                      elsif line.includes?("FormValue(")
-                        add_param_to_endpoint(get_param(line, "FormValue", last_endpoint), last_endpoint)
-                      elsif line.includes?("Header.Get(")
-                        add_param_to_endpoint(get_param(line, "Header"), last_endpoint)
-                      elsif line.includes?("Cookie(")
-                        add_param_to_endpoint(get_param(line, "Cookie"), last_endpoint)
-                      end
-
-                      # Stdlib-style body reads. Gorilla/mux apps almost
-                      # always use `json.NewDecoder(r.Body).Decode(&v)`
-                      # or `io.ReadAll(r.Body)` (the modern replacement
-                      # for `ioutil.ReadAll`) to parse request bodies —
-                      # neither was previously surfaced.
-                      if !last_endpoint.url.empty? &&
-                         (line.matches?(/json\.NewDecoder\([^)]*\.Body\)\s*\.\s*Decode/) ||
-                         line.matches?(/(?:io|ioutil)\.ReadAll\([^)]*\.Body\)/))
-                        body_param = Param.new("body", "", "json")
-                        last_endpoint.params << body_param unless last_endpoint.params.includes?(body_param)
-                      end
-                    end
-                  end
-                rescue
-                  # Skip problematic files
-                  next
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                new_endpoint = Endpoint.new(route.path, verb, details)
+                # mux's `.Queries("type", "{type}", ...)` declares
+                # required query params; bind them to the endpoint.
+                route.query_params.each do |qp|
+                  new_endpoint.params << Param.new(qp, "", "query")
                 end
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                  end
+                end
+                result << new_endpoint
+                last_endpoint = new_endpoint
               end
             end
           end
+
+          # Handle parameter extraction patterns in Go (order matters - check more specific patterns first)
+          if line.includes?("Vars(")
+            add_param_to_endpoint(get_param(line, "Vars"), last_endpoint)
+          elsif line.includes?("Query().Get(")
+            add_param_to_endpoint(get_param(line, "Query"), last_endpoint)
+          elsif line.includes?("PostFormValue(")
+            add_param_to_endpoint(get_param(line, "PostFormValue", last_endpoint), last_endpoint)
+          elsif line.includes?("FormValue(")
+            add_param_to_endpoint(get_param(line, "FormValue", last_endpoint), last_endpoint)
+          elsif line.includes?("Header.Get(")
+            add_param_to_endpoint(get_param(line, "Header"), last_endpoint)
+          elsif line.includes?("Cookie(")
+            add_param_to_endpoint(get_param(line, "Cookie"), last_endpoint)
+          end
+
+          # Stdlib-style body reads. Gorilla/mux apps almost
+          # always use `json.NewDecoder(r.Body).Decode(&v)`
+          # or `io.ReadAll(r.Body)` (the modern replacement
+          # for `ioutil.ReadAll`) to parse request bodies —
+          # neither was previously surfaced.
+          if !last_endpoint.url.empty? &&
+             (line.matches?(/json\.NewDecoder\([^)]*\.Body\)\s*\.\s*Decode/) ||
+             line.matches?(/(?:io|ioutil)\.ReadAll\([^)]*\.Body\)/))
+            body_param = Param.new("body", "", "json")
+            last_endpoint.params << body_param unless last_endpoint.params.includes?(body_param)
+          end
         end
-      rescue e
-        logger.debug e
       end
 
       resolve_public_dirs(public_dirs)

--- a/src/analyzer/analyzers/go/pocketbase.cr
+++ b/src/analyzer/analyzers/go/pocketbase.cr
@@ -17,69 +17,44 @@ module Analyzer::Go
       package_groups, file_contents = collect_package_groups_ts(import_marker: IMPORT_MARKER)
       package_function_bodies = collect_package_function_bodies(file_contents)
       framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      begin
-        WaitGroup.wait do |wg|
-          # Producer — tracked by the WaitGroup
-          wg.spawn do
-            get_files_by_extension(".go").each { |file| channel.send(file) }
-            channel.close
-          end
+      parallel_analyze(get_files_by_extension(".go")) do |path|
+        next if GoEngine.go_test_file?(base_relative_path(path))
+        next unless File.exists?(path)
+        content = file_contents[path]? || read_file_content(path)
+        dir = File.dirname(path)
+        next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, [] of String)
 
-          worker_count.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  next if GoEngine.go_test_file?(base_relative_path(path))
-                  if File.exists?(path)
-                    content = file_contents[path]? || read_file_content(path)
-                    dir = File.dirname(path)
-                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, [] of String)
+        cross_file_groups = ts_groups_for_directory(package_groups, dir)
+        ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups)
+        routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+        ts_routes.each do |r|
+          routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
+          routes_by_line[r.line] << r
+        end
 
-                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups)
-                    routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
-                    ts_routes.each do |r|
-                      routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
-                      routes_by_line[r.line] << r
-                    end
+        route_rows = Set(Int32).new
+        routes_by_line.each_key { |row| route_rows << row }
+        external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
+        callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
-                    route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
-
-                    lines = content.lines
-                    lines.each_with_index do |_line, index|
-                      details = Details.new(PathInfo.new(path, index + 1))
-                      if ts_hits = routes_by_line[index]?
-                        ts_hits.each do |route|
-                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                            endpoint = Endpoint.new(route.path, verb, details)
-                            if entries = callees_by_route[route.line]?
-                              entries.each do |entry|
-                                name, callee_path, callee_line = entry
-                                endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                              end
-                            end
-                            result << endpoint
-                          end
-                        end
-                      end
-                    end
+        lines = content.lines
+        lines.each_with_index do |_line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
+          if ts_hits = routes_by_line[index]?
+            ts_hits.each do |route|
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                endpoint = Endpoint.new(route.path, verb, details)
+                if entries = callees_by_route[route.line]?
+                  entries.each do |entry|
+                    name, callee_path, callee_line = entry
+                    endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                   end
-                rescue e : IO::Error
-                  logger.debug "Skipping #{path}: #{e.message}"
                 end
+                result << endpoint
               end
             end
           end
         end
-      rescue e
-        logger.debug e
       end
 
       resolve_public_dirs(public_dirs)

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -149,11 +149,17 @@ class Analyzer
 
   # `worker_count` capped at `MAX_ANALYZER_WORKERS`.
   #
-  # Deliberately not applied to the per-analyzer walks: those spawn
-  # `--concurrency` fibers uncapped today, and folding them in here would
-  # silently drop a `--concurrency 100` run to 64. Whether the cap should
-  # extend to them is a real question, but it is a behaviour change and
-  # belongs in its own commit.
+  # Applies to everything routed through `parallel_analyze` — which now
+  # includes the Go analyzers, whose hand-inlined walks used to spawn
+  # `--concurrency` fibers uncapped. A `--concurrency 100` run therefore
+  # gives them 64 worker fibers, not 100; the default is
+  # `System.cpu_count.clamp(4, 32)`, so no default scan changes.
+  #
+  # Still uncapped: the walks `java/{armeria,jsp,vertx}.cr`,
+  # `python/django.cr`, `llm_analyzers/unified_ai.cr` and
+  # `FileAnalyzer#analyze` inline for themselves. Those send a different
+  # file set than `parallel_analyze` would iterate, so folding them in is
+  # its own change.
   protected def bounded_worker_count : Int32
     worker_count.clamp(1, MAX_ANALYZER_WORKERS)
   end


### PR DESCRIPTION
## Summary

All 16 `src/analyzer/analyzers/go/*.cr` analyzers inlined the producer/worker/`Channel` skeleton that `Analyzer#parallel_analyze` already provides. They now call it. **Net −399 lines** (4,039 → 3,640 across the sixteen), between −23 and −27 each.

Diff churn reads larger (+1,253 / −1,652) because removing a nesting level re-indents every body line; the file shrinkage is the honest number.

## Claims from the prior analysis — verified, and one was wrong

| claim | verdict |
|---|---|
| every producer is `get_files_by_extension(".go")` | ✅ 15 of 16 |
| `gozero.cr` sends `.go` **and** `.api` | ✅ now `get_files_by_extensions([".go", ".api"])`, same list, same order |
| `next if File.directory?(path)` is a provable no-op | ✅ `file_map` is written only after `next unless info.file?` (`detector.cr:474`). **Dropped.** |
| `if File.exists?(path)` is a provable no-op | ❌ **Wrong — kept.** The walk proves the file existed at *detection* time, not analysis time, and `read_file_content` falls back to a disk read on a cache miss. Without the guard a file deleted mid-scan is read rather than skipped. Rewritten as `next unless`, which also flattens a level. |
| the optimizer sorts before first-wins dedup | ✅ `endpoint_order_key` = `(code_path, line, url, method, technology)` — this is what makes a walk-mechanics change safe |
| `http`/`mux`/`gozero` have only a bare `rescue` | ✅ the other 13 have `rescue e : IO::Error`; none had `rescue File::NotFoundError` |

**One thing the analysis missed:** the outer `begin … rescue e; logger.debug e; end` around `WaitGroup.wait` was already dead. `WaitGroup#spawn` is `::spawn { block ensure done }` and `Fiber#run` swallows unhandled exceptions to stderr, so a worker failure never reached it. Dropped.

## Two deliberate behaviour deltas — not smuggled

**1. Worker cap.** `--concurrency 100` now gives each Go analyzer **64** worker fibers rather than 100 (`MAX_ANALYZER_WORKERS`). `src/models/analyzer.cr` documented this divergence as deliberate and said extending the cap "belongs in its own commit" — this is that commit, for the Go family. The endpoint set is unchanged, verified at `--concurrency 100` on five fixtures. No default scan is affected: `default_concurrency` is `System.cpu_count.clamp(4, 32)`, always under the cap.

**2. Rescue set.** Nothing flipped from propagated to swallowed *out of* the analyzer. But for the 13 `IO::Error` analyzers, a non-`IO::Error` exception used to escape the worker fiber — printing "Unhandled exception in spawn" and **stopping that worker from draining the channel**, which at `--concurrency 1` abandoned every remaining file. It is now caught, logged at debug, and the worker continues. The debug wording changes with it ("Skipping X" → "Error processing file X").

The updated `bounded_worker_count` comment now names the walks that remain uncapped: `java/{armeria,jsp,vertx}.cr`, `python/django.cr`, `llm_analyzers/unified_ai.cr` and `FileAnalyzer#analyze`. Those send a different file set and each needs its own analysis; left for a follow-up.

## Test plan

- **A/B sweep over all 668 fixture projects: byte-identical**, 5,176 endpoints, including `code_paths[].line` and `callees[].line`.
- Per-fixture `-f json --include-callee` over all 69 `go/*` dirs (409 endpoints, no empty fixture): byte-identical.
- **`--concurrency 100`** before and after on gin_crossfile, gin_router_builder, chi_crossfile, mux and gozero: byte-identical.
- `crystal spec spec/unit_test` — 4,759 examples, 0 failures. `crystal spec spec/functional_test` — 22,699 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.