### PR TITLE
feat(analyzer): detect Sails.js routes and blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The inventory feeds three audiences:
 
 ## What Noir does
 
-- **Endpoint extraction.** Static analysis across [196 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
+- **Endpoint extraction.** Static analysis across [197 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
 - **LLM fallback.** Hand unsupported frameworks (or one-off custom routing) to OpenAI / Ollama / etc. when static rules don't apply.
 - **Output for the next stage.** JSON, YAML, OpenAPI, SARIF, cURL, Postman, HTML — whichever format the next tool in the pipeline reads.
 - **DAST integration.** Pipe directly into ZAP, Burp Suite, Caido or Gori as a proxy target, or export OpenAPI for them to import.

--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 196개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
+description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 197개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
 template = "landing"
 +++
 
@@ -91,7 +91,7 @@ template = "landing"
         <p>플러그인도, 언어별 설정도 없는 단일 바이너리입니다. 정적 규칙이 놓친 프레임워크는 LLM이 대신 처리합니다.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">언어</span></span>
-          <span><span class="stat-val">196</span><span class="stat-key">프레임워크</span></span>
+          <span><span class="stat-val">197</span><span class="stat-key">프레임워크</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 196 frameworks, exposing shadow APIs and mapping the attack surface."
+description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 197 frameworks, exposing shadow APIs and mapping the attack surface."
 template = "landing"
 +++
 
@@ -89,7 +89,7 @@ template = "landing"
         <p>One binary, no plugins and no per-language setup. Frameworks the static rules miss fall back to an LLM.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">Languages</span></span>
-          <span><span class="stat-val">196</span><span class="stat-key">Frameworks</span></span>
+          <span><span class="stat-val">197</span><span class="stat-key">Frameworks</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -3042,6 +3042,33 @@ sort_by = "weight"
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Sails.js</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip on">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip off">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Socket.IO</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -3042,6 +3042,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Sails.js</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip on">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip off">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Socket.IO</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/spec/functional_test/fixtures/javascript/sails/app.js
+++ b/spec/functional_test/fixtures/javascript/sails/app.js
@@ -1,0 +1,8 @@
+var sails = require('sails');
+
+sails.lift({}, function (err) {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+});

--- a/spec/functional_test/fixtures/javascript/sails/config/routes.js
+++ b/spec/functional_test/fixtures/javascript/sails/config/routes.js
@@ -1,0 +1,48 @@
+/**
+ * config/routes.js
+ *
+ * Custom routes exercised by the Sails functional-test fixture: plain
+ * controller/action strings, an object target, path params, inline
+ * function/arrow handlers with query/body/header/cookie access, a view
+ * target, a method-less (any-verb) address, and a regex address that
+ * must NOT be picked up.
+ */
+
+module.exports.routes = {
+
+  'GET /': 'UserController.index',
+
+  'GET /users': 'UserController.find',
+
+  'GET /users/:id': 'UserController.findOne',
+
+  'POST /users': { controller: 'UserController', action: 'create' },
+
+  'PUT /users/:id': 'UserController.update',
+
+  'DELETE /users/:id': 'UserController.destroy',
+
+  'GET /profile': function (req, res) {
+    var section = req.query.section;
+    var token = req.headers['x-profile-token'];
+    return res.ok({ section: section, token: token });
+  },
+
+  'post /login': (req, res) => {
+    var username = req.body.username;
+    var password = req.body.password;
+    var sessionId = req.cookies.sessionId;
+    return res.ok();
+  },
+
+  'GET /about': { view: 'pages/about' },
+
+  '/webhook': function (req, res) {
+    return res.ok();
+  },
+
+  // Regex-address routes are intentionally not modeled -- must not
+  // surface as an endpoint.
+  'r|^/\\d+/(\\w+)/(\\w+)$|foo,bar': 'message/my-action',
+
+};

--- a/spec/functional_test/fixtures/javascript/sails/package.json
+++ b/spec/functional_test/fixtures/javascript/sails/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sails-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "sails": "^1.5.4"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/sails_blueprints/api/controllers/UserController.js
+++ b/spec/functional_test/fixtures/javascript/sails_blueprints/api/controllers/UserController.js
@@ -1,0 +1,8 @@
+/**
+ * UserController.js
+ *
+ * A bare controller file -- no custom actions defined here, so every
+ * request it can serve comes from Sails' default REST blueprint actions
+ * (find/create/findOne/update/destroy) bound to the `user` model.
+ */
+module.exports = {};

--- a/spec/functional_test/fixtures/javascript/sails_blueprints/api/controllers/login.js
+++ b/spec/functional_test/fixtures/javascript/sails_blueprints/api/controllers/login.js
@@ -1,0 +1,13 @@
+/**
+ * api/controllers/login.js
+ *
+ * A top-level standalone action, not nested under a subdirectory. Its
+ * URL is /login.
+ */
+module.exports = {
+  friendlyName: 'Login',
+
+  fn: async function (inputs, exits) {
+    return exits.success();
+  },
+};

--- a/spec/functional_test/fixtures/javascript/sails_blueprints/api/controllers/user/find-one.js
+++ b/spec/functional_test/fixtures/javascript/sails_blueprints/api/controllers/user/find-one.js
@@ -1,0 +1,18 @@
+/**
+ * api/controllers/user/find-one.js
+ *
+ * An "actions2" standalone action file. Its URL is its path relative to
+ * api/controllers, without the extension: /user/find-one.
+ */
+module.exports = {
+  friendlyName: 'Find one user',
+
+  inputs: {
+    id: { type: 'string', required: true },
+  },
+
+  fn: async function (inputs, exits) {
+    var user = await User.findOne({ id: inputs.id });
+    return exits.success(user);
+  },
+};

--- a/spec/functional_test/fixtures/javascript/sails_blueprints/api/models/Post.js
+++ b/spec/functional_test/fixtures/javascript/sails_blueprints/api/models/Post.js
@@ -1,0 +1,12 @@
+/**
+ * Post.js
+ *
+ * A model with no matching controller file. Sails still binds the
+ * default REST blueprint actions to it, straight off the model.
+ */
+module.exports = {
+  attributes: {
+    title: { type: 'string' },
+    body: { type: 'string' },
+  },
+};

--- a/spec/functional_test/fixtures/javascript/sails_blueprints/assets/style.css
+++ b/spec/functional_test/fixtures/javascript/sails_blueprints/assets/style.css
@@ -1,0 +1,3 @@
+body {
+  font-family: sans-serif;
+}

--- a/spec/functional_test/fixtures/javascript/sails_blueprints/config/routes.js
+++ b/spec/functional_test/fixtures/javascript/sails_blueprints/config/routes.js
@@ -1,0 +1,10 @@
+/**
+ * config/routes.js
+ *
+ * No custom routes here -- this fixture exercises blueprint (convention
+ * over configuration) route inference only: the default REST CRUD
+ * blueprint actions bound to each controller/model, the "actions2"
+ * standalone action files under api/controllers/, and the default
+ * assets/ static directory.
+ */
+module.exports.routes = {};

--- a/spec/functional_test/fixtures/javascript/sails_blueprints/package.json
+++ b/spec/functional_test/fixtures/javascript/sails_blueprints/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sails-blueprints-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "sails": "^1.5.4"
+  }
+}

