### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Kemal

### DIFF
--- a/spec/functional_test/fixtures/crystal/kemal/src/testapp.cr
+++ b/spec/functional_test/fixtures/crystal/kemal/src/testapp.cr
@@ -29,6 +29,20 @@ ws "/socket" do |socket|
   socket.send "Hello from Kemal!"
 end
 
+query "/search" do |env|
+  env.params.json["q"]?
+  env.params.query["mode"]
+  "search results"
+end
+
+before_query "/admin/*" do |env|
+  env.response.status_code = 403
+end
+
+after_query "/admin/*" do |env|
+  env.response.headers["x-filtered"] = "true"
+end
+
 api = Kemal::Router.new
 api.namespace "/users" do
   get "/" do |env|

--- a/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/app.cr
+++ b/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/app.cr
@@ -12,6 +12,7 @@ module App::Routing
   def register_all
     get "/", Routes::Misc, :home
     post "/users", Routes::Misc, :create_user
+    query "/search", Routes::Misc, :search
 
     register_api_routes
   end

--- a/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/routes/misc.cr
+++ b/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/routes/misc.cr
@@ -8,4 +8,9 @@ module Routes::Misc
     data = env.params.json["user"]
     UserService.create(data)
   end
+
+  def self.search(env)
+    q = env.params.json["q"]?
+    SearchService.run(q)
+  end
 end

--- a/spec/functional_test/testers/crystal/kemal_controller_callees_spec.cr
+++ b/spec/functional_test/testers/crystal/kemal_controller_callees_spec.cr
@@ -14,6 +14,16 @@ users_create = Endpoint.new("/users", "POST").tap do |ep|
   ep.push_callee(Callee.new("UserService.create", line: 9))
 end
 
