### PR TITLE
feat(core): foundation for HTTP QUERY method (RFC 10008) endpoints

### DIFF
--- a/docs/content/development/analyzer_architecture/index.ko.md
+++ b/docs/content/development/analyzer_architecture/index.ko.md
@@ -161,6 +161,7 @@ end
 - **`analyzer_for` 로 tech 선언**. 이 한 줄이 등록의 전부입니다 — 3단계 참조.
 - **재정의 가능한 메서드 오버라이드**. 프레임워크 파싱이 다르면 `get_static_path`, `get_route_path` 등 재정의 (Mux, GoZero 참조).
 - **`parallel_file_scan` 사용**. 채널 + worker pool 을 재구현하지 말 것.
+- **프레임워크가 실제 라우팅하는 verb만** 메서드 테이블에 나열. 특히 `QUERY`(RFC 10008)는 업스트림이 명시적으로 지원할 때만 추가 — 추측성 항목은 프레임워크가 405로 응답할 엔드포인트를 보고하게 됩니다. 와일드카드(`ANY`/`ALL`/`*`) 라우트는 `QUERY`로 확장되지 않으며, 이 정책은 `WILDCARD_HTTP_METHODS`(`src/utils/http_symbols.cr`)에 코어 전역으로 고정되어 있습니다.
 
 ### 3. tech 메타데이터 선언
 

--- a/docs/content/development/analyzer_architecture/index.ko.md
+++ b/docs/content/development/analyzer_architecture/index.ko.md
@@ -161,7 +161,7 @@ end
 - **`analyzer_for` 로 tech 선언**. 이 한 줄이 등록의 전부입니다 — 3단계 참조.
 - **재정의 가능한 메서드 오버라이드**. 프레임워크 파싱이 다르면 `get_static_path`, `get_route_path` 등 재정의 (Mux, GoZero 참조).
 - **`parallel_file_scan` 사용**. 채널 + worker pool 을 재구현하지 말 것.
-- **프레임워크가 실제 라우팅하는 verb만** 메서드 테이블에 나열. 특히 `QUERY`(RFC 10008)는 업스트림이 명시적으로 지원할 때만 추가 — 추측성 항목은 프레임워크가 405로 응답할 엔드포인트를 보고하게 됩니다. 와일드카드(`ANY`/`ALL`/`*`) 라우트는 `QUERY`로 확장되지 않으며, 이 정책은 `WILDCARD_HTTP_METHODS`(`src/utils/http_symbols.cr`)에 코어 전역으로 고정되어 있습니다.
+- **프레임워크가 실제 라우팅하는 verb만** 메서드 테이블에 나열. 특히 `QUERY`(RFC 10008)는 업스트림이 명시적으로 지원할 때만 추가 — 추측성 항목은 프레임워크가 405로 응답할 엔드포인트를 보고하게 됩니다. 와일드카드(`ANY`/`ALL`/`*`) 라우트에도 같은 정책이 적용됩니다: 공용 `WILDCARD_HTTP_METHODS`(`src/utils/http_symbols.cr`)든, 분석 시점에 자체 테이블로 `ANY`를 확장하는 analyzer 로컬 목록이든 `QUERY`를 추가하지 않습니다.
 
 ### 3. tech 메타데이터 선언
 

--- a/docs/content/development/analyzer_architecture/index.md
+++ b/docs/content/development/analyzer_architecture/index.md
@@ -161,7 +161,7 @@ Key points:
 - **Declare the tech with `analyzer_for`**. That single line *is* the registration — see step 3.
 - **Override overridable methods** if your framework's parsing differs (`get_static_path`, `get_route_path`; see Mux or GoZero for examples).
 - **Use `parallel_file_scan`** for the file walk; don't re-implement the channel + worker pool.
-- **Only list verbs the framework actually routes** in your method table. In particular, add `QUERY` (RFC 10008) only when upstream ships explicit support for it — a speculative entry reports endpoints the framework itself answers with 405. Wildcard (`ANY`/`ALL`/`*`) routes never fan out to `QUERY`; that expansion is fixed core-wide in `WILDCARD_HTTP_METHODS` (`src/utils/http_symbols.cr`).
+- **Only list verbs the framework actually routes** in your method table. In particular, add `QUERY` (RFC 10008) only when upstream ships explicit support for it — a speculative entry reports endpoints the framework itself answers with 405. The same policy covers wildcard (`ANY`/`ALL`/`*`) routes: neither the shared `WILDCARD_HTTP_METHODS` (`src/utils/http_symbols.cr`) nor any analyzer-local wildcard fan-out list (several analyzers expand `ANY` at analysis time with their own table) should grow `QUERY`.
 
 ### 3. Declare the tech metadata
 

--- a/docs/content/development/analyzer_architecture/index.md
+++ b/docs/content/development/analyzer_architecture/index.md
@@ -161,6 +161,7 @@ Key points:
 - **Declare the tech with `analyzer_for`**. That single line *is* the registration — see step 3.
 - **Override overridable methods** if your framework's parsing differs (`get_static_path`, `get_route_path`; see Mux or GoZero for examples).
 - **Use `parallel_file_scan`** for the file walk; don't re-implement the channel + worker pool.
+- **Only list verbs the framework actually routes** in your method table. In particular, add `QUERY` (RFC 10008) only when upstream ships explicit support for it — a speculative entry reports endpoints the framework itself answers with 405. Wildcard (`ANY`/`ALL`/`*`) routes never fan out to `QUERY`; that expansion is fixed core-wide in `WILDCARD_HTTP_METHODS` (`src/utils/http_symbols.cr`).
 
 ### 3. Declare the tech metadata
 

--- a/docs/content/usage/more_features/deliver/index.ko.md
+++ b/docs/content/usage/more_features/deliver/index.ko.md
@@ -92,7 +92,7 @@ noir scan ./source -u http://localhost:3000 --probe-via http://localhost:8080 --
 noir scan ./source -u http://localhost:3000 --probe-via http://localhost:8080 --probe-skip "GET:/admin"
 ```
 
-지원 메서드: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, CONNECT.
+지원 메서드: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, CONNECT, QUERY.
 
 `--probe-match`와 `--probe-skip`은 여러 번 지정 가능합니다.
 

--- a/docs/content/usage/more_features/deliver/index.md
+++ b/docs/content/usage/more_features/deliver/index.md
@@ -92,7 +92,7 @@ noir scan ./source -u http://localhost:3000 --probe-via http://localhost:8080 --
 noir scan ./source -u http://localhost:3000 --probe-via http://localhost:8080 --probe-skip "GET:/admin"
 ```
 
