### PR TITLE
feat(analyzer): resolve custom @HttpMethod verbs (QUERY) in JAX-RS / Quarkus / Dropwizard

### DIFF
--- a/spec/functional_test/fixtures/java/dropwizard_custom_verb/src/main/java/com/example/HelloApplication.java
+++ b/spec/functional_test/fixtures/java/dropwizard_custom_verb/src/main/java/com/example/HelloApplication.java
@@ -1,0 +1,20 @@
+package com.example;
+
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+public class HelloApplication extends Application<HelloConfiguration> {
+    public static void main(String[] args) throws Exception {
+        new HelloApplication().run(args);
+    }
+
+    @Override
+    public void initialize(Bootstrap<HelloConfiguration> bootstrap) {
+    }
+
+    @Override
+    public void run(HelloConfiguration configuration, Environment environment) {
+        environment.jersey().register(new com.example.api.SearchResource());
+    }
+}

--- a/spec/functional_test/fixtures/java/dropwizard_custom_verb/src/main/java/com/example/annotation/QUERY.java
+++ b/spec/functional_test/fixtures/java/dropwizard_custom_verb/src/main/java/com/example/annotation/QUERY.java
@@ -1,0 +1,15 @@
+package com.example.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import jakarta.ws.rs.HttpMethod;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@HttpMethod("QUERY")
+public @interface QUERY {
+}

--- a/spec/functional_test/fixtures/java/dropwizard_custom_verb/src/main/java/com/example/api/FilterDto.java
+++ b/spec/functional_test/fixtures/java/dropwizard_custom_verb/src/main/java/com/example/api/FilterDto.java
@@ -1,0 +1,6 @@
+package com.example.api;
+
+public class FilterDto {
+    public String query;
+    public int limit;
+}

