### PR TITLE
feat(analyzer): detect HTTP QUERY routes in ASP.NET Core

### DIFF
--- a/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api/MinimalApiDemo.csproj
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api/MinimalApiDemo.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api/Program.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api/Program.cs
@@ -29,6 +29,13 @@ app.MapPatch("/users/{id}", async (HttpContext context) =>
 app.Map("/fallback", () => Results.Ok());
 app.MapMethods("/bulk", new[] { HttpMethods.Put, "PATCH" }, () => Results.Ok());
 
+// QUERY (RFC 10008) ships natively on .NET 10: HttpMethods.Query and the
+// bare "QUERY" literal both register through MapMethods, standalone or
+// alongside another verb in the same array.
+app.MapMethods("/search", new[] { HttpMethods.Query }, ([FromBody] SearchFilter filter) => Results.Ok(filter));
+app.MapMethods("/search-legacy", new[] { "QUERY" }, () => Results.Ok());
+app.MapMethods("/lookup", new[] { "GET", "QUERY" }, () => Results.Ok());
+
 var api = app.MapGroup("/api");
 var v1 = api.MapGroup("/v1");
 var nested = app.MapGroup("/nested").MapGroup("/v2");
@@ -46,3 +53,4 @@ app.Run();
 record CreateUserRequest(string Name);
 record UpdateUserRequest(string Name);
 record CreateOrderRequest(string Id);
+record SearchFilter(string Keyword);

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/Controllers/BanksController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/Controllers/BanksController.cs
@@ -15,6 +15,18 @@ namespace Demo.Controllers
         [AcceptVerbs("PUT", "POST", Route = "transfer")]
         public IActionResult Transfer([FromForm] string amount) => Ok(amount);
 
+        // QUERY (RFC 10008) routes through [AcceptVerbs] like any other verb
+        // string — no dedicated [HttpQuery] attribute exists yet.
+        [AcceptVerbs("QUERY")]
+        [Route("search")]
+        public IActionResult Search([FromBody] FilterDto filters) => Ok(filters);
+
+        // An unattributed parameter on a QUERY action binds from the body,
+        // the same as it would on PUT/POST/PATCH — not from the URL query
+        // string.
+        [AcceptVerbs("QUERY", Route = "search/implicit")]
+        public IActionResult SearchImplicit(string keyword) => Ok(keyword);
+
         [HttpGet("branch/{branchId}")]
         public IActionResult Branch([FromRoute(Name = "branchId")] string internalBranchKey) =>
             Ok(internalBranchKey);
@@ -24,5 +36,10 @@ namespace Demo.Controllers
 
         [HttpGet("audit")]
         public IActionResult Audit([FromHeader(Name = "X-Tenant")] string tenant) => Ok(tenant);
+    }
+
+    public class FilterDto
+    {
+        public string Keyword { get; set; }
     }
 }