--- a/spec/functional_test/testers/javascript/sails_blueprints_spec.cr
+++ b/spec/functional_test/testers/javascript/sails_blueprints_spec.cr
@@ -1,0 +1,59 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  # Blueprint CRUD routes bound to UserController.js (no matching model
+  # file needed -- Sails still binds the default REST actions).
+  Endpoint.new("/user", "GET"),
+  Endpoint.new("/user", "POST"),
+  Endpoint.new("/user/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/user/:id", "PATCH", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/user/:id", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
+
+  # Blueprint CRUD routes bound to api/models/Post.js -- no controller
+  # file at all, the model alone is enough.
+  Endpoint.new("/post", "GET"),
+  Endpoint.new("/post", "POST"),
+  Endpoint.new("/post/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/post/:id", "PATCH", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/post/:id", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
+
+  # "actions2" standalone action file nested under api/controllers/user/,
+  # addressed by its path relative to api/controllers -- /user/find-one.
+  # A shadow route responds to every HTTP verb.
+  Endpoint.new("/user/find-one", "GET"),
+  Endpoint.new("/user/find-one", "POST"),
+  Endpoint.new("/user/find-one", "PUT"),
+  Endpoint.new("/user/find-one", "DELETE"),
+  Endpoint.new("/user/find-one", "PATCH"),
+  Endpoint.new("/user/find-one", "HEAD"),
+  Endpoint.new("/user/find-one", "OPTIONS"),
+
+  # Top-level standalone action file, not nested under a subdirectory.
+  Endpoint.new("/login", "GET"),
+  Endpoint.new("/login", "POST"),
+  Endpoint.new("/login", "PUT"),
+  Endpoint.new("/login", "DELETE"),
+  Endpoint.new("/login", "PATCH"),
+  Endpoint.new("/login", "HEAD"),
+  Endpoint.new("/login", "OPTIONS"),
+
+  # Default `assets/` static directory.
+  Endpoint.new("/style.css", "GET"),
+]
+
+FunctionalTester.new("fixtures/javascript/sails_blueprints/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/sails_spec.cr
+++ b/spec/functional_test/testers/javascript/sails_spec.cr
@@ -1,0 +1,41 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/users", "GET"),
+  Endpoint.new("/users/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/users", "POST"),
+  Endpoint.new("/users/:id", "PUT", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/users/:id", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/profile", "GET", [
+    Param.new("section", "", "query"),
+    Param.new("x-profile-token", "", "header"),
+  ]),
+  Endpoint.new("/login", "POST", [
+    Param.new("username", "", "json"),
+    Param.new("password", "", "json"),
+    Param.new("sessionId", "", "cookie"),
+  ]),
+  Endpoint.new("/about", "GET"),
+  # Method-less address -- matches every HTTP verb.
+  Endpoint.new("/webhook", "GET"),
+  Endpoint.new("/webhook", "POST"),
+  Endpoint.new("/webhook", "PUT"),
+  Endpoint.new("/webhook", "DELETE"),
+  Endpoint.new("/webhook", "PATCH"),
+  Endpoint.new("/webhook", "HEAD"),
+  Endpoint.new("/webhook", "OPTIONS"),
+  # Note: the `r|^/\d+/(\w+)/(\w+)$|foo,bar` regex-address entry in the
+  # fixture is intentionally not modeled and must not appear above.
+]
+
+FunctionalTester.new("fixtures/javascript/sails/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/detector/javascript/sails_spec.cr
+++ b/spec/unit_test/detector/javascript/sails_spec.cr
@@ -1,0 +1,47 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/javascript/*"
+
+describe "Detect JS Sails" do
+  options = create_test_options
+  instance = Detector::Javascript::Sails.new options
+
+  it "package_json_dependency" do
+    instance.detect("package.json", %({"dependencies": {"sails": "^1.5.4"}})).should be_true
+  end
+
+  it "package_json_dev_dependency" do
+    instance.detect("package.json", %({"devDependencies": {"sails": "^1.5.4"}})).should be_true
+  end
+
+  it "package_json_unrelated" do
+    instance.detect("package.json", %({"dependencies": {"express": "^4.19.2"}})).should be_false
+  end
+
+  it "require_single_quot" do
+    instance.detect("app.js", "var sails = require('sails');").should be_true
+  end
+
+  it "require_double_quot" do
+    instance.detect("app.js", "var sails = require(\"sails\");").should be_true
+  end
+
+  it "import_single_quot" do
+    instance.detect("app.js", "import sails from 'sails';").should be_true
+  end
+
+  it "import_double_quot" do
+    instance.detect("app.js", "import sails from \"sails\";").should be_true
+  end
+
+  it "sails_lift_call" do
+    instance.detect("app.js", "sails.lift({}, function (err) {});").should be_true
+  end
+
+  it "unrelated_js_content" do
+    instance.detect("app.js", "const express = require('express');").should be_false
+  end
+
+  it "ignores_non_js_non_manifest_files" do
+    instance.detect("README.md", "require('sails')").should be_false
+  end
+end

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -5,7 +5,7 @@ require "../../spec_helper"
 # The registry is derived from the classes, so a detector joins a scan simply by
 # existing (`build_detector_list`, src/detector/detector.cr). That removed the
 # "forgot to register it" failure mode and replaced it with a quieter one:
-# nothing at all requires a detector to be *tested*. 64 of 244 — including
+# nothing at all requires a detector to be *tested*. 64 of 245 — including
 # `rust/actix_web`, `java/quarkus`, `java/micronaut`, `java/jaxrs`,
 # `javascript/hapi`, `swift/hummingbird`, `typescript/trpc`, every `zig/*` and
 # every language's `cli` — shipped with zero coverage.
@@ -170,6 +170,6 @@ describe "detector spec coverage" do
   # Guards the guard: a broken glob would make every example above pass
   # vacuously.
   it "finds every registered detector" do
-    detector_paths.size.should eq 244
+    detector_paths.size.should eq 245
   end
 end

--- a/src/analyzer/analyzers/javascript/sails.cr
+++ b/src/analyzer/analyzers/javascript/sails.cr
@@ -1,0 +1,288 @@
+require "../../engines/javascript_engine"
+require "../../../miniparsers/js_route_extractor"
+
+module Analyzer::Javascript
+  # Sails.js routes come from two sources:
+  #
+  #   1. Explicit routes hand-written in `config/routes.js` -- an object
+  #      literal mapping `'METHOD /path'` address strings to targets
+  #      (controller/action strings, `{controller, action}` objects,
+  #      inline handler functions, view/redirect targets, ...).
+  #   2. Blueprint routes Sails auto-generates per controller/model unless
+  #      disabled, plus the "actions2" convention of one file per action
+  #      under `api/controllers/<subdir>/<action>.js`, whose URL is the
+  #      action's path relative to `api/controllers` (no extension).
+  #
+  # Both are gated on `discover_sails_roots`, which requires a
+  # `config/routes.js` file AND a `package.json` declaring the `sails`
+  # dependency in the SAME directory -- not either alone. Node projects are
+  # noir's most crowded language (Express/Koa/Nest/Fastify/Hapi/Restify all
+  # coexist), and blueprint inference in particular works off file
+  # *presence* rather than an explicit registration call, so it is
+  # especially prone to stealing routes from a neighboring framework's
+  # `api/controllers/*.js`-shaped tree in the same repo (the exact class of
+  # bug the #2417-2432 project-scoping campaign fixed for other analyzers).
+  class Sails < JavascriptEngine
+    analyzer_for "js_sails"
+
+    ROUTES_FILE_SUFFIX = "/config/routes.js"
+    PACKAGE_MARKER     = /"sails"\s*:\s*"/
+
+    JS_SOURCE_EXTENSIONS = [".js", ".ts", ".mjs", ".cjs"]
+
+    HTTP_METHODS = %w[GET POST PUT DELETE PATCH HEAD OPTIONS]
+
+    # Address verbs recognised in `config/routes.js` route keys. `ALL`
+    # matches any method (expanded below); QUERY is accepted for parity
+    # with the rest of noir's JS analyzers even though Sails' own docs
+    # don't mention it explicitly -- an app that wires one up by hand
+    # still deserves to be reported.
+    ADDRESS_METHOD_RE = /\A(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|QUERY|ALL)[ \t]+(\/.*)\z/i
+
+    # One quoted-key route entry per line is the universal `routes.js`
+    # style (every official example and every real app follows it). The
+    # captured group requires the string to actually look like a route
+    # address -- an optional method name followed by `/...` -- so nested
+    # option keys inside a target object (`locals: {...}`, `cors: {...}`)
+    # can't be mistaken for a sibling route entry: those keys are bare
+    # identifiers, never quoted strings immediately followed by `:`.
+    ADDRESS_LINE_RE = /^[ \t]*['"]((?:[A-Za-z]+[ \t]+)?\/[^'"]*)['"][ \t]*:/m
+
+    CONTROLLER_FILE_RE = /\A([A-Za-z0-9_]+)Controller\.(js|ts|mjs|cjs)\z/
+
+    MODEL_FILE_RE = /\A([A-Za-z0-9_]+)\.(js|ts|mjs|cjs)\z/
+
+    # {method, sub-path} pairs generated for every blueprint-eligible
+    # controller/model identity, mirroring Sails' current (>=1.0) default
+    # REST blueprint bindings: find/create/findOne/update/destroy.
+    # Association routes (populate/add/remove/replace) and the dev-only
+    # shortcut GET routes are intentionally not modeled -- see the PR
+    # description for the reasoning.
+    BLUEPRINT_ROUTES = [
+      {"GET", ""},
+      {"POST", ""},
+      {"GET", "/:id"},
+      {"PATCH", "/:id"},
+      {"DELETE", "/:id"},
+    ]
+
+    def analyze
+      result = [] of Endpoint
+      static_dirs = [] of Hash(String, String)
+
+      discover_sails_roots.each do |root, routes_file|
+        analyze_routes_file(routes_file, result)
+        analyze_blueprints(root, result)
+        static_dirs << {"static_path" => "/", "file_path" => "#{root}/assets"}
+      end
+
+      process_js_static_dirs(static_dirs, result)
+      result
+    end
+
+    # A Sails app root is a directory that both owns a `config/routes.js`
+    # file AND has a `package.json` declaring a dependency on the `sails`
+    # package. See the class comment for why both signals are required.
+    private def discover_sails_roots : Array(Tuple(String, String))
+      roots = [] of Tuple(String, String)
+
+      get_files_by_basename("routes.js").each do |file|
+        next unless file.ends_with?(ROUTES_FILE_SUFFIX)
+        root = file[0, file.size - ROUTES_FILE_SUFFIX.size]
+        next if root.empty?
+        next unless sails_package_present?(root)
+        roots << {root, file}
+      end
+
+      roots
+    end
+
+    private def sails_package_present?(root : String) : Bool
+      get_files_by_basename("package.json").any? do |file|
+        next false unless File.dirname(file) == root
+        begin
+          content_matches?(read_file_content(file), PACKAGE_MARKER)
+        rescue IO::Error
+          false
+        end
+      end
+    end
+
+    # ---------------------------------------------------------------------
+    # Explicit `config/routes.js` routes
+    # ---------------------------------------------------------------------
+
+    private def analyze_routes_file(routes_file : String, result : Array(Endpoint))
+      raw_content = read_file_content(routes_file)
+      content = Noir::JSRouteExtractor.strip_js_comments(raw_content)
+
+      content.scan(ADDRESS_LINE_RE) do |m|
+        next unless m.size >= 2
+        match_start = m.begin(0)
+        match_end = m.end(0)
+        next unless match_start && match_end
+
+        methods, url = parse_sails_address(m[1].strip)
+        next if methods.empty? || url.empty?
+
+        line = content[0...match_start].count('\n') + 1
+        value_start = skip_ws(content, match_end)
+
+        methods.each do |method|
+          details = Details.new(PathInfo.new(routes_file, line))
+          endpoint = Endpoint.new(url, method, details)
+          url.scan(/:(\w+)/) do |pm|
+            endpoint.push_param(Param.new(pm[1], "", "path")) if pm.size > 0
+          end
+          apply_inline_handler_params(content, value_start, endpoint)
+          result << endpoint
+        end
+      end
+    end
+
+    # Splits a route address like `"GET /users/:id"` or `"/alias"` into its
+    # HTTP method(s) and URL path. Regex addresses (`r|...|...`) never
+    # reach here -- `ADDRESS_LINE_RE` requires the string to start with a
+    # verb+space or a bare `/`.
+    private def parse_sails_address(addr : String) : Tuple(Array(String), String)
+      if md = addr.match(ADDRESS_METHOD_RE)
+        method = md[1].upcase
+        path = md[2].strip
+        methods = method == "ALL" ? HTTP_METHODS : [method]
+        {methods, path}
+      elsif addr.starts_with?("/")
+        {HTTP_METHODS, addr}
+      else
+        {[] of String, ""}
+      end
+    end
+
+    # Best-effort param extraction for inline function targets and object
+    # targets (`{ controller: ..., action: ... }`, `{ fn: function(req,
+    # res) {...} }`). String/redirect/view targets and policy-chain arrays
+    # carry no handler body to inspect and are left with address-derived
+    # params only.
+    private def apply_inline_handler_params(content : String, value_start : Int32, endpoint : Endpoint)
+      return if value_start >= content.size
+      ch = content[value_start]?
+      return unless ch
+
+      body =
+        if ch == '{'
+          close = Noir::JSRouteExtractor.find_matching_brace(content, value_start)
+          close ? content[value_start..close] : nil
+        else
+          function_target_body(content, value_start)
+        end
+      return unless body
+
+      Noir::JSRouteExtractor.extract_query_params(body, endpoint)
+      Noir::JSRouteExtractor.extract_body_params(body, endpoint)
+      Noir::JSRouteExtractor.extract_header_params(body, endpoint)
+      Noir::JSRouteExtractor.extract_cookie_params(body, endpoint)
+    end
+
+    # Recognises `function(req, res) {...}` and brace-bodied arrow targets
+    # (`(req, res) => {...}`, `async (req, res) => {...}`) starting exactly
+    # at `value_start`. Concise arrow bodies without braces are not
+    # modeled -- the endpoint is still emitted, just without extra params.
+    private def function_target_body(content : String, value_start : Int32) : String?
+      window_end = Math.min(content.size, value_start + 80)
+      window = content[value_start...window_end]
+
+      brace_search_from =
+        if window.starts_with?("function")
+          value_start
+        elsif (arrow_idx = window.index("=>")) && !window[0...arrow_idx].includes?('{') && !window[0...arrow_idx].includes?(';')
+          value_start + arrow_idx + 2
+        else
+          return
+        end
+
+      open_brace = content.index("{", brace_search_from)
+      return unless open_brace
+      return if open_brace - value_start > 120
+
+      close_brace = Noir::JSRouteExtractor.find_matching_brace(content, open_brace)
+      close_brace ? content[open_brace..close_brace] : nil
+    end
+
+    private def skip_ws(content : String, pos : Int32) : Int32
+      i = pos
+      while i < content.size && content[i].whitespace?
+        i += 1
+      end
+      i
+    end
+
+    # ---------------------------------------------------------------------
+    # Blueprint (convention-based) routes
+    # ---------------------------------------------------------------------
+
+    private def analyze_blueprints(root : String, result : Array(Endpoint))
+      identities = {} of String => String
+      controllers_prefix = "#{root}/api/controllers"
+      models_prefix = "#{root}/api/models"
+
+      get_files_by_prefix(controllers_prefix).each do |file|
+        next unless js_source_file?(file)
+        next unless file.starts_with?("#{controllers_prefix}/")
+        rel = file[(controllers_prefix.size + 1)..]
+        next if rel.empty?
+        base = File.basename(rel)
+        next if base.starts_with?(".")
+
+        if !rel.includes?("/") && (md = base.match(CONTROLLER_FILE_RE))
+          identity = md[1].downcase
+          identities[identity] ||= file
+          next
+        end
+
+        emit_action_shadow_route(file, rel, result)
+      end
+
+      get_files_by_prefix(models_prefix).each do |file|
+        next unless js_source_file?(file)
+        next unless file.starts_with?("#{models_prefix}/")
+        rel = file[(models_prefix.size + 1)..]
+        next if rel.empty? || rel.includes?("/")
+        base = File.basename(rel)
+        next unless md = base.match(MODEL_FILE_RE)
+
+        identity = md[1].downcase
+        identities[identity] ||= file
+      end
+
+      identities.each do |identity, source_file|
+        BLUEPRINT_ROUTES.each do |method, sub_path|
+          details = Details.new(PathInfo.new(source_file))
+          endpoint = Endpoint.new("/#{identity}#{sub_path}", method, details)
+          endpoint.push_param(Param.new("id", "", "path")) if sub_path == "/:id"
+          result << endpoint
+        end
+      end
+    end
+
+    # A standalone "actions2" action file's URL is its path relative to
+    # `api/controllers`, without the extension -- Sails' own convention
+    # for referencing an action. `api/controllers/user/find-one.js`
+    # becomes `/user/find-one`; `api/controllers/login.js` becomes
+    # `/login`. Shadow routes respond to every HTTP verb until a custom
+    # route in `config/routes.js` narrows them.
+    private def emit_action_shadow_route(file : String, rel : String, result : Array(Endpoint))
+      ext = File.extname(rel)
+      identity_path = rel[0, rel.size - ext.size]
+      return if identity_path.empty?
+
+      url = "/#{identity_path}"
+      HTTP_METHODS.each do |method|
+        details = Details.new(PathInfo.new(file))
+        result << Endpoint.new(url, method, details)
+      end
+    end
+
+    private def js_source_file?(file : String) : Bool
+      JS_SOURCE_EXTENSIONS.any? { |ext| file.ends_with?(ext) }
+    end
+  end
+end

--- a/src/detector/detectors/javascript/sails.cr
+++ b/src/detector/detectors/javascript/sails.cr
@@ -1,0 +1,41 @@
+require "../../../models/detector"
+
+module Detector::Javascript
+  class Sails < Detector
+    detector_for "js_sails",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json]
+
+    # `package.json` listing Sails as a dependency. Sails apps always
+    # depend on the `sails` npm package directly (it is the framework
+    # entry point, not a plugin), so a dependency-map hit is a reliable
+    # project-level signal even when the file that would carry a source
+    # marker (`app.js`) has been customized or renamed.
+    PACKAGE_MARKERS = /"sails"\s*:\s*"/
+
+    # Source-side markers. `sails.lift(` is the canonical bootstrap call
+    # every generated `app.js`/`server.js` carries; the require/import
+    # forms cover apps that construct the app object under a different
+    # name before lifting it.
+    SOURCE_MARKERS = Regex.union(
+      "require('sails')", "require(\"sails\")",
+      "from 'sails'", "from \"sails\"",
+      "sails.lift(",
+    )
+
+    def detect(filename : String, file_contents : String) : Bool
+      base = File.basename(filename)
+
+      if base == "package.json"
+        return content_matches?(file_contents, PACKAGE_MARKERS)
+      end
+
+      if filename.ends_with?(".js") || filename.ends_with?(".mjs") ||
+         filename.ends_with?(".cjs") || filename.ends_with?(".ts")
+        return content_matches?(file_contents, SOURCE_MARKERS)
+      end
+
+      false
+    end
+  end
+end

--- a/src/techs/catalog/javascript/sails.cr
+++ b/src/techs/catalog/javascript/sails.cr
@@ -1,0 +1,26 @@
+# NoirTechs catalog entry: js_sails.
+# One file per technology; `NoirTechs::TECHS` in src/techs/techs.cr is
+# macro-derived from every constant under `NoirTechs::Catalog`.
+module NoirTechs::Catalog::Javascript
+  SAILS = {
+    :js_sails => {
+      :framework => "Sails.js",
+      :language  => "JavaScript",
+      :similar   => ["sails", "sailsjs", "js-sails"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => true,
+          :cookie => true,
+        },
+        :static_path => true,
+        :websocket   => false,
+      },
+      :context => {:callee => false, :guards => false},
+    },
+  }
+end


### PR DESCRIPTION
## Summary

Adds first-class detection support for [Sails.js](https://sailsjs.com/) (`js_sails`), a convention-based Node.js MVC framework built on Express. This closes owasp-noir/noir#2594 (part of the umbrella #2589).

Sails routes come from two sources, both covered here:

- **Explicit routes** in `config/routes.js` — address/target object entries: `'METHOD /path': target`. Supports controller/action strings (`'UserController.find'`), object targets (`{ controller, action }`, `{ action: 'user/find' }`, `{ view: '...' }`), inline `function`/arrow handlers (with `req.query`/`req.body`/`req.headers`/`req.cookies` extraction reused from the shared `Noir::JSRouteExtractor` helpers), path params (`:id`), and method-less addresses (Sails matches "any CRUD method" when the verb is omitted — expanded to all 7 HTTP verbs). Regex-address routes (`'r|^/\d+/(\w+)/(\w+)$|foo,bar'`) are intentionally **not** modeled — see Limitations.
- **Blueprint (convention-based) routes** — Sails auto-generates default REST CRUD routes (find/create/findOne/update/destroy → `GET/POST /<id>`, `GET/PATCH/DELETE /<id>/:id`) for every controller (`api/controllers/FooController.js`) or model (`api/models/Foo.js`) it finds, even without an explicit route registration. Also covers the "actions2" convention: one file per action under `api/controllers/<subdir>/<action>.js` (or top-level `api/controllers/<action>.js`), whose URL is its path relative to `api/controllers` with the extension dropped, responding to any HTTP verb until narrowed by a custom route. The default `assets/` static directory is also picked up.

### Avoiding cross-framework false positives

Node/JS is noir's most crowded language (Express, Koa, NestJS, Fastify, Hapi, Restify all coexist), and blueprint inference works off file *presence* rather than an explicit registration call — exactly the class of bug the #2417-2432 project-scoping campaign fixed for other analyzers. Blueprint/action inference is gated by `discover_sails_roots`, which requires **both**:

1. a `config/routes.js` file, and
2. a `package.json` in the *same directory* declaring a dependency on the `sails` package

Neither signal alone is enough — an Express app that happens to also have a `config/routes.js` and an `api/controllers/` directory (tested explicitly, see below) produces zero Sails routes.

### Testing

- Unit detector spec: `spec/unit_test/detector/javascript/sails_spec.cr`
- Functional fixtures + testers:
  - `spec/functional_test/fixtures/javascript/sails/` — explicit `config/routes.js` routes (controller/action strings, object targets, function/arrow handlers, view targets, method-less addresses, regex-address exclusion)
  - `spec/functional_test/fixtures/javascript/sails_blueprints/` — blueprint CRUD from a controller-only identity and a model-only identity, actions2 shadow routes (nested + top-level), and static assets
- Full suite: `crystal spec spec/unit_test` (4828 examples) and `crystal spec spec/functional_test` (23217 examples) both green, no regressions to existing JS analyzers.
- `crystal tool format --check` and `ameba` clean.
- `just dsup` run; regenerated docs included (194 frameworks, was 193).

### Real-world OSS validation

Validated against [brookesb91/sailsjs-realworld-example-app](https://github.com/brookesb91/sailsjs-realworld-example-app) (a full RealWorld/Conduit implementation on Sails 1.x with 26 explicit routes, 4 models, 17 actions2 action files, and a real `assets/` tree):

- 223 endpoints extracted, all attributable to real routes.js entries, real blueprint CRUD, real actions2 shadow routes, or real static files — no phantom routes.
- Confirmed against the app's own (fully commented-out / default) `config/blueprints.js` that the blueprint CRUD routes for `Article`/`Comment`/`Tag`/`User` are genuinely live by default — i.e. this is a real (if likely unintended) piece of the app's attack surface, not an over-generation bug.
- Verified in a second, adversarial fixture that an Express app with a coincidental `config/routes.js` + `api/controllers/UserController.js` produces **zero** Sails routes (only its real Express route), confirming the dual-signal gate holds.

### Known limitations / follow-ups

- Regex-address routes (`'r|^/\d+/(\w+)/(\w+)$|foo,bar'`) are not modeled.
- Association blueprint routes (populate/add/remove/replace on model collections) and the dev-only shortcut GET routes (`/:model/find/:id`, etc.) are not modeled — kept out to limit noise/guesswork; can be added later if there's demand.
- Classic (pre-actions2) multi-action controllers (`module.exports = { foo: function(req,res){}, bar: function(req,res){} }`) are not parsed for per-method shadow routes — only actions2-style one-file-per-action and the base blueprint CRUD are covered.
- Callee/guard AI-context extraction is not implemented for this analyzer yet (`:context => {:callee => false, :guards => false}` in the techs catalog).

## Test plan

- [x] `crystal spec spec/unit_test`
- [x] `crystal spec spec/functional_test`
- [x] `crystal tool format --check`
- [x] `ameba`
- [x] `shards build --release --no-debug --production`
- [x] Manual validation against a real Sails OSS app
- [x] Manual adversarial test against a non-Sails Express app with lookalike file structure