--- a/spec/functional_test/fixtures/java/dropwizard_custom_verb/src/main/java/com/example/api/SearchResource.java
+++ b/spec/functional_test/fixtures/java/dropwizard_custom_verb/src/main/java/com/example/api/SearchResource.java
@@ -1,0 +1,20 @@
+package com.example.api;
+
+import com.example.annotation.QUERY;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("/search")
+public class SearchResource {
+    @QUERY
+    public Response search(FilterDto filters) {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/status")
+    public Response status() {
+        return Response.ok().build();
+    }
+}

--- a/spec/functional_test/fixtures/java/jaxrs_custom_verb/src/main/java/com/example/annotation/QUERY.java
+++ b/spec/functional_test/fixtures/java/jaxrs_custom_verb/src/main/java/com/example/annotation/QUERY.java
@@ -1,0 +1,15 @@
+package com.example.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import jakarta.ws.rs.HttpMethod;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@HttpMethod("QUERY")
+public @interface QUERY {
+}

--- a/spec/functional_test/fixtures/java/jaxrs_custom_verb/src/main/java/com/example/api/FilterDto.java
+++ b/spec/functional_test/fixtures/java/jaxrs_custom_verb/src/main/java/com/example/api/FilterDto.java
@@ -1,0 +1,6 @@
+package com.example.api;
+
+public class FilterDto {
+    public String query;
+    public int limit;
+}

--- a/spec/functional_test/fixtures/java/jaxrs_custom_verb/src/main/java/com/example/api/SearchResource.java
+++ b/spec/functional_test/fixtures/java/jaxrs_custom_verb/src/main/java/com/example/api/SearchResource.java
@@ -1,0 +1,20 @@
+package com.example.api;
+
+import com.example.annotation.QUERY;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("/search")
+public class SearchResource {
+    @QUERY
+    public Response search(FilterDto filters) {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/status")
+    public Response status() {
+        return Response.ok().build();
+    }
+}

--- a/spec/functional_test/testers/java/dropwizard_custom_verb_spec.cr
+++ b/spec/functional_test/testers/java/dropwizard_custom_verb_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+# Regression test for #2556: a project-defined `@HttpMethod("QUERY")`
+# annotation (declared in its own file, JAX-RS's general custom-verb
+# mechanism) must resolve to verb QUERY on Dropwizard too — it shares
+# `TreeSitterJaxRsExtractor` with `java_jaxrs` / `java_quarkus` — while
+# built-in `@GET` handling stays unaffected.
+expected_endpoints = [
+  Endpoint.new("/search", "QUERY", [
+    Param.new("query", "", "json"),
+    Param.new("limit", "", "json"),
+  ]),
+  Endpoint.new("/search/status", "GET"),
+]
+
+FunctionalTester.new("fixtures/java/dropwizard_custom_verb/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/java/jaxrs_custom_verb_spec.cr
+++ b/spec/functional_test/testers/java/jaxrs_custom_verb_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+# Regression test for #2556: a project-defined `@HttpMethod("QUERY")`
+# annotation (declared in its own file, JAX-RS's general custom-verb
+# mechanism) must resolve to verb QUERY when applied to a resource
+# method in another file, while built-in `@GET` handling stays
+# unaffected.
+expected_endpoints = [
+  Endpoint.new("/search", "QUERY", [
+    Param.new("query", "", "json"),
+    Param.new("limit", "", "json"),
+  ]),
+  Endpoint.new("/search/status", "GET"),
+]
+
+FunctionalTester.new("fixtures/java/jaxrs_custom_verb/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/jaxrs_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/jaxrs_extractor_ts_spec.cr
@@ -364,4 +364,102 @@ describe Noir::TreeSitterJaxRsExtractor do
       {"GET", "/ws/chat/{roomId}", "ws"},
     ])
   end
+
+  it "resolves user-defined @HttpMethod annotations to their declared verb" do
+    source = <<-JAVA
+      package com.example.annotation;
+
+      import java.lang.annotation.ElementType;
+      import java.lang.annotation.Retention;
+      import java.lang.annotation.RetentionPolicy;
+      import java.lang.annotation.Target;
+      import jakarta.ws.rs.HttpMethod;
+
+      @Target(ElementType.METHOD)
+      @Retention(RetentionPolicy.RUNTIME)
+      @HttpMethod("QUERY")
+      public @interface QUERY {
+      }
+
+      @Target(ElementType.METHOD)
+      @Retention(RetentionPolicy.RUNTIME)
+      @HttpMethod("propfind")
+      public @interface PROPFIND {
+      }
+
+      @Target(ElementType.METHOD)
+      @Retention(RetentionPolicy.RUNTIME)
+      public @interface NotAVerb {
+      }
+      JAVA
+
+    Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations(source).should eq({
+      "QUERY"    => "QUERY",
+      "PROPFIND" => "PROPFIND",
+    })
+  end
+
+  it "never lets a custom @HttpMethod annotation shadow a built-in verb name" do
+    source = <<-JAVA
+      package com.example.annotation;
+
+      import jakarta.ws.rs.HttpMethod;
+
+      @HttpMethod("POST")
+      public @interface GET {
+      }
+      JAVA
+
+    Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations(source).should eq({} of String => String)
+  end
+
+  it "applies a resolved custom verb to a resource method alongside body params, leaving built-ins untouched" do
+    annotation_source = <<-JAVA
+      package com.example.annotation;
+
+      import java.lang.annotation.ElementType;
+      import java.lang.annotation.Retention;
+      import java.lang.annotation.RetentionPolicy;
+      import java.lang.annotation.Target;
+      import jakarta.ws.rs.HttpMethod;
+
+      @Target(ElementType.METHOD)
+      @Retention(RetentionPolicy.RUNTIME)
+      @HttpMethod("QUERY")
+      public @interface QUERY {
+      }
+      JAVA
+
+    source = <<-JAVA
+      package com.example.api;
+
+      import com.example.annotation.QUERY;
+      import jakarta.ws.rs.GET;
+      import jakarta.ws.rs.Path;
+      import jakarta.ws.rs.core.Response;
+
+      @Path("/search")
+      public class SearchResource {
+          @QUERY
+          public Response search(FilterDto filters) {
+              return Response.ok().build();
+          }
+
+          @GET
+          @Path("/status")
+          public Response status() {
+              return Response.ok().build();
+          }
+      }
+      JAVA
+
+    custom_verb_annotations = Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations(annotation_source)
+    routes = Noir::TreeSitterJaxRsExtractor.extract_routes(source, custom_verb_annotations: custom_verb_annotations)
+    routes.map { |r| {r.verb, r.path, r.params} }.should eq([
+      {"QUERY", "/search", [
+        Param.new("filters", "FilterDto", "json"),
+      ]},
+      {"GET", "/search/status", [] of Param},
+    ])
+  end
 end

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -45,6 +45,7 @@ module Analyzer::Java
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
       source_cache = Hash(String, String).new
+      custom_verb_cache = Hash(String, Hash(String, String)).new
 
       file_list = all_files()
       path_configs = path_configs_for(file_list)
@@ -80,9 +81,12 @@ module Analyzer::Java
             Noir::TreeSitterJaxRsExtractor.extract_bean_fields_from(root, content))
           subresource_sources = subresource_sources_for(path, content, package_name, source_cache, imports,
             Noir::TreeSitterJaxRsExtractor.extract_class_names_from(root, content))
+          custom_verb_annotations = custom_verb_index_for(path, content, package_name, custom_verb_cache, imports,
+            Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations_from(root, content))
           base_path = path_config.base_path
 
-          Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources, include_callees: include_callee).each do |route|
+          Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources,
+            custom_verb_annotations: custom_verb_annotations, include_callees: include_callee).each do |route|
             line = route.line + 1
             details = Details.new(PathInfo.new(route.file_path || path, line))
             endpoint = Endpoint.new(Noir::URLPath.join_trimmed(base_path, route.path), route.verb, route.params, details)
