### PR TITLE
feat(analyzer): detect HTTP QUERY routes in Flask (#2559)

### DIFF
--- a/spec/functional_test/fixtures/python/django/blog/views.py
+++ b/spec/functional_test/fixtures/python/django/blog/views.py
@@ -342,6 +342,13 @@ class FeedbackView(View):
         message = request.POST.get('message')
         return HttpResponse(message)
 
+    def query(self, params):
+        # A helper that builds a filtered queryset, NOT an HTTP handler —
+        # Django's View.http_method_names (unlike Flask's duck-typed
+        # dispatch) never includes 'query', so this name collision must
+        # not produce a phantom QUERY endpoint.
+        return Article.objects.filter(**params)
+
 
 class EsSearchView(SearchView):
     def get_context(self):

--- a/spec/functional_test/fixtures/python/flask/app.py
+++ b/spec/functional_test/fixtures/python/flask/app.py
@@ -92,6 +92,18 @@ def update_record():
     page = request.args['page'] if record['name'] else None
     return jsonify(record)
 
+@app.route('/search', methods=['QUERY'])
+def search_record():
+    # RFC 10008 HTTP QUERY: a safe, idempotent request that carries its
+    # filter criteria in the request body, like POST but read-only.
+    criteria = request.json.get('criteria')
+    return jsonify({'criteria': criteria})
+
+@app.route('/lookup', methods=['GET', 'QUERY'])
+def lookup_record():
+    term = request.args.get('term')
+    return jsonify({'term': term})
+
 @app.route('/')
 def index():
     return render_template('index.html')

--- a/spec/functional_test/fixtures/python/flask_advanced/app.py
+++ b/spec/functional_test/fixtures/python/flask_advanced/app.py
@@ -26,6 +26,12 @@ def app_post():
     """Test app-level POST shortcut"""
     return jsonify({'method': 'POST'})
 
+@app.query('/app-query')
+def app_query():
+    """Test app-level QUERY shortcut (RFC 10008)"""
+    filter_expr = request.json.get('filter')
+    return jsonify({'method': 'QUERY', 'filter': filter_expr})
+
 @bp.get('/bp-get')
 def bp_get():
     """Test blueprint GET shortcut"""
@@ -51,6 +57,12 @@ def bp_patch():
 def bp_delete():
     """Test blueprint DELETE shortcut"""
     return jsonify({'method': 'DELETE'})
+
+@bp.query('/bp-query')
+def bp_query():
+    """Test blueprint QUERY shortcut (RFC 10008)"""
+    term = request.args.get('term')
+    return jsonify({'method': 'QUERY', 'term': term})
 
 # MethodView class-based views
 class UserAPI(MethodView):
@@ -103,6 +115,20 @@ class AsyncAPI(MethodView):
         """Async POST method"""
         title = request.json.get('title')
         return jsonify({'title': title})
+
+class SearchAPI(MethodView):
+    """MethodView exercising QUERY dispatch (RFC 10008) alongside GET"""
+
+    def get(self):
+        """GET method - simple keyword search"""
+        keyword = request.args.get('keyword')
+        return jsonify({'keyword': keyword})
+
+    def query(self):
+        """QUERY method - structured search body, dispatched like get/post
+        via MethodView's getattr(self, request.method.lower()) lookup"""
+        criteria = request.json.get('criteria')
+        return jsonify({'criteria': criteria})
 
 class ReportView(View):
     """Pluggable View using dispatch_request and class-level methods"""
@@ -159,8 +185,20 @@ bp.add_url_rule('/items', view_func=item_view, methods=['GET', 'POST'])
 async_view = AsyncAPI.as_view('async_api')
 bp.add_url_rule('/async', view_func=async_view, methods=['GET', 'POST'])
 
+# MethodView with an explicit QUERY method (RFC 10008), dispatched the
+# same way as get/post via MethodView.dispatch_request's getattr lookup
+search_view = SearchAPI.as_view('search_api')
+bp.add_url_rule('/search-view', view_func=search_view, methods=['GET', 'QUERY'])
+
 # add_url_rule without explicit methods (should infer from class)
 bp.add_url_rule('/items-inferred', view_func=ItemAPI.as_view('item_inferred'))
+
+# add_url_rule without explicit methods on a QUERY-carrying MethodView:
+# Flask/Werkzeug's `http_method_funcs` (which MethodView.as_view uses to
+# auto-compute `cls.methods` when none is given) includes 'query' as of
+# pallets/flask#6065, so this must infer GET + QUERY from the class body,
+# same as the explicit-methods registration above.
+bp.add_url_rule('/search-view-inferred', view_func=SearchAPI.as_view('search_api_inferred'))
 
 # flask.views.View uses dispatch_request with class-level methods
 bp.add_url_rule('/reports-view', view_func=ReportView.as_view('reports_view'))

--- a/spec/functional_test/fixtures/python/tornado/handlers.py
+++ b/spec/functional_test/fixtures/python/tornado/handlers.py
@@ -14,7 +14,14 @@ class SearchHandler(tornado.web.RequestHandler):
     def get(self):
         tags = self.get_arguments("tags")
         q = self.get_argument("q")
-        self.write({"results": []})
+        self.write({"results": self.query({"q": q})})
+
+    def query(self, filters):
+        # A helper that builds the search filter set, NOT an HTTP handler —
+        # Tornado's RequestHandler.SUPPORTED_METHODS (unlike Flask's
+        # duck-typed dispatch) never includes 'query', so this name
+        # collision must not produce a phantom QUERY endpoint.
+        return [filters]
 
 class NestedDefHandler(tornado.web.RequestHandler):
     def post(self):

--- a/spec/functional_test/testers/python/flask_advanced_spec.cr
+++ b/spec/functional_test/testers/python/flask_advanced_spec.cr
@@ -4,6 +4,7 @@ expected_endpoints = [
   # App-level shortcut decorators
   Endpoint.new("/app-get", "GET"),
   Endpoint.new("/app-post", "POST"),
+  Endpoint.new("/app-query", "QUERY", [Param.new("filter", "", "json")]),
 
   # Blueprint shortcut decorators
   Endpoint.new("/api/bp-get", "GET"),
@@ -11,6 +12,7 @@ expected_endpoints = [
   Endpoint.new("/api/bp-put", "PUT"),
   Endpoint.new("/api/bp-patch", "PATCH"),
   Endpoint.new("/api/bp-delete", "DELETE"),
+  Endpoint.new("/api/bp-query", "QUERY", [Param.new("term", "", "query")]),
 
   # MethodView - UserAPI
   Endpoint.new("/api/users", "GET", [Param.new("username", "", "query")]),
@@ -33,6 +35,12 @@ expected_endpoints = [
   Endpoint.new("/api/items-inferred", "GET", [Param.new("page", "", "query")]),
   Endpoint.new("/api/items-inferred", "POST", [Param.new("name", "", "json")]),
 
+  # MethodView - SearchAPI (inferred methods, no explicit methods= arg —
+  # GET + QUERY inferred from the class body, matching Werkzeug's
+  # http_method_funcs since pallets/flask#6065)
+  Endpoint.new("/api/search-view-inferred", "GET", [Param.new("keyword", "", "query")]),
+  Endpoint.new("/api/search-view-inferred", "QUERY", [Param.new("criteria", "", "json")]),
+
   # flask.views.View dispatch_request with class-level methods
   Endpoint.new("/api/reports-view", "GET", [Param.new("owner", "", "query")]),
   Endpoint.new("/api/reports-view", "POST", [Param.new("title", "", "json")]),
@@ -40,6 +48,10 @@ expected_endpoints = [
   # MethodView - AsyncAPI (async def)
   Endpoint.new("/api/async", "GET", [Param.new("category", "", "query")]),
   Endpoint.new("/api/async", "POST", [Param.new("title", "", "json")]),
+
+  # MethodView - SearchAPI (explicit QUERY method, RFC 10008)
+  Endpoint.new("/api/search-view", "GET", [Param.new("keyword", "", "query")]),
+  Endpoint.new("/api/search-view", "QUERY", [Param.new("criteria", "", "json")]),
 
   # add_url_rule with rule= keyword (not first positional)
   Endpoint.new("/api/items-kwarg", "GET", [Param.new("page", "", "query")]),

--- a/spec/functional_test/testers/python/flask_spec.cr
+++ b/spec/functional_test/testers/python/flask_spec.cr
@@ -9,6 +9,9 @@ expected_endpoints = [
   Endpoint.new("/delete_record", "DELETE", [Param.new("name", "", "json")]),
   Endpoint.new("/get_ip", "GET", [Param.new("X-Forwarded-For", "", "header")]),
   Endpoint.new("/update_record", "POST", [Param.new("page", "", "query"), Param.new("name", "", "json")]),
+  Endpoint.new("/search", "QUERY", [Param.new("criteria", "", "json")]),
+  Endpoint.new("/lookup", "GET", [Param.new("term", "", "query")]),
+  Endpoint.new("/lookup", "QUERY", [Param.new("term", "", "query")]),
   Endpoint.new("/", "GET"),
 ]
 

--- a/spec/unit_test/miniparser/python_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/python_route_extractor_ts_spec.cr
@@ -20,6 +20,8 @@ describe Noir::TreeSitterPythonRouteExtractor do
       {"/delete_record", ["DELETE"], "delete_record"},
       {"/get_ip", ["GET"], "json_sample"},
       {"/login", ["POST"], "login_sample"},
+      {"/lookup", ["GET", "QUERY"], "lookup_record"},
+      {"/search", ["QUERY"], "search_record"},
       {"/sign", ["GET", "POST"], "sign_sample"},
       {"/update_record", ["POST"], "update_record"},
     ])

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -26,18 +26,36 @@ module Analyzer::Python
 
     # `def get(...)` / `async def post(...)` method heads in class-based
     # views. Precompiled — an interpolated literal would be recompiled on
-    # every line of every CBV class body.
-    REGEX_CBV_METHOD_DEF = /\s+(?:async\s+)?def\s+(#{HTTP_METHODS.join("|")})\s*\(/
+    # every line of every CBV class body. Uses `HTTP_METHODS_EXCLUDING_QUERY`
+    # (see `PythonEngine`): Django's CBV dispatch (`View.dispatch`) looks up
+    # `request.method.lower()` against the class's `http_method_names`
+    # allowlist, which does not include `query` upstream — unlike Flask's
+    # duck-typed `getattr(self, request.method.lower())` dispatch, a
+    # `def query(self):` method is genuinely inert unless a view manually
+    # widens that allowlist, so matching it here would report a phantom
+    # route.
+    REGEX_CBV_METHOD_DEF = /\s+(?:async\s+)?def\s+(#{HTTP_METHODS_EXCLUDING_QUERY.join("|")})\s*\(/
 
-    # HTTP_METHODS is a fixed 8-element table (from PythonEngine), so the
+    # HTTP_METHODS is a fixed table (from PythonEngine), so the
     # decorator-stack scan and the `request.method == "..."` scan below
-    # (each an `HTTP_METHODS.each` loop run per decorator line / per
-    # function-body line) can look up a precompiled regex per method name
-    # instead of interpolating and recompiling one on every iteration.
-    # Purely a lookup-table hoist — the matched text/capture groups are
-    # unchanged, so it doesn't affect the line/offset values computed
-    # elsewhere in this file.
-    DECORATOR_METHOD_NAME_REGEXES = HTTP_METHODS.to_h { |m| {m, /[^a-zA-Z0-9](#{m})[^a-zA-Z0-9]/} }
+    # (each an `.each` loop run per decorator line / per function-body
+    # line) can look up a precompiled regex per method name instead of
+    # interpolating and recompiling one on every iteration. Purely a
+    # lookup-table hoist — the matched text/capture groups are unchanged,
+    # so it doesn't affect the line/offset values computed elsewhere in
+    # this file.
+    #
+    # `DECORATOR_METHOD_NAME_REGEXES` also uses `HTTP_METHODS_EXCLUDING_QUERY`,
+    # for the OTHER reason that constant documents: it bare-word-matches a
+    # method name anywhere in a decorator's text (this scan is not CBV-
+    # specific — it runs over the decorator stack above a plain function
+    # too), and real decorators (e.g. DRF-spectacular's
+    # `OpenApiParameter("query", ...)`) commonly carry `query` as a
+    # parameter name rather than a verb restriction.
+    # `REQUEST_METHOD_NAME_REGEXES` keeps the full list: it only fires on
+    # an explicit, quoted `request.method == "QUERY"` comparison, which is
+    # unambiguous developer-written evidence, not a name collision.
+    DECORATOR_METHOD_NAME_REGEXES = HTTP_METHODS_EXCLUDING_QUERY.to_h { |m| {m, /[^a-zA-Z0-9](#{m})[^a-zA-Z0-9]/} }
     REQUEST_METHOD_NAME_REGEXES   = HTTP_METHODS.to_h { |m| {m, /['"](#{m})['"]/} }
 
     # Map request parameters to their respective fields
@@ -1279,7 +1297,7 @@ module Analyzer::Python
                 restricted_methods ||= [] of ::String
                 methods.each { |m| restricted_methods << m unless restricted_methods.includes?(m) }
               else
-                HTTP_METHODS.each do |http_method_name|
+                HTTP_METHODS_EXCLUDING_QUERY.each do |http_method_name|
                   method_name_match = preceding_definition.downcase.match DECORATOR_METHOD_NAME_REGEXES[http_method_name]
                   unless method_name_match.nil?
                     suspicious_http_methods << http_method_name.upcase

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -42,10 +42,14 @@ module Analyzer::Python
       }
     end
 
+    # `QUERY` (RFC 10008) is safe/idempotent like GET but, per the method's
+    # whole purpose, carries its filter criteria in a request body like
+    # POST — so it joins the body-bearing methods for "form"/"json", not
+    # the read-only "query" (query-string) type.
     REQUEST_PARAM_TYPES = {
       "query"  => nil,
-      "form"   => ["POST", "PUT", "PATCH", "DELETE"],
-      "json"   => ["POST", "PUT", "PATCH", "DELETE"],
+      "form"   => ["POST", "PUT", "PATCH", "DELETE", "QUERY"],
+      "json"   => ["POST", "PUT", "PATCH", "DELETE", "QUERY"],
       "cookie" => nil,
       "header" => nil,
     }
@@ -65,7 +69,7 @@ module Analyzer::Python
     # don't recompile them. VIEW_FUNC_KWARG_RE has no whitespace tolerance
     # (unlike Quart's) because Flask's add_url_rule args are matched on
     # space-stripped lines.
-    ROUTE_DECORATOR_RE  = /^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m
+    ROUTE_DECORATOR_RE  = /^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace|query)\s*\(/m
     ROUTE_REGISTRAR_RE  = /\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/
     VIEW_FUNC_KWARG_RE  = /view_func=(#{DOT_NATION})(?:,|\)|$)/
     DOTTED_REFERENCE_RE = /^#{DOT_NATION}$/

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -45,10 +45,15 @@ module Analyzer::Python
       }
     end
 
+    # `QUERY` (RFC 10008) is safe/idempotent like GET but, per the method's
+    # whole purpose, carries its filter criteria in a request body like
+    # POST — so it joins the body-bearing methods for "form"/"json", not
+    # the read-only "query" (query-string) type. Quart mirrors Flask's API
+    # 1:1 (including this table), so it gets the same treatment.
     REQUEST_PARAM_TYPES = {
       "query"  => nil,
-      "form"   => ["POST", "PUT", "PATCH", "DELETE"],
-      "json"   => ["POST", "PUT", "PATCH", "DELETE"],
+      "form"   => ["POST", "PUT", "PATCH", "DELETE", "QUERY"],
+      "json"   => ["POST", "PUT", "PATCH", "DELETE", "QUERY"],
       "cookie" => nil,
       "header" => nil,
     }

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -19,10 +19,14 @@ module Analyzer::Python
       "headers" => {nil, "header"},
     }
 
+    # `QUERY` (RFC 10008) is safe/idempotent like GET but, per the method's
+    # whole purpose, carries its filter criteria in a request body like
+    # POST — so it joins the body-bearing methods for "form"/"json", not
+    # the read-only "query" (query-string) type.
     REQUEST_PARAM_TYPES = {
       "query"  => nil,
-      "form"   => ["POST", "PUT", "PATCH", "DELETE"],
-      "json"   => ["POST", "PUT", "PATCH", "DELETE"],
+      "form"   => ["POST", "PUT", "PATCH", "DELETE", "QUERY"],
+      "json"   => ["POST", "PUT", "PATCH", "DELETE", "QUERY"],
       "cookie" => nil,
       "header" => nil,
     }

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -549,8 +549,16 @@ module Analyzer::Python
           endpoints << endpoint
         end
 
-        # Look for HTTP method handlers (both sync and async)
-        HTTP_METHODS.each do |http_method|
+        # Look for HTTP method handlers (both sync and async). Uses
+        # `HTTP_METHODS_EXCLUDING_QUERY` (see `PythonEngine`): Tornado's
+        # `RequestHandler._execute` rejects any verb outside its
+        # `SUPPORTED_METHODS` class attribute before dispatch, and that
+        # tuple does not include `query` upstream — unlike Flask's duck-typed
+        # `getattr(self, request.method.lower())` dispatch, a
+        # `def query(self):` method is genuinely inert unless a handler
+        # manually widens `SUPPORTED_METHODS`, so matching it here would
+        # report a phantom route.
+        HTTP_METHODS_EXCLUDING_QUERY.each do |http_method|
           if stripped.starts_with?("def #{http_method}(") || stripped.starts_with?("async def #{http_method}(")
             params = extract_path_params_from_method_signature(stripped, route_path)
             extract_params_from_method(lines, line_index, file_path).each do |param|

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -5,8 +5,29 @@ require "json"
 
 module Analyzer::Python
   abstract class PythonEngine < Analyzer
-    # HTTP method names commonly used in REST APIs
-    HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options", "trace"]
+    # HTTP method names commonly used in REST APIs. `query` (RFC 10008) is
+    # included for frameworks whose class-based-view dispatch is duck-typed
+    # (Flask/Quart/Sanic call `getattr(self, request.method.lower())`, so a
+    # `def query(self):` method genuinely serves QUERY requests).
+    HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options", "trace", "query"]
+
+    # `HTTP_METHODS` minus `query`. Analyzers pattern-match a bare method
+    # name against source text in more than one shape — a `def <verb>(...)`
+    # head inside a confirmed handler class, or a verb token appearing
+    # anywhere in a decorator's raw text — and for two reasons a match on
+    # `query` there is not reliable evidence of QUERY support:
+    #
+    #   * The framework dispatches via an explicit method allowlist rather
+    #     than duck-typing (Django's `http_method_names`, Tornado's
+    #     `SUPPORTED_METHODS`), so a same-named helper method — a common
+    #     name for search/filter logic — is genuinely inert, not a route.
+    #   * The match is a bare-word scan of arbitrary decorator text, where
+    #     `query` routinely appears as an unrelated parameter name (e.g.
+    #     DRF-spectacular's `OpenApiParameter("query", ...)`).
+    #
+    # Shared here so each consuming analyzer doesn't redefine the same
+    # subtraction with its own copy of the justification.
+    HTTP_METHODS_EXCLUDING_QUERY = HTTP_METHODS - ["query"]
     # Indentation size in spaces; different sizes can cause analysis issues
     INDENTATION_SIZE = 4
     # Regex for valid Python variable names

--- a/src/miniparsers/python_route_extractor.cr
+++ b/src/miniparsers/python_route_extractor.cr
@@ -20,7 +20,10 @@ module Noir
     extend self
 
     PYTHON_VAR_NAME = /[a-zA-Z_][a-zA-Z0-9_]*/
-    HTTP_METHODS    = %w[get post put patch delete head options trace]
+    # `query` (RFC 10008) recognizes `@<var>.query("/path")` shortcut
+    # decorators (Flask/Werkzeug shipped this; other decorator-based
+    # frameworks fall through harmlessly if they never define it).
+    HTTP_METHODS = %w[get post put patch delete head options trace query]
 
     # One match from `scan_decorators`.
     #

--- a/src/miniparsers/python_route_extractor_ts.cr
+++ b/src/miniparsers/python_route_extractor_ts.cr
@@ -18,7 +18,10 @@ module Noir
   module TreeSitterPythonRouteExtractor
     extend self
 
-    HTTP_METHODS = %w[get post put patch delete head options trace]
+    # `query` (RFC 10008) recognizes `@<var>.query("/path")` shortcut
+    # decorators (Flask/Werkzeug shipped this; other decorator-based
+    # frameworks fall through harmlessly if they never define it).
+    HTTP_METHODS = %w[get post put patch delete head options trace query]
 
     # A `@<router>.route(...)` or `@<router>.<method>(...)` decorator, paired
     # with the `def`/`class` it applies to.


### PR DESCRIPTION
## Summary

- Adds RFC 10008 `QUERY` method detection to the Flask analyzer: `@app.route(..., methods=["QUERY"])`, the `@app.query`/`@bp.query` shortcut decorators (pallets/flask#6065, shipped upstream), and `MethodView`/`Resource` dispatch of a `def query(self):` handler — matching Flask/Werkzeug's duck-typed `getattr(self, request.method.lower())` dispatch.
- `query` is added to the shared `PythonEngine::HTTP_METHODS` table and the two route-extractor `HTTP_METHODS` tables (regex + tree-sitter), since those are consulted by every Python analyzer.
- Flask's (and Quart's/Sanic's) `REQUEST_PARAM_TYPES` now treats `QUERY` as body-bearing for `form`/`json` params (like POST) while staying safe/idempotent (like GET) per the `#2563` foundation decision — a QUERY handler reading `request.json`/`request.form` now keeps those params instead of silently dropping them.
- **Blast-radius audit** (the shared table affects every Python analyzer): Quart and Sanic mirror Flask's duck-typed MethodView dispatch, so they correctly gain QUERY support the same way. Django and Tornado dispatch through an explicit method allowlist (`http_method_names` / `SUPPORTED_METHODS`) that doesn't include `query` upstream, so a `def query(self):` helper method (a very plausible name for search/filter logic, e.g. in a DRF ViewSet or Tornado handler) would otherwise be misread as a phantom route. Added a shared `HTTP_METHODS_EXCLUDING_QUERY` table so those two analyzers keep their existing (correct) behavior.

## Test plan

- [x] New Flask fixtures: `methods=["QUERY"]`, `methods=["GET","QUERY"]`, `@app.query`, `@bp.query`, explicit `MethodView.query` (via `add_url_rule(methods=[...])`), and inferred `MethodView.query` (no explicit `methods=`, relying on Werkzeug's `http_method_funcs`)
- [x] New Quart/Sanic throwaway-fixture verification that QUERY body params (`request.json`) are no longer dropped
- [x] New negative fixtures: a `def query(...)` helper method on a Django `View` and a Tornado `RequestHandler` that must NOT produce a phantom `QUERY` endpoint (both pinned to zero new endpoints)
- [x] Full unit + functional suite: `27527 examples, 0 failures, 0 errors, 0 pending`
- [x] `crystal tool format --check`, `ameba` (2139 files, 0 failures), `typos` — all clean
- [x] Manual round-trip check: OAS3 degrades QUERY to `x-noir-unsupported-methods`, curl output emits the JSON body, ai-context marks it safe (no `unsafe_method` signal) — consistent with the `#2563` foundation work