### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Fiber

### DIFF
--- a/spec/functional_test/fixtures/go/fiber/server.go
+++ b/spec/functional_test/fixtures/go/fiber/server.go
@@ -62,5 +62,25 @@ func main() {
 		},
 	)
 
+	// HTTP QUERY routes (RFC 10008)
+	app.Query("/query-search", func(c *fiber.Ctx) error {
+		var body map[string]interface{}
+		_ = c.BodyParser(&body)
+		_ = c.Query("filter")
+		return c.SendString("query")
+	})
+
+	app.Add(fiber.MethodQuery, "/query-method-const", func(c *fiber.Ctx) error {
+		return c.SendString("add const")
+	})
+
+	app.Add("QUERY", "/query-string-verb", func(c *fiber.Ctx) error {
+		return c.SendString("add string")
+	})
+
+	mygroup.Query("/query-group", func(c *fiber.Ctx) error {
+		return c.SendString("group query")
+	})
+
 	log.Fatal(app.Listen(":3000"))
 }

--- a/spec/functional_test/testers/go/fiber_spec.cr
+++ b/spec/functional_test/testers/go/fiber_spec.cr
@@ -46,6 +46,14 @@ expected_endpoints = [
   Endpoint.new("/inventory", "POST", [
     Param.new("body", "", "json"),
   ]),
+  # server.go: HTTP QUERY routes (RFC 10008)
+  Endpoint.new("/query-search", "QUERY", [
+    Param.new("body", "", "json"),
+    Param.new("filter", "", "query"),
+  ]),
+  Endpoint.new("/query-method-const", "QUERY"),
+  Endpoint.new("/query-string-verb", "QUERY"),
+  Endpoint.new("/admin/query-group", "QUERY"),
 ]
 
 FunctionalTester.new("fixtures/go/fiber/", {

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -961,4 +961,31 @@ describe Noir::TreeSitterGoRouteExtractor do
     routes = Noir::TreeSitterGoRouteExtractor.extract_net_http_routes(source)
     routes.map { |r| {r.verb, r.path} }.should eq([{"ANY", "/handle"}])
   end
+
+  it "extracts Fiber-style Query routes and Add forms (RFC 10008)" do
+    source = <<-GO
+      package main
+      import (
+          fiber "github.com/gofiber/fiber/v2"
+      )
+      func main() {
+          app := fiber.New()
+          app.Query("/search", searchHandler)
+
+          api := app.Group("/api")
+          api.Query("/items", itemsHandler)
+
+          app.Add(fiber.MethodQuery, "/add-const", constHandler)
+          app.Add("QUERY", "/add-string", stringHandler)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source, handle_method: "Add")
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"QUERY", "/search"},
+      {"QUERY", "/api/items"},
+      {"QUERY", "/add-const"},
+      {"QUERY", "/add-string"},
+    ])
+  end
 end

--- a/spec/unit_test/tagger/framework_taggers/go_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_security_spec.cr
@@ -174,6 +174,30 @@ describe "GoSecurityTagger" do
       tag_named(endpoint, "cors").should_not be_nil
       tag_named(endpoint, "csrf-protection").should be_nil
     end
+
+    it "excludes Query route definition lines from global-wrapper false matching" do
+      tmpdir = File.tempname("go_sec_query")
+      Dir.mkdir_p(tmpdir)
+      file = File.join(tmpdir, "main.go")
+      File.write(file, [
+        "package main",
+        "func main() {",
+        "    app := fiber.New()",
+        "    app.Query(\"/search\", searchHandler)",
+        "}",
+      ].join("\n"))
+
+      opts = create_test_options
+      opts["base"] = YAML::Any.new(tmpdir)
+      seed_file_map(tmpdir)
+
+      query_ep = go_endpoint(file, 4, "/search", "QUERY", "go_fiber")
+      GoSecurityTagger.new(opts).perform([query_ep])
+
+      tag_named(query_ep, "csrf-protection").should be_nil
+
+      FileUtils.rm_rf(tmpdir)
+    end
   end
 
   it "handles empty code_paths gracefully" do

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -130,26 +130,19 @@ module Analyzer::Go
       param_type = "json"
       if line.includes?("Query")
         param_type = "query"
