### PR TITLE
refactor(output): drive the terminal field list from a table

### DIFF
--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -25,6 +25,30 @@ class OutputBuilderCommon < OutputBuilder
                           "read_permission", "write_permission", "grant_uri_permissions",
                           "path_permissions", "extras"]
 
+  # Parameter kinds drawn as an indented tree under a `○ <label>: ` header,
+  # in emission order: `{param_type, label, name/value separator}`. Both are
+  # green and both mark params the analyzer could not resolve; the separator
+  # follows the wire syntax of the thing being printed (`Name: value` for a
+  # header, `name=value` for a cookie).
+  PARAM_TREE_FIELDS = [
+    {"header", "headers", ": "},
+    {"cookie", "cookies", "="},
+  ]
+
+  # Parameter kinds drawn as one cyan comma-joined line of names, in emission
+  # order: `{param_type, label}`.
+  PARAM_NAME_FIELDS = [
+    # Intent extras (Bundle inputs, not part of the URI) read by a mobile
+    # handler. Query params bake into the URL, so only "extra" is listed.
+    {"extra", "extras"},
+    # CLI inputs (protocol "cli"): named flags/options, positional arguments,
+    # and consumed environment variables. HTTP endpoints have no params of
+    # these types, so these rows only render for CLI endpoints.
+    {"flag", "flags"},
+    {"argument", "arguments"},
+    {"env", "env"},
+  ]
+
   @ai_context_features : Set(String)? = nil
 
   # The plain report is the only format that frames itself — a heading over
@@ -108,87 +132,43 @@ class OutputBuilderCommon < OutputBuilder
         r_buffer << " #{r_ws}"
       end
 
-      header_params = endpoint.params.select { |p| p.param_type == "header" }
-      if !header_params.empty?
-        r_buffer << "\n  ○ headers: "
-        header_params.each_with_index do |param, index|
-          prefix = index == header_params.size - 1 ? "└── " : "├── "
-          label = param.value.empty? ? param.name : "#{param.name}: #{param.value}"
-          label += " [unresolved]" if param.tags.any? { |t| t.name == "unresolved" }
-          r_header = "#{prefix}#{label}".colorize(:light_green).toggle(@is_color)
-          r_buffer << "\n    #{r_header}"
+      PARAM_TREE_FIELDS.each do |param_type, label, separator|
+        entries = endpoint.params.select { |p| p.param_type == param_type }.map do |param|
+          text = param.value.empty? ? param.name : "#{param.name}#{separator}#{param.value}"
+          # Only these two rows flag unresolved params; the form-body tree
+          # below is drawn the same way but deliberately omits the marker.
+          text += " [unresolved]" if param.tags.any? { |t| t.name == "unresolved" }
+          text
         end
-      end
-
-      cookie_params = endpoint.params.select { |p| p.param_type == "cookie" }
-      if !cookie_params.empty?
-        r_buffer << "\n  ○ cookies: "
-        cookie_params.each_with_index do |param, index|
-          prefix = index == cookie_params.size - 1 ? "└── " : "├── "
-          label = param.value.empty? ? param.name : "#{param.name}=#{param.value}"
-          label += " [unresolved]" if param.tags.any? { |t| t.name == "unresolved" }
-          r_cookie = "#{prefix}#{label}".colorize(:light_green).toggle(@is_color)
-          r_buffer << "\n    #{r_cookie}"
-        end
+        append_tree_field r_buffer, label, entries, :light_green
       end
 
       if !baked[:path_param].empty?
-        r_path_param = baked[:path_param].join(", ").colorize(:cyan).toggle(@is_color)
-        r_buffer << "\n  ○ path: #{r_path_param}"
+        append_field r_buffer, "path", baked[:path_param].join(", "), :cyan
       end
 
       if endpoint_metadata = endpoint.metadata
         MOBILE_METADATA_KEYS.each do |key|
           if value = endpoint_metadata[key]?
-            r_value = value.colorize(:cyan).toggle(@is_color)
-            r_buffer << "\n  ○ #{key}: #{r_value}"
+            append_field r_buffer, key, value, :cyan
           end
         end
       end
 
