### PR TITLE
feat(analyzer): detect HTTP QUERY routes in aiohttp

### DIFF
--- a/spec/functional_test/fixtures/python/aiohttp/app.py
+++ b/spec/functional_test/fixtures/python/aiohttp/app.py
@@ -113,6 +113,13 @@ async def search(request):
     return web.Response(text=f"search {category} q={q}")
 
 
+@routes.route('QUERY', '/search/advanced')
+async def search_advanced(request):
+    data = await request.json()
+    filters = data.get('filters')
+    return web.Response(text=f"advanced search {filters}")
+
+
 @admin_routes.get('/stats')
 async def admin_stats(request):
     section = request.query.get('section')
@@ -136,11 +143,24 @@ async def tenant_create(request):
     return web.Response(text=f"tenant {name}")
 
 
+async def tenant_query(request):
+    data = await request.json()
+    term = data.get('term')
+    return web.Response(text=f"tenant query {term}")
+
+
 tenant_routes = [
     web.get('/tenants/{tenant_id}', tenant_detail),
     web.post('/tenants', tenant_create),
     web.patch('/external/{external_id}', external_handlers.external_patch),
+    web.route('QUERY', '/tenants/query', tenant_query),
 ]
+
+
+async def bulk_lookup(request):
+    data = await request.json()
+    ids = data.get('ids')
+    return web.Response(text=f"bulk lookup {ids}")
 
 
 def setup_routes(app):
@@ -155,6 +175,7 @@ def setup_routes(app):
     add_route('*', '/wildcard', index, name='wildcard')
     app.router.add_get('/feed/{channel}', websocket_feed)
     app.router.add_routes([web.view('/reports/{id}', ReportView)])
+    app.router.add_route('QUERY', '/lookup', bulk_lookup)
     app.router.add_static('/assets/', path='static')
 
 

--- a/spec/functional_test/testers/python/aiohttp_spec.cr
+++ b/spec/functional_test/testers/python/aiohttp_spec.cr
@@ -64,6 +64,9 @@ expected_endpoints = [
     Param.new("category", "", "path"),
     Param.new("q", "", "query"),
   ]),
+  Endpoint.new("/search/advanced", "QUERY", [
+    Param.new("filters", "", "json"),
+  ]),
   Endpoint.new("/admin/stats", "GET", [
     Param.new("section", "", "query"),
   ]),
