### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Vert.x

### DIFF
--- a/spec/functional_test/fixtures/java/vertx/src/main/java/com/example/MainVerticle.java
+++ b/spec/functional_test/fixtures/java/vertx/src/main/java/com/example/MainVerticle.java
@@ -196,4 +196,11 @@ public class MainVerticle {
     String keyword = ctx.queryParam("keyword");
     ctx.response().end("API search " + keyword);
   }
+
+  // SQL-client calls share the `query` spelling with Router but must not
+  // surface as QUERY routes.
+  private void loadUsers(SqlClient client, Pool pool) {
+    client.query("SELECT * FROM users").execute();
+    pool.query("UPDATE users SET active = true").execute();
+  }
 }

--- a/spec/functional_test/fixtures/java/vertx/src/main/java/com/example/MainVerticle.java
+++ b/spec/functional_test/fixtures/java/vertx/src/main/java/com/example/MainVerticle.java
@@ -45,11 +45,21 @@ public class MainVerticle {
     router.route().method(HttpMethod.GET).path(API_PREFIX + TASKS + "/:taskId").handler(this::getTask);
     router.route().path("/jobs/:jobId").method(HttpMethod.POST).handler(this::createJob);
     router.route(API_PREFIX + "/any/:anyId").handler(this::handleAny);
+
+    // HTTP QUERY routes (RFC 10008)
+    router.query("/search").handler(ctx -> {
+      String q = ctx.queryParam("q");
+      ctx.response().end("Search: " + q);
+    });
+    router.route(HttpMethod.QUERY, "/search/items").handler(this::searchItems);
+    router.route("/advanced-search").method(HttpMethod.QUERY).handler(this::advancedSearch);
+    router.route("/multi-search").method(HttpMethod.GET).method(HttpMethod.QUERY).handler(this::multiSearch);
     
     // Sub-router mounting
     Router apiRouter = Router.router(vertx);
     apiRouter.get("/v1/items").handler(this::getItems);
     apiRouter.post("/v1/items").handler(this::createItem);
+    apiRouter.query("/v1/search").handler(this::apiSearch);
     router.mountSubRouter("/api", apiRouter);
 
     Router adminRouter = Router.router(vertx);
@@ -165,5 +175,25 @@ public class MainVerticle {
   private void handleAny(RoutingContext ctx) {
     String anyId = ctx.request().getParam("anyId");
     ctx.response().end("Any method " + anyId);
+  }
+
+  private void searchItems(RoutingContext ctx) {
+    String filter = ctx.queryParam("filter");
+    ctx.response().end("Items search " + filter);
+  }
+
+  private void advancedSearch(RoutingContext ctx) {
+    String query = ctx.queryParam("query");
+    ctx.response().end("Advanced search " + query);
+  }
+
+  private void multiSearch(RoutingContext ctx) {
+    String term = ctx.queryParam("term");
+    ctx.response().end("Multi search " + term);
+  }
+
+  private void apiSearch(RoutingContext ctx) {
+    String keyword = ctx.queryParam("keyword");
+    ctx.response().end("API search " + keyword);
   }
 }

--- a/spec/functional_test/testers/java/vertx_spec.cr
+++ b/spec/functional_test/testers/java/vertx_spec.cr
@@ -25,6 +25,12 @@ expected_endpoints = [
   Endpoint.new("/api/v1/items", "GET"),
   Endpoint.new("/api/v1/items", "POST"),
   Endpoint.new("/admin/metrics/:metricId", "GET", [Param.new("metricId", "", "path")]),
+  Endpoint.new("/search", "QUERY", [Param.new("q", "", "query")]),
+  Endpoint.new("/search/items", "QUERY", [Param.new("filter", "", "query")]),
+  Endpoint.new("/advanced-search", "QUERY", [Param.new("query", "", "query")]),
+  Endpoint.new("/multi-search", "GET", [Param.new("term", "", "query")]),
+  Endpoint.new("/multi-search", "QUERY", [Param.new("term", "", "query")]),
+  Endpoint.new("/api/v1/search", "QUERY", [Param.new("keyword", "", "query")]),
 ]
 
 FunctionalTester.new("fixtures/java/vertx/", {

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -726,36 +726,56 @@ module Analyzer::Java
       content.scan(/(\w+)\.route\s*\(([^)]*)\)/) do |match|
         router_name = match[1]
         route_arg = match[2].strip
-        start = match.end || 0
+        start = match.byte_end(0)
         statement_end = find_statement_end(content, start)
-        chains << FluentRouteChain.new(router_name, route_arg, content[start...statement_end])
+        chains << FluentRouteChain.new(router_name, route_arg, content.byte_slice(start, statement_end - start))
       end
       chains
     end
 
+    # Byte-wise scan for the `;` that ends a fluent chain's statement.
+    # Every tracked delimiter is ASCII and UTF-8 continuation bytes never
+    # collide with ASCII values, so scanning bytes from `start` is safe for
+    # multibyte content and avoids re-walking the file head per chain.
+    # `start` and the return value are byte offsets.
     private def find_statement_end(content : String, start : Int32) : Int32
+      slice = content.to_slice
       paren_depth = 0
       brace_depth = 0
-      in_string = false
-      quote = '\0'
+      quote = 0_u8
       escape = false
+      idx = start
 
-      content.each_char_with_index do |char, idx|
-        next if idx < start
+      while idx < slice.size
+        byte = slice[idx]
 
-        if in_string
+        if quote != 0_u8
           if escape
             escape = false
-          elsif char == '\\'
+          elsif byte === '\\'
             escape = true
-          elsif char == quote
-            in_string = false
+          elsif byte == quote
+            quote = 0_u8
           end
         else
-          case char
+          case byte.unsafe_chr
           when '"', '\''
-            in_string = true
-            quote = char
+            quote = byte
+          when '/'
+            # Comments may carry unbalanced quotes or braces (`// don't`),
+            # which would otherwise derail the depth tracking.
+            nxt = idx + 1 < slice.size ? slice[idx + 1].unsafe_chr : '\0'
+            if nxt == '/'
+              while idx < slice.size && !(slice[idx] === '\n')
+                idx += 1
+              end
+            elsif nxt == '*'
+              idx += 2
+              until idx + 1 >= slice.size || (slice[idx] === '*' && slice[idx + 1] === '/')
+                idx += 1
+              end
+              idx += 1
+            end
           when '('
             paren_depth += 1
           when ')'
@@ -768,9 +788,11 @@ module Analyzer::Java
             return idx if paren_depth == 0 && brace_depth == 0
           end
         end
+
+        idx += 1
       end
 
-      content.size
+      slice.size
     end
 
     private def fluent_route_paths(chain : String, constants : Hash(String, String)) : Array(String)

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -10,11 +10,11 @@ module Analyzer::Java
     analyzer_for "java_vertx"
 
     # Regex patterns for Vert.x route detection
-    REGEX_ROUTER_ROUTE         = /(\w+)\.(get|post|put|delete|patch|head|options|connect|trace)\s*\(([^)]*)\)/i
-    REGEX_ROUTE_METHOD         = /(\w+)\.route\s*\(([^)]*)\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace)\s*\(/i
+    REGEX_ROUTER_ROUTE         = /(\w+)\.(get|post|put|delete|patch|head|options|connect|trace|query)\s*\(([^)]*)\)/i
+    REGEX_ROUTE_METHOD         = /(\w+)\.route\s*\(([^)]*)\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace|query)\s*\(/i
     REGEX_ROUTE_HTTP_METHOD    = /(\w+)\.route\s*\(([^)]*)\)/i
