### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Node.js http/https

### DIFF
--- a/spec/functional_test/fixtures/javascript/http/app.js
+++ b/spec/functional_test/fixtures/javascript/http/app.js
@@ -14,6 +14,15 @@ const server = http.createServer((req, res) => {
       const { name, email } = JSON.parse(body);
       res.end(JSON.stringify({ name, email }));
     });
+  } else if (req.method === 'QUERY' && req.url === '/api/users/search') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      const { query, filter } = JSON.parse(body);
+      res.end(JSON.stringify({ query, filter }));
+    });
   } else if (req.url === '/health') {
     res.writeHead(200);
     res.end('ok');

--- a/spec/functional_test/fixtures/javascript/http/typed.ts
+++ b/spec/functional_test/fixtures/javascript/http/typed.ts
@@ -19,6 +19,18 @@ createHttpsServer((request: IncomingMessage, response: ServerResponse) => {
         response.end();
       }
       break;
+    case 'QUERY':
+      if (pathname === '/api/users/lookup') {
+        let body = '';
+        request.on('data', (chunk: string) => {
+          body += chunk;
+        });
+        request.on('end', () => {
+          const { id, filter } = JSON.parse(body);
+          response.end(JSON.stringify({ id, filter }));
+        });
+      }
+      break;
   }
 
   switch (pathname) {

--- a/spec/functional_test/testers/javascript/http_spec.cr
+++ b/spec/functional_test/testers/javascript/http_spec.cr
@@ -8,11 +8,19 @@ expected_endpoints = [
     Param.new("name", "", "json"),
     Param.new("email", "", "json"),
   ]),
+  Endpoint.new("/api/users/search", "QUERY", [
+    Param.new("query", "", "json"),
+    Param.new("filter", "", "json"),
+  ]),
   Endpoint.new("/health", "GET"),
   Endpoint.new("/api/users/settings", "PUT", [
     Param.new("x-trace-id", "", "header"),
   ]),
   Endpoint.new("/api/users/archive", "DELETE"),
+  Endpoint.new("/api/users/lookup", "QUERY", [
+    Param.new("id", "", "json"),
+    Param.new("filter", "", "json"),
+  ]),
   Endpoint.new("/api/reports", "GET", [
     Param.new("period", "", "query"),
   ]),

--- a/spec/unit_test/detector/javascript/http_spec.cr
+++ b/spec/unit_test/detector/javascript/http_spec.cr
@@ -16,6 +16,17 @@ describe "Detect JS Node http" do
     instance.detect("server.js", content).should be_true
   end
 
+  it "detects http createServer with QUERY method branching" do
+    content = <<-JS
+      const http = require('http');
+      http.createServer((req, res) => {
+        if (req.method === 'QUERY' && req.url === '/search') res.end();
+      });
+      JS
+
+    instance.detect("server.js", content).should be_true
+  end
+
   it "detects node:https aliased TypeScript import" do
     content = <<-TS
       import { createServer as createHttpsServer } from 'node:https';

--- a/spec/unit_test/miniparser/js_http_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_http_route_extractor_spec.cr
@@ -28,5 +28,54 @@ describe Noir::JSHttpRouteExtractor do
       endpoints.any? { |e| e.url == "/api/users" && e.method == "GET" }.should be_true
       endpoints.any? { |e| e.url == "/api/posts" && e.method == "POST" }.should be_true
     end
+
+    it "extracts HTTP QUERY routes from if conditions with body params" do
+      code = <<-JS
+        const http = require('node:http');
+        const server = http.createServer((req, res) => {
+          if (req.method === 'QUERY' && req.url === '/api/items/search') {
+            let body = '';
+            req.on('data', chunk => { body += chunk; });
+            req.on('end', () => {
+              const { query, limit } = JSON.parse(body);
+              res.end(JSON.stringify({ query, limit }));
+            });
+          }
+        });
+        JS
+
+      endpoints = Noir::JSHttpRouteExtractor.extract("app.js", code)
+      endpoints.size.should eq(1)
+      ep = endpoints.first
+      ep.url.should eq("/api/items/search")
+      ep.method.should eq("QUERY")
+      ep.params.map(&.name).should eq(["query", "limit"])
+      ep.params.map(&.param_type).should eq(["json", "json"])
+    end
+
+    it "extracts HTTP QUERY routes from switch statements" do
+      code = <<-JS
+        const http = require('http');
+        const server = http.createServer((req, res) => {
+          const url = new URL(req.url, 'http://localhost');
+          switch (req.method) {
+            case 'QUERY':
+              if (url.pathname === '/search') {
+                const { filter } = JSON.parse('{}');
+                res.end(filter);
+              }
+              break;
+          }
+        });
+        JS
+
+      endpoints = Noir::JSHttpRouteExtractor.extract("server.js", code)
+      endpoints.size.should eq(1)
+      ep = endpoints.first
+      ep.url.should eq("/search")
+      ep.method.should eq("QUERY")
+      ep.params.map(&.name).should eq(["filter"])
+      ep.params.map(&.param_type).should eq(["json"])
+    end
   end
 end

--- a/src/miniparsers/js_http_route_extractor.cr
+++ b/src/miniparsers/js_http_route_extractor.cr
@@ -9,7 +9,7 @@ module Noir
   # routes through a framework DSL.
   class JSHttpRouteExtractor
     HTTP_METHODS = Set{
-      "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE",
+      "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE", "QUERY",
     }
 
     SOURCE_EXTENSIONS = [".js", ".mjs", ".cjs", ".jsx", ".ts", ".mts", ".tsx"]


### PR DESCRIPTION
## Summary
Support HTTP `QUERY` method (RFC 10008) route detection in Node.js `http`/`https` stdlib servers.

- Added `"QUERY"` to `Noir::JSHttpRouteExtractor::HTTP_METHODS` so `req.method === 'QUERY'` and `switch (req.method) { case 'QUERY': ... }` branches are recognized as endpoints.
- Extracted JSON body parameters from `QUERY` handlers.
- Added test fixtures for both `if` and `switch` route shapes under `spec/functional_test/fixtures/javascript/http/` and updated `spec/functional_test/testers/javascript/http_spec.cr`.
- Added unit test cases to `spec/unit_test/miniparser/js_http_route_extractor_spec.cr` and `spec/unit_test/detector/javascript/http_spec.cr`.

Resolves #2545