### PR TITLE
feat(analyzer): detect ServiceStack routes in C#

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The inventory feeds three audiences:
 
 ## What Noir does
 
-- **Endpoint extraction.** Static analysis across [197 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
+- **Endpoint extraction.** Static analysis across [198 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
 - **LLM fallback.** Hand unsupported frameworks (or one-off custom routing) to OpenAI / Ollama / etc. when static rules don't apply.
 - **Output for the next stage.** JSON, YAML, OpenAPI, SARIF, cURL, Postman, HTML — whichever format the next tool in the pipeline reads.
 - **DAST integration.** Pipe directly into ZAP, Burp Suite, Caido or Gori as a proxy target, or export OpenAPI for them to import.

--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 197개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
+description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 198개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
 template = "landing"
 +++
 
@@ -91,7 +91,7 @@ template = "landing"
         <p>플러그인도, 언어별 설정도 없는 단일 바이너리입니다. 정적 규칙이 놓친 프레임워크는 LLM이 대신 처리합니다.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">언어</span></span>
-          <span><span class="stat-val">197</span><span class="stat-key">프레임워크</span></span>
+          <span><span class="stat-val">198</span><span class="stat-key">프레임워크</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 197 frameworks, exposing shadow APIs and mapping the attack surface."
+description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 198 frameworks, exposing shadow APIs and mapping the attack surface."
 template = "landing"
 +++
 
@@ -89,7 +89,7 @@ template = "landing"
         <p>One binary, no plugins and no per-language setup. Frameworks the static rules miss fall back to an LLM.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">Languages</span></span>
-          <span><span class="stat-val">197</span><span class="stat-key">Frameworks</span></span>
+          <span><span class="stat-val">198</span><span class="stat-key">Frameworks</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/usage/supported/callee_coverage/index.ko.md
+++ b/docs/content/usage/supported/callee_coverage/index.ko.md
@@ -26,7 +26,7 @@ JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는
 
 | Language | Frameworks with callee coverage |
 |----------|---------------------------------|
-| C# | ASP.NET Core MVC, ASP.NET Core Minimal API, ASP.NET MVC, Carter, FastEndpoints, System.Net.HttpListener |
+| C# | ASP.NET Core MVC, ASP.NET Core Minimal API, ASP.NET MVC, Carter, FastEndpoints, ServiceStack, System.Net.HttpListener |
 | C++ | Crow, Drogon, cpp-httplib, oat++ |
 | Clojure | Compojure, Pedestal, Reitit |
 | Crystal | Amber, Grip, Kemal, Lucky, Marten |

--- a/docs/content/usage/supported/callee_coverage/index.md
+++ b/docs/content/usage/supported/callee_coverage/index.md
@@ -26,7 +26,7 @@ This matrix lists frameworks where Noir supports per-endpoint callee extraction.
 
 | Language | Frameworks with callee coverage |
 |----------|---------------------------------|
-| C# | ASP.NET Core MVC, ASP.NET Core Minimal API, ASP.NET MVC, Carter, FastEndpoints, System.Net.HttpListener |
+| C# | ASP.NET Core MVC, ASP.NET Core Minimal API, ASP.NET MVC, Carter, FastEndpoints, ServiceStack, System.Net.HttpListener |
 | C++ | Crow, Drogon, cpp-httplib, oat++ |
 | Clojure | Compojure, Pedestal, Reitit |
 | Crystal | Amber, Grip, Kemal, Lucky, Marten |

--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -272,6 +272,33 @@ sort_by = "weight"
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">ServiceStack</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">System.Net.HttpListener</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -272,6 +272,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">ServiceStack</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">System.Net.HttpListener</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/spec/functional_test/fixtures/csharp/servicestack/AppHost.cs
+++ b/spec/functional_test/fixtures/csharp/servicestack/AppHost.cs
@@ -1,0 +1,22 @@
+using ServiceStack;
+using ServiceStackDemo.ServiceModel;
+
+namespace ServiceStackDemo
+{
+    public class AppHost : AppHostBase
+    {
+        public AppHost() : base("ServiceStack Demo", typeof(AppHost).Assembly) { }
+
+        public override void Configure(Container container)
+        {
+            // Chained fluent registration: both calls resolve to Hello's
+            // Name property, declared in a different file.
+            Routes
+                .Add<Hello>("/hello2")
+                .Add<Hello>("/hello2/{Name}");
+
+            // Single-statement fluent registration with an explicit verb.
+            Routes.Add<GetContact>("/contacts", "GET");
+        }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/servicestack/Controllers/UnrelatedController.cs
+++ b/spec/functional_test/fixtures/csharp/servicestack/Controllers/UnrelatedController.cs
@@ -1,0 +1,17 @@
+using ServiceStack;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ServiceStackDemo.Controllers
+{
+    // Not a ServiceStack request DTO: an MVC controller that happens to sit
+    // in a project that also references ServiceStack. The [Route] attribute
+    // here decorates a Controller class, not a request DTO — the
+    // ServiceStack analyzer must not treat it as one (that's the
+    // project-scoping "don't steal ASP.NET MVC's [Route]" concern).
+    [Route("api/[controller]")]
+    public class UnrelatedController : Controller
+    {
+        [HttpGet]
+        public IActionResult Get() => Ok();
+    }
+}

--- a/spec/functional_test/fixtures/csharp/servicestack/ServiceModel/Contacts.cs
+++ b/spec/functional_test/fixtures/csharp/servicestack/ServiceModel/Contacts.cs
@@ -1,0 +1,17 @@
+using ServiceStack;
+
+namespace ServiceStackDemo.ServiceModel
+{
+    // No [Route] attribute here on purpose: this DTO is only wired to a path
+    // through the fluent Routes.Add<GetContact>(...) call in AppHost.cs, so
+    // resolving its properties needs the cross-file type index.
+    public class GetContact : IReturn<GetContactResponse>
+    {
+        public string ContactId { get; set; } = "";
+    }
+
+    public class GetContactResponse
+    {
+        public string Name { get; set; } = "";
+    }
+}

--- a/spec/functional_test/fixtures/csharp/servicestack/ServiceModel/Hello.cs
+++ b/spec/functional_test/fixtures/csharp/servicestack/ServiceModel/Hello.cs
@@ -1,0 +1,18 @@
+using ServiceStack;
+
+namespace ServiceStackDemo.ServiceModel
+{
+    // Attribute-routed request DTO: two [Route] attributes, both GET, so
+    // /hello and /hello/{Name} each answer independently.
+    [Route("/hello", "GET")]
+    [Route("/hello/{Name}", "GET")]
+    public class Hello : IReturn<HelloResponse>
+    {
+        public string? Name { get; set; }
+    }
+
+    public class HelloResponse
+    {
+        public string Result { get; set; } = "";
+    }
+}

--- a/spec/functional_test/fixtures/csharp/servicestack/ServiceModel/Movies.cs
+++ b/spec/functional_test/fixtures/csharp/servicestack/ServiceModel/Movies.cs
@@ -1,0 +1,22 @@
+using ServiceStack;
+
+namespace ServiceStackDemo.ServiceModel
+{
+    // Two independent [Route] attributes on the same DTO, each with its own
+    // verb set. This is the shape ServiceStack's own examples use, and it's
+    // important the verbs on one attribute never leak onto the other: /movies
+    // only answers the write verbs below, /movies/{Id} answers every verb
+    // (the attribute omits a verb list entirely).
+    [Route("/movies", "POST,PUT,PATCH,DELETE")]
+    [Route("/movies/{Id}")]
+    public class Movie : IReturn<MovieResponse>
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = "";
+    }
+
+    public class MovieResponse
+    {
+        public Movie? Result { get; set; }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/servicestack/ServiceStackDemo.csproj
+++ b/spec/functional_test/fixtures/csharp/servicestack/ServiceStackDemo.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ServiceStack" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/spec/functional_test/fixtures/csharp/servicestack/test/ShouldNotAppearRoute.cs
+++ b/spec/functional_test/fixtures/csharp/servicestack/test/ShouldNotAppearRoute.cs
@@ -1,0 +1,15 @@
+using ServiceStack;
+
+namespace ServiceStackDemo.Tests
+{
+    [Route("/test-only", "GET")]
+    public class TestOnlyRequest : IReturn<TestOnlyResponse>
+    {
+        public string Name { get; set; } = "";
+    }
+
+    public class TestOnlyResponse
+    {
+        public string Result { get; set; } = "";
+    }
+}

--- a/spec/functional_test/testers/csharp/servicestack_spec.cr
+++ b/spec/functional_test/testers/csharp/servicestack_spec.cr
@@ -1,0 +1,95 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  # Attribute-routed DTOs (ServiceModel/Hello.cs): two [Route] attributes on
+  # one class, each answering GET independently.
+  Endpoint.new("/hello", "GET", [
+    Param.new("Name", "", "query"),
+  ]),
+  Endpoint.new("/hello/{Name}", "GET", [
+    Param.new("Name", "", "path"),
+  ]),
+
+  # Attribute-routed DTO (ServiceModel/Movies.cs) with two independent
+  # [Route] attributes: /movies only answers the write verbs its own
+  # attribute names, /movies/{Id} (a *different* attribute, no verb list)
+  # answers every verb. The two must not cross-multiply.
+  Endpoint.new("/movies", "POST", [
+    Param.new("Id", "", "json"),
+    Param.new("Title", "", "json"),
+  ]),
+  Endpoint.new("/movies", "PUT", [
+    Param.new("Id", "", "json"),
+    Param.new("Title", "", "json"),
+  ]),
+  Endpoint.new("/movies", "PATCH", [
+    Param.new("Id", "", "json"),
+    Param.new("Title", "", "json"),
+  ]),
+  Endpoint.new("/movies", "DELETE", [
+    Param.new("Id", "", "query"),
+    Param.new("Title", "", "query"),
+  ]),
+  Endpoint.new("/movies/{Id}", "ANY", [
+    Param.new("Id", "", "path"),
+    Param.new("Title", "", "json"),
+  ]),
+
+  # Fluent `Routes.Add<T>(...)` registrations (AppHost.cs). `Hello`'s
+  # properties are declared in a different file, so resolving them exercises
+  # the cross-file type index.
+  Endpoint.new("/hello2", "ANY", [
+    Param.new("Name", "", "json"),
+  ]),
+  Endpoint.new("/hello2/{Name}", "ANY", [
+    Param.new("Name", "", "path"),
+  ]),
+  Endpoint.new("/contacts", "GET", [
+    Param.new("ContactId", "", "query"),
+  ]),
+
+  # A plain ASP.NET Core MVC controller that happens to live in a project
+  # that also references ServiceStack. Owned by cs_aspnet_core_mvc — see the
+  # "project scoping" describe block below.
+  Endpoint.new("/api/Unrelated", "GET"),
+]
+
+tester = FunctionalTester.new("fixtures/csharp/servicestack/", {
+  :techs     => 2,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+
+tester.perform_tests
+
+describe "ServiceStack analyzer edge cases" do
+  it "does not surface routes from /test/ fixtures" do
+    tester.app.endpoints.any?(&.url.includes?("test-only")).should be_false
+  end
+
+  it "marks attribute-routed DTOs with the cs_servicestack technology" do
+    hello = tester.app.endpoints.find { |e| e.url == "/hello" && e.method == "GET" }
+    hello.should_not be_nil
+    hello.as(Endpoint).details.technology.should eq "cs_servicestack"
+  end
+
+  it "marks fluent Routes.Add<T> registrations with the cs_servicestack technology" do
+    contacts = tester.app.endpoints.find { |e| e.url == "/contacts" && e.method == "GET" }
+    contacts.should_not be_nil
+    contacts.as(Endpoint).details.technology.should eq "cs_servicestack"
+  end
+
+  it "does not steal ASP.NET Core MVC's [Route]-decorated controller" do
+    controller_endpoint = tester.app.endpoints.find { |e| e.url == "/api/Unrelated" }
+    controller_endpoint.should_not be_nil
+    controller_endpoint.as(Endpoint).details.technology.should eq "cs_aspnet_core_mvc"
+
+    # No duplicate emitted by the ServiceStack analyzer for the same route.
+    tester.app.endpoints.count { |e| e.url == "/api/Unrelated" }.should eq 1
+  end
+
+  it "does not cross-multiply independent [Route] attributes' verb lists" do
+    # /movies only ever answers the verbs its own attribute names.
+    tester.app.endpoints.any? { |e| e.url == "/movies" && e.method == "GET" }.should be_false
+    tester.app.endpoints.any? { |e| e.url == "/movies" && e.method == "ANY" }.should be_false
+  end
+end

--- a/spec/unit_test/detector/csharp/servicestack_spec.cr
+++ b/spec/unit_test/detector/csharp/servicestack_spec.cr
@@ -1,0 +1,47 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/csharp/*"
+
+describe "Detect C# ServiceStack" do
+  options = create_test_options
+  instance = Detector::CSharp::ServiceStack.new options
+
+  it "csproj package reference" do
+    instance.detect("ServiceStackDemo.csproj", "<PackageReference Include=\"ServiceStack\" Version=\"8.0.0\" />").should be_true
+  end
+
+  it "csproj sub-package reference" do
+    instance.detect("ServiceStackDemo.csproj", "<PackageReference Include=\"ServiceStack.Kestrel\" Version=\"8.0.0\" />").should be_true
+  end
+
+  it "csproj rejects unrelated packages" do
+    instance.detect("Other.csproj", "<PackageReference Include=\"Serilog\" />").should be_false
+  end
+
+  it "request DTO uses ServiceStack" do
+    instance.detect("ServiceModel/Hello.cs", "using ServiceStack;\n[Route(\"/hello\")]\npublic class Hello : IReturn<HelloResponse> {}").should be_true
+  end
+
+  it "request DTO implements IReturn<T> without importing the namespace" do
+    instance.detect("ServiceModel/Hello.cs", "public class Hello : IReturn<HelloResponse> {}").should be_true
+  end
+
+  it "request DTO implements IReturnVoid" do
+    instance.detect("ServiceModel/Ping.cs", "public class Ping : IReturnVoid {}").should be_true
+  end
+
+  it "AppHost registers routes fluently" do
+    instance.detect("AppHost.cs", "public override void Configure(Container c) { Routes.Add<Hello>(\"/hello\"); }").should be_true
+  end
+
+  it "AppHost uses the assembly-scanning convention" do
+    instance.detect("AppHost.cs", "Routes.AddFromAssembly(typeof(MyServices).Assembly);").should be_true
+  end
+
+  it "plain ASP.NET controller does not match" do
+    instance.detect("Controllers/HomeController.cs", "[Route(\"api/[controller]\")]\npublic class HomeController : Controller {}").should be_false
+  end
+
+  it "unrelated .cs file does not match" do
+    instance.detect("Models/User.cs", "public class User { public string Name { get; set; } }").should be_false
+  end
+end

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -5,7 +5,7 @@ require "../../spec_helper"
 # The registry is derived from the classes, so a detector joins a scan simply by
 # existing (`build_detector_list`, src/detector/detector.cr). That removed the
 # "forgot to register it" failure mode and replaced it with a quieter one:
-# nothing at all requires a detector to be *tested*. 64 of 245 — including
+# nothing at all requires a detector to be *tested*. 64 of 246 — including
 # `rust/actix_web`, `java/quarkus`, `java/micronaut`, `java/jaxrs`,
 # `javascript/hapi`, `swift/hummingbird`, `typescript/trpc`, every `zig/*` and
 # every language's `cli` — shipped with zero coverage.
@@ -170,6 +170,6 @@ describe "detector spec coverage" do
   # Guards the guard: a broken glob would make every example above pass
   # vacuously.
   it "finds every registered detector" do
-    detector_paths.size.should eq 245
+    detector_paths.size.should eq 246
   end
 end

--- a/src/analyzer/analyzers/csharp/servicestack.cr
+++ b/src/analyzer/analyzers/csharp/servicestack.cr
@@ -1,0 +1,408 @@
+require "../../../models/analyzer"
+require "./common"
+
+module Analyzer::CSharp
+  # Extracts endpoints from ServiceStack (https://servicestack.net/) request
+  # DTOs. Unlike ASP.NET (Core) MVC, the routable unit is the *request DTO
+  # class itself*, not a controller method:
+  #
+  #   [Route("/hello/{Name}", "GET")]
+  #   public class Hello : IReturn<HelloResponse>
+  #   {
+  #       public string Name { get; set; }
+  #   }
+  #
+  # A DTO class can carry more than one `[Route(...)]` attribute (one per
+  # path/verb combination it answers), and the verb list is a comma (or
+  # space) delimited string on the attribute itself — omitted entirely means
+  # "every verb". Because each attribute names its own verbs, routes are
+  # *not* cross-multiplied against each other the way FastEndpoints'
+  # independent `Routes()`/`Verbs()` calls are: `/movies` and `/movies/{Id}`
+  # in the same class can (and in ServiceStack's own examples do) answer
+  # completely different verb sets.
+  #
+  # ServiceStack also supports registering the same DTOs from code, inside
+  # `AppHostBase.Configure()`:
+  #
+  #   Routes.Add<Hello>("/hello/{Name}");
+  #   Routes.Add<GetContact>("/Contacts", "GET");
+  #
+  # which is handled separately: the call site (usually `AppHost.cs`) rarely
+  # lives next to the DTO declaration, so resolving `Hello`'s properties
+  # needs a small cross-file type index, similar in spirit to (but simpler
+  # than) FastEndpoints' `Endpoint<TRequest>` resolution.
+  #
+  # `[Route]` is also a legal attribute on Controller actions in classic
+  # ASP.NET MVC / Web API, and ASP.NET Core MVC controllers use it too. To
+  # avoid stealing those routes (the concern the analyzer project-scoping
+  # campaign fixed across the language), this analyzer only looks at files
+  # carrying a genuine ServiceStack signal (`IReturn`/`IReturnVoid`, `using
+  # ServiceStack`, or the fluent `Routes.Add` API) and additionally refuses
+  # any class whose base list names `Controller`/`ControllerBase` — a
+  # ServiceStack request DTO never derives from either.
+  class ServiceStack < Analyzer
+    analyzer_for "cs_servicestack"
+
+    include Common
+
+    # Whole-file gate: only files that show a real ServiceStack fingerprint
+    # are scanned at all. `\bIReturn\b` also matches `IReturn<T>` (the `<` is
+    # a non-word char, so `\b` still lands right after "IReturn").
+    SERVICESTACK_SOURCE_RE = /\bIReturn(?:Void)?\b|using\s+ServiceStack\b|\bRoutes\.Add\b/
+
+    # `[Route("/path")]`, `[Route("/path", "GET")]`, `[Route("/path", "GET,POST")]`,
+    # or with other attributes stacked on the same line
+    # (`[Route("/x", "POST"),SystemJson(...)]`). Deliberately does not match
+    # `[FallbackRoute(...)]` — "Route" must immediately follow `[` and
+    # optional whitespace.
+    ROUTE_ATTR_REGEX = /\[\s*Route\s*\(\s*"([^"]*)"(?:\s*,\s*"([^"]*)")?/
+
+    # `class Hello`, `record Hello(string Name)`, `record struct Hello`,
+    # `struct Hello` — an optional generic parameter list, an optional
+    # positional-record parameter list, then an optional base list up to the
+    # first `{` (brace body) or `;` (positional record with no body).
+    CLASS_DECL_REGEX = /\b(?:class|record(?:\s+struct)?|struct)\s+(\w+)(?:<[^>]*>)?(?:\s*\([^)]*\))?\s*(?::\s*([^{;]+))?/
+
+    CONTROLLER_BASE_RE = /\bControllerBase\b|\bController\b/
+
+    # `Routes.Add<Hello>("/hello/{Name}")`, possibly chained
+    # (`Routes.Add<A>("/a").Add<B>("/b")`) or spread across a fluent call
+    # chain starting from a bare `Routes` on its own line.
+    FLUENT_CALL_RE = /\.Add<(\w+)>\s*\(\s*"([^"]*)"(?:\s*,\s*"([^"]*)")?\s*\)/
+
+    private record FluentRegistration,
+      file : String,
+      line : Int32,
+      type_name : String,
+      path : String,
+      verbs_raw : String?
+
+    private record TypeDef, file : String, params : Array(Param)
+
+    def analyze
+      include_callee = callees_needed?
+
+      cs_files = get_files_by_extension(".cs").reject { |f| Common.csharp_test_path?(base_relative_path(f)) }
+
+      servicestack_files = [] of String
+      fluent_registrations = [] of FluentRegistration
+      wanted = Set(String).new
+
+      cs_files.each do |file|
+        next unless File.exists?(file)
+        content = read_file_content(file)
+        next unless content_matches?(content, SERVICESTACK_SOURCE_RE)
+
+        servicestack_files << file
+        collect_fluent_registrations(content, file).each do |reg|
+          fluent_registrations << reg
+          wanted << reg.type_name
+        end
+      end
+
+      return @result if servicestack_files.empty?
+
+      servicestack_files.each do |file|
+        analyze_attribute_routes(file, read_file_content(file), include_callee)
+      end
+
+      unless fluent_registrations.empty?
+        type_index = build_type_index(cs_files, wanted)
+        fluent_registrations.each do |reg|
+          analyze_fluent_registration(reg, type_index, include_callee)
+        end
+      end
+
+      @result
+    end
+
+    # ---- attribute-routed DTOs ---------------------------------------------
+
+    private def analyze_attribute_routes(file : String, content : String, include_callee : Bool)
+      lexer = Noir::CSharpLexer.new(content)
+      lines = lexer.code_lines
+      masked_lines = lexer.masked_lines
+
+      pending_routes = [] of Tuple(String, String?)
+      i = 0
+      while i < lines.size
+        line = lines[i]
+        trimmed = line.strip
+
+        if trimmed.starts_with?("[") && (m = ROUTE_ATTR_REGEX.match(line))
+          pending_routes << {m[1], m[2]?}
+          i += 1
+          next
+        end
+
+        unless pending_routes.empty?
+          if class_match = CLASS_DECL_REGEX.match(line)
+            base_list = class_match[2]? || ""
+            block, end_index = extract_type_block(lines, masked_lines, i)
+            unless base_list.matches?(CONTROLLER_BASE_RE)
+              params = extract_props_from_block(block)
+              pending_routes.each do |(raw_path, verbs_raw)|
+                verbs(verbs_raw).each do |http_method|
+                  endpoint = build_endpoint(raw_path, http_method, file, i + 1, params)
+                  attach_csharp_callees(endpoint, block, file, i + 1, include_callee)
+                  @result << endpoint
+                end
+              end
+            end
+            pending_routes = [] of Tuple(String, String?)
+            i = end_index
+          elsif trimmed.empty? || trimmed.starts_with?("[") || trimmed.starts_with?("//") || trimmed.starts_with?("*")
+            # Doc-comment lines, blank separators, and other stacked
+            # attributes between the [Route] attribute(s) and the DTO
+            # declaration — keep accumulating.
+          else
+            # Some other statement appeared before a class/record/struct
+            # declaration — most likely a method-level [Route] (legacy
+            # ServiceStack SOAP-style services), which this analyzer does
+            # not resolve. Drop the pending routes rather than mis-attach
+            # them to an unrelated type further down.
+            pending_routes = [] of Tuple(String, String?)
+          end
+        end
+
+        i += 1
+      end
+    end
+
+    # `verbs_raw` is a comma- or space-delimited verb list ("GET,POST",
+    # "POST PUT"), or nil/blank meaning "every verb" — ServiceStack's own
+    # semantics for an omitted second `[Route]` argument.
+    private def verbs(verbs_raw : String?) : Array(String)
+      return ["ANY"] if verbs_raw.nil? || verbs_raw.strip.empty?
+
+      list = verbs_raw.split(/[,\s]+/).map(&.strip.upcase).reject(&.empty?)
+      list.empty? ? ["ANY"] : list.uniq
+    end
+
+    # Counts braces (and, for positional records with no body, the
+    # terminating `;`) over `masked_lines` so a `}`/`;` inside a string
+    # literal can't end the block early. Mirrors
+    # `Analyzer::CSharp::FastEndpoints#extract_request_type_block`.
+    private def extract_type_block(lines : Array(String), masked_lines : Array(String), start_index : Int32) : Tuple(String, Int32)
+      io = String::Builder.new
+      brace = 0
+      started = false
+      paren = 0
+      i = start_index
+      while i < lines.size
+        line = lines[i]
+        masked = masked_lines[i]? || line
+        io << line
+        io << '\n'
+        brace += masked.count('{') - masked.count('}')
+        paren += masked.count('(') - masked.count(')')
+        started ||= brace > 0 || masked.includes?("{")
+        if !started && masked.includes?(";") && paren <= 0
+          break
+        end
+        if started && brace <= 0
+          break
+        end
+        i += 1
+      end
+      {io.to_s, i}
+    end
+
+    # Plain public auto-properties (`public string Name { get; set; }`) and
+    # positional-record parameters. ServiceStack request DTOs bind
+    # automatically from the route template / query string / body — unlike
+    # ASP.NET or FastEndpoints there are no `[FromQuery]`/`[FromBody]`-style
+    # binding attributes to key off, so every property is reported untyped
+    # (`param_type` blank) and `build_endpoint` fills in path vs. the
+    # verb-appropriate default.
+    private def extract_props_from_block(block : String) : Array(Param)
+      params = [] of Param
+      block.each_line do |raw_line|
+        line = raw_line.strip
+        next if line.empty?
+        next if line.starts_with?("//")
+        next if line.starts_with?("[")
+
+        if match = line.match(/public\s+(?:required\s+|virtual\s+|override\s+|static\s+|readonly\s+)*[\w\?<>\[\],\s\.]+?\s+(\w+)\s*\{\s*get;/)
+          params << Param.new(match[1], "", "")
+          next
+        end
+
+        # Positional record: `public record GetContact(string ContactId);`
+        if positional_match = line.match(/^(?:public\s+)?(?:sealed\s+)?(?:record(?:\s+struct)?|struct)\s+\w+\s*\(([^)]*)\)/)
+          arglist = positional_match[1]
+          split_csharp_parameters(arglist).each do |arg|
+            cleaned = arg.strip
+            next if cleaned.empty?
+            if name_match = cleaned.match(/(\w+)\s*(?:=\s*[^,]+)?\s*$/)
+              params << Param.new(name_match[1], "", "")
+            end
+          end
+        end
+      end
+      params.uniq(&.name)
+    end
+
+    # ---- fluent `Routes.Add<T>(...)` ---------------------------------------
+
+    # Finds every `Routes...Add<T>("path"[, "verbs"])` call in `content`,
+    # single-statement (`Routes.Add<Hello>("/hello");`) or chained
+    # (`Routes\n    .Add<A>("/a")\n    .Add<B>("/b");`). Scoped to the text
+    # between each bare `Routes` occurrence and the next `;` so unrelated
+    # `.Add<T>(...)`-shaped calls elsewhere in the file aren't picked up.
+    private def collect_fluent_registrations(content : String, file : String) : Array(FluentRegistration)
+      registrations = [] of FluentRegistration
+      return registrations unless content.includes?("Routes")
+
+      lexer = Noir::CSharpLexer.new(content)
+      code = lexer.code_source
+
+      pos = 0
+      while start = code.index(/\bRoutes\b/, pos)
+        stop = code.index(';', start) || code.size
+        statement = code[start...stop]
+        line_no = code[0...start].count('\n') + 1
+
+        statement.scan(FLUENT_CALL_RE) do |m|
+          type_name = m[1]?
+          path = m[2]?
+          next if type_name.nil? || path.nil? || path.empty?
+          registrations << FluentRegistration.new(file, line_no, type_name, path, m[3]?)
+        end
+
+        pos = stop + 1
+      end
+
+      registrations
+    end
+
+    # Small cross-file type index for the `wanted` DTO names referenced by a
+    # `Routes.Add<T>(...)` call. Only the (few) referenced names are indexed
+    # — see `Analyzer::CSharp::FastEndpoints#build_request_type_index` for
+    # why a repo-wide union would be wrong (and slow).
+    private def build_type_index(files : Array(String), wanted : Set(String)) : Hash(String, Array(TypeDef))
+      index = Hash(String, Array(TypeDef)).new
+      return index if wanted.empty?
+
+      wanted_re = Regex.union(wanted.to_a.map { |name| /\b#{Regex.escape(name)}\b/ })
+      type_decl_regex = /\b(?:class|record(?:\s+struct)?|struct)\s+([A-Za-z_]\w*)\b/
+
+      files.each do |file|
+        next unless File.exists?(file)
+        content = read_file_content(file)
+        next unless content_matches?(content, wanted_re)
+
+        lexer = Noir::CSharpLexer.new(content)
+        lines = lexer.code_lines
+        masked_lines = lexer.masked_lines
+
+        i = 0
+        while i < lines.size
+          if match = type_decl_regex.match(lines[i])
+            type_name = match[1]
+            block, end_index = extract_type_block(lines, masked_lines, i)
+            if wanted.includes?(type_name)
+              params = extract_props_from_block(block)
+              unless params.empty?
+                defs = index[type_name] ||= [] of TypeDef
+                defs << TypeDef.new(file, params) unless defs.any? { |d| d.file == file }
+              end
+            end
+            i = end_index
+          end
+          i += 1
+        end
+      end
+
+      index
+    end
+
+    # Nearest-first resolution: the file the `Routes.Add<T>` call itself
+    # lives in, then a repo-unique declaration. Ambiguous (several
+    # unrelated same-named DTOs, none in the call's own file) resolves to no
+    # extra params rather than guessing — path params still come through
+    # from the route template regardless.
+    private def resolve_fluent_params(type_index : Hash(String, Array(TypeDef)), type_name : String, file : String) : Array(Param)
+      defs = type_index[type_name]?
+      return [] of Param if defs.nil? || defs.empty?
+
+      if same_file = defs.find { |d| d.file == file }
+        return same_file.params
+      end
+
+      defs.size == 1 ? defs.first.params : [] of Param
+    end
+
+    private def analyze_fluent_registration(reg : FluentRegistration, type_index : Hash(String, Array(TypeDef)), include_callee : Bool)
+      params = resolve_fluent_params(type_index, reg.type_name, reg.file)
+      verbs(reg.verbs_raw).each do |http_method|
+        endpoint = build_endpoint(reg.path, http_method, reg.file, reg.line, params)
+        @result << endpoint
+      end
+    end
+
+    # ---- shared endpoint construction --------------------------------------
+
+    private def build_endpoint(raw_route : String, http_method : String, file : String, line : Int32, dto_params : Array(Param)) : Endpoint
+      route = normalize_route(raw_route)
+      path_params = build_path_params(route)
+      default_type = default_param_type(http_method)
+
+      collected = [] of Param
+      path_params.each { |param| collected << param }
+
+      dto_params.each do |param|
+        next if collected.any? { |p| p.name == param.name }
+        if path_params.any? { |p| p.name == param.name }
+          collected << Param.new(param.name, "", "path")
+        else
+          ptype = param.param_type.empty? ? default_type : param.param_type
+          collected << Param.new(param.name, param.value, ptype)
+        end
+      end
+
+      details = Details.new(PathInfo.new(file, line))
+      endpoint = Endpoint.new(route, http_method, details)
+      collected.each { |param| endpoint.params << param }
+      endpoint
+    end
+
+    private def normalize_route(route : String) : String
+      normalized = route.strip
+      normalized = normalized.gsub(/^\//, "").gsub(/\/+/, "/")
+      normalized = "/" + normalized
+      normalized = "/" if normalized == "//"
+      normalized
+    end
+
+    private def build_path_params(route : String) : Array(Param)
+      params = [] of Param
+      route.scan(/\{([^}\/]+)\}/) do |match|
+        raw = match[1]? || ""
+        next if raw.empty?
+        # `Common.route_placeholder_name` strips a *leading* `*` (ASP.NET
+        # Core's `{*catchAll}` convention, which ServiceStack's newer
+        # `{**Name}` multi-segment wildcard also satisfies). ServiceStack's
+        # older/legacy wildcard syntax puts the `*` as a *suffix* instead
+        # (`{ItemPath*}`, per `RouteAttribute`'s own doc comment), so strip
+        # that side too.
+        cleaned = Common.route_placeholder_name(raw).rstrip('*')
+        next if cleaned.empty?
+        params << Param.new(cleaned, "", "path") unless params.any? { |p| p.name == cleaned }
+      end
+      params
+    end
+
+    # GET/HEAD/OPTIONS/DELETE read from the query string; POST/PUT/PATCH and
+    # the unspecified-verb `ANY` (ServiceStack itself treats "any verb" as
+    # including body-carrying ones) bind from the JSON request body.
+    private def default_param_type(http_method : String) : String
+      case http_method
+      when "GET", "HEAD", "OPTIONS", "DELETE"
+        "query"
+      else
+        "json"
+      end
+    end
+  end
+end

--- a/src/detector/detectors/csharp/servicestack.cr
+++ b/src/detector/detectors/csharp/servicestack.cr
@@ -1,0 +1,28 @@
+require "../../../models/detector"
+
+module Detector::CSharp
+  class ServiceStack < Detector
+    detector_for "cs_servicestack", extensions: %w[.cs .csproj]
+
+    # ServiceStack (https://servicestack.net/) request DTOs are recognized by
+    # the `IReturn<T>`/`IReturnVoid` marker interfaces they implement, the
+    # `using ServiceStack;` import their file carries, or the fluent
+    # `Routes.Add<T>(...)` registration API used from `AppHost.Configure()`.
+    def detect(filename : String, file_contents : String) : Bool
+      if filename.ends_with?(".csproj")
+        return true if file_contents.includes?("Include=\"ServiceStack\"") ||
+                       file_contents.includes?("Include='ServiceStack'") ||
+                       file_contents.includes?("\"ServiceStack.")
+      end
+
+      return false unless filename.ends_with?(".cs")
+
+      return true if file_contents.includes?("using ServiceStack")
+      return true if file_contents.includes?(": IReturn<") || file_contents.includes?(", IReturn<")
+      return true if file_contents.includes?("IReturnVoid")
+      return true if file_contents.includes?("Routes.Add<") || file_contents.includes?("Routes.AddFromAssembly")
+
+      false
+    end
+  end
+end

--- a/src/techs/catalog/csharp/servicestack.cr
+++ b/src/techs/catalog/csharp/servicestack.cr
@@ -1,0 +1,26 @@
+# NoirTechs catalog entry: cs_servicestack.
+# One file per technology; `NoirTechs::TECHS` in src/techs/techs.cr is
+# macro-derived from every constant under `NoirTechs::Catalog`.
+module NoirTechs::Catalog::Csharp
+  SERVICESTACK = {
+    :cs_servicestack => {
+      :framework => "ServiceStack",
+      :language  => "C#",
+      :similar   => ["servicestack", "service-stack", "cs-servicestack", "cs_servicestack", "c# servicestack", "c#-servicestack", "c#_servicestack"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => false,
+          :cookie => false,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+      :context => {:callee => true},
+    },
+  }
+end


### PR DESCRIPTION
## Summary

Adds detector + analyzer + techs-catalog support for [ServiceStack](https://servicestack.net/), a .NET web services framework, covering both of its routing styles:

- **Attribute-routed request DTOs** — `[Route("/path", "GET")]` decorates the request DTO class itself (the routable unit, not a controller method). A DTO can carry multiple independent `[Route]` attributes, each with its own verb list (comma/space-delimited per `RouteAttribute`'s own doc comment, or omitted meaning "every verb"). These are intentionally **not** cross-multiplied against each other — ServiceStack's own examples (`Movie`) put different verb sets on different `[Route]` attributes of the same class.
- **Fluent `Routes.Add<T>("/path"[, "verbs"])`** registered from `AppHostBase.Configure()`, single-statement or chained (`Routes.Add<A>("/a").Add<B>("/b")`). Resolving the registered DTO's properties uses a small cross-file type index (only the referenced type names, not a repo-wide union — same idea as `FastEndpoints`' `Endpoint<TRequest>` resolution, simplified since ServiceStack DTOs don't need the same generic-argument unwrapping), nearest-file-first with no guess on ambiguity.

### Project scoping

`[Route]` is also legal on ASP.NET (Core) MVC controllers, so both the detector and analyzer gate on genuine ServiceStack signals (`IReturn`/`IReturnVoid`, `using ServiceStack`, `Routes.Add`) and the analyzer additionally refuses any class whose base list names `Controller`/`ControllerBase` — a ServiceStack request DTO never derives from either. Covered by a dedicated fixture (`Controllers/UnrelatedController.cs`) asserting the MVC-owned route is *not* duplicated under `cs_servicestack`.

### Files

- `src/detector/detectors/csharp/servicestack.cr`
- `src/analyzer/analyzers/csharp/servicestack.cr`
- `src/techs/catalog/csharp/servicestack.cr`
- `spec/unit_test/detector/csharp/servicestack_spec.cr`
- `spec/functional_test/fixtures/csharp/servicestack/` + `spec/functional_test/testers/csharp/servicestack_spec.cr`
- Regenerated docs (`just dsup`) + bumped the detector-coverage guard count

## Validation against a real repo

Cloned `ServiceStack/ai-server` (a real, actively maintained ServiceStack app) and ran the built `bin/noir` against it:

- All **16** registered `[Route(...)]` attributes across 5 files were extracted correctly (verified 1:1 against `grep -rn "\[Route("`), including:
  - Multi-attribute stacking with a trailing unrelated attribute on the same line (`[Route("/v1/chat/completions", "POST"),SystemJson(...)]`)
  - A DTO with two independent `[Route]` attributes (`GetGeneration`: `/generation/{Id}` and `/generation/ref/{RefId}`), each correctly resolving its *own* path param while the other property falls back to `query`
  - Both wildcard path styles: the newer `{**Path}` prefix and the legacy `{Path*}` suffix (per `RouteAttribute`'s own doc comment)
  - Attributes preceded by other stacked attributes (`[Tag(...)]`, `[ValidateApiKey]`) before the DTO class declaration
- No cross-analyzer interference: the repo's own `cs_aspnet_core_minimal_api` and `kamal` endpoints came through unaffected, no duplicates.

## Test plan

- [x] `crystal spec spec/unit_test` — 4845 examples, 0 failures
- [x] `crystal spec spec/functional_test` — 23230 examples, 0 failures
- [x] `crystal tool format --check` clean
- [x] `lib/ameba/bin/ameba.cr` clean on new/changed files
- [x] `just build-release` (`shards build --release --no-debug --production`) succeeds
- [x] `just dsup` regenerated docs included in the commit
- [x] Manual scan against `ServiceStack/ai-server` cross-checked against source

Closes #2593