### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Express

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_query/app.js
+++ b/spec/functional_test/fixtures/javascript/express_query/app.js
@@ -1,0 +1,25 @@
+const express = require('express');
+
+const app = express();
+const router = express.Router();
+
+// app.query
+app.query('/search', (req, res) => {
+  const q = req.query.q;
+  res.json({ results: [] });
+});
+
+// router.query
+router.query('/items', (req, res) => {
+  const filter = req.query.filter;
+  res.json({ items: [] });
+});
+
+// app.route().query() chaining
+app.route('/filter')
+  .query((req, res) => {
+    const category = req.query.category;
+    res.json({ filtered: [] });
+  });
+
+module.exports = app;

--- a/spec/functional_test/testers/javascript/express_query_spec.cr
+++ b/spec/functional_test/testers/javascript/express_query_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/search", "QUERY", [
+    Param.new("q", "", "query"),
+  ]),
+  Endpoint.new("/items", "QUERY", [
+    Param.new("filter", "", "query"),
+  ]),
+  Endpoint.new("/filter", "QUERY", [
+    Param.new("category", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/express_query/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -18,6 +18,7 @@ describe Noir::JSRouteExtractor do
       Noir::JSRouteExtractor.normalize_http_method("DELETE").should eq("DELETE")
       Noir::JSRouteExtractor.normalize_http_method("PATCH").should eq("PATCH")
       Noir::JSRouteExtractor.normalize_http_method("HEAD").should eq("HEAD")
+      Noir::JSRouteExtractor.normalize_http_method("QUERY").should eq("QUERY")
     end
 
     it "uppercases methods" do
@@ -341,6 +342,26 @@ describe Noir::JSRouteExtractor do
       begin
         routes = Noir::JSRouteExtractor.extract_routes(file.path, content)
         routes.any? { |r| r.url == "/users" && r.method == "GET" }.should be_true
+      ensure
+        file.delete
+      end
+    end
+
+    it "extracts HTTP QUERY routes in express source" do
+      content = <<-JS
+        const express = require("express");
+        const app = express();
+        const router = express.Router();
+        app.query("/search", (req, res) => res.json([]));
+        router.query("/items", (req, res) => res.json([]));
+        app.route("/filter").query((req, res) => res.json([]));
+        JS
+      file = File.tempfile("app", ".js", &.print(content))
+      begin
+        routes = Noir::JSRouteExtractor.extract_routes(file.path, content)
+        routes.any? { |r| r.url == "/search" && r.method == "QUERY" }.should be_true
+        routes.any? { |r| r.url == "/items" && r.method == "QUERY" }.should be_true
+        routes.any? { |r| r.url == "/filter" && r.method == "QUERY" }.should be_true
       ensure
         file.delete
       end

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -295,7 +295,7 @@ module Analyzer::Javascript
       current_router = ""
       lines.each_with_index do |line, index|
         # Detect current router - support case variations of HTTP methods
-        if line =~ /(\w+)\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|Del|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)/
+        if line =~ /(\w+)\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|Del|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)/
           current_router = $1
         end
 
@@ -379,7 +379,7 @@ module Analyzer::Javascript
           prefix = m[2]
 
           # Now find all endpoints defined on this router
-          http_methods = %w[get post put delete patch options head all]
+          http_methods = %w[get post put delete patch options head all query]
 
           http_methods.each do |http_method|
             endpoint_pattern = cached_regex("express:nested_router:#{router_var}:#{http_method}") do
@@ -511,7 +511,7 @@ module Analyzer::Javascript
         next if router_prefix.empty?
 
         # Look for route handlers on this router
-        http_methods = %w[get post put delete patch options head all]
+        http_methods = %w[get post put delete patch options head all query]
 
         http_methods.each do |method|
           # Enhanced pattern to catch more route handler formats
@@ -557,7 +557,7 @@ module Analyzer::Javascript
 
     # Special method to process versioned routers like v1Router
     private def process_versioned_router(content : String, result : Array(Endpoint), path : String, router_name : String, prefix : String)
-      http_methods = %w[get post put delete patch options head all]
+      http_methods = %w[get post put delete patch options head all query]
 
       http_methods.each do |method|
         pattern = cached_regex("express:versioned_router:#{router_name}:#{method}") do
@@ -796,11 +796,11 @@ module Analyzer::Javascript
     def line_to_endpoint(line : String, router_detected : Bool = false) : Endpoint
       # Match both app.method and router.method patterns
       # Support case variations and catch v1Router, apiRouter, and any *Router patterns
-      combined_pattern = /\b(?:app|router|route|r|Router|v\d+Router|apiRouter|[\w]+Router)\s*\.\s*(?:get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)\s*\(\s*['"]([^'"]+)['"]/
+      combined_pattern = /\b(?:app|router|route|r|Router|v\d+Router|apiRouter|[\w]+Router)\s*\.\s*(?:get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)\s*\(\s*['"]([^'"]+)['"]/
 
       if line =~ combined_pattern
         # Extract the actual method used
-        method_match = line.match(/\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)\s*\(/)
+        method_match = line.match(/\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)\s*\(/)
         if method_match
           actual_method = method_match[1].downcase
           actual_method = "delete" if actual_method == "del"
@@ -810,9 +810,9 @@ module Analyzer::Javascript
       end
 
       # Also try simple pattern match (without router name constraint)
-      simple_pattern = /\.\s*(?:get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)\s*\(\s*['"]([^'"]+)['"]/
+      simple_pattern = /\.\s*(?:get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)\s*\(\s*['"]([^'"]+)['"]/
       if line =~ simple_pattern
-        method_match = line.match(/\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)\s*\(/)
+        method_match = line.match(/\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)\s*\(/)
         if method_match
           actual_method = method_match[1].downcase
           actual_method = "delete" if actual_method == "del"
@@ -822,7 +822,7 @@ module Analyzer::Javascript
       end
 
       # Handle route method with method as a parameter - case variations
-      if line =~ /\b(?:app|router|route|r|Router|v\d+Router|apiRouter|[\w]+Router)\s*\.\s*route\s*\(\s*['"]([^'"]+)['"].*?\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|Del|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)\s*\(/
+      if line =~ /\b(?:app|router|route|r|Router|v\d+Router|apiRouter|[\w]+Router)\s*\.\s*route\s*\(\s*['"]([^'"]+)['"].*?\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|Del|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)\s*\(/
         path = $1
         method = $2.downcase
         # Handle special case for Del -> delete
@@ -838,10 +838,10 @@ module Analyzer::Javascript
       # Try to extract method from current line and path from next line
 
       # Check if current line has the method call (case variations)
-      if line =~ /\b(?:app|router|route|r|Router|v\d+Router|apiRouter|[\w]+Router)\s*\.\s*(?:get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)\s*\(/ ||
-         line =~ /\.\s*(?:get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)\s*\(/
+      if line =~ /\b(?:app|router|route|r|Router|v\d+Router|apiRouter|[\w]+Router)\s*\.\s*(?:get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)\s*\(/ ||
+         line =~ /\.\s*(?:get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)\s*\(/
         # Extract the actual method used
-        method_match = line.match(/\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)\s*\(/)
+        method_match = line.match(/\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|del|Del|DEL|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL|query|Query|QUERY)\s*\(/)
         if method_match
           actual_method = method_match[1].downcase
           actual_method = "delete" if actual_method == "del"
@@ -933,7 +933,7 @@ module Analyzer::Javascript
         scan_pos = search_start
         loop do
           # Look for .method( pattern
-          method_match = content.match(/\.\s*(get|post|put|delete|patch|head|options)\s*\(/, scan_pos)
+          method_match = content.match(/\.\s*(get|post|put|delete|patch|head|options|query)\s*\(/, scan_pos)
           break unless method_match
           pos = method_match.begin(0)
           break unless pos

--- a/src/minilexers/js_lexer.cr
+++ b/src/minilexers/js_lexer.cr
@@ -237,7 +237,8 @@ module Noir
         lower_identifier = identifier.downcase
         if lower_identifier == "get" || lower_identifier == "post" || lower_identifier == "put" ||
            lower_identifier == "delete" || lower_identifier == "options" || lower_identifier == "head" ||
-           lower_identifier == "patch" || lower_identifier == "del" || lower_identifier == "all"
+           lower_identifier == "patch" || lower_identifier == "del" || lower_identifier == "all" ||
+           lower_identifier == "query"
           add_token(:http_method, identifier)
         else
           add_token(:identifier, identifier)

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -47,7 +47,7 @@ module Noir
 
     private def http_method_name?(value : String) : Bool
       case value.downcase
-      when "get", "post", "put", "delete", "options", "head", "patch", "del", "all"
+      when "get", "post", "put", "delete", "options", "head", "patch", "del", "all", "query"
         true
       else
         false
@@ -513,6 +513,35 @@ module Noir
       nil
     end
 
+    private def skip_matching_paren(lparen_idx : Int32) : Int32?
+      return unless lparen_idx < @tokens.size && @tokens[lparen_idx].type == :lparen
+      idx = lparen_idx + 1
+      paren_depth = 1
+      bracket_depth = 0
+      brace_depth = 0
+
+      while idx < @tokens.size && paren_depth > 0
+        token = @tokens[idx]
+        case token.type
+        when :lparen
+          paren_depth += 1
+        when :rparen
+          paren_depth -= 1
+          return idx if paren_depth == 0
+        when :lbracket
+          bracket_depth += 1
+        when :rbracket
+          bracket_depth -= 1 if bracket_depth > 0
+        when :lbrace
+          brace_depth += 1
+        when :rbrace
+          brace_depth -= 1 if brace_depth > 0
+        end
+        idx += 1
+      end
+      nil
+    end
+
     # Pre-scan tokens to identify router variables
     # Routers are identified by:
     # 1. Assignment from express.Router(): const router = express.Router()
@@ -729,22 +758,27 @@ module Noir
           end
 
           start_pos = @tokens[idx].position
-          each_prefixed_path(paths, router_var, router_prefixes) do |path_entry, prefixed_path|
-            # Scan ahead for chained HTTP method calls (bounded to avoid O(n^2))
-            j = idx + 5
-            steps = 0
-            max_steps = 1000
-            while j < limit - 1 && steps < max_steps
-              if @tokens[j].type == :dot && http_method?(@tokens[j + 1])
-                results << create_route_with_params(@tokens[j + 1].value, prefixed_path, path_entry.path, start_pos, path_entry.is_regex?)
-                j += 2
-                steps += 2
-                next
-              elsif @tokens[j].type == :semicolon
-                break
+          route_rparen = skip_matching_paren(idx + 3)
+          if route_rparen
+            each_prefixed_path(paths, router_var, router_prefixes) do |path_entry, prefixed_path|
+              # Scan ahead for chained HTTP method calls (bounded to avoid O(n^2))
+              j = route_rparen + 1
+              steps = 0
+              max_steps = 1000
+              while j + 2 < limit && steps < max_steps
+                if @tokens[j].type == :dot && http_method?(@tokens[j + 1]) && @tokens[j + 2].type == :lparen
+                  results << create_route_with_params(@tokens[j + 1].value, prefixed_path, path_entry.path, start_pos, path_entry.is_regex?)
+                  method_rparen = skip_matching_paren(j + 2)
+                  break unless method_rparen
+                  j = method_rparen + 1
+                  steps += 1
+                  next
+                elsif @tokens[j].type == :semicolon
+                  break
+                end
+                j += 1
+                steps += 1
               end
-              j += 1
-              steps += 1
             end
           end
 
@@ -991,10 +1025,10 @@ module Noir
         end
 
         # Now look for the next chained method
-        while method_idx < @tokens.size - 1
+        while method_idx < @tokens.size - 2
           if @tokens[method_idx].type == :dot &&
-             method_idx + 1 < @tokens.size &&
-             http_method?(@tokens[method_idx + 1])
+             http_method?(@tokens[method_idx + 1]) &&
+             @tokens[method_idx + 2].type == :lparen
             method = @tokens[method_idx + 1].value.upcase
 
             # Create routes for all prefixed paths
@@ -1066,10 +1100,10 @@ module Noir
 
         # Look for method chaining after .route('/path')
         method_idx = idx + 6 # Skip past string and closing paren
-        while method_idx < @tokens.size - 1
+        while method_idx < @tokens.size - 2
           if @tokens[method_idx].type == :dot &&
-             method_idx + 1 < @tokens.size &&
-             http_method?(@tokens[method_idx + 1])
+             http_method?(@tokens[method_idx + 1]) &&
+             @tokens[method_idx + 2].type == :lparen
             method = @tokens[method_idx + 1].value.upcase
 
             # Create routes for all prefixed paths

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -332,8 +332,8 @@ module Noir
     # `.route(`, plus Express-style mounts `.use(` which feed into the
     # cross-file router prefix table). Matching is millions of times
     # cheaper than tokenizing the file.
-    BRACKET_ROUTE_CALL_PATTERN  = /\[\s*['"](?:get|post|put|delete|del|patch|options|head|all)['"]\s*\]\s*\(/i
-    FLEXIBLE_ROUTE_CALL_PATTERN = /\.(?:\s|\n|\r)*(?:get|post|put|delete|del|patch|options|head|all|route|register|use)(?:\s|\n|\r)*\(/i
+    BRACKET_ROUTE_CALL_PATTERN  = /\[\s*['"](?:get|post|put|delete|del|patch|options|head|all|query)['"]\s*\]\s*\(/i
+    FLEXIBLE_ROUTE_CALL_PATTERN = /\.(?:\s|\n|\r)*(?:get|post|put|delete|del|patch|options|head|all|query|route|register|use)(?:\s|\n|\r)*\(/i
 
     # A 22-literal `includes?` pre-pass used to run ahead of these two
     # patterns (`".get("`, `".get ("`, ... for each verb). Every one of


### PR DESCRIPTION
## Summary
Detect HTTP `QUERY` (RFC 10008) method endpoints in Express applications (`app.query()`, `router.query()`, and chained `app.route().query()`).

## Changes
- **JSLexer & JSParser**: Recognise `query` as an HTTP method token / verb name. Ensure chained `.route()` parsing skips handler argument bodies using `skip_matching_paren` so property reads like `req.query` inside handlers are not misinterpreted as route calls.
- **JSRouteExtractor**: Include `query` in candidate route call patterns (`BRACKET_ROUTE_CALL_PATTERN`, `FLEXIBLE_ROUTE_CALL_PATTERN`) and method normalization.
- **Express Analyzer**: Add `query` to inline verb lists and fallback regex scanners. Keep `app.all()` expanding strictly to the wildcard method set (excluding `QUERY` per #2540 / RFC 10008).
- **Tests**:
  - Added unit test cases to `spec/unit_test/miniparser/js_route_extractor_spec.cr` for `QUERY` method normalization and route extraction.
  - Added functional test `spec/functional_test/testers/javascript/express_query_spec.cr` and fixture `spec/functional_test/fixtures/javascript/express_query/app.js`.

Closes #2542