### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Rails

### DIFF
--- a/spec/functional_test/fixtures/ruby/rails/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails/config/routes.rb
@@ -1,10 +1,19 @@
 Rails.application.routes.draw do
-    resources :posts
-    # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-    # Defines the root path route ("/")
-    # root "articles#index"
-    get "up" => "rails/health#show", as: :rails_health_check
-    get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-    get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  resources :posts do
+    member do
+      query :search
+    end
   end
+
+  query "search", to: "posts#index"
+  match "filter", to: "posts#index", via: :query
+  match "both", to: "posts#index", via: [:get, :query]
+
+  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  # Defines the root path route ("/")
+  # root "articles#index"
+  get "up" => "rails/health#show", as: :rails_health_check
+  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+end

--- a/spec/functional_test/testers/ruby/rails_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_spec.cr
@@ -23,6 +23,27 @@ expected_endpoints = [
     Param.new("context", "", "json"),
   ]),
   Endpoint.new("/posts/1", "DELETE"),
+  Endpoint.new("/posts/1/search", "QUERY"),
+  Endpoint.new("/search", "QUERY", [
+    Param.new("user_name", "", "cookie"),
+    Param.new("login", "", "cookie"),
+    Param.new("discount", "", "cookie"),
+  ]),
+  Endpoint.new("/filter", "QUERY", [
+    Param.new("user_name", "", "cookie"),
+    Param.new("login", "", "cookie"),
+    Param.new("discount", "", "cookie"),
+  ]),
+  Endpoint.new("/both", "GET", [
+    Param.new("user_name", "", "cookie"),
+    Param.new("login", "", "cookie"),
+    Param.new("discount", "", "cookie"),
+  ]),
+  Endpoint.new("/both", "QUERY", [
+    Param.new("user_name", "", "cookie"),
+    Param.new("login", "", "cookie"),
+    Param.new("discount", "", "cookie"),
+  ]),
   Endpoint.new("/up", "GET"),
   Endpoint.new("/service-worker", "GET"),
   Endpoint.new("/manifest", "GET"),

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -332,7 +332,7 @@ module Analyzer::Ruby
         when "member"     then scan.stack << Frame.new(:member) if opens_block
         when "collection" then scan.stack << Frame.new(:collection) if opens_block
         when "new"        then scan.stack << Frame.new(:new) if opens_block
-        when "get", "post", "put", "patch", "delete", "head", "options"
+        when "get", "post", "put", "patch", "delete", "head", "options", "query"
           handle_verb_route(directive.upcase, args, scan)
         when "match" then handle_match(args, scan)
         else


### PR DESCRIPTION
## Summary
- Added support for Rails HTTP `QUERY` route DSL introduced in Rails (rails/rails#57973).
- Added `query` to the HTTP verb handling in `src/analyzer/analyzers/ruby/rails.cr`.
- Supports bare `query`, `via: :query`, `via: [:get, :query]`, and nested `member` / `collection` `query` blocks.
- Added functional test fixtures and spec assertions for Rails `QUERY` endpoints.

Closes #2549