@@ -216,6 +220,43 @@ module Analyzer::Java
         end
 
         beans.each { |name, params| result[name] ||= params }
+      end
+
+      result
+    end
+
+    # Build the cross-file `@HttpMethod("VERB")` custom-annotation
+    # index for `path`. Same traversal as `bean_index_for` — the
+    # annotation type is typically declared in its own file, so this
+    # needs the same current file + same-package siblings + imports
+    # walk, gated on the file mentioning JAX-RS so unrelated `.java`
+    # files aren't parsed for annotation declarations.
+    private def custom_verb_index_for(path : String,
+                                      content : String,
+                                      package_name : String,
+                                      cache : Hash(String, Hash(String, String)),
+                                      imports : Array(Noir::ImportGraph::ImportRef)? = nil,
+                                      current_file_verbs : Hash(String, String)? = nil) : Hash(String, String)
+      result = Hash(String, String).new
+      resolved_imports = imports || Noir::TreeSitterJavaParameterExtractor.extract_imports(content)
+
+      Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
+        verbs = cache[file] ||= begin
+          if file == path && current_file_verbs
+            current_file_verbs
+          else
+            body = file == path ? content : read_file_content(file)
+            if body.includes?("jakarta.ws.rs") || body.includes?("javax.ws.rs")
+              Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations(body)
+            else
+              Hash(String, String).new
+            end
+          end
+        rescue IO::Error
+          Hash(String, String).new
+        end
+
+        verbs.each { |name, verb| result[name] ||= verb }
       end
 
       result

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -25,6 +25,7 @@ module Analyzer::Java
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
       source_cache = Hash(String, String).new
+      custom_verb_cache = Hash(String, Hash(String, String)).new
 
       file_list = all_files()
       application_base_paths = application_base_paths_for(file_list)
@@ -57,9 +58,12 @@ module Analyzer::Java
             Noir::TreeSitterJaxRsExtractor.extract_bean_fields_from(root, content))
           subresource_sources = subresource_sources_for(path, content, package_name, source_cache, imports,
             Noir::TreeSitterJaxRsExtractor.extract_class_names_from(root, content))