-Supported HTTP methods: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, CONNECT.
+Supported HTTP methods: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, CONNECT, QUERY.
 
 Multiple `--probe-match` / `--probe-skip` flags compose:
 

--- a/spec/functional_test/fixtures/specification/http_file/query_method/notes.rest
+++ b/spec/functional_test/fixtures/specification/http_file/query_method/notes.rest
@@ -1,0 +1,3 @@
+Query /users for the list of accounts.
+Query api.example.com/v1/search when you need full-text results.
+Query https://api.example.com/search to list products.

--- a/spec/functional_test/fixtures/specification/http_file/query_method/search.http
+++ b/spec/functional_test/fixtures/specification/http_file/query_method/search.http
@@ -1,0 +1,5 @@
+### Search products (RFC 10008 QUERY)
+QUERY https://api.example.com/products/search
+Content-Type: application/x-www-form-urlencoded
+
+q=widget&limit=10

--- a/spec/functional_test/fixtures/specification/oas3/query_method/openapi.yaml
+++ b/spec/functional_test/fixtures/specification/oas3/query_method/openapi.yaml
@@ -1,0 +1,19 @@
+openapi: 3.2.0
+info:
+  title: Query method sample
+  version: 1.0.0
+paths:
+  /products/search:
+    query:
+      summary: Search products (RFC 10008 QUERY)
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                q:
+                  type: string
+      responses:
+        '200':
+          description: OK

--- a/spec/functional_test/testers/specification/http_file_spec.cr
+++ b/spec/functional_test/testers/specification/http_file_spec.cr
@@ -49,3 +49,16 @@ FunctionalTester.new("fixtures/specification/http_file/rest_ext/", {
 }, [
   Endpoint.new("/ping", "GET"),
 ]).perform_tests
+
+# RFC 10008 `QUERY` round-trips: the detector recognizes a file whose only
+# request uses the verb, and the analyzer emits it unchanged with its form
+# body — no GET downgrade anywhere in the pipeline.
+FunctionalTester.new("fixtures/specification/http_file/query_method/", {
+  :techs     => 1,
+  :endpoints => 1,
+}, [
+  Endpoint.new("/products/search", "QUERY", [
+    Param.new("q", "widget", "form"),
+    Param.new("limit", "10", "form"),
+  ]),
+]).perform_tests