-    REGEX_ROUTER_ROUTE_HANDLER = /router\.(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.handler\s*\(\s*this::([\w$]+)\s*\)/i
-    REGEX_ROUTE_METHOD_HANDLER = /\.route\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*this::([\w$]+)\s*\)/i
+    REGEX_ROUTER_ROUTE_HANDLER = /router\.(get|post|put|delete|patch|head|options|connect|trace|query)\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.handler\s*\(\s*this::([\w$]+)\s*\)/i
+    REGEX_ROUTE_METHOD_HANDLER = /\.route\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace|query)\s*\(\s*this::([\w$]+)\s*\)/i
     REGEX_ROUTE_ANY_HANDLER    = /(\w+)\.route\s*\(([^)]*)\)\s*\.handler\s*\(\s*this::([\w$]+)\s*\)/i
     # Bare `route(path).handler(...)` — candidate set for lambda/terminal
     # handlers; method-ref form is handled by REGEX_ROUTE_ANY_HANDLER.
@@ -29,7 +29,7 @@ module Analyzer::Java
     # Unambiguous query accessors on RoutingContext (not getParam/pathParam).
     REGEX_QUERY_PARAM      = /\.\s*queryParam\s*\(\s*["']([^"']+)["']\s*\)/
     REGEX_QUERY_PARAMS_GET = /\.\s*queryParams\s*\(\s*\)\s*\.\s*get\s*\(\s*["']([^"']+)["']\s*\)/