+          custom_verb_annotations = custom_verb_index_for(path, content, package_name, custom_verb_cache, imports,
+            Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations_from(root, content))
           application_base_path = application_base_path_for(path, package_name, application_base_paths)
 
-          Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources, include_callees: include_callee).each do |route|
+          Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources,
+            custom_verb_annotations: custom_verb_annotations, include_callees: include_callee).each do |route|
             line = route.line + 1
             details = Details.new(PathInfo.new(route.file_path || path, line))
             endpoint_path = route.protocol == "ws" ? route.path : Noir::URLPath.join_trimmed(application_base_path, route.path)
@@ -371,6 +375,43 @@ module Analyzer::Java
         end
 
         beans.each { |name, params| result[name] ||= params }
+      end
+
+      result
+    end
+
+    # Build the cross-file `@HttpMethod("VERB")` custom-annotation
+    # index for `path`. Same traversal as `bean_index_for` — the
+    # annotation type is typically declared in its own file, so this
+    # needs the same current file + same-package siblings + imports
+    # walk, gated on the file mentioning JAX-RS so unrelated `.java`
+    # files aren't parsed for annotation declarations.
+    private def custom_verb_index_for(path : String,
+                                      content : String,
+                                      package_name : String,
+                                      cache : Hash(String, Hash(String, String)),
+                                      imports : Array(Noir::ImportGraph::ImportRef)? = nil,
+                                      current_file_verbs : Hash(String, String)? = nil) : Hash(String, String)
+      result = Hash(String, String).new
+      resolved_imports = imports || Noir::TreeSitterJavaParameterExtractor.extract_imports(content)
+
+      Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
+        verbs = cache[file] ||= begin
+          if file == path && current_file_verbs
+            current_file_verbs
+          else
+            body = file == path ? content : read_file_content(file)
+            if body.includes?("jakarta.ws.rs") || body.includes?("javax.ws.rs")
+              Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations(body)
+            else
+              Hash(String, String).new
+            end
+          end
+        rescue IO::Error
+          Hash(String, String).new
+        end
+
+        verbs.each { |name, verb| result[name] ||= verb }
       end
 
       result

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -36,6 +36,7 @@ module Analyzer::Java
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
       source_cache = Hash(String, String).new
+      custom_verb_cache = Hash(String, Hash(String, String)).new
 
       file_list = all_files()
       path_configs = path_configs_for(file_list)
@@ -69,6 +70,8 @@ module Analyzer::Java
             Noir::TreeSitterJaxRsExtractor.extract_bean_fields_from(root, content))
           subresource_sources = subresource_sources_for(path, content, package_name, source_cache, imports,
             Noir::TreeSitterJaxRsExtractor.extract_class_names_from(root, content))
+          custom_verb_annotations = custom_verb_index_for(path, content, package_name, custom_verb_cache, imports,
+            Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations_from(root, content))
           application_base_path = application_base_path_for(path, package_name, application_base_paths)
           configured_base_path = configured_base_path_for(path, path_configs, application_base_path)
 
@@ -76,7 +79,8 @@ module Analyzer::Java
             @result << endpoint
           end
 
-          Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources, include_callees: include_callee).each do |route|
+          Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources,
+            custom_verb_annotations: custom_verb_annotations, include_callees: include_callee).each do |route|
             line = route.line + 1
             details = Details.new(PathInfo.new(route.file_path || path, line))
             endpoint = Endpoint.new(Noir::URLPath.join_trimmed(configured_base_path, route.path), route.verb, route.params, details)
@@ -677,6 +681,43 @@ module Analyzer::Java
         end
 
         beans.each { |name, params| result[name] ||= params }
