### PR TITLE
feat(analyzer): detect HTTP QUERY routes in NestJS (@QueryMethod)

### DIFF
--- a/spec/functional_test/fixtures/javascript/nestjs/users.controller.ts
+++ b/spec/functional_test/fixtures/javascript/nestjs/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Delete, Param, Query, Body, Headers, Req, UploadedFile, UseGuards, UseInterceptors, Version } from '@nestjs/common';
+import { Controller, Get, Post, Put, Delete, Param, Query, Body, Headers, Req, UploadedFile, UseGuards, UseInterceptors, Version, QueryMethod } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 
 @Controller('users')
@@ -34,6 +34,19 @@ export class UserController {
   }
 }
 
+@Controller('search')
+export class SearchController {
+  @QueryMethod()
+  find(@Body() filters: any) {
+    return [];
+  }
+
+  @QueryMethod('advanced')
+  advanced(@Body() dto: any) {
+    return [];
+  }
+}
+
 @Controller('protected')
 export class ProtectedController {
   @Get()
@@ -64,3 +77,4 @@ export class AdminController {
     return {};
   }
 }
+

--- a/spec/functional_test/fixtures/typescript/nestjs/users.controller.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Delete, Param, Query, Body, Headers } from '@nestjs/common';
+import { Controller, Get, Post, Put, Delete, Param, Query, Body, Headers, QueryMethod } from '@nestjs/common';
 
 @Controller('users')
 export class UserController {
@@ -33,6 +33,19 @@ export class UserController {
   }
 }
 
+@Controller('search')
+export class SearchController {
+  @QueryMethod()
+  find(@Body() filters: any) {
+    return [];
+  }
+
+  @QueryMethod('advanced')
+  advanced(@Body() dto: any) {
+    return [];
+  }
+}
+
 @Controller('protected')
 export class ProtectedController {
   @Get()
@@ -40,3 +53,4 @@ export class ProtectedController {
     return {};
   }
 }
+

--- a/spec/functional_test/testers/javascript/nestjs_spec.cr
+++ b/spec/functional_test/testers/javascript/nestjs_spec.cr
@@ -21,6 +21,13 @@ expected_endpoints = [
     Param.new("name", "", "query"),
     Param.new("email", "", "query"),
   ]),
+  # HTTP QUERY method routes (@QueryMethod)
+  Endpoint.new("/search", "QUERY", [
+    Param.new("body", "", "body"),
+  ]),
+  Endpoint.new("/search/advanced", "QUERY", [
+    Param.new("body", "", "body"),
+  ]),
   # Header parameters
   Endpoint.new("/protected", "GET", [
     Param.new("authorization", "", "header"),

--- a/spec/functional_test/testers/typescript/nestjs_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_spec.cr
@@ -21,6 +21,13 @@ expected_endpoints = [
     Param.new("name", "", "query"),
     Param.new("email", "", "query"),
   ]),
+  # HTTP QUERY method routes (@QueryMethod)
+  Endpoint.new("/search", "QUERY", [
+    Param.new("body", "", "body"),
+  ]),
+  Endpoint.new("/search/advanced", "QUERY", [
+    Param.new("body", "", "body"),
+  ]),
   # Header parameters
   Endpoint.new("/protected", "GET", [
     Param.new("authorization", "", "header"),

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -621,20 +621,21 @@ module Analyzer::Javascript
 
     private def process_http_methods(class_content : String, base_paths : Array(String), controller_versions : Array(String), file_path : String, result : Array(Endpoint), include_callee : Bool, controller_start_line : Int32, literal_values : Hash(String, Array(String)))
       method_map = {
-        "Get"     => ["GET"],
-        "Post"    => ["POST"],
-        "Put"     => ["PUT"],
-        "Delete"  => ["DELETE"],
-        "Patch"   => ["PATCH"],
-        "Options" => ["OPTIONS"],
-        "Head"    => ["HEAD"],
+        "Get"         => ["GET"],
+        "Post"        => ["POST"],
+        "Put"         => ["PUT"],
+        "Delete"      => ["DELETE"],
+        "Patch"       => ["PATCH"],
+        "Options"     => ["OPTIONS"],
+        "Head"        => ["HEAD"],
+        "QueryMethod" => ["QUERY"],
         # `@Sse` opens a Server-Sent Events stream — HTTP GET under
         # the hood, so it counts as a real route.
         "Sse" => ["GET"],
         "All" => ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
       }
 
-      class_content.scan(/@(Get|Post|Put|Delete|Patch|Options|Head|Sse|All)\s*\(/) do |match|
+      class_content.scan(/@(Get|Post|Put|Delete|Patch|Options|Head|QueryMethod|Sse|All)\s*\(/) do |match|
         decorator_start = match.begin(0)
         next unless decorator_start
 


### PR DESCRIPTION
## Summary
Resolves #2543

NestJS added support for `RequestMethod.QUERY` and the `@QueryMethod()` route decorator in [nestjs/nest#17162](https://github.com/nestjs/nest/pull/17162). This PR adds `@QueryMethod()` support to the NestJS analyzer in Noir.

## Changes
- Updated `src/analyzer/analyzers/javascript/nestjs.cr`:
  - Added `"QueryMethod" => ["QUERY"]`: to `method_map`
  - Added `QueryMethod` to the route decorator scan regex (`/@(Get|Post|Put|Delete|Patch|Options|Head|QueryMethod|Sse|All)\s*\(/)
  - Since `Analyzer::Typescript::Nestjs` inherits from `Analyzer::Javascript::Nestjs`, this covers both JS and TS NestJS projects.
- Preserved existing `@Query()` parameter decorator behavior (extracting query parameters).
- Added test fixtures and expected endpoints in:
  - `spec/functional_test/fixtures/javascript/nestjs/users.controller.ts`
  - `spec/functional_test/fixtures/typescript/nestjs/users.controller.ts`
  - `spec/functional_test/testers/javascript/nestjs_spec.cr`
  - `spec/functional_test/testers/typescript/nestjs_spec.cr`

## Verification
- `just check`: Format check and Ameba lint pass (2,139 files inspected, 0 failures)
- `just test`: 22,729 examples, 0 failures
- `just build`: Binary compiles cleanly
- Verified CLI JSON output on JS and TS NestJS fixtures