### PR TITLE
feat(analyzer): detect HTTP QUERY routes in http4k (#2553)

### DIFF
--- a/spec/functional_test/fixtures/kotlin/http4k/src/main/kotlin/com/example/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/http4k/src/main/kotlin/com/example/Application.kt
@@ -1,20 +1,39 @@
 package com.example
 
+import org.http4k.contract.ContractRoute
+import org.http4k.contract.contract
+import org.http4k.contract.meta
+import org.http4k.core.Method
 import org.http4k.core.Method.DELETE
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.PATCH
 import org.http4k.core.Method.POST
 import org.http4k.core.Method.PUT
+import org.http4k.core.Method.QUERY
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.routing.bind
 import org.http4k.routing.routes
 
+fun searchContract(): ContractRoute {
+    return "/contract-search" meta {
+        summary = "Search items"
+    } bindContract Method.QUERY to { req: Request ->
+        val q = req.query("q")
+        Response(OK)
+    }
+}
+
 val app = routes(
     "/hello" bind GET to { req: Request ->
         val name = req.query("name")
         Response(OK).body("hello $name")
+    },
+
+    "/search" bind Method.QUERY to { req: Request ->
+        val filter = req.query("filter")
+        Response(OK)
     },
 
     "/users" bind POST to { req: Request ->
@@ -30,6 +49,10 @@ val app = routes(
 
     "/api" bind routes(
         "/status" bind GET to { _: Request -> Response(OK) },
+        "/search" bind Method.QUERY to { req: Request ->
+            val filter = req.query("filter")
+            Response(OK)
+        },
         "/v1" bind routes(
             "/health" bind GET to { _: Request -> Response(OK) },
             "/submit" bind POST to { req: Request ->
@@ -41,7 +64,10 @@ val app = routes(
                 val category = req.query("category")
                 Response(OK)
             }
-        )
+        ),
+        contract {
+            routes += searchContract()
+        }
     ),
 
     "/sessions/{id}" bind DELETE to { req: Request ->

--- a/spec/functional_test/testers/kotlin/http4k_spec.cr
+++ b/spec/functional_test/testers/kotlin/http4k_spec.cr
@@ -4,6 +4,9 @@ expected_endpoints = [
   Endpoint.new("/hello", "GET", [
     Param.new("name", "", "query"),
   ]),
+  Endpoint.new("/search", "QUERY", [
+    Param.new("filter", "", "query"),
+  ]),
   Endpoint.new("/users", "POST", [
     Param.new("body", "", "json"),
   ]),
@@ -13,6 +16,9 @@ expected_endpoints = [
     Param.new("body", "", "json"),
   ]),
   Endpoint.new("/api/status", "GET"),
+  Endpoint.new("/api/search", "QUERY", [
+    Param.new("filter", "", "query"),
+  ]),
   Endpoint.new("/api/v1/health", "GET"),
   Endpoint.new("/api/v1/submit", "POST", [
     Param.new("body", "", "json"),
@@ -21,6 +27,9 @@ expected_endpoints = [
   Endpoint.new("/api/v1/items/{itemId}", "GET", [
     Param.new("itemId", "", "path"),
     Param.new("category", "", "query"),
+  ]),
+  Endpoint.new("/api/contract-search", "QUERY", [
+    Param.new("q", "", "query"),
   ]),
   Endpoint.new("/sessions/{id}", "DELETE", [
     Param.new("id", "", "path"),

--- a/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
@@ -148,4 +148,54 @@ describe Noir::TreeSitterHttp4kExtractor do
       {"POST", "/api/knock"},
     ])
   end
+
+  it "extracts HTTP QUERY routes from bind, nested routes, and bindContract" do
+    helper = <<-KT
+      import org.http4k.contract.ContractRoute
+      import org.http4k.contract.meta
+      import org.http4k.core.Method.QUERY
+
+      fun SearchContract(): ContractRoute {
+          return "/contract-search" meta {
+              summary = "Search items"
+          } bindContract Method.QUERY to searchHandler
+      }
+      KT
+
+    source = <<-KT
+      import org.http4k.contract.contract
+      import org.http4k.core.Method.QUERY
+      import org.http4k.core.Method.GET
+      import org.http4k.core.Method
+      import org.http4k.routing.bind
+      import org.http4k.routing.routes
+
+      val app = routes(
+          "/search" bind Method.QUERY to { req -> Response(OK) },
+          "/bare-search" bind QUERY to { req -> Response(OK) },
+          "/api" bind routes(
+              "/nested-search" bind Method.QUERY to { req -> Response(OK) },
+              contract {
+                  descriptionPath = "/api-docs"
+                  routes += SearchContract()
+              }
+          ),
+          "/items" bind routes(
+              Method.QUERY to { req -> Response(OK) }
+          )
+      )
+      KT
+
+    contract_routes = Noir::TreeSitterHttp4kExtractor.extract_contract_route_functions(helper)
+    routes = Noir::TreeSitterHttp4kExtractor.extract_routes(source, contract_routes: contract_routes)
+
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"QUERY", "/search"},
+      {"QUERY", "/bare-search"},
+      {"QUERY", "/api/nested-search"},
+      {"GET", "/api/api-docs"},
+      {"QUERY", "/api/contract-search"},
+      {"QUERY", "/items"},
+    ])
+  end
 end

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -29,7 +29,7 @@ module Noir
   # Recognised:
   #
   #   * Verbs `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`,
-  #     `OPTIONS`, `TRACE`, `CONNECT` — both bare (`GET`) and
+  #     `OPTIONS`, `TRACE`, `CONNECT`, `QUERY` — both bare (`GET`) and
   #     `Method.GET`-qualified.
   #   * Inline lambda handler — scanned for `req.query("name")`,
   #     `req.header("X-Foo")`, `req.form("x")`, `req.bodyString()`
@@ -51,7 +51,7 @@ module Noir
 
     HTTP_VERBS = Set{
       "GET", "POST", "PUT", "DELETE", "PATCH",
-      "HEAD", "OPTIONS", "TRACE", "CONNECT",
+      "HEAD", "OPTIONS", "TRACE", "CONNECT", "QUERY",
     }
 
     struct Route


### PR DESCRIPTION
## Summary
Detect HTTP `QUERY` routes in http4k (both bare `QUERY` and `Method.QUERY`, nested `routes(...)`, and `bindContract` routes).

## Changes
- `src/miniparsers/http4k_extractor_ts.cr`: Add `QUERY` to `HTTP_VERBS` and update doc comments.
- `spec/unit_test/miniparser/http4k_extractor_ts_spec.cr`: Add unit tests for `QUERY` route extraction across bare, qualified, nested `routes(...)`, and `bindContract`.
- `spec/functional_test/fixtures/kotlin/http4k/src/main/kotlin/com/example/Application.kt`: Add `bind Method.QUERY to`, nested `routes(...)` with `QUERY`, and `bindContract` fixture routes.
- `spec/functional_test/testers/kotlin/http4k_spec.cr`: Add expected `QUERY` endpoints.

## Verification
- `crystal spec spec/unit_test/miniparser/http4k_extractor_ts_spec.cr` passed.
- `just test-func-one kotlin/http4k` passed.
- `just test-func-lang kotlin` passed (683 examples, 0 failures).
- `just test-unit` passed (4779 examples, 0 failures).
- `just check` passed (format check and 2139 files Ameba lint passed).
- `./bin/noir -b spec/functional_test/fixtures/kotlin/http4k` validated.

Closes #2553