+# HTTP QUERY (RFC 10008, kemalcr/kemal#769) controller-reference form —
+# the same `query "/path", Controller, :action` dispatch Noir already
+# resolves for `get`. Cross-file dispatch (like `users_create` above)
+# carries callees but not params — the handler body lives in another
+# file, outside this route line's per-line param scan.
+search = Endpoint.new("/search", "QUERY").tap do |ep|
+  ep.push_callee(Callee.new("env.params.json", line: 13))
+  ep.push_callee(Callee.new("SearchService.run", line: 14))
+end
+
 # `{{namespace = Routes::API}}` + `{{namespace}}::Items` resolves to
 # `Routes::API::Items`, so this route still carries its handler's callees.
 items_show = Endpoint.new("/api/items/:id", "GET", [
@@ -26,6 +36,7 @@ end
 expected_endpoints = [
   home,
   users_create,
+  search,
   items_show,
 ]
 

--- a/spec/functional_test/testers/crystal/kemal_spec.cr
+++ b/spec/functional_test/testers/crystal/kemal_spec.cr
@@ -4,6 +4,13 @@ expected_endpoints = [
   Endpoint.new("/", "GET", [Param.new("x-api-key", "", "header")]),
   Endpoint.new("/paren", "GET", [Param.new("kind", "", "query")]),
   Endpoint.new("/socket", "GET"),
+  # HTTP QUERY (RFC 10008, kemalcr/kemal#769) block form. `before_query` /
+  # `after_query` filters below (same base path) must NOT appear as
+  # endpoints — mirrors how `before_get`/`after_get` are already excluded.
+  Endpoint.new("/search", "QUERY", [
+    Param.new("q", "", "json"),
+    Param.new("mode", "", "query"),
+  ]),
   Endpoint.new("/query", "POST", [
     Param.new("query", "", "form"),
     Param.new("my_auth", "", "cookie"),

--- a/spec/unit_test/analyzer/analyzer_kemal_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_kemal_spec.cr
@@ -144,6 +144,42 @@ describe "kemal namespace routing" do
     Dir.delete(temp_dir)
   end
 
+  it "parses HTTP QUERY routes and excludes before_query/after_query filters" do
+    temp_dir = File.tempname("kemal_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "test.cr")
+
+    File.write(temp_file, <<-CRYSTAL)
+      query "/search" do |env|
+        env.params.json["q"]?
+        env.params.query["mode"]
+        "search results"
+      end
+
+      before_query "/admin/*" do |env|
+        env.response.status_code = 403
+      end
+
+      after_query "/admin/*" do |env|
+        env.response.headers["x-filtered"] = "true"
+      end
+      CRYSTAL
+
+    endpoints = instance.analyze_file(temp_file)
+    endpoints.size.should eq(1)
+    endpoints[0].url.should eq("/search")
+    endpoints[0].method.should eq("QUERY")
+
+    params = endpoints[0].params
+    params.size.should eq(2)
+    params.find { |p| p.name == "q" }.try(&.param_type).should eq("json")
+    params.find { |p| p.name == "mode" }.try(&.param_type).should eq("query")
+
+    # Cleanup
+    File.delete(temp_file)
+    Dir.delete(temp_dir)
+  end
+
   it "handles routes outside namespace normally" do
     temp_dir = File.tempname("kemal_test")
     Dir.mkdir_p(temp_dir)

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -188,7 +188,7 @@ module Analyzer::Crystal
     end
 
     private def extract_route_target(line : String) : Tuple(String, String)?
-      if match = line.match(/\b(?:get|post|put|delete|patch|head|options|ws)\s+['"][^'"]+['"]\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\s*,\s*:(\w+)/)
+      if match = line.match(/\b(?:get|post|put|delete|patch|head|options|ws|query)\s+['"][^'"]+['"]\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\s*,\s*:(\w+)/)
         {match[1], match[2]}
       end
     end
@@ -287,10 +287,25 @@ module Analyzer::Crystal
       Param.new("", "", "")
     end
 
+    # Kemal's `query` route DSL (RFC 10008, kemalcr/kemal#769) is
+    # Kemal-specific, unlike `get`/`post`/etc. which the shared engine's
+    # SIMPLE_ROUTE_RE already covers for every Crystal analyzer (Amber,
+    # Lucky). It's stitched in via `match_crystal_simple_route(..., extra:)`
+    # instead of touching that shared pattern, mirroring Lucky's TRACE
+    # extra route. The same `(?:^|[^.\w])` lead-in that keeps `before_get`
+    # / `after_get` from matching `get` also keeps `before_query` /
+    # `after_query` filters from matching here — they must not emit
+    # endpoints.
+    QUERY_ROUTE_PATTERN = /(?:^|[^.\w])query\s*(?:\(\s*)?['"](.+?)['"]/
+    KEMAL_EXTRA_ROUTES  = [{"QUERY", QUERY_ROUTE_PATTERN}] of Tuple(String, Regex)
+
     def line_to_endpoint(content : String) : Endpoint
       # Shared engine helper: precompiled per-verb patterns + includes?
       # gates. Replaces 8 sequential unguarded .scan calls per source line.
-      match_crystal_simple_route(Noir::CrystalCalleeExtractor.strip_comment(content))
+      match_crystal_simple_route(
+        Noir::CrystalCalleeExtractor.strip_comment(content),
+        extra: KEMAL_EXTRA_ROUTES
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

kemalcr/kemal#769 ("Add HTTP QUERY method (RFC 10008) support", merged 2026-08-14) adds a `query` route DSL, `Kemal::Router#query`, and `before_query` / `after_query` filters, generated through Kemal's existing `HTTP_METHODS` / `FILTER_METHODS` macros — the dispatch code is unchanged, so no upstream surprises to work around.

- Recognize `query "/path" do |env| … end` (block and paren forms), stitched in via `match_crystal_simple_route(..., extra:)` — the same mechanism Lucky already uses for its unique `TRACE` route — so the shared `SIMPLE_ROUTE_RE` (also used by Amber/Lucky) stays untouched and this is Kemal-only.
- Resolve the controller-reference form `query "/path", Controller, :action` the same way `get "/path", Controller, :action` already resolves cross-file callees.
- `before_query` / `after_query` filters correctly emit **no** endpoint — the existing `(?:^|[^.\w])` lead-in that already excludes `before_get` / `after_get` from matching excludes these too, verified with a dedicated test.
- No param-location changes needed: Kemal's param extraction is driven purely by the accessor used (`env.params.query[...]` / `env.params.json[...]` / `env.params.body[...]`), not by the enclosing route verb, so `QUERY` routes already get correct `query`/`json`/`form` param locations for free.

Depends on the already-merged foundation (#2563 / issue #2540) — `QUERY` is already in `ALLOWED_HTTP_METHODS`.

## Test plan

- [x] `spec/unit_test/analyzer/analyzer_kemal_spec.cr` — new unit test: block-form `query` route detected as `QUERY`, correct `q`(json)/`mode`(query) param locations, `before_query`/`after_query` emit nothing
- [x] `spec/functional_test/testers/crystal/kemal_spec.cr` — fixture extended with a `query "/search"` block route + `before_query`/`after_query` filters (total endpoint count assertion catches any phantom endpoint leak)
- [x] `spec/functional_test/testers/crystal/kemal_controller_callees_spec.cr` — fixture extended with the controller-reference form `query "/search", Routes::Misc, :search`, asserting cross-file callee resolution
- [x] `crystal spec spec/functional_test/testers/crystal/` — 503 examples, 0 failures
- [x] `crystal spec spec/unit_test` — 4779 examples, 0 failures (isolated `CRYSTAL_CACHE_DIR`)
- [x] `crystal spec spec/functional_test` — 22725 examples, 0 failures (isolated `CRYSTAL_CACHE_DIR`)
- [x] `crystal tool format --check` — clean
- [x] `ameba` on changed files — 0 failures