-      end
-      if line.includes?("FormValue")
+      elsif line.includes?("FormValue")
         param_type = "form"
-      end
-      # `c.Params("id")` — Fiber path-variable accessor (also
-      # `.ParamsInt("id")`). Distinct from `c.Query`/`c.FormValue`;
-      # was previously falling through to the `json` default.
-      if line.includes?(".Params(") || line.includes?(".ParamsInt(")
+      elsif line.includes?(".Params(") || line.includes?(".ParamsInt(")
         param_type = "path"
       end
 
-      first = line.strip.split("(")
-      if first.size > 1
-        second = first[1].split(")")
-        if second.size > 1
-          param_name = second[0].gsub("\"", "")
-          rtn = Param.new(param_name, "", param_type)
+      # Capture the accessor's first string-literal argument.
+      # Skip route registrations like `app.Query("/search", handler)`.
+      if match = line.match(/\.(?:Query|FormValue|Params|ParamsInt)\s*\(\s*"([^"]*)"/)
+        param_name = match[1]
+        return Param.new("", "", "") if param_name.starts_with?("/")
 
-          return rtn
-        end
+        return Param.new(param_name, "", param_type)
       end
 
       Param.new("", "", "")

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -239,7 +239,7 @@ module Analyzer::Go
       package_groups[dir]? || Hash(String, String).new
     end
 