@@ -90,6 +93,12 @@ expected_endpoints = [
     Param.new("external_id", "", "path"),
     Param.new("mode", "", "query"),
     Param.new("title", "", "json"),
+  ]),
+  Endpoint.new("/tenant-api/tenants/query", "QUERY", [
+    Param.new("term", "", "json"),
+  ]),
+  Endpoint.new("/lookup", "QUERY", [
+    Param.new("ids", "", "json"),
   ]),
 ]
 

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -51,7 +51,12 @@ module Analyzer::Python
     WEB_METHOD_GUARD_RE = /\bweb\.(?:#{METHODS_ALT})\s*\(/
     WEB_METHOD_RE       = /\bweb\.(#{METHODS_ALT})\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/
     WEB_VIEW_RE         = /\bweb\.view\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/
-    DEF_METHOD_RE       = /^\s*(?:async\s+)?def\s+(#{METHODS_ALT})\s*\(/
+    # Method-first `web.route("METHOD", "/path", handler)` — the only way to
+    # reach a route whose verb has no dedicated `web.<method>()` shorthand
+    # (e.g. `QUERY`, RFC 10008). Same free-form method capture as
+    # ROUTE_DECO_RE/ADD_ROUTE_RE, so any verb works, not just QUERY.
+    WEB_ROUTE_RE  = /\bweb\.route\s*\(\s*[rf]?['"]([A-Za-z*]+)['"]\s*,\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/
+    DEF_METHOD_RE = /^\s*(?:async\s+)?def\s+(#{METHODS_ALT})\s*\(/
 
     # Spaces are stripped before the `add_<method>` match, so the route
     # path is re-extracted from the original (spaced) line. Precompile one
@@ -311,6 +316,26 @@ module Analyzer::Python
                 handler_name = web_match[3]
                 prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
                   handler_routes[path] << {Helper.normalized_join(prefix, route_path), method_name.upcase, line_index, handler_name}
+                end
+              end
+            end
+
+            # Style C (method-first): `web.route("METHOD", "/path", handler)`
+            # entries, resolved through the same list/receiver prefix logic
+            # as the Style C block above. Guarded separately from
+            # WEB_METHOD_GUARD_RE since `route` isn't one of the METHODS_ALT
+            # shorthand names (see WEB_ROUTE_RE for why this shape exists).
+            if stripped.includes?("web.route(")
+              effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
+              effective_line.scan(WEB_ROUTE_RE) do |web_route_match|
+                next if web_route_match.size < 4
+                route_method = web_route_match[1]
+                route_path = web_route_match[2]
+                handler_name = web_route_match[3]
+                prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
+                  expand_aiohttp_methods(route_method).each do |expanded_method|
+                    handler_routes[path] << {Helper.normalized_join(prefix, route_path), expanded_method, line_index, handler_name}
+                  end
                 end
               end
             end


### PR DESCRIPTION
## Description
Closes #2560

aiohttp added `QUERY` ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html)) routing support via `app.router.add_route()` and `web.route()`.

### What already worked (no code change)
The existing method-first regexes (`ADD_ROUTE_RE`, `ROUTE_DECO_RE`) already capture free-form verb strings, so these two shapes from the issue were already detected:
- `app.router.add_route("QUERY", "/path", handler)` (imperative)
- `@routes.route("QUERY", "/path")` (decorator)

### What was missing
`app.add_routes([web.route("QUERY", "/path", handler)])` — aiohttp never defined a `web.query()` shorthand function, so the existing `web.<method>()` regex (built from a fixed verb list) never matched this shape. Added `WEB_ROUTE_RE` plus a handling block that reuses the existing list/receiver prefix-resolution logic already used for `web.<method>(...)`.

### Deliberately not implemented
I checked upstream `aio-libs/aiohttp` source (`hdrs.py`, `web_routedef.py`, `web_urldispatcher.py`) rather than trusting the issue's route-shape list at face value, since two of the listed shapes turned out to be non-functional in aiohttp today:
- **`@routes.query(...)` shorthand** — does not exist upstream. `RouteTableDef`/`web_routedef.py` only define `route/head/get/post/put/patch/delete/options/view` — no `query`.
- **`class SearchView(web.View): async def query(self): ...`** — `METH_QUERY` was [deliberately excluded from `METH_ALL`](https://github.com/aio-libs/aiohttp/pull/13301) (adding it would break `RouteDef.register()`'s `add_query` lookup for the `web.route()` shape above). `View._iter()` gates dispatch on `self.request.method in hdrs.METH_ALL`, so a `QUERY` request to any `web.View` currently raises `405 Method Not Allowed` regardless of whether the class defines a `query` method.

Implementing either would have made Noir report endpoints that aiohttp itself rejects — the same "don't invent endpoints for verbs that would 405" principle from the RFC 10008 foundation work (#2540).

### Changes
- **aiohttp analyzer**: added `WEB_ROUTE_RE` and a new handling block for `web.route("METHOD", "/path", handler)` list entries (reuses `expand_aiohttp_methods` for the `"*"` case, consistent with existing wildcard-does-not-expand-to-QUERY policy).
- **Fixtures & tests**: extended `spec/functional_test/fixtures/python/aiohttp/app.py` with a decorator QUERY route, an imperative QUERY route, and a `web.route("QUERY", ...)` entry inside the existing `tenant_routes` list (exercises sub-app prefixing too). Updated `aiohttp_spec.cr` with the three new expected endpoints.

### Validation
- `crystal spec spec/unit_test spec/functional_test`: 27,503 examples, 0 failures
- `just check` (format + ameba, full repo): 2,139 files inspected, 0 failures
- Manually verified against upstream aiohttp source and a standalone reproduction fixture that all four route shapes from the issue behave as implemented (two detected pre-existing, one newly detected, one correctly left undetected since it 405s upstream)