-      # Intent extras (Bundle inputs, not part of the URI) read by a mobile
-      # handler. Query params bake into the URL, so only "extra" is listed.
-      extra_params = endpoint.params.select { |p| p.param_type == "extra" }
-      if !extra_params.empty?
-        r_extras = extra_params.map(&.name).join(", ").colorize(:cyan).toggle(@is_color)
-        r_buffer << "\n  ○ extras: #{r_extras}"
-      end
-
-      # CLI inputs (protocol "cli"): named flags/options, positional
-      # arguments, and consumed environment variables. HTTP endpoints have
-      # no params of these types, so these sections only render for CLI
-      # endpoints.
-      flag_params = endpoint.params.select { |p| p.param_type == "flag" }
-      if !flag_params.empty?
-        r_flags = flag_params.map(&.name).join(", ").colorize(:cyan).toggle(@is_color)
-        r_buffer << "\n  ○ flags: #{r_flags}"
-      end
-
-      argument_params = endpoint.params.select { |p| p.param_type == "argument" }
-      if !argument_params.empty?
-        r_arguments = argument_params.map(&.name).join(", ").colorize(:cyan).toggle(@is_color)
-        r_buffer << "\n  ○ arguments: #{r_arguments}"
-      end
-
-      env_params = endpoint.params.select { |p| p.param_type == "env" }
-      if !env_params.empty?
-        r_env = env_params.map(&.name).join(", ").colorize(:cyan).toggle(@is_color)
-        r_buffer << "\n  ○ env: #{r_env}"
+      PARAM_NAME_FIELDS.each do |param_type, label|
+        selected = endpoint.params.select { |p| p.param_type == param_type }
+        append_field r_buffer, label, selected.map(&.name).join(", "), :cyan unless selected.empty?
       end
 
       if baked[:body_type] == "form"
-        form_params = endpoint.params.select { |p| p.param_type == "form" }
-        unless form_params.empty?
-          r_buffer << "\n  ○ body: "
-          form_params.each_with_index do |param, index|
-            prefix = index == form_params.size - 1 ? "└── " : "├── "
-            label = param.value.empty? ? param.name : "#{param.name}=#{param.value}"
-            r_buffer << "\n    #{("#{prefix}#{label}").colorize(:cyan).toggle(@is_color)}"
-          end
+        # Same tree shape as headers/cookies but cyan, and with no
+        # "[unresolved]" marker even on params carrying that tag.
+        form_entries = endpoint.params.select { |p| p.param_type == "form" }.map do |param|
+          param.value.empty? ? param.name : "#{param.name}=#{param.value}"
         end
+        append_tree_field r_buffer, "body", form_entries, :cyan
       elsif !baked[:body].empty?
-        r_body = baked[:body].colorize(:cyan).toggle(@is_color)
-        r_buffer << "\n  ○ body: #{r_body}"
+        append_field r_buffer, "body", baked[:body], :cyan
       end
 
       tags = baked[:tags].reject { |t| t == "unresolved" } # will handle unresolved directly in the logs
@@ -196,26 +176,21 @@ class OutputBuilderCommon < OutputBuilder
         tags << tag.name.to_s
       end
 
-      if !tags.empty?
-        r_tags = tags.join(" ").colorize(:light_magenta).toggle(@is_color)
-        r_buffer << "\n  ○ tags: #{r_tags}"
-      end
+      # Space-joined, unlike every other multi-value row above, which uses ", ".
+      append_field r_buffer, "tags", tags.join(" "), :light_magenta unless tags.empty?
 
       # Show technology only if include_techs flag is set
       if any_to_bool(@options["include_techs"]?) && endpoint.details.technology
-        r_tech = endpoint.details.technology.to_s.colorize(:light_blue).toggle(@is_color)
-        r_buffer << "\n  ○ tech: #{r_tech}"
+        append_field r_buffer, "tech", endpoint.details.technology.to_s, :light_blue
       end
 
       if any_to_bool(@options["include_path"]?)
         details = endpoint.details
         if details.code_paths && !details.code_paths.empty?
           details.code_paths.each do |code_path|