-    GO_HTTP_ROUTE_CALL_RE = /\.(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|Get|Post|Put|Delete|Patch|Head|Options|ANY|Any|All)\s*\(/
+    GO_HTTP_ROUTE_CALL_RE = /\.(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|QUERY|Get|Post|Put|Delete|Patch|Head|Options|Query|ANY|Any|All)\s*\(/
 
     # Crystal recompiles an interpolated regex literal on every evaluation
     # (a full PCRE2 JIT compile); the per-framework extra route methods are

--- a/src/miniparsers/go_route_extractor_ts/core.cr
+++ b/src/miniparsers/go_route_extractor_ts/core.cr
@@ -19,8 +19,8 @@ module Noir
     # objects. Mixed case is allowed because both `r.GET(...)` (Gin) and
     # `r.Get(...)` (fiber, gin alt) appear in the wild.
     HTTP_VERB_METHODS = Set{
-      "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
-      "Get", "Post", "Put", "Delete", "Patch", "Head", "Options",
+      "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "QUERY",
+      "Get", "Post", "Put", "Delete", "Patch", "Head", "Options", "Query",
       "ANY", "Any", "All",
     }
 
@@ -973,6 +973,8 @@ module Noir
         elsif handler_text.empty?
           # First non-string positional arg after the path is treated as
           # the handler — matches Gin/Echo/Fiber calling conventions.
+          next if Noir::TreeSitter.node_type(arg) == "interpreted_string_literal" ||
+                  Noir::TreeSitter.node_type(arg) == "raw_string_literal"
           handler_text = Noir::TreeSitter.node_text(arg, source)
         end
         arg_index += 1
@@ -1486,7 +1488,26 @@ module Noir
       end
     end
 
-    # Decode a Go string literal node's text content. Interpreted
+    # An HTTP method written as a string literal ("POST") or an
+    # `http.MethodX` / `fiber.MethodX` selector; both collapse to the
+    # bare upper-cased verb.
+    private def decode_method_token(node : LibTreeSitter::TSNode, source : String) : String
+      case Noir::TreeSitter.node_type(node)
+      when "interpreted_string_literal", "raw_string_literal"
+        Noir::TreeSitter.node_text(node, source).gsub(/^["`]|["`]$/, "").upcase
+      when "selector_expression"
+        text = Noir::TreeSitter.node_text(node, source)
+        if idx = text.index("Method")
+          text[(idx + "Method".size)..].upcase
+        else
+          ""
+        end
+      else
+        ""
+      end
+    end
+
+    # Tree-sitter splits string literals into quote and content nodes. Interpreted
     # literals (`"foo"`) expose an `interpreted_string_literal_content`
     # named child; raw literals (`` `foo` ``) keep their contents as the
     # whole node text minus the backticks. We concatenate content children

--- a/src/miniparsers/go_route_extractor_ts/gozero.cr
+++ b/src/miniparsers/go_route_extractor_ts/gozero.cr
@@ -209,25 +209,6 @@ module Noir
       {gozero_unwrap(key), gozero_unwrap(val)}
     end
 
-    # An HTTP method written as a string literal ("POST") or an
-    # `http.MethodX` selector; both collapse to the bare upper-cased verb.
-    # Shared by go-zero's `Method:` struct field and mux's `.Methods(...)`.
-    private def decode_method_token(node : LibTreeSitter::TSNode, source : String) : String
-      case Noir::TreeSitter.node_type(node)
-      when "interpreted_string_literal", "raw_string_literal"
-        Noir::TreeSitter.node_text(node, source).gsub(/^["`]|["`]$/, "").upcase
-      when "selector_expression"
-        text = Noir::TreeSitter.node_text(node, source)
-        if idx = text.index("Method")
-          text[(idx + "Method".size)..].upcase
-        else
-          ""
-        end
-      else
-        ""
-      end
-    end
-
     private def gozero_string_value(node : LibTreeSitter::TSNode, source : String) : String
       case Noir::TreeSitter.node_type(node)
       when "interpreted_string_literal", "raw_string_literal"

--- a/src/tagger/framework_taggers/go/go_security.cr
+++ b/src/tagger/framework_taggers/go/go_security.cr
@@ -68,7 +68,7 @@ class GoSecurityTagger < FrameworkTagger
   # A route-definition call. Used only to *exclude* route lines from the
   # global-wrapper branch (inline route middleware is handled per-endpoint),
   # so an over-broad verb set here is safe.
-  ROUTE_DEF = /\b(?:GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|CONNECT|TRACE|Get|Post|Put|Delete|Patch|Options|Head|Connect|Trace|Any|All|Handle|HandleFunc|Match|Add)\s*\(/
+  ROUTE_DEF = /\b(?:GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|CONNECT|TRACE|QUERY|Get|Post|Put|Delete|Patch|Options|Head|Connect|Trace|Query|Any|All|Handle|HandleFunc|Match|Add)\s*\(/
 
   def initialize(options : Hash(String, YAML::Any))
     super


### PR DESCRIPTION
## Summary

Detects HTTP `QUERY` (RFC 10008) routes in Go Fiber applications across all router shapes:
- `app.Query("/search", handler)`
- `group.Query("/search", handler)`
- `app.Add(fiber.MethodQuery, "/search", handler)`
- `app.Add("QUERY", "/search", handler)`

## Changes

- `src/miniparsers/go_route_extractor_ts/core.cr`:
  - Added `"QUERY"` and `"Query"` to `HTTP_VERB_METHODS`.
  - Added `decode_method_token` helper to resolve string literals and `MethodX` selectors (e.g. `fiber.MethodQuery`).
  - Skipped string literals when identifying handler arguments in `decode_verb_call`.
- `src/miniparsers/go_route_extractor_ts/gozero.cr`:
  - Removed duplicate `decode_method_token`.
- `src/analyzer/engines/go_engine.cr`:
  - Added `QUERY` and `Query` to `GO_HTTP_ROUTE_CALL_RE`.
- `src/tagger/framework_taggers/go/go_security.cr`:
  - Added `QUERY` and `Query` to `ROUTE_DEF`.
- `src/analyzer/analyzers/go/fiber.cr`:
  - Updated `get_param` regex to avoid capturing route registration paths as query/path parameters.
- Tests:
  - Added unit tests for Tree-sitter Go extractor QUERY routes and `Add` forms in `spec/unit_test/miniparser/go_route_extractor_ts_spec.cr`.
  - Added unit test in `spec/unit_test/tagger/framework_taggers/go_security_spec.cr`.
  - Added test cases in Fiber functional fixture (`server.go`) and spec (`fiber_spec.cr`) asserting QUERY method and parameters.

Closes #2546