-    HTTP_METHODS           = %w[GET POST PUT DELETE PATCH HEAD OPTIONS CONNECT TRACE]
+    HTTP_METHODS           = %w[GET POST PUT DELETE PATCH HEAD OPTIONS CONNECT TRACE QUERY]
     # Response-terminating RoutingContext/response calls used to distinguish
     # real route handlers from pass-through middleware lambdas (`.next()`).
     TERMINAL_HANDLER_MARKERS = [".end(", ".json(", ".redirect(", ".sendFile(", ".fail("]
@@ -40,6 +40,15 @@ module Analyzer::Java
       getter endpoint : String
 
       def initialize(@router_name, @method, @endpoint)
+      end
+    end
+
+    private struct FluentRouteChain
+      getter router_name : String
+      getter route_arg : String
+      getter chain : String
+
+      def initialize(@router_name, @route_arg, @chain)
       end
     end
 
@@ -81,8 +90,8 @@ module Analyzer::Java
                     # Skip if no Vert.x related content
                     next unless content.includes?("Router") || content.includes?("vertx")
 
-                    callees_by_route = include_callee ? extract_method_reference_callees(content, path) : {} of String => Array(Callee)
                     constants = path.ends_with?(".java") ? Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content) : Hash(String, String).new
+                    callees_by_route = include_callee ? extract_method_reference_callees(content, path, constants) : {} of String => Array(Callee)
                     client_names = client_receivers(content)
                     route_candidates = extract_route_candidates(content, constants, client_names)
                     # Only resolve handler bodies when unambiguous query accessors appear.
@@ -249,12 +258,27 @@ module Analyzer::Java
       end
 
       # Find fluent Route API chains like
-      # `router.route().method(HttpMethod.GET).path("/path")`.
-      extract_fluent_route_chains(content).each do |entry|
-        router_name, chain = entry
-        endpoints = fluent_route_paths(chain, constants)
-        methods = fluent_route_methods(chain)
-        next if endpoints.empty? || methods.empty?
+      # `router.route().method(HttpMethod.GET).path("/path")` or
+      # `router.route("/search").method(HttpMethod.QUERY)`.
+      extract_fluent_route_chains(content).each do |chain_info|
+        router_name = chain_info.router_name
+        next if client_names.includes?(router_name)
+
+        methods = fluent_route_methods(chain_info.chain)
+        next if methods.empty?
+
+        endpoints = [] of String
+        unless chain_info.route_arg.empty?
+          args = split_top_level_args(chain_info.route_arg)
+          if args.size == 1
+            if initial_path = resolve_route_path_arg(args[0], constants)
+              endpoints << initial_path unless initial_path.empty?
+            end
+          end
+        end
+        endpoints.concat(fluent_route_paths(chain_info.chain, constants))
+        endpoints.uniq!
+        next if endpoints.empty?
 
         methods.each do |method|
           endpoints.each do |endpoint|