--- a/spec/functional_test/testers/specification/http_file_spec.cr
+++ b/spec/functional_test/testers/specification/http_file_spec.cr
@@ -52,7 +52,10 @@ FunctionalTester.new("fixtures/specification/http_file/rest_ext/", {
 
 # RFC 10008 `QUERY` round-trips: the detector recognizes a file whose only
 # request uses the verb, and the analyzer emits it unchanged with its form
-# body — no GET downgrade anywhere in the pipeline.
+# body — no GET downgrade anywhere in the pipeline. The fixture dir also
+# holds `notes.rest`, prose whose sentences all start with "Query <url-ish>":
+# the endpoint count staying at 1 is the regression guard that mixed-case
+# "Query" prose is never fabricated into endpoints.
 FunctionalTester.new("fixtures/specification/http_file/query_method/", {
   :techs     => 1,
   :endpoints => 1,

--- a/spec/functional_test/testers/specification/oas3_spec.cr
+++ b/spec/functional_test/testers/specification/oas3_spec.cr
@@ -168,3 +168,15 @@ FunctionalTester.new("fixtures/specification/oas3_edge_cases/", {
 }, edge_case_url_endpoints, {
   "url" => YAML::Any.new("https://api.example.com"),
 }).perform_tests
+
+# OpenAPI 3.2 added `query` as a Path Item operation key for RFC 10008's
+# QUERY method; a spec declaring it yields a QUERY endpoint instead of the
+# operation being silently skipped.
+FunctionalTester.new("fixtures/specification/oas3/query_method/", {
+  :techs     => 1,
+  :endpoints => 1,
+}, [
+  Endpoint.new("/products/search", "QUERY", [
+    Param.new("q", "", "form"),
+  ]),
+]).perform_tests

--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -2472,6 +2472,17 @@ describe "NoirAIContext" do
     context.signals.find!(&.kind.== "unsafe_method").name.should contain("User.destroy")
   end
 
+  it "emits unsafe_method when a QUERY handler invokes a mutating callee" do
+    # RFC 10008 defines QUERY as safe + idempotent, so a mutation behind it
+    # is the same verb-vs-implementation mismatch as a mutating GET.
+    endpoint = Endpoint.new("/products/search", "QUERY")
+    endpoint.push_callee(Callee.new("Cart.update", "controller.rb", 9))
+
+    context = NoirAIContext.apply([endpoint])[0].ai_context.should_not be_nil
+    context.signals.map(&.kind).should contain("unsafe_method")
+    context.signals.find!(&.kind.== "unsafe_method").name.should contain("QUERY")
+  end
+
   it "does NOT emit unsafe_method for mobile deep-link endpoints" do
     endpoint = Endpoint.new("myapp://open", "GET")
     endpoint.protocol = "mobile-scheme"

--- a/spec/unit_test/deliver/send_req_spec.cr
+++ b/spec/unit_test/deliver/send_req_spec.cr
@@ -411,6 +411,21 @@ describe SendReq do
       end
     end
 
+    it "fills the template for a QUERY — it joined the read-only fill set" do
+      server = CapturingServer.new
+      begin
+        ep = Endpoint.new(server.url_for("/users/{id}"), "QUERY")
+        ep.params << Param.new("id", "", "path")
+
+        SendReq.new(base_deliver_options).run([ep])
+
+        server.requests.first[:method].should eq("QUERY")
+        server.requests.first[:path].should eq("/users/1")
+      ensure
+        server.close
+      end
+    end
+
     it "uses a string for a non-numeric param name" do
       server = CapturingServer.new
       begin

--- a/spec/unit_test/deliver/send_req_spec.cr
+++ b/spec/unit_test/deliver/send_req_spec.cr
@@ -148,6 +148,29 @@ describe SendReq do
     end
   end
 
+  it "sends a QUERY request with its form body on the wire" do
+    server = CapturingServer.new
+    begin
+      # RFC 10008: the whole point of QUERY is a safe request that carries
+      # content, so the probe must put the params in the body, not the URL.
+      ep = Endpoint.new(server.url_for("/products/search"), "QUERY")
+      ep.params << Param.new("q", "widget", "form")
+
+      sender = SendReq.new(base_deliver_options)
+      sender.run([ep])
+
+      server.requests.size.should eq(1)
+      req = server.requests.first
+      req[:method].should eq("QUERY")
+      req[:path].should eq("/products/search")
+      req[:headers]["Content-Type"]?.should_not be_nil
+      req[:headers]["Content-Type"].should contain("application/x-www-form-urlencoded")
+      req[:body].should contain("q=widget")
+    ensure
+      server.close
+    end
+  end
+
   it "sends a POST with JSON body when the endpoint has json params" do
     server = CapturingServer.new
     begin

--- a/spec/unit_test/detector/specification/http_file_spec.cr
+++ b/spec/unit_test/detector/specification/http_file_spec.cr
@@ -35,6 +35,20 @@ describe "Detect HTTP/REST Client Files" do
     instance.detect("search.http", content).should be_true
   end
 
+  it "ignores 'Query <url-ish>' prose — QUERY only counts in uppercase" do
+    # Unlike "Get started with the API", prose idiomatically puts a URL-ish
+    # token right after "Query", so the case-lenient match that is safe for
+    # the classic verbs would fabricate request files out of documentation.
+    prose = <<-RST
+      Query /users for the list of accounts.
+      Query api.example.com/v1/search when you need full-text results.
+      Query https://api.example.com/search to list products.
+      RST
+
+    instance.detect("guide.rest", prose).should be_false
+    instance.detect("lower.http", "query /products/search\n").should be_false
+  end
+
   it "ignores non-.http/.rest filenames" do
     content = "GET https://api.example.com/users\n"
     instance.detect("requests.txt", content).should be_false

--- a/spec/unit_test/detector/specification/http_file_spec.cr
+++ b/spec/unit_test/detector/specification/http_file_spec.cr
@@ -24,6 +24,17 @@ describe "Detect HTTP/REST Client Files" do
     instance.detect("ping.rest", content).should be_true
   end
 
+  it "detects a file whose only request uses the QUERY verb" do
+    content = <<-HTTP
+      QUERY https://api.example.com/products/search
+      Content-Type: application/x-www-form-urlencoded
+
+      q=widget
+      HTTP
+
+    instance.detect("search.http", content).should be_true
+  end
+
   it "ignores non-.http/.rest filenames" do
     content = "GET https://api.example.com/users\n"
     instance.detect("requests.txt", content).should be_false

--- a/spec/unit_test/models/deliver_spec.cr
+++ b/spec/unit_test/models/deliver_spec.cr
@@ -117,6 +117,22 @@ describe "Method-based filtering" do
     result.none? { |ep| ep.method == "GET" && ep.url.includes?("/api") }.should be_true
   end
 
+  it "reads --probe-skip QUERY as a method pattern, not a URL substring" do
+    options["probe_match"] = YAML::Any.new([] of YAML::Any)
+    options["probe_skip"] = YAML::Any.new([YAML::Any.new("QUERY")])
+    deliver = Deliver.new options
+
+    endpoints = [
+      Endpoint.new("/products/search", "QUERY"),
+      # URL contains the word "query"; a substring match would drop this too.
+      Endpoint.new("/query-builder", "GET"),
+    ]
+
+    result = deliver.apply_filters(endpoints)
+    result.map(&.method).should eq(["GET"])
+    result[0].url.should eq("/query-builder")
+  end
+
   it "supports multiple matchers with different patterns" do
     options["probe_match"] = YAML::Any.new([YAML::Any.new("GET"), YAML::Any.new("POST:/login")])
     options["probe_skip"] = YAML::Any.new([] of YAML::Any)

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -23,6 +23,18 @@ describe "EndpointOptimizer" do
       result[1].method.should eq("POST")
     end
 
+    it "keeps QUERY endpoints instead of downgrading them to GET" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/api/search", "QUERY"),
+        Endpoint.new("/api/search", "query"), # same endpoint, lowercase verb
+        Endpoint.new("/api/search", "GET"),
+      ]
+
+      result = optimizer.optimize_endpoints(endpoints)
+      result.map(&.method).sort!.should eq(["GET", "QUERY"])
+    end
+
     # An analyzer that can tell a param exists but not what it is called
     # (`request.getCookies()` hands back the whole jar) used to stand that
     # in with an empty name, and every builder rendered the hole:

--- a/spec/unit_test/output_builder/curl_spec.cr
+++ b/spec/unit_test/output_builder/curl_spec.cr
@@ -68,4 +68,26 @@ describe "OutputBuilderCurl" do
     lines.map { |line| line.split("'")[1] }.should eq(WILDCARD_HTTP_METHODS)
     lines.any?(&.includes?("'ANY'")).should be_false
   end
+
+  it "prints a QUERY endpoint with its body intact" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderCurl.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/products/search", "QUERY")
+    endpoint.push_param(Param.new("q", "widget", "form"))
+
+    builder.print([endpoint])
+    line = builder.io.to_s.split("\n").reject(&.empty?)[0]
+
+    line.should start_with("curl -i -X 'QUERY' '/products/search'")
+    line.should contain("--data-raw 'q=widget'")
+    line.should contain("-H 'Content-Type: application/x-www-form-urlencoded'")
+  end
 end

--- a/spec/unit_test/output_builder/httpie_spec.cr
+++ b/spec/unit_test/output_builder/httpie_spec.cr
@@ -125,4 +125,24 @@ describe "OutputBuilderHttpie" do
     line.should contain("'avatar='")
     line.should_not contain("--form")
   end
+
+  it "prints a QUERY endpoint with its body intact" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHttpie.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/products/search", "QUERY")
+    endpoint.push_param(Param.new("q", "widget", "form"))
+
+    builder.print([endpoint])
+    line = builder.io.to_s.strip
+
+    line.should eq("http --form 'QUERY' '/products/search' 'q=widget'")
+  end
 end

--- a/spec/unit_test/output_builder/oas2_spec.cr
+++ b/spec/unit_test/output_builder/oas2_spec.cr
@@ -209,4 +209,28 @@ describe "OutputBuilderOas2" do
     delete_op["parameters"].as_a.any? { |p| p["in"].as_s == "path" }.should be_false
     delete_op["x-noir-unmapped-path-params"].as_a.should eq([JSON::Any.new("id")])
   end
+
+  it "degrades a QUERY endpoint to x-noir-unsupported-methods, not to get" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderOas2.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/products/search", "QUERY")
+    endpoint.push_param(Param.new("q", "widget", "form"))
+
+    builder.print([endpoint])
+    path_item = JSON.parse(builder.io.to_s)["paths"]["/products/search"]
+
+    # Swagger 2.0 has no `query` operation key; the verb must survive in the
+    # extension instead of being dropped or rewritten to another method.
+    path_item["x-noir-unsupported-methods"].as_a.should eq([JSON::Any.new("QUERY")])
+    path_item.as_h.keys.should_not contain("query")
+    path_item.as_h.keys.should_not contain("get")
+  end
 end

--- a/spec/unit_test/output_builder/oas3_spec.cr
+++ b/spec/unit_test/output_builder/oas3_spec.cr
@@ -213,4 +213,29 @@ describe "OutputBuilderOas3" do
     typed_params = paths["/reports/{report_id}"]["get"]["parameters"].as_a
     typed_params.map { |p| {p["in"].as_s, p["name"].as_s} }.should eq([{"path", "report_id"}])
   end
+
+  it "degrades a QUERY endpoint to x-noir-unsupported-methods, not to get" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+      "url"     => YAML::Any.new(""),
+    }
+    builder = OutputBuilderOas3.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/products/search", "QUERY")
+    endpoint.push_param(Param.new("q", "widget", "form"))
+
+    builder.print([endpoint])
+    path_item = JSON.parse(builder.io.to_s)["paths"]["/products/search"]
+
+    # OpenAPI 3.0.3 has no `query` operation key; the verb must survive in
+    # the extension instead of being dropped or rewritten to another method.
+    path_item["x-noir-unsupported-methods"].as_a.should eq([JSON::Any.new("QUERY")])
+    path_item.as_h.keys.should_not contain("query")
+    path_item.as_h.keys.should_not contain("get")
+  end
 end

--- a/spec/unit_test/output_builder/postman_spec.cr
+++ b/spec/unit_test/output_builder/postman_spec.cr
@@ -290,4 +290,18 @@ describe "OutputBuilderPostman URLs" do
       "GET /wp-admin/admin-ajax.php?action=save_settings",
     ])
   end