+      end
+
+      result
+    end
+
+    # Build the cross-file `@HttpMethod("VERB")` custom-annotation
+    # index for `path`. Same traversal as `bean_index_for` — the
+    # annotation type is typically declared in its own file, so this
+    # needs the same current file + same-package siblings + imports
+    # walk, gated on the file mentioning JAX-RS so unrelated `.java`
+    # files aren't parsed for annotation declarations.
+    private def custom_verb_index_for(path : String,
+                                      content : String,
+                                      package_name : String,
+                                      cache : Hash(String, Hash(String, String)),
+                                      imports : Array(Noir::ImportGraph::ImportRef)? = nil,
+                                      current_file_verbs : Hash(String, String)? = nil) : Hash(String, String)
+      result = Hash(String, String).new
+      resolved_imports = imports || Noir::TreeSitterJavaParameterExtractor.extract_imports(content)
+
+      Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
+        verbs = cache[file] ||= begin
+          if file == path && current_file_verbs
+            current_file_verbs
+          else
+            body = file == path ? content : read_file_content(file)
+            if body.includes?("jakarta.ws.rs") || body.includes?("javax.ws.rs")
+              Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations(body)
+            else
+              Hash(String, String).new
+            end
+          end
+        rescue IO::Error
+          Hash(String, String).new
+        end
+
+        verbs.each { |name, verb| result[name] ||= verb }
       end
 
       result

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -125,10 +125,12 @@ module Noir
                        bean_index : Hash(String, Array(Param)) = {} of String => Array(Param),
                        subresource_sources : Hash(String, SourceEntry) = {} of String => SourceEntry,
                        *,
+                       custom_verb_annotations : Hash(String, String) = {} of String => String,
                        include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_java(source) do |root|
-        routes.concat(extract_routes_from(root, source, dto_index, bean_index, subresource_sources, include_callees: include_callees))
+        routes.concat(extract_routes_from(root, source, dto_index, bean_index, subresource_sources,
+          custom_verb_annotations: custom_verb_annotations, include_callees: include_callees))
       end
       routes
     end
@@ -142,6 +144,7 @@ module Noir
                             bean_index : Hash(String, Array(Param)) = {} of String => Array(Param),
                             subresource_sources : Hash(String, SourceEntry) = {} of String => SourceEntry,
                             *,
+                            custom_verb_annotations : Hash(String, String) = {} of String => String,
                             include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       classes = collect_classes(root, source)
@@ -152,7 +155,8 @@ module Noir
         collect_server_endpoint_route(decl, source, routes, constants, class_name)
         next unless annotation_string_value(decl, "Path", source, constants, class_name)
         collect_class_routes(decl, source, dto_index, bean_index, routes, include_callees,
-          class_index: classes, constants: constants, subresource_sources: subresource_sources)
+          class_index: classes, constants: constants, subresource_sources: subresource_sources,
+          custom_verb_annotations: custom_verb_annotations)
       end
       routes
     end
@@ -222,6 +226,45 @@ module Noir
       results
     end
 
