### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Laravel

### DIFF
--- a/spec/functional_test/fixtures/php/laravel/routes/web.php
+++ b/spec/functional_test/fixtures/php/laravel/routes/web.php
@@ -45,10 +45,31 @@ Route::group(['prefix' => 'admin'], function () {
     Route::post('/settings', function () {
         return redirect('/admin/settings');
     });
+    Route::query('/logs', function () {
+        return response()->json(['logs' => []]);
+    });
 });
 
 Route::match(['get', 'post'], '/contact', function () {
     return view('contact');
+});
+
+Route::match(['get', 'query'], '/filter', function () {
+    return view('contact');
+});
+
+Route::query('/search', [ProductController::class, 'index']);
+
+Route::addRoute('QUERY', '/advanced-search', function () {
+    return response()->json(['status' => 'ok']);
+});
+
+Route::query('/search-chained', function () {
+    return response()->json(['status' => 'ok']);
+})->middleware('auth');
+
+Route::middleware('auth')->query('/secure-search', function () {
+    return response()->json(['status' => 'ok']);
 });
 
 Route::any('/webhook', function () {
@@ -60,6 +81,9 @@ Route::middleware('auth:sanctum')->get('/me', [UserController::class, 'me']);
 Route::middleware(['auth'])->prefix('api/v1')->group(function () {
     Route::get('/profile', [UserController::class, 'profile']);
     Route::post('/profile', [UserController::class, 'updateProfile']);
+    Route::query('/query-items', function () {
+        return response()->json(['items' => []]);
+    });
     Route::apiResource('tokens', ProductController::class);
 
     Route::prefix('reports')->group(function () {

--- a/spec/functional_test/testers/php/laravel_spec.cr
+++ b/spec/functional_test/testers/php/laravel_spec.cr
@@ -19,6 +19,12 @@ expected_endpoints = [
   Endpoint.new("/v1.0/albums/{record}/songs/{track}", "GET", [Param.new("record", "", "path"), Param.new("track", "", "path")]),
   Endpoint.new("/contact", "GET"),
   Endpoint.new("/contact", "POST"),
+  Endpoint.new("/filter", "GET"),
+  Endpoint.new("/filter", "QUERY"),
+  Endpoint.new("/search", "QUERY"),
+  Endpoint.new("/advanced-search", "QUERY"),
+  Endpoint.new("/search-chained", "QUERY"),
+  Endpoint.new("/secure-search", "QUERY"),
   Endpoint.new("/webhook", "GET"),
   Endpoint.new("/webhook", "POST"),
   Endpoint.new("/products", "GET"),
@@ -31,9 +37,11 @@ expected_endpoints = [
   Endpoint.new("/user", "GET"),
   Endpoint.new("/admin/settings", "GET"),
   Endpoint.new("/admin/settings", "POST"),
+  Endpoint.new("/admin/logs", "QUERY"),
   Endpoint.new("/me", "GET"),
   Endpoint.new("/api/v1/profile", "GET"),
   Endpoint.new("/api/v1/profile", "POST"),
+  Endpoint.new("/api/v1/query-items", "QUERY"),
   Endpoint.new("/api/v1/tokens", "GET"),
   Endpoint.new("/api/v1/tokens/{token}", "DELETE", [Param.new("token", "", "path")]),
   Endpoint.new("/api/v1/reports/daily", "GET"),
@@ -46,5 +54,5 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/laravel/", {
   :techs     => 2,  # Detection still sees both php_laravel and php_pure
-  :endpoints => 70, # Analysis suppresses redundant php_pure and unprefixed group endpoints
+  :endpoints => 78, # Analysis suppresses redundant php_pure and unprefixed group endpoints
 }, expected_endpoints).perform_tests

--- a/spec/unit_test/analyzer/analyzer_laravel_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_laravel_spec.cr
@@ -1,0 +1,254 @@
+require "file_utils"
+require "../../spec_helper"
+require "../../../src/models/code_locator"
+require "../../../src/analyzer/analyzers/php/laravel"
+
+describe Analyzer::Php::Laravel do
+  options = create_test_options
+  analyzer = Analyzer::Php::Laravel.new(options)
+
+  describe "HTTP QUERY and Route methods" do
+    it "detects Route::query routes" do
+      temp_dir = File.tempname("laravel_test")
+      routes_dir = File.join(temp_dir, "routes")
+      Dir.mkdir_p(routes_dir)
+      temp_file = File.join(routes_dir, "web.php")
+
+      File.write(temp_file, <<-'PHP')
+        <?php
+        use Illuminate\Support\Facades\Route;
+
+        Route::query('/search', [SearchController::class, 'index']);
+        Route::query('/items/{id}/details', function ($id) {
+            return response()->json(['id' => $id]);
+        });
+        PHP
+
+      endpoints = analyzer.analyze_file(temp_file)
+      endpoints.size.should eq(2)
+
+      ep1 = endpoints.find { |e| e.url == "/search" }
+      ep1.should_not be_nil
+      if ep1
+        ep1.method.should eq("QUERY")
+        ep1.params.should be_empty
+      end
+
+      ep2 = endpoints.find { |e| e.url == "/items/{id}/details" }
+      ep2.should_not be_nil
+      if ep2
+        ep2.method.should eq("QUERY")
+        ep2.params.size.should eq(1)
+        ep2.params[0].name.should eq("id")
+        ep2.params[0].param_type.should eq("path")
+      end
+
+      File.delete(temp_file)
+      Dir.delete(routes_dir)
+      Dir.delete(temp_dir)
+    end
+
+    it "detects Route::match with QUERY in array" do
+      temp_dir = File.tempname("laravel_test")
+      routes_dir = File.join(temp_dir, "routes")
+      Dir.mkdir_p(routes_dir)
+      temp_file = File.join(routes_dir, "web.php")
+
+      File.write(temp_file, <<-'PHP')
+        <?php
+        use Illuminate\Support\Facades\Route;
+
+        Route::match(['get', 'query'], '/filter', function () {
+            return response()->json([]);
+        });
+        PHP
+
+      endpoints = analyzer.analyze_file(temp_file)
+      endpoints.size.should eq(2)
+      methods = endpoints.map(&.method).sort!
+      methods.should eq(["GET", "QUERY"])
+      endpoints.all? { |e| e.url == "/filter" }.should be_true
+
+      File.delete(temp_file)
+      Dir.delete(routes_dir)
+      Dir.delete(temp_dir)
+    end
+
+    it "detects Route::addRoute with QUERY as string or array" do
+      temp_dir = File.tempname("laravel_test")
+      routes_dir = File.join(temp_dir, "routes")
+      Dir.mkdir_p(routes_dir)
+      temp_file = File.join(routes_dir, "web.php")
+
+      File.write(temp_file, <<-'PHP')
+        <?php
+        use Illuminate\Support\Facades\Route;
+
+        Route::addRoute('QUERY', '/advanced-search', function () {
+            return response()->json([]);
+        });
+        Route::addRoute(['GET', 'QUERY'], '/multi-search', function () {
+            return response()->json([]);
+        });
+        PHP
+
+      endpoints = analyzer.analyze_file(temp_file)
+      endpoints.size.should eq(3)
+
+      adv = endpoints.find { |e| e.url == "/advanced-search" }
+      adv.should_not be_nil
+      adv.try(&.method).should eq("QUERY")
+
+      multi = endpoints.select { |e| e.url == "/multi-search" }
+      multi.size.should eq(2)
+      multi.map(&.method).sort!.should eq(["GET", "QUERY"])
+
+      File.delete(temp_file)
+      Dir.delete(routes_dir)
+      Dir.delete(temp_dir)
+    end
+
+    it "detects chained Route::query and chained Route::addRoute" do
+      temp_dir = File.tempname("laravel_test")
+      routes_dir = File.join(temp_dir, "routes")
+      Dir.mkdir_p(routes_dir)
+      temp_file = File.join(routes_dir, "web.php")
+
+      File.write(temp_file, <<-'PHP')
+        <?php
+        use Illuminate\Support\Facades\Route;
+
+        Route::middleware('auth')->query('/secure-search', function () {
+            return response()->json([]);
+        });
+        Route::query('/search-chained', function () {
+            return response()->json([]);
+        })->middleware('auth');
+        Route::prefix('v1')->middleware('auth')->addRoute('QUERY', '/v1-search', function () {
+            return response()->json([]);
+        });
+        PHP
+
+      endpoints = analyzer.analyze_file(temp_file)
+      endpoints.size.should eq(3)
+
+      ep1 = endpoints.find { |e| e.url == "/secure-search" }
+      ep1.should_not be_nil
+      ep1.try(&.method).should eq("QUERY")
+
+      ep2 = endpoints.find { |e| e.url == "/search-chained" }
+      ep2.should_not be_nil
+      ep2.try(&.method).should eq("QUERY")
+
+      ep3 = endpoints.find { |e| e.url == "/v1/v1-search" }
+      ep3.should_not be_nil
+      ep3.try(&.method).should eq("QUERY")
+
+      File.delete(temp_file)
+      Dir.delete(routes_dir)
+      Dir.delete(temp_dir)
+    end
+
+    it "detects Route::query inside route groups" do
+      temp_dir = File.tempname("laravel_test")
+      routes_dir = File.join(temp_dir, "routes")
+      Dir.mkdir_p(routes_dir)
+      temp_file = File.join(routes_dir, "web.php")
+
+      File.write(temp_file, <<-'PHP')
+        <?php
+        use Illuminate\Support\Facades\Route;
+
+        Route::prefix('api/v2')->group(function () {
+            Route::query('/products', function () {
+                return response()->json([]);
+            });
+            Route::match(['get', 'query'], '/categories', function () {
+                return response()->json([]);
+            });
+        });
+        PHP
+
+      endpoints = analyzer.analyze_file(temp_file)
+      endpoints.size.should eq(3)
+
+      ep1 = endpoints.find { |e| e.url == "/api/v2/products" }
+      ep1.should_not be_nil
+      ep1.try(&.method).should eq("QUERY")
+
+      cats = endpoints.select { |e| e.url == "/api/v2/categories" }
+      cats.size.should eq(2)
+      cats.map(&.method).sort!.should eq(["GET", "QUERY"])
+
+      File.delete(temp_file)
+      Dir.delete(routes_dir)
+      Dir.delete(temp_dir)
+    end
+
+    it "does not include QUERY in Route::any fan-out" do
+      temp_dir = File.tempname("laravel_test")
+      routes_dir = File.join(temp_dir, "routes")
+      Dir.mkdir_p(routes_dir)
+      temp_file = File.join(routes_dir, "web.php")
+
+      File.write(temp_file, <<-'PHP')
+        <?php
+        use Illuminate\Support\Facades\Route;
+
+        Route::any('/wildcard', function () {
+            return response()->json([]);
+        });
+        PHP
+
+      endpoints = analyzer.analyze_file(temp_file)
+      methods = endpoints.map(&.method)
+      methods.should_not contain("QUERY")
+      methods.sort!.should eq(["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"])
+
+      File.delete(temp_file)
+      Dir.delete(routes_dir)
+      Dir.delete(temp_dir)
+    end
+
+    it "detects controller methods with #[Route] attribute using QUERY" do
+      temp_dir = File.tempname("laravel_test")
+      controller_dir = File.join(temp_dir, "app", "Http", "Controllers")
+      Dir.mkdir_p(controller_dir)
+      temp_file = File.join(controller_dir, "SearchController.php")
+
+      File.write(temp_file, <<-'PHP')
+        <?php
+        namespace App\Http\Controllers;
+
+        class SearchController
+        {
+            #[Route('/search/attr-array', methods: ['QUERY'])]
+            public function searchArray()
+            {
+                return response()->json([]);
+            }
+
+            #[Route('/search/attr-string', methods: 'QUERY')]
+            public function searchString()
+            {
+                return response()->json([]);
+            }
+        }
+        PHP
+
+      endpoints = analyzer.analyze_file(temp_file)
+      endpoints.size.should eq(2)
+
+      ep1 = endpoints.find { |e| e.url == "/search/attr-array" }
+      ep1.should_not be_nil
+      ep1.try(&.method).should eq("QUERY")
+
+      ep2 = endpoints.find { |e| e.url == "/search/attr-string" }
+      ep2.should_not be_nil
+      ep2.try(&.method).should eq("QUERY")
+
+      File.delete(temp_file)
+      FileUtils.rm_rf(temp_dir)
+    end
+  end
+end

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -111,7 +111,7 @@ module Analyzer::Php
 
       # Look for Laravel Route attributes on controller methods
       # e.g., #[Route('/users', methods: ['GET'])]
-      method_matches = content.scan(/#\[Route\s*\(([^]]*)\]\s*public\s+function\s+(\w+)/m)
+      method_matches = content.scan(/#\[Route\s*\((.*?)\)\]\s*(?:public\s+)?function\s+(\w+)/m)
       method_matches.each do |match|
         attribute_content = match[1] # This is the content of the attribute
 
@@ -148,15 +148,18 @@ module Analyzer::Php
 
     # `Route::get('/x', …)` and friends: the verb is capture 1, the path
     # capture 2.
-    VERB_REGEX = /Route::(get|post|put|patch|delete|options|head)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
+    VERB_REGEX = /Route::(get|post|put|patch|delete|options|head|query)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
     # The same, behind a fluent prelude — `Route::middleware('auth')->prefix('v1')->get('/x', …)`.
     # Capture 1 is the whole prelude (a `->`-separated chain of calls; the
     # inner `[^;]*?` keeps each call's argument list inside one statement),
     # capture 2 the verb, capture 3 the path.
-    CHAINED_VERB_REGEX = /Route::((?:\w+\s*\([^;]*?\)\s*->\s*)+)(get|post|put|patch|delete|options|head)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
-    # `Route::match(['get', 'post'], '/x', …)`: capture 1 is the verb array
-    # literal, capture 2 the path.
-    MATCH_REGEX = /Route::match\s*\(\s*\[([^\]]+)\]\s*,\s*['"]([^'"]+)['"]\s*,/mi
+    CHAINED_VERB_REGEX = /Route::((?:\w+\s*\([^;]*?\)\s*->\s*)+)(get|post|put|patch|delete|options|head|query)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
+    # `Route::match(['get', 'post'], '/x', …)` or `Route::addRoute('QUERY', '/x', …)`:
+    # capture 1 is the verb specification (array literal or string literal), capture 2 the path.
+    MATCH_REGEX = /Route::(?:match|addRoute)\s*\(\s*(\[[^\]]+\]|['"][^'"]+['"])\s*,\s*['"]([^'"]+)['"]\s*,/mi
+    # The match/addRoute routes behind a fluent prelude. Capture 1 is the prelude,
+    # capture 2 the verb specification, capture 3 the path.
+    CHAINED_MATCH_REGEX = /Route::((?:\w+\s*\([^;]*?\)\s*->\s*)+)(?:match|addRoute)\s*\(\s*(\[[^\]]+\]|['"][^'"]+['"])\s*,\s*['"]([^'"]+)['"]\s*,/mi
     # `Route::any('/x', …)`: capture 1 is the path; the verbs are implied.
     ANY_REGEX = /Route::any\s*\(\s*['"]([^'"]+)['"]\s*,/mi
     # `Route::view` / `redirect` / `permanentRedirect`: capture 1 is the verb
@@ -170,7 +173,7 @@ module Analyzer::Php
     # Any `Route::…('path', …` registration, whatever verb or chain precedes
     # it. Used only to locate handler-closure bodies up front; the six scans
     # above are what actually decide which registrations become endpoints.
-    ROUTE_REGISTRATION_RE = /Route::(?:\w+\s*\([^;]*?\)\s*->\s*)*\w+\s*\(\s*(?:\[[^\]]*\]\s*,\s*)?['"][^'"]*['"]\s*,/mi
+    ROUTE_REGISTRATION_RE = /Route::(?:\w+\s*\([^;]*?\)\s*->\s*)*\w+\s*\(\s*(?:(?:\[[^\]]*\]|['"][^'"]*['"])\s*,\s*)?['"][^'"]*['"]\s*,/mi
 
     # Methods a single `Route::any` registration stands for.
     ANY_ROUTE_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
@@ -217,10 +220,16 @@ module Analyzer::Php
         emit_handler_route(endpoints, ctx, route_match, [verb.upcase], chained_full_path(prefix, chain, route_path))
       end
 
-      # Route::match(['get', 'post'], ...) — the verbs come from the array literal.
+      # Route::match(['get', 'post'], ...) / Route::addRoute('QUERY', ...) — the verbs come from the array or string literal.
       each_laravel_route(ctx, MATCH_REGEX) do |route_match|
         verb_array, route_path = route_match[1], route_match[2]
         emit_handler_route(endpoints, ctx, route_match, extract_methods_from_array(verb_array), build_full_path(prefix, route_path))
+      end
+
+      # Chained Route::match / Route::addRoute
+      each_laravel_route(ctx, CHAINED_MATCH_REGEX) do |route_match|
+        chain, verb_array, route_path = route_match[1], route_match[2], route_match[3]
+        emit_handler_route(endpoints, ctx, route_match, extract_methods_from_array(verb_array), chained_full_path(prefix, chain, route_path))
       end
 
       # Route::any(...) — one registration standing for every verb.


### PR DESCRIPTION
## Description
Resolves #2550

This PR adds detection for the HTTP `QUERY` route method in the Laravel analyzer (`src/analyzer/analyzers/php/laravel.cr`), following upstream Laravel PR [laravel/framework#60655](https://github.com/laravel/framework/pull/60655).

### Changes
1. **Laravel Verb Regexes**:
   - Added `query` to `VERB_REGEX` and `CHAINED_VERB_REGEX` to support `Route::query('/search', ...)` and chained forms like `Route::middleware(...)->query(...)`.
2. **Match and AddRoute Support**:
   - Updated `MATCH_REGEX` and added `CHAINED_MATCH_REGEX` to match both `Route::match` and `Route::addRoute` accepting array literals (`['GET', 'QUERY']`) or string literals (`'QUERY'`).
3. **Route Registration Delimiter**:
   - Updated `ROUTE_REGISTRATION_RE` to properly skip string and array method arguments during handler closure body segmentation.
4. **Controller Attribute Parsing**:
   - Fixed `#[Route(...)]` attribute regex to support nested brackets in method specifications (e.g. `#[Route('/search', methods: ['QUERY'])]`).
5. **RFC 10008 Compliance**:
   - Kept `ANY_ROUTE_METHODS` unchanged (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, `HEAD`) without `QUERY` per RFC 10008 & foundation #2540.
6. **Tests**:
   - Added functional test fixtures and expected endpoints in `spec/functional_test/fixtures/php/laravel/routes/web.php` and `spec/functional_test/testers/php/laravel_spec.cr`.
   - Added comprehensive unit tests in `spec/unit_test/analyzer/analyzer_laravel_spec.cr`.

### Verification
- `just build`: Successful
- `just test`: 22,729 examples, 0 failures
- `crystal tool format --check`: Clean
- Ameba lint: Clean (0 failures)
- Verified binary against Crystal and Laravel fixtures.