@@ -448,6 +472,44 @@ module Analyzer::Java
 
           params = scan_query_params(body)
           result[route_key("ANY", endpoint)] = params unless params.empty?
+        end
+      end
+
+      extract_fluent_route_chains(content).each do |chain_info|
+        next if client_names.includes?(chain_info.router_name)
+
+        methods = fluent_route_methods(chain_info.chain)
+        next if methods.empty?
+
+        endpoints = [] of String
+        unless chain_info.route_arg.empty?
+          args = split_top_level_args(chain_info.route_arg)
+          if args.size == 1
+            if initial_path = resolve_route_path_arg(args[0], constants)
+              endpoints << initial_path if !initial_path.empty? && vertx_route_path?(initial_path)
+            end
+          end
+        end
+        endpoints.concat(fluent_route_paths(chain_info.chain, constants).select { |p| vertx_route_path?(p) })
+        endpoints.uniq!
+        next if endpoints.empty?
+
+        if handler_match = chain_info.chain.match(/\.\s*handler\s*\(/i)
+          open_idx = (handler_match.end || 1) - 1
+          close_idx = find_matching_paren(chain_info.chain, open_idx)
+          if close_idx
+            handler_arg = chain_info.chain[(open_idx + 1)...close_idx]
+            if body = resolve_handler_arg(handler_arg, method_bodies)
+              params = scan_query_params(body)
+              unless params.empty?
+                methods.each do |method|
+                  endpoints.each do |endpoint|
+                    result[route_key(method, endpoint)] = params
+                  end
+                end
+              end
+            end
+          end
         end
       end
 
@@ -659,14 +721,56 @@ module Analyzer::Java
       nil
     end
 
-    private def extract_fluent_route_chains(content : String) : Array(Tuple(String, String))
-      chains = [] of Tuple(String, String)
-      content.scan(/(\w+)\.route\s*\(\s*\)/) do |match|
+    private def extract_fluent_route_chains(content : String) : Array(FluentRouteChain)
+      chains = [] of FluentRouteChain
+      content.scan(/(\w+)\.route\s*\(([^)]*)\)/) do |match|
+        router_name = match[1]
+        route_arg = match[2].strip
         start = match.end || 0
-        statement_end = content.index(';', start) || content.size
-        chains << {match[1], content[start...statement_end]}
+        statement_end = find_statement_end(content, start)
+        chains << FluentRouteChain.new(router_name, route_arg, content[start...statement_end])
       end
       chains
+    end
+
+    private def find_statement_end(content : String, start : Int32) : Int32
+      paren_depth = 0
+      brace_depth = 0
+      in_string = false
+      quote = '\0'
+      escape = false
+
+      content.each_char_with_index do |char, idx|
+        next if idx < start
+
+        if in_string
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            in_string = false
+          end
+        else
+          case char
+          when '"', '\''
+            in_string = true
+            quote = char
+          when '('
+            paren_depth += 1
+          when ')'
+            paren_depth -= 1 if paren_depth > 0
+          when '{'
+            brace_depth += 1
+          when '}'
+            brace_depth -= 1 if brace_depth > 0
+          when ';'
+            return idx if paren_depth == 0 && brace_depth == 0
+          end
+        end
+      end
+
+      content.size
     end
 
     private def fluent_route_paths(chain : String, constants : Hash(String, String)) : Array(String)
@@ -713,7 +817,7 @@ module Analyzer::Java
       endpoint
     end
 
-    private def extract_method_reference_callees(content : String, path : String) : Hash(String, Array(Callee))
+    private def extract_method_reference_callees(content : String, path : String, constants : Hash(String, String)) : Hash(String, Array(Callee))
       handlers_by_route = {} of String => String
 
       content.scan(REGEX_ROUTER_ROUTE_HANDLER) do |match|
