### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Ktor

### DIFF
--- a/spec/functional_test/fixtures/kotlin/ktor/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor/Application.kt
@@ -43,9 +43,25 @@ fun Application.configureRouting() {
             call.respondText("Deleted user $id")
         }
         
+        query("/search") {
+            val query = call.receive<SearchRequest>()
+            val filter = call.parameters["filter"]
+            call.respondText("Searched: ${query.query}")
+        }
+        
+        route("/items", HttpMethod.Query) {
+            handle {
+                call.respondText("Queried items")
+            }
+        }
+        
         route("/api") {
             get("/status") {
                 call.respondText("API is running")
+            }
+
+            query("/search") {
+                call.respondText("API search")
             }
             
             route("/v1") {
@@ -85,3 +101,4 @@ fun Application.configureRouting() {
 
 data class User(val name: String, val email: String)
 data class SubmitData(val content: String)
+data class SearchRequest(val query: String)

--- a/spec/functional_test/fixtures/kotlin/ktor/ExtensionRoutes.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor/ExtensionRoutes.kt
@@ -15,5 +15,13 @@ fun Route.extensionRoutes() {
                 call.respondText("Method route")
             }
         }
+
+        route("/query-method") {
+            method(HttpMethod.Query) {
+                handle {
+                    call.respondText("Query method route")
+                }
+            }
+        }
     }
 }

--- a/spec/functional_test/testers/kotlin/ktor_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_spec.cr
@@ -3,6 +3,7 @@ require "../../func_spec.cr"
 expected_endpoints = [
   Endpoint.new("/extension", "GET"),
   Endpoint.new("/extension/method", "POST"),
+  Endpoint.new("/extension/query-method", "QUERY"),
   Endpoint.new("/", "GET"),
   Endpoint.new("/users/{id}", "GET", [
     Param.new("id", "", "path"),
@@ -15,7 +16,13 @@ expected_endpoints = [
   Endpoint.new("/users/{id}", "DELETE", [
     Param.new("id", "", "path"),
   ]),
+  Endpoint.new("/search", "QUERY", [
+    Param.new("body", "SearchRequest", "json"),
+    Param.new("filter", "", "query"),
+  ]),
+  Endpoint.new("/items", "QUERY"),
   Endpoint.new("/api/status", "GET"),
+  Endpoint.new("/api/search", "QUERY"),
   Endpoint.new("/api/v1/health", "GET"),
   Endpoint.new("/api/v1/submit", "POST", [Param.new("body", "SubmitData", "json")]),
   Endpoint.new("/api/v1/items/{itemId}", "GET", [

--- a/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
@@ -189,11 +189,43 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
           patch("/e") { }
           head("/f") { }
           options("/g") { }
+          query("/h") { }
       }
       KT
 
     routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
-    routes.map(&.verb).should eq(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"])
+    routes.map(&.verb).should eq(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "QUERY"])
+  end
+
+  it "extracts HTTP QUERY routes from verb builder, HttpMethod.Query, and nested route prefixes" do
+    source = <<-KT
+      routing {
+          query("/search") {
+              val query = call.receive<SearchRequest>()
+              val filter = call.parameters["filter"]
+          }
+          route("/items", HttpMethod.Query) {
+              handle { call.respondText("items") }
+          }
+          route("/actions") {
+              method(HttpMethod.Query) {
+                  handle { call.respondText("actions") }
+              }
+              query("/lookup") { }
+          }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"QUERY", "/search"},
+      {"QUERY", "/items"},
+      {"QUERY", "/actions"},
+      {"QUERY", "/actions/lookup"},
+    ])
+    routes[0].receive_type.should eq("SearchRequest")
+    routes[0].has_body?.should be_true
+    routes[0].query_params.should eq(["filter"])
   end
 
   describe "handler-body parameter scan" do

--- a/spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr
@@ -589,6 +589,17 @@ describe Noir::TreeSitterKotlinParameterExtractor do
       form_params.map { |p| {p.name, p.param_type} }.should eq([
         {"api", "form"},
       ])
+
+      query_verb_source = <<-KT
+        class C {
+            @RequestMapping("/x", method = [RequestMethod.QUERY], params = ["api=v1"])
+            fun queryMethod(): String = ""
+        }
+        KT
+      query_verb_params = extract(query_verb_source, "C", "queryMethod", "QUERY")
+      query_verb_params.map { |p| {p.name, p.param_type} }.should eq([
+        {"api", "form"},
+      ])
     end
 
     it "appends headers= constraints as header params" do

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -21,7 +21,7 @@ module Noir
   #
   # Recognises:
   #
-  #   * Verb DSL calls — `get`/`post`/`put`/`delete`/`patch`/`head`/`options`
+  #   * Verb DSL calls — `get`/`post`/`put`/`delete`/`patch`/`head`/`options`/`query`
   #     with a string-literal path argument and a trailing lambda body.
   #   * `route("/x") { ... }` blocks contributing to the path prefix.
   #   * `authenticate("realm") { ... }` blocks acting as transparent
@@ -50,6 +50,7 @@ module Noir
       "patch"   => "PATCH",
       "head"    => "HEAD",
       "options" => "OPTIONS",
+      "query"   => "QUERY",
       # WebSocket / SSE handlers are registered with the same path +
       # trailing-lambda DSL as the HTTP verbs. The connection opens with
       # a GET (the WebSocket upgrade / SSE stream are both GET requests),


### PR DESCRIPTION
## Summary
Detect HTTP `QUERY` routes in Ktor (KTOR-7882 / RFC 10008).

## Changes
- **Route Extractor**: Added `"query" => "QUERY"` to `TreeSitterKotlinKtorRouteExtractor::HTTP_VERB_NAMES`.
  - Supports `query("/path") { ... }` verb builder.
  - Supports `route("/path", HttpMethod.Query) { handle { ... } }`.
  - Supports `method(HttpMethod.Query) { handle { ... } }`.
  - Supports nested route prefixes (e.g. `route("/api") { query("/search") { ... } }`).
- **Parameter Extractor**: Verified that `QUERY` is excluded from `TreeSitterKotlinParameterExtractor::QUERY_VERB_PARAMS` (which is `Set{"GET", "HEAD", "OPTIONS"}`), ensuring parameters default to body/form rather than query string.
- **Unit Tests**:
  - `spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr`: Added unit tests for standard verbs with `query`, verb builder, `HttpMethod.Query`, and nested route prefixes.
  - `spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr`: Added unit test verifying `QUERY` route constraints default to `form`.
- **Functional Tests**:
  - `spec/functional_test/fixtures/kotlin/ktor/`: Added fixture routes covering `query("/search")`, `route("/items", HttpMethod.Query)`, nested `query`, and `method(HttpMethod.Query)`.
  - `spec/functional_test/testers/kotlin/ktor_spec.cr`: Updated expected endpoints and assertions.

Closes #2552