+
+  it "keeps a QUERY endpoint's verb and body in the collection" do
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/products/search", "QUERY")
+    endpoint.push_param(Param.new("q", "widget", "form"))
+
+    builder.print([endpoint])
+    request = JSON.parse(builder.io.to_s)["item"][0]["request"]
+
+    request["method"].as_s.should eq("QUERY")
+    request["body"]["urlencoded"].as_a.map(&.["key"].as_s).should eq(["q"])
+  end
 end

--- a/spec/unit_test/output_builder/powershell_spec.cr
+++ b/spec/unit_test/output_builder/powershell_spec.cr
@@ -102,5 +102,13 @@ describe "OutputBuilderPowershell" do
     line.should start_with("Invoke-WebRequest -CustomMethod \"QUERY\" -Uri \"/products/search\"")
     line.should contain("-Body \"q=widget\"")
     line.should contain("application/x-www-form-urlencoded")
+
+    # CONNECT is outside the enum too; pin it so a future "add CONNECT to
+    # ENUM_METHODS" edit (it looks plausibly missing next to TRACE) fails
+    # here instead of regressing every CONNECT endpoint to -Method.
+    builder.io = IO::Memory.new
+    builder.print([Endpoint.new("/tunnel", "CONNECT")])
+    connect_line = builder.io.to_s.split("\n").reject(&.empty?)[0]
+    connect_line.should start_with("Invoke-WebRequest -CustomMethod \"CONNECT\"")
   end
 end

--- a/spec/unit_test/output_builder/powershell_spec.cr
+++ b/spec/unit_test/output_builder/powershell_spec.cr
@@ -79,4 +79,28 @@ describe "OutputBuilderPowershell" do
     lines.map { |line| line.split("\"")[1] }.should eq(WILDCARD_HTTP_METHODS)
     lines.any?(&.includes?("\"ANY\"")).should be_false
   end
+
+  it "routes verbs outside the -Method enum through -CustomMethod" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderPowershell.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/products/search", "QUERY")
+    endpoint.push_param(Param.new("q", "widget", "form"))
+
+    builder.print([endpoint])
+    line = builder.io.to_s.split("\n").reject(&.empty?)[0]
+
+    # Invoke-WebRequest validates -Method against its enum, which has no
+    # QUERY — the emitted command must use -CustomMethod to be runnable.
+    line.should start_with("Invoke-WebRequest -CustomMethod \"QUERY\" -Uri \"/products/search\"")
+    line.should contain("-Body \"q=widget\"")
+    line.should contain("application/x-www-form-urlencoded")
+  end
 end

--- a/spec/unit_test/tagger/taggers/admin_spec.cr
+++ b/spec/unit_test/tagger/taggers/admin_spec.cr
@@ -108,6 +108,20 @@ describe "AdminTagger" do
       endpoint.tags.size.should eq(0)
     end
 
