### PR TITLE
feat(java): detect HTTP QUERY routes in Micronaut

### DIFF
--- a/spec/functional_test/fixtures/java/micronaut/src/main/java/com/example/api/BookController.java
+++ b/spec/functional_test/fixtures/java/micronaut/src/main/java/com/example/api/BookController.java
@@ -7,6 +7,7 @@ import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.CookieValue;
+import io.micronaut.http.annotation.CustomHttpMethod;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
@@ -14,6 +15,7 @@ import io.micronaut.http.annotation.Patch;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.Query;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.annotation.RequestBean;
 import io.micronaut.http.multipart.CompletedFileUpload;
@@ -75,6 +77,16 @@ public class BookController implements BookApi {
 
     @Get("/filter")
     public HttpResponse<?> filter(@RequestBean BookFilter filter) {
+        return HttpResponse.ok();
+    }
+
+    @Query("/search")
+    public HttpResponse<?> searchByQuery(@Body Book book) {
+        return HttpResponse.ok();
+    }
+
+    @CustomHttpMethod(method = "QUERY", value = "/advanced")
+    public HttpResponse<?> advancedSearch(@Body Book book) {
         return HttpResponse.ok();
     }
 

--- a/spec/functional_test/testers/java/micronaut_spec.cr
+++ b/spec/functional_test/testers/java/micronaut_spec.cr
@@ -31,6 +31,16 @@ expected_endpoints = [
     Param.new("author", "", "query"),
     Param.new("year", "", "query"),
   ]),
+  Endpoint.new("/books/search", "QUERY", [
+    Param.new("title", "", "json"),
+    Param.new("author", "", "json"),
+    Param.new("year", "", "json"),
+  ]),
+  Endpoint.new("/books/advanced", "QUERY", [
+    Param.new("title", "", "json"),
+    Param.new("author", "", "json"),
+    Param.new("year", "", "json"),
+  ]),
   Endpoint.new("/books/template", "GET", [
     Param.new("q", "", "query"),
   ]),

--- a/spec/unit_test/miniparser/micronaut_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/micronaut_extractor_ts_spec.cr
@@ -272,4 +272,67 @@ describe Noir::TreeSitterMicronautExtractor do
       {"GET", "/api/chat/{topic}/{username}", "ws"},
     ])
   end
+
+  it "detects the QUERY verb annotation and CustomHttpMethod QUERY, keeping @QueryValue distinct" do
+    source = <<-JAVA
+      package com.example.api;
+
+      import io.micronaut.http.annotation.Body;
+      import io.micronaut.http.annotation.Controller;
+      import io.micronaut.http.annotation.CustomHttpMethod;
+      import io.micronaut.http.annotation.Get;
+      import io.micronaut.http.annotation.Query;
+      import io.micronaut.http.annotation.QueryValue;
+
+      @Controller("/search")
+      public class SearchController {
+          @Get("/")
+          public String list(@QueryValue(value = "q", defaultValue = "all") String query) {
+              return "";
+          }
+
+          @Query("/")
+          public String search(@Body FilterDto filters) {
+              return "";
+          }
+
+          @CustomHttpMethod(method = "QUERY", value = "/adv")
+          public String advanced(@Body AdvDto dto) {
+              return "";
+          }
+      }
+
+      class FilterDto {
+          private String term;
+          public void setTerm(String term) { this.term = term; }
+      }
+
+      class AdvDto {
+          private String expression;
+          public void setExpression(String expression) { this.expression = expression; }
+      }
+      JAVA
+
+    dto_index = {
+      "FilterDto" => [
+        Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("term", "private", true, ""),
+      ],
+      "AdvDto" => [
+        Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("expression", "private", true, ""),
+      ],
+    } of String => Array(Noir::TreeSitterJavaParameterExtractor::FieldInfo)
+
+    routes = Noir::TreeSitterMicronautExtractor.extract_routes(source, dto_index)
+    routes.map { |r| {r.verb, r.path, r.params} }.should eq([
+      {"GET", "/search/", [
+        Param.new("q", "all", "query"),
+      ]},
+      {"QUERY", "/search/", [
+        Param.new("term", "", "json"),
+      ]},
+      {"QUERY", "/search/adv", [
+        Param.new("expression", "", "json"),
+      ]},
+    ])
+  end
 end

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -16,8 +16,9 @@ module Noir
   #   * Class-level `@ServerWebSocket("/x")` — surfaced as `GET`
   #     with `protocol = "ws"`.
   #   * Verb annotations: `@Get`, `@Post`, `@Put`, `@Delete`,
-  #     `@Patch`, `@Head`, `@Options` from
-  #     `io.micronaut.http.annotation`.
+  #     `@Patch`, `@Head`, `@Options`, `@Query` from
+  #     `io.micronaut.http.annotation`, plus `@CustomHttpMethod(method
+  #     = "...")` for non-standard verbs.
   #   * Path supplied positionally (`@Get("/x")`) or via the
   #     `value` / `uri` / `uris` keyword. Array forms (`uris =
   #     {"/a", "/b"}`) fan out into one route per path.
@@ -49,6 +50,7 @@ module Noir
       "Patch"   => "PATCH",
       "Head"    => "HEAD",
       "Options" => "OPTIONS",
+      "Query"   => "QUERY",
     }
 
     PARAM_ANNOTATION_FORMAT = {
@@ -272,6 +274,14 @@ module Noir
             verb_node = ann
             method_args = args
             break
+          elsif ann_name == "CustomHttpMethod"
+            custom_verb = annotation_string_arg(args, source, Set{"method"}, constants, class_name)
+            unless custom_verb.nil? || custom_verb.empty?
+              verb = custom_verb.upcase
+              verb_node = ann
+              method_args = args
+              break
+            end
           end
         end
         next unless verb && verb_node
@@ -328,6 +338,14 @@ module Noir
             verb_node = ann
             method_args = args
             break
+          elsif ann_name == "CustomHttpMethod"
+            custom_verb = annotation_string_arg(args, source, Set{"method"}, constants, interface_name)
+            unless custom_verb.nil? || custom_verb.empty?
+              verb = custom_verb.upcase
+              verb_node = ann
+              method_args = args
+              break
+            end
           end
         end
         next unless verb && verb_node


### PR DESCRIPTION
## Summary
- Add `@Query` (RFC 10008 / RFC via micronaut-core#12780) to the Micronaut verb-annotation table, using the same `value`/`uri`/`uris`/`consumes`/`produces`/`processes` resolution already shared by `@Get`/`@Post`/etc.
- Accept `@CustomHttpMethod(method = "QUERY", ...)` as an alternate way to declare a `QUERY` (or any non-standard verb) route, reusing the existing `annotation_string_arg` helper to read the `method` attribute.
- `@QueryValue` parameter binding is untouched, so a `@Get` handler's query params and a `@Query`/`@CustomHttpMethod` route stay distinct — pinned by a unit spec and a functional fixture case (`GET /books/search` vs `QUERY /books/search`).

Verified upstream via the merged PR (micronaut-projects/micronaut-core#12780): the new `@Query` annotation mirrors `@Get`'s shape exactly, and `@CustomHttpMethod` is a pre-existing Micronaut annotation with a required `method` attribute.

Closes #2555

## Test plan
- [x] `crystal spec spec/unit_test spec/functional_test` — 27,508 examples, 0 failures
- [x] `crystal tool format --check` / `ameba` on touched files — clean
- [x] `typos` on touched files — clean
- [x] `shards build --release --no-debug --production` + manual run against the fixture confirms `GET /books/search?q=all`, `QUERY /books/search`, and `QUERY /books/advanced` are all detected and distinct