-            if code_path.line.nil?
-              r_buffer << "\n  ○ file: #{code_path.path}"
-            else
-              r_buffer << "\n  ○ file: #{code_path.path} (line #{code_path.line})"
-            end
+            location = code_path.line.nil? ? code_path.path : "#{code_path.path} (line #{code_path.line})"
+            # The one row printed without color; every sibling colorizes.
+            append_field r_buffer, "file", location, nil
           end
         end
       end
@@ -224,34 +199,59 @@ class OutputBuilderCommon < OutputBuilder
       if any_to_bool(@options["ai_context"]?) && !context.nil?
         unless context.empty?
           features = ai_context_feature_filter
-          visible = (features.includes?("guards") && !context.guards.empty?) ||
-                    (features.includes?("callee") && !context.callees.empty?) ||
-                    (features.includes?("sources") && !context.sources.empty?) ||
-                    (features.includes?("sinks") && !context.sinks.empty?) ||
-                    (features.includes?("validators") && !context.validators.empty?) ||
-                    (features.includes?("signals") && !context.signals.empty?)
+          # {feature name, printed label, entries}. The two names differ for
+          # callees on purpose: the flag is `--ai-context callee` (singular),
+          # the printed block is "callees".
+          blocks = {
+            {"guards", "guards", context.guards},
+            {"callee", "callees", context.callees},
+            {"sources", "sources", context.sources},
+            {"sinks", "sinks", context.sinks},
+            {"validators", "validators", context.validators},
+            {"signals", "signals", context.signals},
+          }
 
-          if visible
+          if blocks.any? { |feature, _, entries| features.includes?(feature) && !entries.empty? }
+            # No trailing space after the colon here, unlike every `append_field`
+            # row — the entries start on their own lines two levels deeper.
             r_buffer << "\n  ○ ai_context:"
-            append_ai_context_block(r_buffer, "guards", context.guards) if features.includes?("guards")
-            append_ai_context_block(r_buffer, "callees", context.callees) if features.includes?("callee")
-            append_ai_context_block(r_buffer, "sources", context.sources) if features.includes?("sources")
-            append_ai_context_block(r_buffer, "sinks", context.sinks) if features.includes?("sinks")
-            append_ai_context_block(r_buffer, "validators", context.validators) if features.includes?("validators")
-            append_ai_context_block(r_buffer, "signals", context.signals) if features.includes?("signals")
+            blocks.each do |feature, label, entries|
+              append_ai_context_block(r_buffer, label, entries) if features.includes?(feature)
+            end
           end
         end
       elsif any_to_bool(@options["include_callee"]?) && !endpoint.callees.empty?
-        r_buffer << "\n  ○ callees: "
-        endpoint.callees.each_with_index do |callee, index|
-          prefix = index == endpoint.callees.size - 1 ? "└── " : "├── "
-          label = callee.line ? "#{callee.name} (line #{callee.line})" : callee.name
-          r_callee = "#{prefix}#{label}".colorize(:light_cyan).toggle(@is_color)
-          r_buffer << "\n    #{r_callee}"
+        callee_entries = endpoint.callees.map do |callee|
+          callee.line ? "#{callee.name} (line #{callee.line})" : callee.name
         end
+        append_tree_field r_buffer, "callees", callee_entries, :light_cyan
       end
 
       ob_puts r_buffer.to_s
+    end
+  end
+
+  # One `○ <label>: <value>` row under the endpoint line. `color` is nil for
+  # the one row that is printed uncolorized.
+  private def append_field(r_buffer : String::Builder, label : String, value : String, color : Symbol?)
+    r_buffer << "\n  ○ " << label << ": "
+    if color
+      r_buffer << value.colorize(color).toggle(@is_color)
+    else
+      r_buffer << value
+    end
+  end
+
+  # A `○ <label>: ` row whose values hang below it as an indented tree. Note
+  # the header keeps its trailing space even though nothing follows it on
+  # that line.
+  private def append_tree_field(r_buffer : String::Builder, label : String, entries : Array(String), color : Symbol)
+    return if entries.empty?
+
+    r_buffer << "\n  ○ " << label << ": "
+    entries.each_with_index do |entry, index|
+      prefix = index == entries.size - 1 ? "└── " : "├── "
+      r_buffer << "\n    " << "#{prefix}#{entry}".colorize(color).toggle(@is_color)
     end
   end
 