+    # `@HttpMethod("VERB")` is JAX-RS's general mechanism for declaring
+    # a custom HTTP verb — Jersey/RESTEasy Reactive's `QUERY` support
+    # (and any other non-standard verb a project defines) is just a
+    # user annotation type meta-annotated with it:
+    #
+    #   @HttpMethod("QUERY")
+    #   @Target(ElementType.METHOD)
+    #   @Retention(RetentionPolicy.RUNTIME)
+    #   public @interface QUERY {}
+    #
+    # Reads every `@interface` declaration in `source` and maps its
+    # simple name to the verb it declares. A name that collides with a
+    # built-in (`HTTP_VERB_ANNOTATIONS`) is skipped — the hard-coded
+    # table stays authoritative for those.
+    def extract_custom_verb_annotations(source : String) : Hash(String, String)
+      Noir::TreeSitter.parse_java(source) do |root|
+        return extract_custom_verb_annotations_from(root, source)
+      end
+      Hash(String, String).new
+    end
+
+    def extract_custom_verb_annotations_from(root : LibTreeSitter::TSNode, source : String) : Hash(String, String)
+      results = Hash(String, String).new
+      constants = TreeSitterJavaRouteExtractor.extract_string_constants_from(root, source)
+      walk_annotation_types(root) do |decl|
+        name = type_identifier_text(decl, source)
+        next if name.empty?
+        next if HTTP_VERB_ANNOTATIONS.has_key?(name)
+
+        verb = annotation_string_value(decl, "HttpMethod", source, constants, name)
+        next unless verb
+        verb = verb.strip.upcase
+        next if verb.empty?
+
+        results[name] = verb
+      end
+      results
+    end
+
     # ---- private ------------------------------------------------------
 
     private def collect_classes(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
@@ -238,6 +281,14 @@ module Noir
       block.call(node) if ty == "class_declaration" || ty == "interface_declaration"
       Noir::TreeSitter.each_named_child(node) do |child|
         walk_classes(child, &block)
+      end
+    end
+
+    private def walk_annotation_types(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      ty = Noir::TreeSitter.node_type(node)
+      block.call(node) if ty == "annotation_type_declaration"
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_annotation_types(child, &block)
       end
     end
 
@@ -263,7 +314,8 @@ module Noir
                                      subresource_sources : Hash(String, SourceEntry) = {} of String => SourceEntry,
                                      current_file : String? = nil,
                                      visited : Set(String)? = nil,
-                                     method_excludes : Set(String) = Set(String).new)
+                                     method_excludes : Set(String) = Set(String).new,
+                                     custom_verb_annotations : Hash(String, String) = {} of String => String)
       class_name = type_identifier_text(decl, source)
       local_constants = constants || TreeSitterJavaRouteExtractor.extract_string_constants(source)
       own_class_path = annotation_string_value(decl, "Path", source, local_constants, class_name) || ""
@@ -289,6 +341,10 @@ module Noir
             verb = mapped
             verb_node = ann
             break
+          elsif mapped = custom_verb_annotations[ann_name]?
+            verb = mapped
+            verb_node = ann
+            break
           end
         end
 
@@ -307,12 +363,12 @@ module Noir
             collect_class_routes(subresource, source, dto_index, bean_index, routes, include_callees,
               base_path: full_path, inherited_consumes: method_consumes, class_index: local_class_index,
               constants: local_constants, subresource_sources: subresource_sources, current_file: current_file,
-              visited: local_visited)
+              visited: local_visited, custom_verb_annotations: custom_verb_annotations)
           elsif source_entry = subresource_sources[return_type]?
             subresource_path, subresource_source = source_entry
             collect_cross_file_subresource(return_type, subresource_path, subresource_source,
               full_path, method_consumes, dto_index, bean_index, routes, include_callees,
-              subresource_sources, local_visited)
+              subresource_sources, local_visited, custom_verb_annotations)
           end
           next
         end
@@ -329,10 +385,10 @@ module Noir
 
       collect_implemented_interface_routes(decl, source, class_path, class_consumes,
         dto_index, bean_index, routes, include_callees, local_class_index,
-        local_constants, subresource_sources, current_file, local_visited)
+        local_constants, subresource_sources, current_file, local_visited, custom_verb_annotations)
       collect_superclass_routes(decl, source, class_path, class_consumes,
         dto_index, bean_index, routes, include_callees, local_class_index,
-        local_constants, subresource_sources, current_file, local_visited)
+        local_constants, subresource_sources, current_file, local_visited, custom_verb_annotations)
     end
 
     private def collect_implemented_interface_routes(decl : LibTreeSitter::TSNode,
@@ -347,7 +403,8 @@ module Noir
                                                      constants : Hash(String, String),
                                                      subresource_sources : Hash(String, SourceEntry),
                                                      current_file : String?,
-                                                     visited : Set(String))
+                                                     visited : Set(String),
+                                                     custom_verb_annotations : Hash(String, String) = {} of String => String)
       return unless Noir::TreeSitter.node_type(decl) == "class_declaration"
 
       implemented_names = implemented_interface_names(decl, source)