+    it "treats QUERY as read-only for the weak privilege param heuristic" do
+      tagger = AdminTagger.new(default_tagger_options)
+
+      # QUERY is safe + idempotent (RFC 10008), so a weak privilege param
+      # here stays below the threshold exactly as it does on a GET.
+      endpoint = Endpoint.new("/api/roles", "QUERY", [
+        Param.new("privilege", "read", "form"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
     it "does not tag a benign path that merely contains the substring" do
       tagger = AdminTagger.new(default_tagger_options)
 

--- a/spec/unit_test/tagger/taggers/webhook_spec.cr
+++ b/spec/unit_test/tagger/taggers/webhook_spec.cr
@@ -155,5 +155,17 @@ describe "WebhookTagger" do
       endpoint.tags.size.should eq(1)
       endpoint.tags[0].name.should eq("webhook")
     end
+
+    it "treats QUERY as a read, like GET, on a medium-signal URL" do
+      tagger = WebhookTagger.new(default_tagger_options)
+
+      # Same URL as the POST case above; QUERY is safe + idempotent
+      # (RFC 10008), so the write-only medium signal must not fire.
+      endpoint = Endpoint.new("/payment/notify", "QUERY")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/spec/unit_test/utils/http_symbols_spec.cr
+++ b/spec/unit_test/utils/http_symbols_spec.cr
@@ -55,4 +55,20 @@ describe "http_symbols test" do
     requestable_http_methods("ANY").should eq(WILDCARD_HTTP_METHODS)
     requestable_http_methods("SEARCH").should eq([] of String)
   end
+
+  it "sends an explicitly declared QUERY endpoint as-is" do
+    requestable_http_methods("QUERY").should eq(["QUERY"])
+  end
+
+  it "does not fan wildcard routes out to QUERY" do
+    # The ANY-expansion decision: QUERY appears only where a route
+    # declares it explicitly, never via ANY/ALL/* expansion.
+    WILDCARD_HTTP_METHODS.should_not contain("QUERY")
+    expand_synthetic_http_methods("ANY").should_not contain("QUERY")
+  end
+
+  it "recognizes QUERY as a method token for probe filters" do
+    endpoint_method_token?("QUERY").should be_true
+    endpoint_method_token?("query").should be_true
+  end
 end

--- a/src/ai_context/builder.cr
+++ b/src/ai_context/builder.cr
@@ -1,4 +1,5 @@
 require "../models/endpoint"
+require "../utils/http_symbols"
 require "./patterns"
 require "./pattern_matcher"
 require "./source_reader"
@@ -184,7 +185,7 @@ module NoirAIContext
       # HEAD endpoint (often the GET-side of a `methods=['GET',
       # 'POST']` Flask split) has no security impact. Don't let it
       # bump priority on those routes.
-      method_safe = SAFE_METHODS.includes?(endpoint.method)
+      method_safe = SAFE_METHODS.includes?(endpoint.method.upcase)
       sharp_signal = context.signals.any? do |s|
         case s.kind
         when "csrf_exempt"
@@ -237,8 +238,9 @@ module NoirAIContext
     # CSRF / side-effect-on-read bug — the verb says "safe / idempotent"
     # but the code says otherwise. `QUERY` makes the same promise
     # (RFC 10008 defines it safe + idempotent), so a mutating QUERY
-    # handler earns the same signal.
-    SAFE_METHODS = Set{"GET", "HEAD", "OPTIONS", "QUERY"}
+    # handler earns the same signal. The shared set keeps this file,
+    # the taggers, and the probe path-filler agreeing on what a read is.
+    SAFE_METHODS = SAFE_HTTP_METHODS
 
     # Each verb may be followed by additional word chars
     # (`destroy_all`, `createMany`, `deleteOne`, `updateUser`), so we
@@ -254,11 +256,13 @@ module NoirAIContext
     # split that into one endpoint per method but share the
     # callees list. The mutating callee in the GET endpoint is
     # often the POST branch's call, not actually reachable via GET.
-    METHOD_DISPATCH_PATTERN = /(?:request\.method\s*==|req\.method\s*==|r\.Method\s*==|request\.getMethod\(\)\s*\.equals|\.match\(\s*['"](?:GET|POST|PUT|PATCH|DELETE)['"])/i
+    METHOD_DISPATCH_PATTERN = /(?:request\.method\s*==|req\.method\s*==|r\.Method\s*==|request\.getMethod\(\)\s*\.equals|\.match\(\s*['"](?:GET|POST|PUT|PATCH|DELETE|QUERY)['"])/i
 
     private def add_unsafe_method_signal(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
       return if endpoint.mobile?
-      return unless SAFE_METHODS.includes?(endpoint.method)
+      # Upcase like the taggers do: the optimizer normalizes before this
+      # runs on a scan, but library callers can hand in raw endpoints.
+      return unless SAFE_METHODS.includes?(endpoint.method.upcase)
       return if context.signals.any? { |s| s.kind == "unsafe_method" }
 
       mutating = endpoint.callees.find(&.name.matches?(MUTATING_CALLEE_PATTERN))
@@ -948,7 +952,7 @@ module NoirAIContext
 
     private def safe_kotlin_query_identifier_without_lookup?(endpoint : Endpoint, param : Param) : Bool
       return false unless endpoint.details.technology == "kotlin_spring"
-      return false unless SAFE_METHODS.includes?(endpoint.method)
+      return false unless SAFE_METHODS.includes?(endpoint.method.upcase)
       return false unless param.param_type == "query" && identifier_like?(param.name)
 
       !object_lookup_callee(endpoint)
@@ -1258,7 +1262,7 @@ module NoirAIContext
         # Explicit CSRF bypass is a negative signal. CSRF only
         # protects state-changing methods, so suppress it on safe
         # endpoints split out from multi-method handlers.
-        unless SAFE_METHODS.includes?(endpoint.method)
+        unless SAFE_METHODS.includes?(endpoint.method.upcase)
           CSRF_EXEMPT_PATTERNS.each do |pattern|
             next if context.signals.any? { |s| s.kind == "csrf_exempt" }
             if entry = PatternMatcher.detect_single_pattern(pattern, "", snippet, path_info.path, path_info.line, "route_source")

--- a/src/ai_context/builder.cr
+++ b/src/ai_context/builder.cr
@@ -235,8 +235,10 @@ module NoirAIContext
     # endpoint that mutates server state through a callee
     # (`User.create`, `record.destroy`, `db.delete`, …) is a textbook
     # CSRF / side-effect-on-read bug — the verb says "safe / idempotent"
-    # but the code says otherwise.
-    SAFE_METHODS = Set{"GET", "HEAD", "OPTIONS"}
+    # but the code says otherwise. `QUERY` makes the same promise
+    # (RFC 10008 defines it safe + idempotent), so a mutating QUERY
+    # handler earns the same signal.
+    SAFE_METHODS = Set{"GET", "HEAD", "OPTIONS", "QUERY"}
 
     # Each verb may be followed by additional word chars
     # (`destroy_all`, `createMany`, `deleteOne`, `updateUser`), so we
@@ -282,7 +284,7 @@ module NoirAIContext
         "unsafe_method",
         "#{endpoint.method} → #{mutating.name}",
         source: "heuristic",
-        description: "Safe-method (GET/HEAD/OPTIONS) endpoint invokes a state-changing callee; CSRF protections typically don't gate read methods, so a mutation through one is suspect.",
+        description: "Safe-method (GET/HEAD/OPTIONS/QUERY) endpoint invokes a state-changing callee; CSRF protections typically don't gate read methods, so a mutation through one is suspect.",
         path: mutating.path || anchor.try(&.path),
         line: mutating.line || anchor.try(&.line),
         confidence: 56,

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -24,7 +24,7 @@ module Analyzer::AI
     AGENT_CONTEXT_MAX_CHARS            = 100 * 1024
     AGENT_GREP_SNIPPET_MAX_CHARS       = 220
     AGENT_DEFAULT_FILE_PATTERN         = "*.{go,py,js,ts,java,rb,php,cs,cr,kt,rs,swift,scala,graphql}"
-    VALID_METHODS                      = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]
+    VALID_METHODS                      = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "QUERY"]
     VALID_PARAM_TYPES                  = ["query", "json", "form", "header", "cookie", "path"]
     MAX_ENDPOINT_URL_LENGTH            = 2048
     MAX_PARAM_NAME_LENGTH              =  128

--- a/src/analyzer/analyzers/specification/http_file.cr
+++ b/src/analyzer/analyzers/specification/http_file.cr
@@ -160,6 +160,12 @@ module Analyzer::Specification
 
       first = parts[0].upcase
       if HTTP_METHODS.includes?(first)
+        # `QUERY` must be spelled uppercase to count as a request verb.
+        # Prose idiomatically follows "Query" with a URL-ish token ("Query
+        # /users for the list."), so the case-lenient reading that is safe
+        # for the classic verbs fabricates endpoints from documentation for
+        # this one. The detector's REQUEST_LINE applies the same rule.
+        return {nil, nil} if first == "QUERY" && parts[0] != "QUERY"
         return {nil, nil} if parts.size < 2
         target = parts[1]
         # An explicit method is not enough — the target must be URL-ish, so a

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -6,7 +6,10 @@ module Analyzer::Specification
   class Oas3 < SpecificationEngine
     analyzer_for "oas3"
 
-    HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
+    # `query` is the OpenAPI 3.2 Path Item operation key for RFC 10008's
+    # QUERY method; the detector accepts every 3.x document, so a spec
+    # declaring it must not have the operation silently skipped.
+    HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace", "query"}
 
     def get_base_path(servers : JSON::Any)
       server_base_path(servers.as_a.map { |server_obj| server_url_json(server_obj) })

--- a/src/detector/detectors/specification/http_file.cr
+++ b/src/detector/detectors/specification/http_file.cr
@@ -11,7 +11,10 @@ module Detector::Specification
     # signal shared by the VS Code REST Client and JetBrains HTTP Client
     # dialects, and requiring the URL-ish char keeps `.rest` reStructuredText
     # prose ("Get started with the API", "Delete the file") from matching.
-    REQUEST_LINE = /^[ \t]*(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT)[ \t]+\S*[.\/:{]/im
+    # The verb alternation mirrors `ALLOWED_HTTP_METHODS` — the analyzer
+    # parses every verb in that list, so a file whose only request uses one
+    # (e.g. `QUERY`) must still be detected here.
+    REQUEST_LINE = /^[ \t]*(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT|QUERY)[ \t]+\S*[.\/:{]/im
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)

--- a/src/detector/detectors/specification/http_file.cr
+++ b/src/detector/detectors/specification/http_file.cr
@@ -1,5 +1,7 @@
 require "../../../models/detector"
 require "../../../models/code_locator"
+require "../../../models/locator_keys"
+require "../../../utils/http_symbols"
 
 module Detector::Specification
   class HttpFile < Detector
@@ -11,10 +13,15 @@ module Detector::Specification
     # signal shared by the VS Code REST Client and JetBrains HTTP Client
     # dialects, and requiring the URL-ish char keeps `.rest` reStructuredText
     # prose ("Get started with the API", "Delete the file") from matching.
-    # The verb alternation mirrors `ALLOWED_HTTP_METHODS` — the analyzer
+    #
+    # The alternation is derived from `ALLOWED_HTTP_METHODS` — the analyzer
     # parses every verb in that list, so a file whose only request uses one
-    # (e.g. `QUERY`) must still be detected here.
-    REQUEST_LINE = /^[ \t]*(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT|QUERY)[ \t]+\S*[.\/:{]/im
+    # must still be detected here. `QUERY` alone is matched case-sensitively:
+    # unlike the classic verbs, English prose idiomatically puts a URL-ish
+    # token right after "Query" ("Query /users for the list."), so the
+    # lenient match that is safe for GET/POST would fabricate endpoints from
+    # documentation. The analyzer applies the same uppercase rule.
+    REQUEST_LINE = /^[ \t]*(?:#{(ALLOWED_HTTP_METHODS - ["QUERY"]).join('|')}|(?-i:QUERY))[ \t]+\S*[.\/:{]/im
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)

--- a/src/llm/prompt.cr
+++ b/src/llm/prompt.cr
@@ -1,7 +1,7 @@
 # LLM prompts and formats for AI-powered endpoint analysis
 
 module LLM
-  SHARED_RULES       = "Output only JSON. No explanations. method in [GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD]. param_type in [query, json, form, header, cookie, path]."
+  SHARED_RULES       = "Output only JSON. No explanations. method in [GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, QUERY]. param_type in [query, json, form, header, cookie, path]. Use QUERY only when the code explicitly routes that verb."
   AGENT_SHARED_RULES = "Output only JSON. No markdown fences. Use only the defined action names. Do not guess endpoints without reading code."
 
   # Shared accuracy guidance injected into the endpoint-extraction
@@ -70,7 +70,7 @@ module LLM
     #{ENDPOINT_GUIDANCE}
 
     Output format:
-    - The "method" field should strictly use one of these values: "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD".
+    - The "method" field should strictly use one of these values: "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "QUERY". Use "QUERY" only when the code explicitly routes that verb.
     - The "param_type" must strictly use one of these values: "query", "json", "form", "header", "cookie", "path".
     - Do not include any explanations, comments, or additional text.
     - Output only the JSON result.
@@ -138,7 +138,7 @@ module LLM
     - A route prefix may be declared in one file and consumed in another within the same bundle; cross-reference files to resolve the full path.
 
     Output format:
-    - The "method" field should strictly use one of these values: "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD".
+    - The "method" field should strictly use one of these values: "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "QUERY". Use "QUERY" only when the code explicitly routes that verb.
     - The "param_type" must strictly use one of these values: "query", "json", "form", "header", "cookie", "path".
     - Include endpoints from ALL files in the bundle.
     - Do not include any explanations, comments, or additional text.
@@ -167,7 +167,7 @@ module LLM
     - Emit a separate endpoint for each HTTP method a route handles, and capture query/json/form/header/cookie/path parameters.
     - Include only endpoints the code actually serves; ignore URLs found only in comments, docs, tests, or outbound third-party calls. Do not fabricate endpoints.
     - Use finalize only when confident enough.
-    - Keep endpoint method to [GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD].
+    - Keep endpoint method to [GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, QUERY]; use QUERY only when the code explicitly routes that verb.
     - Use param_type in [query, json, form, header, cookie, path].
     PROMPT
 

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -185,7 +185,7 @@ class Deliver
   EXPORT_READ_TIMEOUT    = 60.seconds
 
   # Verbs whose path templates get filled in before probing. Restricted to
-  # the read-only ones on purpose.
+  # the read-only ones (the shared safe set, QUERY included) on purpose.
   #
   # `register_path_param` in the optimizer only substitutes a placeholder when
   # `--set-pvalue-path` supplied a value, so on a default scan `/users/{id}`
@@ -195,7 +195,7 @@ class Deliver
   # against a live record. Read-only verbs get the benefit without that risk;
   # for the rest the literal template still reaches an intercepting proxy,
   # where the user can edit and replay it deliberately.
-  PROBE_PATH_FILL_METHODS = Set{"GET", "HEAD", "OPTIONS"}
+  PROBE_PATH_FILL_METHODS = SAFE_HTTP_METHODS
 
   # Path-param names that name a number. A framework route constrained to an
   # integer (`/users/{id:int}`, Django's `<int:pk>`) rejects a word, so these

--- a/src/output_builder/html.cr
+++ b/src/output_builder/html.cr
@@ -452,7 +452,7 @@ class OutputBuilderHtml < OutputBuilder
 
   # Distinct HTTP methods present, ordered by a canonical verb priority.
   private def present_methods(endpoints : Array(Endpoint)) : Array(String)
-    order = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+    order = ["GET", "POST", "PUT", "PATCH", "DELETE", "QUERY", "HEAD", "OPTIONS"]
     methods = endpoints.map(&.method.upcase).uniq!
     methods.sort_by! { |m| {order.index(m) || order.size, m} }
   end

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -3,6 +3,11 @@ require "uri"
 require "../utils/http_symbols"
 
 module OutputBuilderOasCommon
+  # The operation keys a Path Item Object accepts in OpenAPI 3.0, the newest
+  # version Noir emits. `query` (RFC 10008) is deliberately not one of them —
+  # no OAS version Noir writes (2.0 / 3.0.3) can express it, so a QUERY
+  # endpoint degrades to the `x-noir-unsupported-methods` extension below
+  # rather than being dropped or downgraded to `get`.
   VALID_OPERATION_METHODS = Set{"get", "put", "post", "delete", "options", "head", "patch", "trace"}
   ANY_OPERATION_METHODS   = WILDCARD_HTTP_METHODS.map(&.downcase)
 

--- a/src/output_builder/powershell.cr
+++ b/src/output_builder/powershell.cr
@@ -4,13 +4,20 @@ require "../utils/http_symbols"
 
 @[Noir::OutputFormat(name: "powershell", description: "PowerShell Invoke-WebRequest commands", order: 110)]
 class OutputBuilderPowershell < OutputBuilder
+  # The verbs Invoke-WebRequest's `-Method` accepts — it validates against
+  # the WebRequestMethod enum, so a verb outside this set (QUERY, CONNECT)
+  # is rejected before any request is sent and must go through
+  # `-CustomMethod` instead. The two flags are otherwise equivalent.
+  ENUM_METHODS = Set{"GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "OPTIONS", "MERGE", "PATCH"}
+
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       next if endpoint.non_http? # mobile deep links / CLI commands aren't HTTP requests
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
       expand_synthetic_http_methods(endpoint.method).each do |method|
-        cmd = "Invoke-WebRequest -Method \"#{escape_powershell(method)}\" -Uri \"#{escape_powershell(baked[:url])}\""
+        method_flag = ENUM_METHODS.includes?(method) ? "-Method" : "-CustomMethod"
+        cmd = "Invoke-WebRequest #{method_flag} \"#{escape_powershell(method)}\" -Uri \"#{escape_powershell(baked[:url])}\""
 
         # Build headers hash including cookies
         header_parts = [] of String

--- a/src/tagger/taggers/admin.cr
+++ b/src/tagger/taggers/admin.cr
@@ -1,5 +1,6 @@
 require "../../models/tagger"
 require "../../models/endpoint"
+require "../../utils/http_symbols"
 
 # Flags administrative / privileged endpoints. These are high-value
 # targets for broken access control, privilege escalation, and forced
@@ -41,10 +42,9 @@ class AdminTagger < Tagger
   WEAK_PRIVILEGE_PARAM_NAMES_NORMALIZED =
     WEAK_PRIVILEGE_PARAM_NAMES.map(&.gsub(/[-_]/, "")).to_set
 
-  # `QUERY` counts as a read (RFC 10008: safe + idempotent), so a weak
-  # privilege param on a QUERY endpoint stays below the tag threshold,
-  # exactly as it does on a GET.
-  READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS", "QUERY"}
+  # The shared safe set (QUERY included per RFC 10008): a weak privilege
+  # param on a read stays below the tag threshold, exactly as on a GET.
+  READ_ONLY_METHODS = SAFE_HTTP_METHODS
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|

--- a/src/tagger/taggers/admin.cr
+++ b/src/tagger/taggers/admin.cr
@@ -41,7 +41,10 @@ class AdminTagger < Tagger
   WEAK_PRIVILEGE_PARAM_NAMES_NORMALIZED =
     WEAK_PRIVILEGE_PARAM_NAMES.map(&.gsub(/[-_]/, "")).to_set
 
-  READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS"}
+  # `QUERY` counts as a read (RFC 10008: safe + idempotent), so a weak
+  # privilege param on a QUERY endpoint stays below the tag threshold,
+  # exactly as it does on a GET.
+  READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS", "QUERY"}
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|

--- a/src/tagger/taggers/webhook.cr
+++ b/src/tagger/taggers/webhook.cr
@@ -27,7 +27,9 @@ class WebhookTagger < Tagger
   # signals on "not a read", which — unlike an explicit POST/PUT/PATCH
   # allow-list — also covers wildcard ("ANY"/"*") and blank methods that
   # several analyzers emit for catch-all routes.
-  READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS"}
+  # `QUERY` counts as a read: RFC 10008 defines it as safe + idempotent,
+  # so it must not trip the "not a read" write heuristic the way POST does.
+  READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS", "QUERY"}
 
   # OAuth / OIDC / SSO authorization-code callbacks (`/oauth/callback`,
   # `/auth/<provider>/callback`) are browser-redirect handlers, not

--- a/src/tagger/taggers/webhook.cr
+++ b/src/tagger/taggers/webhook.cr
@@ -1,5 +1,6 @@
 require "../../models/tagger"
 require "../../models/endpoint"
+require "../../utils/http_symbols"
 
 # Flags inbound webhook / callback endpoints — routes that receive
 # server-to-server notifications from third parties (payment providers,
@@ -27,9 +28,9 @@ class WebhookTagger < Tagger
   # signals on "not a read", which — unlike an explicit POST/PUT/PATCH
   # allow-list — also covers wildcard ("ANY"/"*") and blank methods that
   # several analyzers emit for catch-all routes.
-  # `QUERY` counts as a read: RFC 10008 defines it as safe + idempotent,
-  # so it must not trip the "not a read" write heuristic the way POST does.
-  READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS", "QUERY"}
+  # The shared safe set (QUERY included per RFC 10008): a QUERY route must
+  # not trip the "not a read" write heuristic the way POST does.
+  READ_ONLY_METHODS = SAFE_HTTP_METHODS
 
   # OAuth / OIDC / SSO authorization-code callbacks (`/oauth/callback`,
   # `/auth/<provider>/callback`) are browser-redirect handlers, not

--- a/src/utils/http_symbols.cr
+++ b/src/utils/http_symbols.cr
@@ -1,3 +1,10 @@
+# The concrete verbs a wildcard route (`ANY`/`ALL`/`*`) fans out to.
+#
+# `QUERY` (RFC 10008) is deliberately absent: fanning every wildcard route
+# out to a QUERY endpoint would add one endpoint per catch-all route in
+# every framework — reported, probed, and exported — for a verb almost no
+# deployed app intends to serve. A `QUERY` endpoint is emitted only where
+# a route declares the verb explicitly.
 WILDCARD_HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD", "TRACE"]
 SYNTHETIC_ANY_METHODS = ["ANY", "ALL", "*"]
 
@@ -18,6 +25,11 @@ def get_symbol(method : String)
   symbol[method]
 end
 
+# The real HTTP methods an endpoint can carry. `QUERY` (RFC 10008) is
+# accepted core-wide, but a framework analyzer adds it to its own verb
+# table only when the upstream framework actually routes the verb —
+# adding it speculatively would report endpoints the framework itself
+# answers with 405.
 ALLOWED_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT", "QUERY"]
 
 # Verbs an endpoint can carry that are not HTTP methods: the wildcard

--- a/src/utils/http_symbols.cr
+++ b/src/utils/http_symbols.cr
@@ -32,6 +32,14 @@ end
 # answers with 405.
 ALLOWED_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT", "QUERY"]
 
+# The verbs the read-vs-write heuristics treat as reads: GET/HEAD/OPTIONS
+# plus QUERY (safe + idempotent per RFC 10008). TRACE, though RFC-safe, is
+# excluded — it echoes the request rather than reading a resource, and no
+# consumer ever counted it as a read. One shared set so the admin/webhook
+# taggers, the ai_context unsafe-method signal, and the probe path-filler
+# cannot drift on which verbs are safe. Callers normalize case themselves.
+SAFE_HTTP_METHODS = Set{"GET", "HEAD", "OPTIONS", "QUERY"}
+
 # Verbs an endpoint can carry that are not HTTP methods: the wildcard
 # `ANY`, and the AsyncAPI / messaging verbs the optimizer allow-lists so
 # event-driven endpoints aren't downgraded to `GET`.


### PR DESCRIPTION
Closes #2540.

Lands the shared plumbing every per-framework `QUERY` issue depends on. `QUERY` was already accepted by the core model (`ALLOWED_HTTP_METHODS`, `get_symbol`); this PR audits and fixes everything around it, then hardens the result against the findings of a full multi-angle code review.

## Shared-surface audit

| Surface | Result |
| :-- | :-- |
| `optimizer` | Already passes `QUERY` through (spec added to lock in no GET downgrade) |
| `output_builder` | curl/httpie/postman/markdown pass the verb through with the body intact; **powershell** now emits `-CustomMethod` for verbs outside the `-Method` enum (QUERY, CONNECT); **oas2/oas3** degrade `QUERY` to the existing `x-noir-unsupported-methods` extension — decided and documented, never dropped or rewritten to `get` |
| `deliver` + probe | `QUERY` probes go out with their form/json body (proved over a real socket in `send_req_spec`); `--probe-skip QUERY` parses as a method token; QUERY joined the probe **path-template fill set** so `QUERY /users/{id}` is probed as `/users/1` like GET |
| `tagger` / `passive_scan` | admin + webhook taggers treat `QUERY` as a read; spring-security CSRF logic already correct by omission |
| `ai_context` | `QUERY` joins the safe-method vocabulary — a mutating QUERY handler earns `unsafe_method`; the `.match('QUERY')` dispatch suppression works; checks now case-normalize like the taggers |
| `llm` | LLM analyzer vocabulary accepts `QUERY` (explicit-routing-only instruction) instead of coercing it to GET |
| spec inputs | `.http`/`.rest` files: detector + analyzer accept `QUERY` request lines — **uppercase only**, because `Query <url-ish>` is idiomatic English prose and the case-lenient match fabricated endpoints from documentation (reproduced, regression-tested at unit + functional level); HAR passes through; **OAS 3.2 `query:` operations** now parse into QUERY endpoints |

## Decisions recorded

- **`ANY` does not expand to `QUERY`** — neither `WILDCARD_HTTP_METHODS` nor analyzer-local wildcard tables; rationale on the constant, convention in the analyzer-architecture docs (en/ko): a framework analyzer adds `QUERY` only when upstream actually routes it.
- One shared `SAFE_HTTP_METHODS` set now backs the admin/webhook taggers, the ai_context safe-method signal, and the probe path filler, ending four-copy drift.

## Verification

- 4,778 unit + 22,713 functional examples pass; format + ameba clean.
- A/B sweep (baseline `main` vs branch) over all 668 fixture dirs, default config: **byte-identical everywhere** except the two dirs that gained the new QUERY fixtures. With `--include=path,techs,callee --ai-context -T`: additionally 11 files whose only change is the `unsafe_method` description string gaining `/QUERY`.
- New fixtures: `.http` QUERY request (+ a `Query …` prose `.rest` file proving no fabrication) and an OpenAPI 3.2 `query:` operation.

Deferred (cosmetic): HTML report color styling for the QUERY badge/chip — it renders with the default badge; adding a dedicated hue means new CSS tokens in every report and can ride separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)