### PR TITLE
feat(html): first-class badge/chip color for the QUERY method

### DIFF
--- a/spec/unit_test/output_builder/html_spec.cr
+++ b/spec/unit_test/output_builder/html_spec.cr
@@ -201,6 +201,7 @@ describe "OutputBuilderHtml" do
       Endpoint.new("/test", "PUT"),
       Endpoint.new("/test", "PATCH"),
       Endpoint.new("/test", "DELETE"),
+      Endpoint.new("/test", "QUERY"),
       Endpoint.new("/test", "OPTIONS"),
     ]
 
@@ -213,7 +214,27 @@ describe "OutputBuilderHtml" do
     output.should contain("method-put")
     output.should contain("method-patch")
     output.should contain("method-delete")
+    output.should contain("method-query")
     output.should contain("method-default")
+  end
+
+  it "assigns a dedicated chip class to QUERY endpoints" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/test", "QUERY")])
+    output = builder.io.to_s
+
+    output.should contain("method-query")
+    output.should_not contain("class=\"method-badge method-default\"")
+    output.should contain("chip-query")
   end
 
   it "handles all parameter types" do

--- a/src/output_builder/html.cr
+++ b/src/output_builder/html.cr
@@ -467,7 +467,7 @@ class OutputBuilderHtml < OutputBuilder
   # Hue modifier for pressed filter chips; only known verbs/severities get one.
   private def chip_hue_class(name : String) : String
     case name.downcase
-    when "get", "post", "put", "patch", "delete",
+    when "get", "post", "put", "patch", "delete", "query",
          "critical", "high", "medium", "low"
       " chip-#{name.downcase}"
     else
@@ -482,6 +482,7 @@ class OutputBuilderHtml < OutputBuilder
     when "PUT"    then "method-put"
     when "PATCH"  then "method-patch"
     when "DELETE" then "method-delete"
+    when "QUERY"  then "method-query"
     else               "method-default"
     end
   end

--- a/src/output_builder/html_assets/css.cr
+++ b/src/output_builder/html_assets/css.cr
@@ -38,6 +38,9 @@ module HtmlReportAssets
       --m-delete: #be123c;
       --m-delete-soft: rgba(190, 18, 60, 0.08);
       --m-delete-line: rgba(190, 18, 60, 0.38);
+      --m-query: #0e7490;
+      --m-query-soft: rgba(14, 116, 144, 0.08);
+      --m-query-line: rgba(14, 116, 144, 0.38);
       /* semantic severity hues */
       --sev-critical-bg: #b91c1c;
       --sev-critical-ink: #fdf2f2;
@@ -80,6 +83,9 @@ module HtmlReportAssets
       --m-delete: #f87171;
       --m-delete-soft: rgba(248, 113, 113, 0.09);
       --m-delete-line: rgba(248, 113, 113, 0.34);
+      --m-query: #22d3ee;
+      --m-query-soft: rgba(34, 211, 238, 0.09);
+      --m-query-line: rgba(34, 211, 238, 0.34);
       --sev-critical-bg: #e05252;
       --sev-critical-ink: #0b0b10;
       --sev-high: #f87171;
@@ -265,6 +271,7 @@ module HtmlReportAssets
     .chip.chip-put[aria-pressed="true"] { color: var(--m-put); background: var(--m-put-soft); border-color: var(--m-put-line); }
     .chip.chip-patch[aria-pressed="true"] { color: var(--m-patch); background: var(--m-patch-soft); border-color: var(--m-patch-line); }
     .chip.chip-delete[aria-pressed="true"] { color: var(--m-delete); background: var(--m-delete-soft); border-color: var(--m-delete-line); }
+    .chip.chip-query[aria-pressed="true"] { color: var(--m-query); background: var(--m-query-soft); border-color: var(--m-query-line); }
     .chip.chip-critical[aria-pressed="true"] { color: var(--sev-critical-ink); background: var(--sev-critical-bg); border-color: var(--sev-critical-bg); }
     .chip.chip-high[aria-pressed="true"] { color: var(--sev-high); background: var(--sev-high-soft); border-color: var(--sev-high-line); }
     .chip.chip-medium[aria-pressed="true"] { color: var(--sev-medium); background: var(--sev-medium-soft); border-color: var(--sev-medium-line); }
@@ -478,6 +485,9 @@ module HtmlReportAssets
     .method-put { color: var(--m-put); background: var(--m-put-soft); border-color: var(--m-put-line); }
     .method-patch { color: var(--m-patch); background: var(--m-patch-soft); border-color: var(--m-patch-line); }
     .method-delete { color: var(--m-delete); background: var(--m-delete-soft); border-color: var(--m-delete-line); }
+    .method-query { color: var(--m-query); background: var(--m-query-soft); border-color: var(--m-query-line); }
+    /* HEAD/OPTIONS intentionally stay hueless (method-default): they're not
+       primary request-risk verbs, so no dedicated color is assigned. */
     .method-default { background: transparent; color: var(--ink-3); border-color: var(--line-2); border-style: dashed; }
 
     .protocol-badge {


### PR DESCRIPTION
## Summary
- Adds `--m-query` / `--m-query-soft` / `--m-query-line` CSS tokens (light + dark theme) using a cyan hue distinct from the existing GET/POST/PUT/PATCH/DELETE colors
- Wires `QUERY` into `get_method_class` and `chip_hue_class` in `src/output_builder/html.cr` so QUERY endpoints get `method-query` / `chip-query` instead of the unstyled `method-default`
- `HEAD`/`OPTIONS` stay intentionally hueless (`method-default`); left a comment in the CSS so the next verb doesn't reopen the question

Follow-up to #2540 / #2563 (deferred there as cosmetic).

## Test plan
- [x] `crystal spec spec/unit_test/output_builder/html_spec.cr` — 27 examples, 0 failures (added a new spec asserting QUERY gets `method-query`/`chip-query`, not `method-default`)
- [x] `crystal spec spec/unit_test/output_builder/` — full output_builder suite green (194 examples)
- [x] `just build-release` then scanned a fixture with a `QUERY` route and inspected the generated HTML report: `method-query`/`chip-query` classes render with the new tokens wired to both light/dark blocks
- [x] Computed WCAG contrast for the chosen hue against `--bg` in both themes (~5.4:1 light, ~11.4:1 dark) — in line with the existing GET green

Closes #2564