@@ -360,12 +417,13 @@ module Noir
           collect_class_routes(interface_decl, source, dto_index, bean_index, routes, include_callees,
             base_path: Noir::URLPath.join_trimmed(class_path, interface_path), inherited_consumes: class_consumes,
             class_index: class_index, constants: constants, subresource_sources: subresource_sources,
-            current_file: current_file, visited: visited, method_excludes: method_excludes)
+            current_file: current_file, visited: visited, method_excludes: method_excludes,
+            custom_verb_annotations: custom_verb_annotations)
         elsif source_entry = subresource_sources[interface_name]?
           interface_source_path, interface_source = source_entry
           collect_cross_file_interface(interface_name, interface_source_path, interface_source,
             class_path, class_consumes, dto_index, bean_index, routes, include_callees,
-            subresource_sources, visited, method_excludes)
+            subresource_sources, visited, method_excludes, custom_verb_annotations)
         end
       end
     end
@@ -388,7 +446,8 @@ module Noir
                                           constants : Hash(String, String),
                                           subresource_sources : Hash(String, SourceEntry),
                                           current_file : String?,
-                                          visited : Set(String))
+                                          visited : Set(String),
+                                          custom_verb_annotations : Hash(String, String) = {} of String => String)
       return unless Noir::TreeSitter.node_type(decl) == "class_declaration"
 
       super_name = extended_class_name(decl, source)
@@ -399,12 +458,13 @@ module Noir
         collect_class_routes(super_decl, source, dto_index, bean_index, routes, include_callees,
           base_path: class_path, inherited_consumes: class_consumes,
           class_index: class_index, constants: constants, subresource_sources: subresource_sources,
-          current_file: current_file, visited: visited, method_excludes: method_excludes)
+          current_file: current_file, visited: visited, method_excludes: method_excludes,
+          custom_verb_annotations: custom_verb_annotations)
       elsif source_entry = subresource_sources[super_name]?
         super_source_path, super_source = source_entry
         collect_cross_file_superclass(super_name, super_source_path, super_source,
           class_path, class_consumes, dto_index, bean_index, routes, include_callees,
-          subresource_sources, visited, method_excludes)
+          subresource_sources, visited, method_excludes, custom_verb_annotations)
       end
     end
 
@@ -419,7 +479,8 @@ module Noir
                                               include_callees : Bool,
                                               subresource_sources : Hash(String, SourceEntry),
                                               visited : Set(String),
-                                              method_excludes : Set(String))
+                                              method_excludes : Set(String),
+                                              custom_verb_annotations : Hash(String, String) = {} of String => String)
       Noir::TreeSitter.parse_java(super_source) do |root|
         classes = collect_classes(root, super_source)
         super_decl = classes[super_name]?
@@ -428,7 +489,8 @@ module Noir
         collect_class_routes(super_decl, super_source, dto_index, bean_index, routes, include_callees,
           base_path: class_path, inherited_consumes: class_consumes,
           class_index: classes, constants: constants, subresource_sources: subresource_sources,
-          current_file: super_path, visited: visited, method_excludes: method_excludes)
+          current_file: super_path, visited: visited, method_excludes: method_excludes,
+          custom_verb_annotations: custom_verb_annotations)
       end
     end
 
@@ -443,7 +505,8 @@ module Noir
                                              include_callees : Bool,
                                              subresource_sources : Hash(String, SourceEntry),
                                              visited : Set(String),
-                                             method_excludes : Set(String))
+                                             method_excludes : Set(String),
+                                             custom_verb_annotations : Hash(String, String) = {} of String => String)
       Noir::TreeSitter.parse_java(interface_source) do |root|
         classes = collect_classes(root, interface_source)
         interface_decl = classes[interface_name]?
@@ -453,7 +516,8 @@ module Noir
         collect_class_routes(interface_decl, interface_source, dto_index, bean_index, routes, include_callees,
           base_path: Noir::URLPath.join_trimmed(class_path, own_path), inherited_consumes: class_consumes,
           class_index: classes, constants: constants, subresource_sources: subresource_sources,
-          current_file: interface_path, visited: visited, method_excludes: method_excludes)
+          current_file: interface_path, visited: visited, method_excludes: method_excludes,
+          custom_verb_annotations: custom_verb_annotations)
       end
     end
 