@@ -734,6 +838,47 @@ module Analyzer::Java
         next if endpoint.empty? || handler_name.empty?
 
         handlers_by_route[route_key(method, endpoint)] = handler_name
+      end
+
+      content.scan(/(\w+)\.route\s*\(([^)]*)\)\s*\.handler\s*\(\s*this::([\w$]+)\s*\)/i) do |match|
+        next if match.size < 4
+        args = split_top_level_args(match[2])
+        next unless args.size >= 2
+
+        method = resolve_http_method_arg(args[0])
+        endpoint = resolve_route_path_arg(args[1], constants)
+        handler_name = match[3]
+        next if method.nil? || !method.in?(HTTP_METHODS)
+        next if endpoint.nil? || endpoint.empty? || handler_name.empty?
+
+        handlers_by_route[route_key(method, endpoint)] = handler_name
+      end
+
+      extract_fluent_route_chains(content).each do |chain_info|
+        methods = fluent_route_methods(chain_info.chain)
+        next if methods.empty?
+
+        endpoints = [] of String
+        unless chain_info.route_arg.empty?
+          args = split_top_level_args(chain_info.route_arg)
+          if args.size == 1
+            if initial_path = resolve_route_path_arg(args[0], constants)
+              endpoints << initial_path unless initial_path.empty?
+            end
+          end
+        end
+        endpoints.concat(fluent_route_paths(chain_info.chain, constants))
+        endpoints.uniq!
+        next if endpoints.empty?
+
+        if m = chain_info.chain.match(/\.\s*handler\s*\(\s*this::([\w$]+)\s*\)/i)
+          handler_name = m[1]
+          methods.each do |method|
+            endpoints.each do |endpoint|
+              handlers_by_route[route_key(method, endpoint)] = handler_name
+            end
+          end
+        end
       end
 
       return {} of String => Array(Callee) if handlers_by_route.empty?


### PR DESCRIPTION
## Summary
Adds support for detecting HTTP `QUERY` (RFC 10008) routes in the Java Vert.x analyzer (`Analyzer::Java::Vertx`).

## Changes
- **`src/analyzer/analyzers/java/vertx.cr`**:
  - Added `QUERY` to `HTTP_METHODS`.
  - Updated `REGEX_ROUTER_ROUTE`, `REGEX_ROUTE_METHOD`, `REGEX_ROUTER_ROUTE_HANDLER`, and `REGEX_ROUTE_METHOD_HANDLER` to include `query`.
  - Enhanced fluent route chain parsing (`extract_fluent_route_chains`) with statement-end tracking and `FluentRouteChain` to support:
    - `router.query("/search")` shorthand
    - `router.route(HttpMethod.QUERY, "/search")`
    - `router.route("/search").method(HttpMethod.QUERY)`
    - `router.route("/search").method(HttpMethod.GET).method(HttpMethod.QUERY)` (multi-`.method()` chains)
    - `router.route().path("/search").method(HttpMethod.QUERY)`
  - Added query param extraction and callee resolution for fluent route chains and `route(HttpMethod, path)`.
- **`spec/functional_test/fixtures/java/vertx/src/main/java/com/example/MainVerticle.java`**:
  - Added fixture endpoints covering all four `QUERY` route shapes as well as sub-router mounting (`apiRouter.query(...)`).
- **`spec/functional_test/testers/java/vertx_spec.cr`**:
  - Added expected endpoints for `QUERY` routes with query parameters.

## Verification
- `just build`: Successful compilation (`shards build`)
- `just check`: 0 formatting or linting failures (`crystal tool format --check` + `ameba` on 2,139 files)
- `crystal spec spec/unit_test`: 4,778 examples, 0 failures
- `crystal spec spec/functional_test/testers/java/vertx_spec.cr`: 102 examples, 0 failures
- `crystal spec spec/functional_test/testers/java/vertx_callees_spec.cr`: 24 examples, 0 failures
- `./bin/noir -b spec/functional_test/fixtures/java/vertx`: 30 endpoints correctly detected

Closes #2554