--- a/spec/functional_test/testers/csharp/aspnet_core_minimal_api_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_minimal_api_spec.cr
@@ -24,6 +24,14 @@ expected_endpoints = [
   Endpoint.new("/fallback", "ANY"),
   Endpoint.new("/bulk", "PUT"),
   Endpoint.new("/bulk", "PATCH"),
+  # QUERY (RFC 10008): HttpMethods.Query, a bare "QUERY" literal, and QUERY
+  # alongside another verb in the same MapMethods array.
+  Endpoint.new("/search", "QUERY", [
+    Param.new("filter", "", "json"),
+  ]),
+  Endpoint.new("/search-legacy", "QUERY"),
+  Endpoint.new("/lookup", "GET"),
+  Endpoint.new("/lookup", "QUERY"),
   Endpoint.new("/api/v1/products/{sku}", "GET", [
     Param.new("sku", "", "path"),
     Param.new("X-Mode", "", "header"),
@@ -62,5 +70,20 @@ describe "ASP.NET Core Minimal API analyzer edge cases" do
     users = tester.app.endpoints.find { |e| e.url == "/users" && e.method == "GET" }
     users.should_not be_nil
     users.as(Endpoint).details.technology.should eq "cs_aspnet_core_minimal_api"
+  end
+
+  it "recognizes QUERY (RFC 10008) from HttpMethods.Query and the bare literal in MapMethods" do
+    search = tester.app.endpoints.find! { |e| e.url == "/search" && e.method == "QUERY" }
+    search.params.map(&.name).should eq(["filter"])
+    search.params.first.param_type.should eq "json"
+
+    tester.app.endpoints.any? { |e| e.url == "/search-legacy" && e.method == "QUERY" }.should be_true
+  end
+
+  it "keeps QUERY alongside another verb in the same MapMethods array" do
+    tester.app.endpoints.count { |e| e.url == "/lookup" }.should eq 2
+    %w[GET QUERY].each do |verb|
+      tester.app.endpoints.any? { |e| e.url == "/lookup" && e.method == verb }.should be_true
+    end
   end
 end

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_modern_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_modern_spec.cr
@@ -38,6 +38,15 @@ banks_update_patch = Endpoint.new("/banks", "PATCH", [Param.new("accountNumber",
 banks_transfer_put = Endpoint.new("/banks/transfer", "PUT", [Param.new("amount", "", "form")])
 banks_transfer_post = Endpoint.new("/banks/transfer", "POST", [Param.new("amount", "", "form")])
 
+# QUERY (RFC 10008) routes through [AcceptVerbs] like any other verb string;
+# the [Route("search")] base arrives on the line after [AcceptVerbs("QUERY")]
+# and is still picked up.
+banks_search_query = Endpoint.new("/banks/search", "QUERY", [Param.new("filters", "", "json")])
+
+# An unattributed parameter on a QUERY action binds from the body, same as
+# it does on PUT/POST/PATCH, not from the URL query string.
+banks_search_implicit = Endpoint.new("/banks/search/implicit", "QUERY", [Param.new("keyword", "", "form")])
+
 # `[FromRoute(Name = "branchId")] string internalBranchKey` binds the route
 # value, so the parameter is `branchId`; `{page=5}` carries a template default
 # that is not part of the URL.
@@ -59,6 +68,8 @@ expected_endpoints = [
   banks_update_patch,
   banks_transfer_put,
   banks_transfer_post,
+  banks_search_query,
+  banks_search_implicit,
   banks_branch,
   banks_page,
   banks_audit,
@@ -93,6 +104,18 @@ describe "ASP.NET Core MVC modern controller edge cases" do
   it "emits one endpoint per verb listed in [AcceptVerbs]" do
     tester.app.endpoints.count { |e| e.url == "/banks" }.should eq 2
     tester.app.endpoints.count { |e| e.url == "/banks/transfer" }.should eq 2
+  end
+
+  it "recognizes QUERY (RFC 10008) in [AcceptVerbs] with its [Route] base and body param" do
+    search = tester.app.endpoints.find! { |e| e.url == "/banks/search" && e.method == "QUERY" }
+    search.params.map(&.name).should eq(["filters"])
+    search.params.first.param_type.should eq "json"
+  end
+
+  it "binds an unattributed QUERY parameter from the body, not the query string" do
+    implicit = tester.app.endpoints.find! { |e| e.url == "/banks/search/implicit" && e.method == "QUERY" }
+    implicit.params.map(&.name).should eq(["keyword"])
+    implicit.params.first.param_type.should eq "form"
   end
 
   it "uses the explicit [From*(Name = ...)] binding name, not the C# identifier" do

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -313,7 +313,10 @@ module Analyzer::CSharp
     # entirely, so such actions fell back to the conventional GET route.
     ACCEPT_VERBS_RE       = /\[AcceptVerbs\s*\(([^\]]*)\)\s*\]/
     ACCEPT_VERBS_ROUTE_RE = /\bRoute\s*=\s*@?"([^"]+)"/
-    ACCEPT_VERB_TOKENS    = %w[GET POST PUT DELETE PATCH HEAD OPTIONS]
+    # ASP.NET Core routing has always accepted an arbitrary method string
+    # through `[AcceptVerbs(...)]`; QUERY (RFC 10008) ships natively as
+    # `HttpMethods.Query` starting with .NET 10.
+    ACCEPT_VERB_TOKENS = %w[GET POST PUT DELETE PATCH HEAD OPTIONS QUERY]
 
     private def collect_accept_verbs(line : String, route_attr : String) : Tuple(Array(String), String)?
       match = ACCEPT_VERBS_RE.match(line)
@@ -445,7 +448,10 @@ module Analyzer::CSharp
 
     private def default_param_type(http_method : String) : String
       case http_method
-      when "POST", "PUT", "PATCH"
+      when "POST", "PUT", "PATCH", "QUERY"
+        # QUERY (RFC 10008) carries its criteria in the request body, same as
+        # POST — an unattributed complex-type parameter binds from there, not
+        # the URL query string.
         "form"
       else
         "query"


### PR DESCRIPTION
## Summary

Closes #2557 (depends on foundation #2540, shipped as #2563).

.NET 10 (LTS) ships native `QUERY` support via `HttpMethods.Query` / `HttpMethods.IsQuery`. ASP.NET Core routing already accepted arbitrary method strings, so the two route surfaces needed different treatment:

- **Minimal APIs / Carter** — `MapMethods("/x", new[] { HttpMethods.Query }, …)` and `MapMethods("/x", ["QUERY"], …)` already worked: `MinimalApiSupport#extract_http_methods` extracts any quoted literal or `HttpMethods.X` identifier generically, with no verb whitelist. Verified against the built binary before touching anything — no analyzer change needed here.
- **MVC controllers** — `[AcceptVerbs("QUERY")]` did *not* work: `ACCEPT_VERB_TOKENS` in `aspnet_core_mvc.cr` is a hand-maintained whitelist that predates RFC 10008, so the verb was silently dropped. Added `QUERY` to that list.
- While fixing that, found and fixed a second gap: `default_param_type` — used when an action parameter has no `[From*]` attribute — only treated POST/PUT/PATCH as body-carrying. An `[AcceptVerbs("QUERY")]` action with an unattributed complex-type parameter would have been misclassified as a `query`-string param instead of a body param. QUERY carries its payload in the body per RFC 10008, same as POST, so it now shares that branch.
- Checked `carter.cr` (reuses the same generic `MinimalApiSupport` extraction — already correct) and `fastendpoints.cr` (its `Http` enum has no `Query` member upstream yet, per `api-ref.fast-endpoints.com` — left untouched, matching the "only wire up what upstream actually ships" convention from the foundation PR).

## Test plan

- [x] Fixture: `MapMethods` with `HttpMethods.Query` (constant), a bare `"QUERY"` literal, and QUERY alongside `GET` in one array (`aspnet_core_minimal_api`)
- [x] Fixture: `[AcceptVerbs("QUERY")]` with an explicit `[FromBody]` param, and with an unattributed param to cover the `default_param_type` fix (`aspnet_core_mvc_modern`)
- [x] `crystal spec spec/functional_test/testers/csharp` — 843 examples, 0 failures
- [x] `crystal spec spec/unit_test spec/functional_test` (isolated `CRYSTAL_CACHE_DIR` to rule out cross-worktree cache contamination in this environment) — 27,513 examples, 0 failures
- [x] `crystal tool format --check` / `ameba` — clean
- [x] Manually verified against a built binary before and after the fix (`[AcceptVerbs("QUERY")]` reported `GET` before, `QUERY` after)