### PR DESCRIPTION
## Summary

`OutputBuilder::Common#print` was ~206 lines and 66 branch points, made of twenty near-identical "if the collection is non-empty, append a labelled row" blocks. Adding a field meant copying six lines for the twenty-first time.

| | before | after |
|---|---|---|
| `print` lines | 206 | **158** |
| branch points in the method | 66 | **39** |
| incl. the two new helpers | 66 | 42 |

The file total is unchanged (277): the ~48 lines left the method and came back as two tables and two comment-heavy helpers. The win is not line count — it is that a new field is now a table row.

## It was two shapes, not one

The twenty blocks turned out to be two, so there are two appenders rather than one loop:

- `append_field(buf, label, value, color)` — a `\n  ○ <label>: <value>` row; `color : Symbol?`, nil meaning "print raw".
- `append_tree_field(buf, label, entries, color)` — a `○ <label>: ` header with entries hanging below as `├──`/`└──`.

Fed by two constant tables (`PARAM_TREE_FIELDS`, `PARAM_NAME_FIELDS`) plus a local tuple for the six ai_context categories, which replaces a 6-clause `||` chain and six hand-written `if` lines. Every remaining row — `path`, mobile metadata, both `body` forms, `tags`, `tech`, `file`, `callees` — is one call to one appender, and each row's original comment travels with it.

## Ten near-misses between the "identical" blocks — all preserved, all documented in place

This is why the table was built from the real code rather than a template:

1. `tags` joins on `" "`; every other multi-value row joins on `", "`.
2. `tags` is `:light_magenta`; the other joined rows are `:cyan`.
3. The form-body tree omits the `[unresolved]` marker its visually identical header/cookie siblings append.
4. `headers` separates name/value with `": "`; `cookies` and form-body use `"="`.
5. `file` is the only row printed with no colour at all.
6. `ai_context:` is the only header with no trailing space after the colon.
7. `tech` uses `:light_blue` and is gated on option + truthiness rather than `.empty?`.
8. The ai_context feature name and printed label disagree for one row: the flag is `--ai-context callee`, the block prints `callees`.
9. The tree headers emit a trailing space that nothing follows.
10. `extras` is emitted from two different sources, so an endpoint carrying both prints two `○ extras:` rows.

## Real defects found, deliberately NOT fixed

- **Two `MOBILE_METADATA_KEYS` rows can never print**: `metadata["query"]` and `metadata["extras"]` are written by no analyzer in `src/`. Left in place, in order.
- `if details.code_paths && !details.code_paths.empty?` — `code_paths` is a non-nil `Array(PathInfo)`, so the first half is always true. Left verbatim.

## Test plan

**The 667-project JSON A/B does not cover this method at all** — it compares endpoint JSON, and this renders terminal text. The oracle is the rendered output.

- **108 captures (54 cases × 2 colour modes) byte-identical**, taken against the unmodified tree. Colour captures run stdout on a real pty, because `@is_color` is `… && STDOUT.tty?` — a plain pipe silently disables the very thing under test.
- Independently re-verified after rebasing onto current `main`: **24 captures over 12 fixtures, 73,028 bytes, byte-identical**, with ANSI escapes confirmed present in every colour capture.
- Coverage observed in the captures: all 20 `○` labels the code can emit, both tree prefixes, both `name: value` / `name=value` forms, `[unresolved]` markers, all four mobile protocol prefixes, `[server-action]`, `[websocket]`, all five ai_context categories that fire, all four status-colour branches plus the `[error]` no-server branch, and passive scan with and without findings. The only unreachable rows are the two dead metadata keys above.
- `crystal spec spec/unit_test` — 4,760 examples, 0 failures. `crystal spec spec/functional_test` — 22,699 examples, 0 failures.
- `ameba`, `crystal tool format --check`, repo-wide `typos` — clean.