### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Phoenix / Plug

### DIFF
--- a/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex
@@ -79,6 +79,10 @@ defmodule ElixirPhoenixWeb.Router do
 
     match :post, "/hooks", PageController, :home
     match :put, "/hooks", PageController, :home
+    # RFC 10008 HTTP QUERY method: Phoenix routes sit on Plug, whose
+    # `query/2` macro already ships, so `match :query, ...` routes today
+    # even ahead of phoenixframework/phoenix#6737.
+    match :query, "/hooks", PageController, :home
   end
 
   # Nested resources: the child collection mounts under the parent's

--- a/spec/functional_test/fixtures/elixir/plug/lib/router.ex
+++ b/spec/functional_test/fixtures/elixir/plug/lib/router.ex
@@ -93,6 +93,17 @@ defmodule ElixirPlug.Router do
     send_resp(conn, 200, "Simple match")
   end
 
+  # RFC 10008 HTTP QUERY method (elixir-plug/plug#1319)
+  query "/reports" do
+    filters = conn.body_params["filters"]
+    send_resp(conn, 200, "Report results")
+  end
+
+  # `via:` also accepts a single atom, not just a list
+  match "/webhook-query", via: :query do
+    send_resp(conn, 200, "Webhook query received")
+  end
+
   # Catch-all route
   match _ do
     send_resp(conn, 404, "Not found")

