### PR TITLE
feat(analyzer): detect Masonite routes in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The inventory feeds three audiences:
 
 ## What Noir does
 
-- **Endpoint extraction.** Static analysis across [198 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
+- **Endpoint extraction.** Static analysis across [199 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
 - **LLM fallback.** Hand unsupported frameworks (or one-off custom routing) to OpenAI / Ollama / etc. when static rules don't apply.
 - **Output for the next stage.** JSON, YAML, OpenAPI, SARIF, cURL, Postman, HTML — whichever format the next tool in the pipeline reads.
 - **DAST integration.** Pipe directly into ZAP, Burp Suite, Caido or Gori as a proxy target, or export OpenAPI for them to import.

--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 198개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
+description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 199개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
 template = "landing"
 +++
 
@@ -91,7 +91,7 @@ template = "landing"
         <p>플러그인도, 언어별 설정도 없는 단일 바이너리입니다. 정적 규칙이 놓친 프레임워크는 LLM이 대신 처리합니다.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">언어</span></span>
-          <span><span class="stat-val">198</span><span class="stat-key">프레임워크</span></span>
+          <span><span class="stat-val">199</span><span class="stat-key">프레임워크</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 198 frameworks, exposing shadow APIs and mapping the attack surface."
+description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 199 frameworks, exposing shadow APIs and mapping the attack surface."
 template = "landing"
 +++
 
@@ -89,7 +89,7 @@ template = "landing"
         <p>One binary, no plugins and no per-language setup. Frameworks the static rules miss fall back to an LLM.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">Languages</span></span>
-          <span><span class="stat-val">198</span><span class="stat-key">Frameworks</span></span>
+          <span><span class="stat-val">199</span><span class="stat-key">Frameworks</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/usage/supported/callee_coverage/index.ko.md
+++ b/docs/content/usage/supported/callee_coverage/index.ko.md
@@ -42,7 +42,7 @@ JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는
 | Lua | Lapis, lor |
 | PHP | CakePHP, CodeIgniter, Hyperf, Laminas, Laravel, Lumen, Phalcon, Pure, Slim, Symfony, ThinkPHP, Yii2 |
 | Perl | Catalyst, Dancer2, Mojolicious |
-| Python | Bottle, Django, Django Ninja, Falcon, FastAPI, Flask, Litestar, Pyramid, Quart, Robyn, Sanic, Starlette, Tornado, aiohttp, http.server |
+| Python | Bottle, Django, Django Ninja, Falcon, FastAPI, Flask, Litestar, Masonite, Pyramid, Quart, Robyn, Sanic, Starlette, Tornado, aiohttp, http.server |
 | R | Plumber |
 | Ruby | Grape, Hanami, Rails, Roda, Sinatra, WEBrick |
 | Rust | Actix Web, Axum, Gotham, Loco, Poem, RWF, Rocket, Salvo, Tide, Warp |

--- a/docs/content/usage/supported/callee_coverage/index.md
+++ b/docs/content/usage/supported/callee_coverage/index.md
@@ -42,7 +42,7 @@ This matrix lists frameworks where Noir supports per-endpoint callee extraction.
 | Lua | Lapis, lor |
 | PHP | CakePHP, CodeIgniter, Hyperf, Laminas, Laravel, Lumen, Phalcon, Pure, Slim, Symfony, ThinkPHP, Yii2 |
 | Perl | Catalyst, Dancer2, Mojolicious |
-| Python | Bottle, Django, Django Ninja, Falcon, FastAPI, Flask, Litestar, Pyramid, Quart, Robyn, Sanic, Starlette, Tornado, aiohttp, http.server |
+| Python | Bottle, Django, Django Ninja, Falcon, FastAPI, Flask, Litestar, Masonite, Pyramid, Quart, Robyn, Sanic, Starlette, Tornado, aiohttp, http.server |
 | R | Plumber |
 | Ruby | Grape, Hanami, Rails, Roda, Sinatra, WEBrick |
 | Rust | Actix Web, Axum, Gotham, Loco, Poem, RWF, Rocket, Salvo, Tide, Warp |

--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -4147,6 +4147,33 @@ sort_by = "weight"
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Masonite</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip on">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Pyramid</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -4147,6 +4147,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Masonite</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip on">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Pyramid</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/spec/functional_test/fixtures/python/masonite/app/controllers/PostController.py
+++ b/spec/functional_test/fixtures/python/masonite/app/controllers/PostController.py
@@ -1,0 +1,30 @@
+"""A PostController Module — implements every action Route.resource /
+Route.api generate so the fixture's resource routes actually resolve."""
+from masonite.controllers import Controller
+from masonite.request import Request
+from masonite.response import Response
+
+
+class PostController(Controller):
+    def index(self, response: Response):
+        return response.json([])
+
+    def create(self, response: Response):
+        return response.view("posts.create")
+
+    def store(self, request: Request, response: Response):
+        title = request.input("title")
+        return response.json({"title": title})
+
+    def show(self, response: Response, id):
+        return response.json({"id": id})
+
+    def edit(self, response: Response, id):
+        return response.json({"id": id})
+
+    def update(self, request: Request, response: Response, id):
+        title = request.input("title")
+        return response.json({"id": id, "title": title})
+
+    def destroy(self, response: Response, id):
+        return response.json({"id": id})

--- a/spec/functional_test/fixtures/python/masonite/app/controllers/UserController.py
+++ b/spec/functional_test/fixtures/python/masonite/app/controllers/UserController.py
@@ -1,0 +1,42 @@
+"""A UserController Module."""
+from masonite.controllers import Controller
+from masonite.request import Request
+from masonite.response import Response
+
+
+class UserController(Controller):
+    def store(self, request: Request, response: Response):
+        name = request.input("name")
+        email = request.input("email")
+        return response.json({"name": name, "email": email})
+
+    def show(self, request: Request, response: Response, id):
+        return response.json({"id": id})
+
+    def search(self, request: Request, response: Response):
+        sort = request.input("sort")
+        return response.json({"sort": sort})
+
+    def settings(self, request: Request, response: Response):
+        theme = request.input("theme")
+        return response.json({"theme": theme})
+
+    def update_profile(self, request: Request, response: Response):
+        bio = request.input("bio")
+        return response.json({"bio": bio})
+
+    def index(self, request: Request, response: Response):
+        page = request.input("page")
+        return response.json({"page": page})
+
+    def create(self, request: Request, response: Response):
+        username = request.input("username")
+        return response.json({"username": username})
+
+    def webhook(self, request: Request, response: Response):
+        token = request.header("X-Webhook-Token")
+        return response.json({"token": token})
+
+    def touch(self, request: Request, response: Response, id):
+        session = request.cookie("session_id")
+        return response.json({"id": id, "session": session})

--- a/spec/functional_test/fixtures/python/masonite/app/controllers/WelcomeController.py
+++ b/spec/functional_test/fixtures/python/masonite/app/controllers/WelcomeController.py
@@ -1,0 +1,10 @@
+"""A WelcomeController Module."""
+from masonite.views import View
+from masonite.controllers import Controller
+
+
+class WelcomeController(Controller):
+    """WelcomeController Controller Class."""
+
+    def show(self, view: View):
+        return view.render("welcome")

--- a/spec/functional_test/fixtures/python/masonite/requirements.txt
+++ b/spec/functional_test/fixtures/python/masonite/requirements.txt
@@ -1,0 +1,1 @@
+masonite

--- a/spec/functional_test/fixtures/python/masonite/routes/web.py
+++ b/spec/functional_test/fixtures/python/masonite/routes/web.py
@@ -1,0 +1,47 @@
+"""Web Routes."""
+from masonite.routes import Route
+
+from app.controllers.UserController import UserController
+
+ROUTES = [
+    # String controller binding ("preferred" per docs), '__call__' default.
+    Route.get("/", "WelcomeController@show"),
+
+    # Class/method controller binding.
+    Route.post("/users", UserController.store),
+
+    # Required + typed + optional path parameters.
+    Route.get("/users/@id", UserController.show),
+    Route.get("/typed/@id:integer", UserController.show),
+    Route.get("/search/?term", UserController.search),
+
+    # Nested groups: prefix composes outer -> inner.
+    Route.group([
+        Route.get("/settings", UserController.settings),
+        Route.group([
+            Route.put("/profile", UserController.update_profile),
+        ], prefix="/security"),
+    ], prefix="/account", middleware=["auth"]),
+
+    # Group whose inner route is bare "/" — must not leave a trailing slash.
+    Route.group([
+        Route.get("/", UserController.index),
+        Route.post("/", UserController.create),
+    ], prefix="/admin/users"),
+
+    # Resource + API resource expansion.
+    *Route.resource("posts", "PostController"),
+    *Route.api("api/posts", "PostController"),
+
+    # Specialized helpers.
+    Route.view("/about", "about"),
+    Route.redirect("/old-home", "/"),
+    Route.permanent_redirect("/legacy", "/"),
+
+    # any() / match() helpers.
+    Route.any("/webhook", UserController.webhook),
+    Route.match(["put", "patch"], "/users/@id/touch", UserController.touch),
+
+    # Unresolvable controller reference — must still surface a bare endpoint.
+    Route.get("/health", "MissingController@ping"),
+]

--- a/spec/functional_test/fixtures/python/masonite_callees/app/controllers/UserController.py
+++ b/spec/functional_test/fixtures/python/masonite_callees/app/controllers/UserController.py
@@ -1,0 +1,10 @@
+from masonite.controllers import Controller
+from masonite.response import Response
+
+from app.db import fetch_user
+
+
+class UserController(Controller):
+    def show(self, response: Response, uid):
+        user = fetch_user(uid)
+        return response.json(user)

--- a/spec/functional_test/fixtures/python/masonite_callees/app/db.py
+++ b/spec/functional_test/fixtures/python/masonite_callees/app/db.py
@@ -1,0 +1,2 @@
+def fetch_user(uid):
+    return {"id": uid}

--- a/spec/functional_test/fixtures/python/masonite_callees/routes/web.py
+++ b/spec/functional_test/fixtures/python/masonite_callees/routes/web.py
@@ -1,0 +1,5 @@
+from masonite.routes import Route
+
+ROUTES = [
+    Route.get("/users/@uid", "UserController@show"),
+]

--- a/spec/functional_test/fixtures/python/masonite_multi_base/service_a/app/controllers/ItemController.py
+++ b/spec/functional_test/fixtures/python/masonite_multi_base/service_a/app/controllers/ItemController.py
@@ -1,0 +1,9 @@
+from masonite.controllers import Controller
+from masonite.request import Request
+from masonite.response import Response
+
+
+class ItemController(Controller):
+    def index(self, request: Request, response: Response):
+        region = request.input("region")
+        return response.json({"service": "a", "region": region})

--- a/spec/functional_test/fixtures/python/masonite_multi_base/service_a/routes/web.py
+++ b/spec/functional_test/fixtures/python/masonite_multi_base/service_a/routes/web.py
@@ -1,0 +1,5 @@
+from masonite.routes import Route
+
+ROUTES = [
+    Route.get("/a-items", "ItemController@index"),
+]

--- a/spec/functional_test/fixtures/python/masonite_multi_base/service_b/app/controllers/ItemController.py
+++ b/spec/functional_test/fixtures/python/masonite_multi_base/service_b/app/controllers/ItemController.py
@@ -1,0 +1,9 @@
+from masonite.controllers import Controller
+from masonite.request import Request
+from masonite.response import Response
+
+
+class ItemController(Controller):
+    def index(self, request: Request, response: Response):
+        zone = request.input("zone")
+        return response.json({"service": "b", "zone": zone})

--- a/spec/functional_test/fixtures/python/masonite_multi_base/service_b/routes/web.py
+++ b/spec/functional_test/fixtures/python/masonite_multi_base/service_b/routes/web.py
@@ -1,0 +1,5 @@
+from masonite.routes import Route
+
+ROUTES = [
+    Route.get("/b-items", "ItemController@index"),
+]

--- a/spec/functional_test/fixtures/python/masonite_static/config/filesystem.py
+++ b/spec/functional_test/fixtures/python/masonite_static/config/filesystem.py
@@ -1,0 +1,14 @@
+from masonite.environment import env
+from masonite.utils.location import base_path
+
+
+DISKS = {
+    "default": "local",
+    "local": {"driver": "file", "path": base_path("storage/framework/filesystem")},
+}
+
+STATICFILES = {
+    # folder          # template alias
+    "storage/static": "static/",
+    "storage/public": "/",
+}

--- a/spec/functional_test/fixtures/python/masonite_static/routes/web.py
+++ b/spec/functional_test/fixtures/python/masonite_static/routes/web.py
@@ -1,0 +1,5 @@
+from masonite.routes import Route
+
+ROUTES = [
+    Route.get("/", "WelcomeController@show"),
+]

--- a/spec/functional_test/fixtures/python/masonite_static/storage/public/robots.txt
+++ b/spec/functional_test/fixtures/python/masonite_static/storage/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/spec/functional_test/fixtures/python/masonite_static/storage/static/app.css
+++ b/spec/functional_test/fixtures/python/masonite_static/storage/static/app.css
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/spec/functional_test/testers/python/masonite_callees_spec.cr
+++ b/spec/functional_test/testers/python/masonite_callees_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Masonite. The fixture exercises
+# the string controller binding + a same-file import; the spec confirms
+# that a callee with a reachable imported definition resolves to the
+# definition location instead of the call site inside the controller.
+db_path = "./spec/functional_test/fixtures/python/masonite_callees/app/db.py"
+
+expected_endpoints = [
+  Endpoint.new("/users/{uid}", "GET", [
+    Param.new("uid", "", "path"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("fetch_user", db_path, 1))
+  end,
+]
+
+FunctionalTester.new("fixtures/python/masonite_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/masonite_multi_base_spec.cr
+++ b/spec/functional_test/testers/python/masonite_multi_base_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Two independent services, each defining its own `ItemController` with
+# an `index` action reading a different query input. Confirms controller
+# resolution is scoped to the route file's own base path rather than a
+# blind project-wide class-name search — without that scoping,
+# service_b's route would resolve to service_a's same-named controller.
+base_paths = [
+  YAML::Any.new("./spec/functional_test/fixtures/python/masonite_multi_base/service_a"),
+  YAML::Any.new("./spec/functional_test/fixtures/python/masonite_multi_base/service_b"),
+]
+
+expected_endpoints = [
+  Endpoint.new("/a-items", "GET", [
+    Param.new("region", "", "query"),
+  ]),
+  Endpoint.new("/b-items", "GET", [
+    Param.new("zone", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/masonite_multi_base/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "base" => YAML::Any.new(base_paths),
+}).perform_tests

--- a/spec/functional_test/testers/python/masonite_spec.cr
+++ b/spec/functional_test/testers/python/masonite_spec.cr
@@ -1,0 +1,119 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  # String controller binding, no `@method` -> defaults to `__call__`.
+  Endpoint.new("/", "GET"),
+
+  # Class/method controller binding.
+  Endpoint.new("/users", "POST", [
+    Param.new("name", "", "query"),
+    Param.new("email", "", "query"),
+  ]),
+
+  # Required + typed (`:integer`) path parameters — both map to the same
+  # `show` handler.
+  Endpoint.new("/users/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/typed/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+
+  # Optional path parameter (`?term`) alongside an unrelated query input
+  # read inside the handler.
+  Endpoint.new("/search/{term}", "GET", [
+    Param.new("term", "", "path"),
+    Param.new("sort", "", "query"),
+  ]),
+
+  # Nested Route.group: prefixes compose outer -> inner.
+  Endpoint.new("/account/settings", "GET", [
+    Param.new("theme", "", "query"),
+  ]),
+  Endpoint.new("/account/security/profile", "PUT", [
+    Param.new("bio", "", "query"),
+  ]),
+
+  # Group whose inner route is bare "/" must not leave a trailing slash.
+  Endpoint.new("/admin/users", "GET", [
+    Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/admin/users", "POST", [
+    Param.new("username", "", "query"),
+  ]),
+
+  # Route.resource("posts", "PostController") -> 7 REST routes.
+  Endpoint.new("/posts", "GET"),
+  Endpoint.new("/posts/create", "GET"),
+  Endpoint.new("/posts", "POST", [
+    Param.new("title", "", "query"),
+  ]),
+  Endpoint.new("/posts/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/posts/{id}/edit", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/posts/{id}", "PUT", [
+    Param.new("id", "", "path"),
+    Param.new("title", "", "query"),
+  ]),
+  Endpoint.new("/posts/{id}", "PATCH", [
+    Param.new("id", "", "path"),
+    Param.new("title", "", "query"),
+  ]),
+  Endpoint.new("/posts/{id}", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
+
+  # Route.api("api/posts", "PostController") -> 5 REST-API routes.
+  Endpoint.new("/api/posts", "GET"),
+  Endpoint.new("/api/posts", "POST", [
+    Param.new("title", "", "query"),
+  ]),
+  Endpoint.new("/api/posts/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/api/posts/{id}", "PUT", [
+    Param.new("id", "", "path"),
+    Param.new("title", "", "query"),
+  ]),
+  Endpoint.new("/api/posts/{id}", "PATCH", [
+    Param.new("id", "", "path"),
+    Param.new("title", "", "query"),
+  ]),
+  Endpoint.new("/api/posts/{id}", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
+
+  # Specialized helpers.
+  Endpoint.new("/about", "GET"),
+  Endpoint.new("/old-home", "GET"),
+  Endpoint.new("/legacy", "GET"),
+
+  # Route.any -> all six verbs.
+  Endpoint.new("/webhook", "GET", [Param.new("X-Webhook-Token", "", "header")]),
+  Endpoint.new("/webhook", "POST", [Param.new("X-Webhook-Token", "", "header")]),
+  Endpoint.new("/webhook", "PUT", [Param.new("X-Webhook-Token", "", "header")]),
+  Endpoint.new("/webhook", "PATCH", [Param.new("X-Webhook-Token", "", "header")]),
+  Endpoint.new("/webhook", "DELETE", [Param.new("X-Webhook-Token", "", "header")]),
+  Endpoint.new("/webhook", "OPTIONS", [Param.new("X-Webhook-Token", "", "header")]),
+
+  # Route.match(["put", "patch"], ...).
+  Endpoint.new("/users/{id}/touch", "PUT", [
+    Param.new("id", "", "path"),
+    Param.new("session_id", "", "cookie"),
+  ]),
+  Endpoint.new("/users/{id}/touch", "PATCH", [
+    Param.new("id", "", "path"),
+    Param.new("session_id", "", "cookie"),
+  ]),
+
+  # Unresolvable controller reference — still surfaces a bare endpoint.
+  Endpoint.new("/health", "GET"),
+]
+
+FunctionalTester.new("fixtures/python/masonite/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/python/masonite_static_spec.cr
+++ b/spec/functional_test/testers/python/masonite_static_spec.cr
@@ -1,0 +1,17 @@
+require "../../func_spec.cr"
+
+# Masonite maps local directories to URL prefixes via `STATICFILES` in
+# `config/filesystem.py` (the default project skeleton ships
+# `"storage/static": "static/"`, `"storage/public": "/"`, ...). This
+# fixture confirms that mapping is read and the files under each mapped
+# directory surface as GET endpoints under the matching URL prefix.
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/static/app.css", "GET"),
+  Endpoint.new("/robots.txt", "GET"),
+]
+
+FunctionalTester.new("fixtures/python/masonite_static/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/detector/python/masonite_spec.cr
+++ b/spec/unit_test/detector/python/masonite_spec.cr
@@ -1,0 +1,27 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/python/*"
+
+describe "Detect Python Masonite" do
+  options = create_test_options
+  instance = Detector::Python::Masonite.new options
+
+  it "detect_masonite - routes/web.py (from masonite.routes import Route)" do
+    instance.detect("routes/web.py", "from masonite.routes import Route").should be_true
+  end
+
+  it "detect_masonite - app/controllers/WelcomeController.py (from masonite.controllers import Controller)" do
+    instance.detect("app/controllers/WelcomeController.py", "from masonite.controllers import Controller").should be_true
+  end
+
+  it "detect_masonite - Kernel.py (import masonite.foundation)" do
+    instance.detect("Kernel.py", "import masonite.foundation").should be_true
+  end
+
+  it "detect_masonite - negative (no masonite)" do
+    instance.detect("app.py", "from flask import Flask").should be_false
+  end
+
+  it "detect_masonite - non-py file" do
+    instance.detect("routes/web.txt", "from masonite.routes import Route").should be_false
+  end
+end

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -5,7 +5,7 @@ require "../../spec_helper"
 # The registry is derived from the classes, so a detector joins a scan simply by
 # existing (`build_detector_list`, src/detector/detector.cr). That removed the
 # "forgot to register it" failure mode and replaced it with a quieter one:
-# nothing at all requires a detector to be *tested*. 64 of 246 — including
+# nothing at all requires a detector to be *tested*. 64 of 247 — including
 # `rust/actix_web`, `java/quarkus`, `java/micronaut`, `java/jaxrs`,
 # `javascript/hapi`, `swift/hummingbird`, `typescript/trpc`, every `zig/*` and
 # every language's `cli` — shipped with zero coverage.
@@ -170,6 +170,6 @@ describe "detector spec coverage" do
   # Guards the guard: a broken glob would make every example above pass
   # vacuously.
   it "finds every registered detector" do
-    detector_paths.size.should eq 246
+    detector_paths.size.should eq 247
   end
 end

--- a/src/analyzer/analyzers/python/masonite.cr
+++ b/src/analyzer/analyzers/python/masonite.cr
@@ -1,0 +1,619 @@
+require "../../engines/python_engine"
+
+module Analyzer::Python
+  # Reference: https://docs.masoniteproject.com/features/routing
+  #
+  # Masonite (current v4/v5 API) routes live in `routes/web.py` (and
+  # sibling `routes/*.py` modules such as `routes/api.py`) as a plain
+  # list assigned to `ROUTES`, built from classmethods on
+  # `masonite.routes.Route`:
+  #
+  #   Route.get/post/put/patch/delete/options(url, controller, **opts)
+  #   Route.any(url, controller)                    -> all six verbs
+  #   Route.match([methods], url, controller)
+  #   Route.group([...routes...], prefix=, middleware=, name=, domain=)
+  #   Route.resource(base_url, controller)           -> 7 REST routes
+  #   Route.api(base_url, controller)                -> 5 REST-API routes
+  #   Route.view(url, template, data)                -> GET, no controller
+  #   Route.redirect/permanent_redirect(url, new)    -> GET, no controller
+  #
+  # `controller` is either the documented string binding
+  # (`'WelcomeController@show'`, defaulting to `__call__` with no `@`)
+  # or a direct class/method reference (`WelcomeController.show`) — both
+  # are handled. `Route.fallback(...)` (a catch-all with no concrete
+  # path) and route `.name(...)`/`.domain(...)` are intentionally not
+  # modeled — they carry no attack-surface information Noir tracks.
+  #
+  # NOTE — Masonite ≤3 used a different, now-legacy routing API: bare
+  # `Get`/`Post`/`RouteGroup` classes imported directly from
+  # `masonite.routes` (e.g. `Get('/x', 'C@m')`,
+  # `RouteGroup([...], prefix=...)`) with controllers resolved under
+  # `app/http/controllers`. That shape is NOT handled here; this
+  # analyzer targets the current `Route.*` DSL used by the official
+  # project skeleton (MasoniteFramework/cookie-cutter, `app/controllers`)
+  # and current docs. A legacy-style project still gets detected as
+  # Masonite (the detector only looks for `masonite` imports) but yields
+  # no routes from this analyzer.
+  class Masonite < PythonEngine
+    analyzer_for "python_masonite"
+
+    HTTP_VERB_METHODS = {
+      "get"     => ["GET"],
+      "post"    => ["POST"],
+      "put"     => ["PUT"],
+      "patch"   => ["PATCH"],
+      "delete"  => ["DELETE"],
+      "options" => ["OPTIONS"],
+    }
+    ANY_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+
+    # Verbs recognized while scanning `Route.<verb>(...)` call sites.
+    # Anything else (`.compile`, `.set_controller_locations`,
+    # `.fallback`, `.default`, ...) is deliberately left unmatched.
+    ROUTE_CALL_VERBS = Set{
+      "get", "post", "put", "patch", "delete", "options",
+      "any", "match", "group", "resource", "api", "view",
+      "redirect", "permanent_redirect",
+    }
+
+    # `Route.resource(base_url, controller)` — see
+    # `masonite.routes.Route.resource`: seven conventional REST routes.
+    RESOURCE_ACTIONS = [
+      {["GET"], "", "index"},
+      {["GET"], "/create", "create"},
+      {["POST"], "", "store"},
+      {["GET"], "/@id", "show"},
+      {["GET"], "/@id/edit", "edit"},
+      {["PUT", "PATCH"], "/@id", "update"},
+      {["DELETE"], "/@id", "destroy"},
+    ]
+
+    # `Route.api(base_url, controller)` — API-style subset (no
+    # create/edit HTML forms).
+    API_RESOURCE_ACTIONS = [
+      {["GET"], "", "index"},
+      {["POST"], "", "store"},
+      {["GET"], "/@id", "show"},
+      {["PUT", "PATCH"], "/@id", "update"},
+      {["DELETE"], "/@id", "destroy"},
+    ]
+
+    @masonite_base_path : ::String = ""
+    @controller_file_cache = Hash(::String, ::String?).new
+
+    def analyze
+      endpoints = [] of Endpoint
+
+      masonite_route_files.each do |file, base_path|
+        @masonite_base_path = base_path
+        content = read_file_content(file)
+        extract_route_endpoints(content, file).each { |endpoint| endpoints << endpoint }
+      end
+
+      extract_static_endpoints.each { |endpoint| endpoints << endpoint }
+
+      endpoints
+    end
+
+    # `routes/*.py` files that actually pull in Masonite's routing DSL —
+    # scoped this way (directory convention + a genuine import signal +
+    # actual `Route.` usage) so a same-named `routes/web.py` belonging to
+    # a different framework in the same repo/monorepo is never touched.
+    private def masonite_route_files : Array({::String, ::String})
+      files = [] of {::String, ::String}
+
+      python_source_files.each do |file|
+        relative = base_relative_path(file)
+        next unless relative.includes?("/routes/") || relative.starts_with?("routes/")
+
+        content = read_file_content(file)
+        next unless content.matches?(/\bfrom\s+masonite(\.routes)?\s+import\b/) || content.matches?(/\bimport\s+masonite\.routes\b/)
+        next unless content.includes?("Route.")
+
+        files << {file, python_base_path_for(file)}
+      end
+
+      files
+    end
+
+    private def extract_route_endpoints(content : ::String, route_file : ::String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      calls = scan_route_calls(content)
+      return endpoints if calls.empty?
+
+      calls.each do |call|
+        next if call.verb == "group" # groups only contribute a prefix to their children
+
+        prefix = accumulated_prefix(call, calls)
+
+        case call.verb
+        when "get", "post", "put", "patch", "delete", "options"
+          args = split_masonite_args(call.args)
+          next if args.size < 2
+          url = route_string_arg(args, 0, "url")
+          next unless url
+          endpoints.concat build_endpoints_for_route(prefix, url, HTTP_VERB_METHODS[call.verb], args[1]?, route_file, call.line)
+        when "any"
+          args = split_masonite_args(call.args)
+          next if args.size < 2
+          url = route_string_arg(args, 0, "url")
+          next unless url
+          endpoints.concat build_endpoints_for_route(prefix, url, ANY_METHODS, args[1]?, route_file, call.line)
+        when "match"
+          args = split_masonite_args(call.args)
+          next if args.size < 3
+          methods = args[0].scan(/[rf]?['"]([A-Za-z]+)['"]/).map(&.[1].upcase)
+          next if methods.empty?
+          url = route_string_arg(args, 1, "url")
+          next unless url
+          endpoints.concat build_endpoints_for_route(prefix, url, methods, args[2]?, route_file, call.line)
+        when "resource"
+          args = split_masonite_args(call.args)
+          next if args.size < 2
+          base = Helper.extract_python_string(args[0])
+          controller = Helper.extract_python_string(args[1])
+          next unless base && controller
+          RESOURCE_ACTIONS.each do |(methods, suffix, action)|
+            endpoints.concat build_endpoints_for_route(prefix, "#{base}#{suffix}", methods, "#{controller}@#{action}", route_file, call.line)
+          end
+        when "api"
+          args = split_masonite_args(call.args)
+          next if args.size < 2
+          base = Helper.extract_python_string(args[0])
+          controller = Helper.extract_python_string(args[1])
+          next unless base && controller
+          API_RESOURCE_ACTIONS.each do |(methods, suffix, action)|
+            endpoints.concat build_endpoints_for_route(prefix, "#{base}#{suffix}", methods, "#{controller}@#{action}", route_file, call.line)
+          end
+        when "view"
+          args = split_masonite_args(call.args)
+          next if args.empty?
+          url = route_string_arg(args, 0, "url")
+          next unless url
+          endpoints.concat build_endpoints_for_route(prefix, url, ["GET"], nil, route_file, call.line)
+        when "redirect", "permanent_redirect"
+          args = split_masonite_args(call.args)
+          next if args.empty?
+          url = route_string_arg(args, 0, "url")
+          next unless url
+          endpoints.concat build_endpoints_for_route(prefix, url, ["GET"], nil, route_file, call.line)
+        end
+      end
+
+      endpoints
+    end
+
+    # `args[index]` as a plain string literal, falling back to a
+    # `keyword=` spelling of the same positional slot (rare, but cheap
+    # to support).
+    private def route_string_arg(args : Array(::String), index : Int32, keyword : ::String) : ::String?
+      arg = args[index]?
+      return unless arg
+      Helper.extract_python_string(arg) || begin
+        if m = arg.strip.match(/\A#{Regex.escape(keyword)}\s*=\s*(.+)\z/m)
+          Helper.extract_python_string(m[1])
+        end
+      end
+    end
+
+    private def build_endpoints_for_route(prefix : ::String,
+                                          url : ::String,
+                                          methods : Array(::String),
+                                          controller_raw : ::String?,
+                                          route_file : ::String,
+                                          line : Int32) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      full_url = normalize_masonite_path(Helper.normalized_join(prefix, url))
+      path_params = masonite_path_params(url)
+      resolved = controller_raw ? parse_controller_ref(controller_raw) : nil
+
+      methods.each do |http_method|
+        if resolved
+          class_name, method_name = resolved
+          if endpoint = build_endpoint_from_controller(full_url, http_method, class_name, method_name, path_params)
+            endpoints << endpoint
+            next
+          end
+        end
+
+        details = Details.new(PathInfo.new(route_file, line))
+        endpoint = Endpoint.new(full_url, http_method, [] of Param, details)
+        path_params.each { |param| endpoint.push_param(param) }
+        endpoints << endpoint
+      end
+
+      endpoints
+    end
+
+    private def build_endpoint_from_controller(url : ::String,
+                                               http_method : ::String,
+                                               class_name : ::String,
+                                               method_name : ::String,
+                                               path_params : Array(Param)) : Endpoint?
+      filepath = find_controller_class_file(class_name, @masonite_base_path)
+      return unless filepath
+
+      content = read_file_content(filepath)
+      class_start_index = content.index(/class\s+#{Regex.escape(class_name)}\s*[\(:]/)
+      return unless class_start_index
+
+      class_codeblock = parse_code_block(content[class_start_index..])
+      return unless class_codeblock
+
+      class_lines = class_codeblock.split("\n")
+      def_re = /^\s*(?:async\s+)?def\s+#{Regex.escape(method_name)}\s*\(/
+      def_offset = class_lines.index(&.matches?(def_re))
+      return unless def_offset
+
+      method_block = parse_code_block(class_lines[def_offset..])
+      return unless method_block
+
+      body_start_line = content[0, class_start_index].count('\n')
+      definition_line = body_start_line + def_offset + 1
+
+      details = Details.new(PathInfo.new(filepath, definition_line))
+      endpoint = Endpoint.new(url, http_method, [] of Param, details)
+      path_params.each { |param| endpoint.push_param(param) }
+      extract_masonite_params(method_block).each { |param| endpoint.push_param(param) }
+
+      build_callees_from(
+        method_block,
+        body_start_line + def_offset,
+        filepath,
+        definition_base_path: @masonite_base_path,
+        source: content
+      ).each { |callee| endpoint.push_callee(callee) }
+
+      endpoint
+    end
+
+    # Resolve `'ControllerName@method'` / `'ns.ControllerName@method'`
+    # (string binding, defaulting to `__call__` with no `@method`) or a
+    # bare `ControllerName.method` / `ControllerName` reference (class
+    # binding) into `{class_name, method_name}`.
+    #
+    # `raw` is either real Python source text (a quoted string literal or
+    # a bare dotted expression) or the synthetic `"Name@action"` text
+    # `extract_route_endpoints` builds for `Route.resource`/`Route.api`
+    # expansion — already unquoted, so it's accepted as-is when it has
+    # the same `Name@method` shape a quoted string would decode to.
+    private def parse_controller_ref(raw : ::String) : Tuple(::String, ::String)?
+      expr = raw.strip
+      synthetic = expr.matches?(/\A[A-Za-z_][A-Za-z0-9_.]*@[A-Za-z_][A-Za-z0-9_]*\z/) ? expr : nil
+
+      if str = Helper.extract_python_string(expr) || synthetic
+        left, _, right = str.partition("@")
+        class_name = left.split(".").last?
+        return unless class_name
+        return if class_name.empty?
+        return {class_name, right.empty? ? "__call__" : right}
+      end
+
+      if m = expr.match(/\A([A-Za-z_][A-Za-z0-9_]*)(?:\.([A-Za-z_][A-Za-z0-9_]*))?\z/)
+        return {m[1], m[2]? || "__call__"}
+      end
+
+      nil
+    end
+
+    # Find the file defining `class <class_name>` — Masonite's own
+    # resolution walks a configurable `controllers.location` (default
+    # `app/controllers`), which Noir doesn't model as project
+    # configuration; a project-wide class-name search is the practical
+    # equivalent given every real Masonite project (including the
+    # official skeleton) names the file after the class.
+    #
+    # `preferred_base` (the calling route file's own configured base
+    # path) is ranked first so a multi-base scan of several independent
+    # services never resolves service B's route to service A's
+    # same-named controller — only falling back to a cross-base match
+    # when nothing in the route's own base defines the class.
+    private def find_controller_class_file(class_name : ::String, preferred_base : ::String) : ::String?
+      cache_key = "#{preferred_base}::#{class_name}"
+      return @controller_file_cache[cache_key] if @controller_file_cache.has_key?(cache_key)
+
+      class_re = /^\s*class\s+#{Regex.escape(class_name)}\s*[\(:]/
+      target_basename = "#{class_name}.py"
+
+      candidates = python_source_files.select do |file|
+        File.basename(file) == target_basename || base_relative_path(file).includes?("/controllers/")
+      end
+      candidates = python_source_files if candidates.empty?
+
+      candidates.sort_by! do |file|
+        {
+          python_base_path_for(file) == preferred_base ? 0 : 1,
+          File.basename(file) == target_basename ? 0 : 1,
+          base_relative_path(file).includes?("/controllers/") ? 0 : 1,
+          file,
+        }
+      end
+
+      found = candidates.find do |file|
+        begin
+          read_file_content(file).each_line.any?(&.matches?(class_re))
+        rescue
+          false
+        end
+      end
+
+      @controller_file_cache[cache_key] = found
+      found
+    end
+
+    # `request.param(...)` -> path, `request.input(...)`/`request.only(...)`
+    # -> query (Masonite's `InputBag` merges the query string and the
+    # POST/JSON body behind a single accessor, same ambiguity as Flask's
+    # `request.values` — mirrored here with the same "query" bucket),
+    # `request.cookie(...)` -> cookie, `request.header(...)` -> header.
+    private def extract_masonite_params(body : ::String) : Array(Param)
+      params = [] of Param
+      seen = Set(::String).new
+      record = ->(name : ::String, type : ::String) do
+        key = "#{type}:#{name}"
+        unless seen.includes?(key)
+          params << Param.new(name, "", type)
+          seen << key
+        end
+      end
+
+      body.scan(/\brequest\.input\(\s*[rf]?['"]([^'"]+)['"]/) { |m| record.call(m[1], "query") }
+      body.scan(/\brequest\.param\(\s*[rf]?['"]([^'"]+)['"]/) { |m| record.call(m[1], "path") }
+      body.scan(/\brequest\.cookie\(\s*[rf]?['"]([^'"]+)['"]/) { |m| record.call(m[1], "cookie") }
+      body.scan(/\brequest\.header\(\s*[rf]?['"]([^'"]+)['"]/) { |m| record.call(m[1], "header") }
+      body.scan(/\brequest\.only\(([^)]*)\)/) do |m|
+        m[1].scan(/[rf]?['"]([^'"]+)['"]/) { |inner| record.call(inner[1], "query") }
+      end
+
+      params
+    end
+
+    # `@name` (required) / `?name` (optional) segments, each with an
+    # optional `:compiler` suffix (`@id:integer`), are Masonite's path
+    # parameters.
+    private def masonite_path_params(url : ::String) : Array(Param)
+      params = [] of Param
+      url.split('/').each do |segment|
+        next unless segment.starts_with?('@') || segment.starts_with?('?')
+        name = segment[1..].split(':').first
+        next if name.empty?
+        params << Param.new(name, "", "path")
+      end
+      params
+    end
+
+    private def normalize_masonite_path(url : ::String) : ::String
+      segments = url.split('/').map do |segment|
+        if segment.starts_with?('@') || segment.starts_with?('?')
+          "{#{segment[1..].split(':').first}}"
+        else
+          segment
+        end
+      end
+      normalized = Helper.normalize_path(segments.join('/'))
+
+      # Masonite strips a trailing slash from every compiled route except
+      # the bare root (`HTTPRoute.__init__`) — a group whose inner route
+      # is `"/"` (e.g. `Route.group([Route.get("/", ...)],
+      # prefix="/admin/users")`) would otherwise serve `/admin/users`
+      # but Noir would record `/admin/users/`.
+      normalized.size > 1 && normalized.ends_with?("/") ? normalized[0..-2] : normalized
+    end
+
+    # Static assets — Masonite maps local directories to URL prefixes via
+    # `STATICFILES` in `config/filesystem.py` (default skeleton ships
+    # `"storage/static": "static/"`, `"storage/public": "/"`, ...).
+    private def extract_static_endpoints : Array(Endpoint)
+      endpoints = [] of Endpoint
+
+      config_files = python_source_files.select do |file|
+        File.basename(file) == "filesystem.py" && base_relative_path(file).includes?("config/")
+      end
+
+      config_files.each do |file|
+        content = read_file_content(file)
+        mappings = static_asset_mappings(content)
+        next if mappings.empty?
+
+        base = python_base_path_for(file)
+        mappings.each do |local_dir, url_prefix|
+          prefix = File.join(base, local_dir)
+          prefix = "#{prefix}/" unless prefix.ends_with?("/")
+
+          begin
+            get_files_by_prefix(prefix).each do |asset_file|
+              relative_path = asset_file.sub(prefix, "")
+              endpoints << Endpoint.new(Helper.normalized_join(url_prefix, relative_path), "GET")
+            end
+          rescue e
+            logger.debug e
+          end
+        end
+      end
+
+      endpoints
+    end
+
+    private def static_asset_mappings(content : ::String) : Array(Tuple(::String, ::String))
+      mappings = [] of Tuple(::String, ::String)
+      start = content.index(/\bSTATICFILES\s*=\s*\{/)
+      return mappings unless start
+
+      brace_index = content.index('{', start)
+      return mappings unless brace_index
+
+      close_index = matching_close(content, brace_index, '{', '}')
+      return mappings unless close_index
+
+      block = content[(brace_index + 1)...close_index]
+      block.scan(/['"]([^'"]+)['"]\s*:\s*['"]([^'"]*)['"]/) do |m|
+        mappings << {m[1], m[2]}
+      end
+
+      mappings
+    end
+
+    # ---- Route.* call-site scanning -----------------------------------
+
+    private record MasoniteCall, verb : ::String, args : ::String, start_pos : Int32, end_pos : Int32, line : Int32
+
+    # Flat scan for every `Route.<verb>(...)` call in the file (nested or
+    # not — a call inside a `Route.group([...])` list is found here too,
+    # at its own byte range). Nesting is later recovered from those byte
+    # ranges in `accumulated_prefix`, which avoids needing a recursive
+    # parse of the (possibly deeply nested) route-list literal.
+    private def scan_route_calls(content : ::String) : Array(MasoniteCall)
+      calls = [] of MasoniteCall
+
+      content.scan(/\bRoute\.([A-Za-z_][A-Za-z0-9_]*)\s*\(/) do |m|
+        verb = m[1]
+        next unless ROUTE_CALL_VERBS.includes?(verb)
+
+        open_index = m.end(0) - 1
+        close_index = matching_close(content, open_index, '(', ')')
+        next unless close_index
+
+        args_text = content[(open_index + 1)...close_index]
+        line = content[0, m.begin(0)].count('\n') + 1
+        calls << MasoniteCall.new(verb, args_text, m.begin(0), close_index, line)
+      end
+
+      calls
+    end
+
+    # The nearest-enclosing `Route.group(...)` call's contributed prefix
+    # chain, outermost first, joined into one normalized path prefix.
+    private def accumulated_prefix(call : MasoniteCall, calls : Array(MasoniteCall)) : ::String
+      chain = [] of ::String
+      current = immediate_parent(call, calls)
+      while current
+        chain << group_prefix(current)
+        current = immediate_parent(current, calls)
+      end
+
+      chain.reverse.reduce("") { |acc, part| Helper.normalized_join(acc, part) }
+    end
+
+    private def immediate_parent(call : MasoniteCall, calls : Array(MasoniteCall)) : MasoniteCall?
+      enclosing = calls.select do |candidate|
+        candidate.verb == "group" && candidate.start_pos < call.start_pos && candidate.end_pos > call.end_pos
+      end
+      return if enclosing.empty?
+
+      enclosing.min_by { |candidate| candidate.end_pos - candidate.start_pos }
+    end
+
+    private def group_prefix(call : MasoniteCall) : ::String
+      text = call.args
+      list_open = text.index('[')
+      list_close = list_open ? matching_close(text, list_open, '[', ']') : nil
+      tail = list_close ? text[(list_close + 1)..] : text
+
+      if m = tail.match(/\bprefix\s*=\s*[rf]?['"]([^'"]*)['"]/)
+        m[1]
+      else
+        ""
+      end
+    end
+
+    # Index of the delimiter matching `open_char` at `open_index`,
+    # skipping delimiters inside single/double-quoted strings (with
+    # backslash-escape tracking). Triple-quoted strings are not
+    # modeled — route registration call sites never contain one.
+    private def matching_close(text : ::String, open_index : Int32, open_char : Char, close_char : Char) : Int32?
+      depth = 1
+      i = open_index + 1
+      in_quote : Char? = nil
+      escaped = false
+
+      while i < text.size
+        ch = text[i]
+        if in_quote
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          i += 1
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+        when open_char
+          depth += 1
+        when close_char
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+
+      nil
+    end
+
+    # Top-level comma split honoring nested `()`/`[]`/`{}` and quotes.
+    private def split_masonite_args(text : ::String) : Array(::String)
+      parts = [] of ::String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      text.each_char do |ch|
+        if in_quote
+          current << ch
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+          current << ch
+        when '('
+          paren_depth += 1
+          current << ch
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+          current << ch
+        when '['
+          bracket_depth += 1
+          current << ch
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+          current << ch
+        when '{'
+          brace_depth += 1
+          current << ch
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+          current << ch
+        when ','
+          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+            parts << current.to_s
+            current = String::Builder.new
+          else
+            current << ch
+          end
+        else
+          current << ch
+        end
+      end
+
+      parts << current.to_s
+      parts
+    end
+  end
+end

--- a/src/detector/detectors/python/masonite.cr
+++ b/src/detector/detectors/python/masonite.cr
@@ -1,0 +1,19 @@
+require "../../../models/detector"
+
+module Detector::Python
+  class Masonite < Detector
+    detector_for "python_masonite", extensions: %w[.py]
+
+    def detect(filename : String, file_contents : String) : Bool
+      return false unless filename.ends_with?(".py")
+
+      # Match framework imports (`masonite.routes`, `masonite.controllers`,
+      # `masonite.views`, plain `import masonite`, ...) while avoiding
+      # unrelated `masonite_*` packages.
+      has_from_import = file_contents.match(/(^|\n)\s*from\s+masonite(\.|\s+import\s+)/)
+      has_import = file_contents.match(/(^|\n)\s*import\s+masonite(\s|,|\.|$)/)
+
+      !!(has_from_import || has_import)
+    end
+  end
+end

--- a/src/techs/catalog/python/masonite.cr
+++ b/src/techs/catalog/python/masonite.cr
@@ -1,0 +1,26 @@
+# NoirTechs catalog entry: python_masonite.
+# One file per technology; `NoirTechs::TECHS` in src/techs/techs.cr is
+# macro-derived from every constant under `NoirTechs::Catalog`.
+module NoirTechs::Catalog::Python
+  MASONITE = {
+    :python_masonite => {
+      :framework => "Masonite",
+      :language  => "Python",
+      :similar   => ["masonite", "python-masonite", "python_masonite"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => false,
+          :header => true,
+          :cookie => true,
+        },
+        :static_path => true,
+        :websocket   => false,
+      },
+      :context => {:callee => true, :guards => true},
+    },
+  }
+end


### PR DESCRIPTION
## Summary

Adds full detector + analyzer + techs-catalog support for [Masonite](https://docs.masoniteproject.com/), a batteries-included Python MVC framework, targeting the current v4/v5 `Route.*` DSL.

- **Detector** (`src/detector/detectors/python/masonite.cr`): fires on `from masonite...import` / `import masonite` (mirrors `pyramid.cr`/`flask.cr`).
- **Analyzer** (`src/analyzer/analyzers/python/masonite.cr`): scans `routes/*.py` files that both live under a `routes/` directory *and* carry a genuine `masonite.routes` import + `Route.` usage — this dual signal keeps a same-named `routes/web.py` belonging to another framework in the same repo/monorepo untouched.
  - `Route.get/post/put/patch/delete/options/any/match`
  - `Route.group(...)` — nested `prefix=`/composition (prefixes accumulate outer→inner)
  - `Route.resource(base, controller)` / `Route.api(base, controller)` — expanded into the 7/5 conventional REST routes per Masonite's own `Route.resource`/`Route.api` source
  - `Route.view` / `Route.redirect` / `Route.permanent_redirect`
  - Both documented controller-binding styles: string (`'Controller@method'`, defaulting to `__call__`) and class/method reference (`Controller.method`)
  - Path params: required (`@id`), optional (`?id`), typed (`@id:integer`) — normalized to Noir's `{id}` form
  - `request.input/param/cookie/header/only(...)` → query/path/cookie/header params
  - Static assets via `STATICFILES` in `config/filesystem.py` (`{"storage/static": "static/", ...}`)
  - 1-hop callee extraction, reusing the shared Python import graph for cross-file resolution
  - Controller-class resolution is scoped to the calling route file's own configured base path first (falling back to a project-wide search) — otherwise a multi-base scan of two services with a same-named controller (e.g. both defining `ItemController`) would cross-resolve one service's route to the other's controller.
- **Techs catalog** (`src/techs/catalog/python/masonite.cr`): `python_masonite`, query/path/header/cookie params + static_path + callee/guards context. `body` is `false` — Masonite's `InputBag` merges query string and POST/JSON body behind one `request.input()` accessor with no separate body-only reader, so there's no distinct "form" signal to extract (mirrors Flask's `request.values` ambiguity, mapped the same way to `query`).

**Out of scope / known limitation**: Masonite ≤3 used a different, legacy routing API (bare `Get`/`Post`/`RouteGroup` classes imported directly from `masonite.routes`, controllers under `app/http/controllers`). That shape is not handled — a legacy-style project still gets detected as Masonite (the detector only looks for `masonite` imports) but yields no routes from this analyzer. Noted in the analyzer's header comment.

## Validation

- Unit + functional specs: `crystal spec spec/unit_test spec/functional_test` — 28,095 examples, 0 failures.
- New fixtures under `spec/functional_test/fixtures/python/masonite*`: main routing-shapes fixture (35 endpoints covering every construct above), a callee-resolution fixture, a `STATICFILES` fixture, and a multi-base fixture proving controller-resolution isolation between two same-named-controller services.
- `just dsup` run; regenerated docs/README included.
- `crystal tool format --check` and `ameba` clean.
- **Real OSS validation**: shallow-cloned and scanned several real Masonite repos with the built binary:
  - `MasoniteFramework/cookie-cutter` (the official v4 project skeleton used by `masonite new`) — correctly extracts the sole route, resolves the string-bound controller, and (after adding local test asset files) correctly picks up `STATICFILES`-mapped static assets.
  - `tahseenjamal/masonite-5.4-book-code` — a community book's example code targeting Masonite 5.4. Its `ch04-routing` chapter is a dedicated fixture exercising literally every routing construct (all 7 verbs, named routes, both required/typed/optional params, single + nested groups, `Route.resource`/`Route.api`, `Route.view`/`redirect`/`permanent_redirect`, `Route.any`/`Route.match`, class-based controller refs) — all 37 expected endpoints extracted correctly, including catching a real trailing-slash bug (`Route.group([Route.get("/", ...)], prefix="/admin/users")` was producing `/admin/users/` instead of `/admin/users`, now fixed to match Masonite's own `HTTPRoute` normalization) and a controller-resolution bug where `Route.resource`/`Route.api`-synthesized `"Controller@action"` refs (unquoted, unlike real Python source) weren't matched by the string-binding parser.
  - Its `blog` chapter (a fuller realistic app: posts/comments/tags/admin/install flows) — 27 endpoints, with `--include callee` correctly surfacing calls like `Post.where`, `Comment.create`, `Gate.authorize`.
  - `vaibhavmule/masonite-realworld-example-app` — a Masonite ≤3 (legacy `RouteGroup`/`Get`/`Post` API) app, used as a negative check: detector correctly fires (`python_masonite` detected from `wsgi.py`), analyzer correctly yields 0 routes (legacy syntax out of scope) with no crash.
  - `MasoniteFramework/masonite` (the framework's own source) — 0 phantom routes; its route-shaped files all live under `tests/` fixture paths and are correctly excluded by the existing Python test-path convention.

Closes #2596