@@ -467,7 +531,8 @@ module Noir
                                                routes : Array(Route),
                                                include_callees : Bool,
                                                subresource_sources : Hash(String, SourceEntry),
-                                               visited : Set(String))
+                                               visited : Set(String),
+                                               custom_verb_annotations : Hash(String, String) = {} of String => String)
       Noir::TreeSitter.parse_java(subresource_source) do |root|
         classes = collect_classes(root, subresource_source)
         subresource = classes[return_type]?
@@ -476,7 +541,7 @@ module Noir
         collect_class_routes(subresource, subresource_source, dto_index, bean_index, routes, include_callees,
           base_path: base_path, inherited_consumes: inherited_consumes, class_index: classes,
           constants: constants, subresource_sources: subresource_sources, current_file: subresource_path,
-          visited: visited)
+          visited: visited, custom_verb_annotations: custom_verb_annotations)
       end
     end
 


### PR DESCRIPTION
## Summary

Closes #2556. Depends on foundation #2540 (already merged, #2563).

JAX-RS lets a project declare its own HTTP verb via the general
`@HttpMethod("X")` meta-annotation mechanism:

```java
@HttpMethod("QUERY")
@Target(ElementType.METHOD)
@Retention(RetentionPolicy.RUNTIME)
public @interface QUERY {}
```

```java
@Path("/search")
public class SearchResource {
    @QUERY
    public Result search(FilterDto filters) { ... }
}
```

The shared `TreeSitterJaxRsExtractor` only recognized the built-in
`@GET`/`@POST`/`@PUT`/... annotations, so any custom verb declared this
way — QUERY, PROPFIND, SEARCH, or a project's own — was invisible, not
just `QUERY` specifically.

- `Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations(_from)`
  walks `@interface` declarations meta-annotated with `@HttpMethod("X")`
  and maps the annotation's simple name to its declared verb (uppercased).
  A name that collides with a built-in verb annotation is skipped so the
  hard-coded table stays authoritative.
- `collect_class_routes` and its same-file/cross-file superclass,
  interface, and subresource helpers now check this map alongside the
  built-in verb table when resolving a method's HTTP verb.
- Since the annotation is typically declared in its own file,
  `jaxrs.cr`, `quarkus.cr`, and `dropwizard.cr` (all three share this
  extractor) each build a per-file custom-verb index via the same
  `ImportGraph`-based cross-file walk already used for `@BeanParam`
  bean fields and subresource-locator resolution, gated on the file
  mentioning `jakarta.ws.rs`/`javax.ws.rs`.

## Test plan

- [x] New unit tests in `jaxrs_extractor_ts_spec.cr`: resolves
      `@HttpMethod("QUERY")`/`@HttpMethod("propfind")` meta-annotations
      to their declared verb, never lets a custom annotation shadow a
      built-in verb name, and applies a resolved custom verb to a
      resource method (with body-param expansion) while a `@GET`
      method in the same class is unaffected.
- [x] New functional fixtures + testers for `java_jaxrs` and
      `java_dropwizard`: the `@HttpMethod("QUERY")` annotation is
      declared in its own file and imported by a resource class in
      another file, proving the cross-file `ImportGraph` resolution
      path — asserts `QUERY` + expanded body params, and that the
      sibling `@GET` route is unchanged. Manually verified `java_quarkus`
      end-to-end with the built binary as well (same shared extractor).
- [x] `crystal spec` — full suite, 27514 examples, 0 failures
- [x] `crystal tool format --check` and `ameba` clean on all touched files
- [x] Manual `./bin/noir` run against the new fixtures confirms
      `QUERY /search` with json body params `query`/`limit`, and
      `GET /search/status` unaffected