--- a/spec/functional_test/testers/elixir/phoenix_spec.cr
+++ b/spec/functional_test/testers/elixir/phoenix_spec.cr
@@ -41,6 +41,8 @@ expected_endpoints = [
   Endpoint.new("/api/swaggerui", "GET"),
   Endpoint.new("/api/hooks", "POST", [Param.new("q", "", "query"), Param.new("page", "", "form"), Param.new("limit", "", "form")]),
   Endpoint.new("/api/hooks", "PUT", [Param.new("q", "", "query"), Param.new("page", "", "form"), Param.new("limit", "", "form")]),
+  # RFC 10008 HTTP QUERY method via `match :query, ...`
+  Endpoint.new("/api/hooks", "QUERY", [Param.new("q", "", "query"), Param.new("page", "", "form"), Param.new("limit", "", "form")]),
   Endpoint.new("/dev/dashboard", "GET"),
   Endpoint.new("/dev/mailbox", "GET"),
   # Nested resources under a scope: child mounts on the parent's

--- a/spec/functional_test/testers/elixir/plug_spec.cr
+++ b/spec/functional_test/testers/elixir/plug_spec.cr
@@ -16,6 +16,9 @@ expected_endpoints = [
   Endpoint.new("/webhook", "POST"),
   Endpoint.new("/webhook", "PUT"),
   Endpoint.new("/simple", "GET"),
+  # RFC 10008 HTTP QUERY method: bare `query/2` macro and `via: :query`
+  Endpoint.new("/reports", "QUERY", [Param.new("filters", "", "form")]),
+  Endpoint.new("/webhook-query", "QUERY"),
   # ApiRouter endpoints
   Endpoint.new("/status", "GET"),
   Endpoint.new("/data", "POST"),

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -23,6 +23,15 @@ module Analyzer::Elixir
     # the same 7 PCRE2 patterns on every call (~3.4M recompiles on a 2400-file
     # repo, the dominant scan cost). The pattern depends only on the fixed verb
     # set, so build it once. See `add_standard_route` for the shape rationale.
+    # RFC 10008's `query` is deliberately absent here. Unlike Plug (which
+    # already ships `query/2`), Phoenix's own router macro is still pending
+    # (phoenixframework/phoenix#6737); adding a bare verb here — via
+    # `add_standard_route`, which has no `plug_route_path?`-style leading-`/`
+    # guard — would misread any unrelated `query("literal", CapitalizedMod)`
+    # local function (a common Ecto/dispatch-helper shape) as a route. Since
+    # a Phoenix router sits on Plug, `match :query, ...` already routes today
+    # without needing this table — see `match_route_methods` below, which
+    # upcases whatever verb atom it's given.
     STANDARD_ROUTE_METHODS = {
       "get"     => "GET",
       "post"    => "POST",

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -46,7 +46,7 @@ module Analyzer::Elixir
     # verb/`match`/`forward` macros. Files with none of those tokens
     # cannot contribute endpoints (models, views, plain modules).
     PLUG_ROUTE_EVIDENCE_RE = /
-      \b(?:get|post|put|patch|delete|head|options|forward|match)
+      \b(?:get|post|put|patch|delete|head|options|query|forward|match)
       \s*(?:\(\s*)?["']
     /x
 
@@ -229,6 +229,8 @@ module Analyzer::Elixir
       "head"    => "HEAD",
       "options" => "OPTIONS",
       "forward" => "FORWARD",
+      # RFC 10008, shipped in elixir-plug/plug#1319 (merged 2026-06-25).
+      "query" => "QUERY",
     }
 
     # Precompiled per-verb route regexes. `line_to_endpoint` runs once per
@@ -261,6 +263,11 @@ module Analyzer::Elixir
               endpoints << Endpoint.new(path, method_match[1].upcase)
             end
           end
+        elsif via_match = line.match(/(?:^|[^.\w])match\s+["\']([^"\']+)["\'][^:]*via:\s*:(\w+)/)
+          # match "/path", via: :query — Plug.Router's `via:` also accepts
+          # a single atom, not just a list.
+          path = via_match[1]
+          endpoints << Endpoint.new(path, via_match[2].upcase) if plug_route_path?(path)
         end
 
         # Match simple match statements (defaults to GET)


### PR DESCRIPTION
Closes #2558

## Summary
- `elixir_plug`: add `query/2` (shipped in elixir-plug/plug#1319, merged 2026-06-25) to the standard route-macro table, and teach `match "/path", via: :query` — a single atom, not just a bracketed list — to `line_to_endpoint`. Both paths already run through the existing `plug_route_path?` leading-`/` guard.
- `elixir_phoenix`: `match :query, "/path", Controller, :action` already routes today with **no code change**, since a Phoenix router sits on Plug and `match_route_methods` just upcases whatever verb atom it's given. Phoenix's own bare `query` router macro (phoenixframework/phoenix#6737) is intentionally **not** added to `STANDARD_ROUTE_METHODS` yet — see review note below.
- Fixture coverage: Phoenix `match :query` (inside a `scope`/`pipe_through`), Plug bare `query/2`, and Plug `via: :query`.

## Review note (why Phoenix's `STANDARD_ROUTE_METHODS` is untouched)
An earlier draft added `"query" => "QUERY"` to Phoenix's `STANDARD_ROUTE_METHODS` too, matching the issue's literal suggestion. A review pass caught that this table's regex (`add_standard_route`) has no `plug_route_path?`-style guard requiring the captured path to start with `/` — unlike Plug. Adding a bare `query` verb there would misread any unrelated two-arg `query("literal", CapitalizedModule)` local function (a common Ecto/dispatch-helper shape) as a route, and I confirmed this false-positive with a synthetic fixture before removing the addition. Since Phoenix's own `query` macro doesn't exist upstream yet anyway, and `match :query` already covers the real, working case, this is pure downside with no present-day upside — dropped in favor of the comment now in place documenting why.

## Test plan
- [x] `just build-release`
- [x] `crystal spec spec/functional_test/` — 22,727 examples, 0 failures
- [x] `crystal spec spec/unit_test/` — 4,778 examples, 0 failures
- [x] `crystal tool format --check` / ameba lint — clean (full repo + touched files)
- [x] Manually confirmed the pre-fix `STANDARD_ROUTE_METHODS` addition produced a phantom `QUERY` endpoint from a synthetic Ecto-style `query/2` helper, and that the final diff does not