### PR TITLE
feat(analyzer): detect Padrino controller and mount routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The inventory feeds three audiences:
 
 ## What Noir does
 
-- **Endpoint extraction.** Static analysis across [199 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
+- **Endpoint extraction.** Static analysis across [200 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
 - **LLM fallback.** Hand unsupported frameworks (or one-off custom routing) to OpenAI / Ollama / etc. when static rules don't apply.
 - **Output for the next stage.** JSON, YAML, OpenAPI, SARIF, cURL, Postman, HTML — whichever format the next tool in the pipeline reads.
 - **DAST integration.** Pipe directly into ZAP, Burp Suite, Caido or Gori as a proxy target, or export OpenAPI for them to import.

--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 199개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
+description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 200개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
 template = "landing"
 +++
 
@@ -91,7 +91,7 @@ template = "landing"
         <p>플러그인도, 언어별 설정도 없는 단일 바이너리입니다. 정적 규칙이 놓친 프레임워크는 LLM이 대신 처리합니다.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">언어</span></span>
-          <span><span class="stat-val">199</span><span class="stat-key">프레임워크</span></span>
+          <span><span class="stat-val">200</span><span class="stat-key">프레임워크</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 199 frameworks, exposing shadow APIs and mapping the attack surface."
+description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 200 frameworks, exposing shadow APIs and mapping the attack surface."
 template = "landing"
 +++
 
@@ -89,7 +89,7 @@ template = "landing"
         <p>One binary, no plugins and no per-language setup. Frameworks the static rules miss fall back to an LLM.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">Languages</span></span>
-          <span><span class="stat-val">199</span><span class="stat-key">Frameworks</span></span>
+          <span><span class="stat-val">200</span><span class="stat-key">Frameworks</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/usage/supported/callee_coverage/index.ko.md
+++ b/docs/content/usage/supported/callee_coverage/index.ko.md
@@ -44,7 +44,7 @@ JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는
 | Perl | Catalyst, Dancer2, Mojolicious |
 | Python | Bottle, Django, Django Ninja, Falcon, FastAPI, Flask, Litestar, Masonite, Pyramid, Quart, Robyn, Sanic, Starlette, Tornado, aiohttp, http.server |
 | R | Plumber |
-| Ruby | Grape, Hanami, Rails, Roda, Sinatra, WEBrick |
+| Ruby | Grape, Hanami, Padrino, Rails, Roda, Sinatra, WEBrick |
 | Rust | Actix Web, Axum, Gotham, Loco, Poem, RWF, Rocket, Salvo, Tide, Warp |
 | Scala | Akka HTTP, Play Framework, Scalatra, Tapir, ZIO HTTP, http4s |
 | Swift | Hummingbird, Kitura, Vapor |

--- a/docs/content/usage/supported/callee_coverage/index.md
+++ b/docs/content/usage/supported/callee_coverage/index.md
@@ -44,7 +44,7 @@ This matrix lists frameworks where Noir supports per-endpoint callee extraction.
 | Perl | Catalyst, Dancer2, Mojolicious |
 | Python | Bottle, Django, Django Ninja, Falcon, FastAPI, Flask, Litestar, Masonite, Pyramid, Quart, Robyn, Sanic, Starlette, Tornado, aiohttp, http.server |
 | R | Plumber |
-| Ruby | Grape, Hanami, Rails, Roda, Sinatra, WEBrick |
+| Ruby | Grape, Hanami, Padrino, Rails, Roda, Sinatra, WEBrick |
 | Rust | Actix Web, Axum, Gotham, Loco, Poem, RWF, Rocket, Salvo, Tide, Warp |
 | Scala | Akka HTTP, Play Framework, Scalatra, Tapir, ZIO HTTP, http4s |
 | Swift | Hummingbird, Kitura, Vapor |

--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -4535,6 +4535,33 @@ sort_by = "weight"
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Padrino</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip on">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Rails</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -4535,6 +4535,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Padrino</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip on">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Rails</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/spec/functional_test/fixtures/ruby/padrino/Gemfile
+++ b/spec/functional_test/fixtures/ruby/padrino/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'padrino', '0.15.2'
+gem 'sinatra'
+gem 'rack'

--- a/spec/functional_test/fixtures/ruby/padrino/app/app.rb
+++ b/spec/functional_test/fixtures/ruby/padrino/app/app.rb
@@ -1,0 +1,18 @@
+require 'padrino-core'
+
+# The primary app. A bare `get :name do` written directly in the class
+# body (no enclosing `controllers` block) is still a valid named route —
+# `Padrino::Routing` is mixed into every `Padrino::Application` subclass.
+class PadrinoTest < Padrino::Application
+  register Padrino::Helpers
+
+  get '/' do
+    puts params[:query]
+    puts cookies[:session]
+  end
+
+  get :status do
+    # url_for(:status) => "/status"
+    'ok'
+  end
+end

--- a/spec/functional_test/fixtures/ruby/padrino/app/controllers/posts.rb
+++ b/spec/functional_test/fixtures/ruby/padrino/app/controllers/posts.rb
@@ -1,0 +1,43 @@
+# Regression guard: route DSL inside an RDoc-style comment is
+# documentation, not a registration.
+#
+#     get :should_not_appear do
+#       'nope'
+#     end
+
+PadrinoTest.controllers :posts do
+  get :index do
+    # url_for(:posts, :index) => "/posts"
+    params[:page]
+  end
+
+  get :show, with: :id do
+    # url_for(:posts, :show, id: 5) => "/posts/show/5"
+    params[:id]
+  end
+
+  get :archive, map: '/posts/archive/:year' do
+    # url_for(:posts, :archive, year: 2024) => "/posts/archive/2024"
+    params[:year]
+  end
+
+  post :create do
+    # url_for(:posts, :create) => "/posts/create"
+    request.env["HTTP_X_REQUEST_ID"]
+  end
+
+  get "/latest" do
+    # A literal-path route nested inside a controller block is still
+    # grouped under the controller's own prefix, same as `namespace`.
+    params[:limit]
+  end
+end
+
+# `parent:` prepends the parent resource's own segment + `:<parent>_id`
+# ahead of the controller's name segment.
+PadrinoTest.controllers :comments, parent: :post do
+  get :index do
+    # url_for(:comments, :index, post_id: 5) => "/post/5/comments"
+    params[:sort]
+  end
+end

--- a/spec/functional_test/fixtures/ruby/padrino_mount/Gemfile
+++ b/spec/functional_test/fixtures/ruby/padrino_mount/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'padrino', '0.15.2'

--- a/spec/functional_test/fixtures/ruby/padrino_mount/app/admin/app.rb
+++ b/spec/functional_test/fixtures/ruby/padrino_mount/app/admin/app.rb
@@ -1,0 +1,5 @@
+class Admin < Padrino::Application
+  get '/dashboard' do
+    params[:range]
+  end
+end

--- a/spec/functional_test/fixtures/ruby/padrino_mount/app/admin/controllers/users.rb
+++ b/spec/functional_test/fixtures/ruby/padrino_mount/app/admin/controllers/users.rb
@@ -1,0 +1,11 @@
+Admin.controllers :users do
+  get :index do
+    # Mounted under /admin -> url_for(:users, :index) => "/admin/users"
+    params[:page]
+  end
+
+  get :show, map: '/users/:id/profile' do
+    # `map:` is relative to the mount prefix, not the controller name.
+    params[:id]
+  end
+end

--- a/spec/functional_test/fixtures/ruby/padrino_mount/app/core/app.rb
+++ b/spec/functional_test/fixtures/ruby/padrino_mount/app/core/app.rb
@@ -1,0 +1,9 @@
+class CoreApp < Padrino::Application
+  get '/' do
+    'core home'
+  end
+
+  get '/health' do
+    'ok'
+  end
+end

--- a/spec/functional_test/fixtures/ruby/padrino_mount/config/apps.rb
+++ b/spec/functional_test/fixtures/ruby/padrino_mount/config/apps.rb
@@ -1,0 +1,6 @@
+##
+# This file mounts each app in the Padrino project to a specified sub-uri.
+# Mounts the core application for this project at the root, and the admin
+# sub-app under /admin.
+Padrino.mount('core', app_class: 'CoreApp').to('/')
+Padrino.mount('admin').to('/admin')

--- a/spec/functional_test/testers/ruby/padrino_mount_spec.cr
+++ b/spec/functional_test/testers/ruby/padrino_mount_spec.cr
@@ -1,0 +1,25 @@
+require "../../func_spec.cr"
+
+# `config/apps.rb` mounts `core` at `/` (a no-op prefix) and `admin` at
+# `/admin` — every route declared inside `app/admin/**` (both the plain
+# `class Admin < Padrino::Application` routes and the `Admin.controllers
+# :users do ... end` named routes, `map:` included) must inherit the
+# `/admin` prefix, while `app/core/**` stays unprefixed.
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/health", "GET"),
+  Endpoint.new("/admin/dashboard", "GET", [
+    Param.new("range", "", "query"),
+  ]),
+  Endpoint.new("/admin/users", "GET", [
+    Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/admin/users/:id/profile", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/ruby/padrino_mount/", {
+  :techs     => 1,
+  :endpoints => 5,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/ruby/padrino_spec.cr
+++ b/spec/functional_test/testers/ruby/padrino_spec.cr
@@ -1,0 +1,52 @@
+require "../../func_spec.cr"
+
+# The Gemfile here also declares `sinatra` (a realistic pin many real
+# Padrino apps carry) to exercise `ruby_padrino`'s `:supersedes` over
+# `ruby_sinatra`. Detection still sees both (`:techs => 2` below —
+# `filter_redundant_generic_techs` only trims which *analyzer* runs, not
+# the reported detection list; see the Lumen/Laravel tester for the same
+# shape), but only the Padrino analyzer actually runs: every route the
+# Sinatra analyzer would have found (the literal `get '/' do` /
+# `get "/latest" do` routes below) still comes out, from the Padrino
+# analyzer alone, with no duplicate reported under `ruby_sinatra`.
+expected_endpoints = [
+  Endpoint.new("/", "GET", [
+    Param.new("query", "", "query"),
+    Param.new("session", "", "cookie"),
+  ]),
+  Endpoint.new("/status", "GET"),
+  Endpoint.new("/posts", "GET", [
+    Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/posts/show/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/posts/archive/:year", "GET", [
+    Param.new("year", "", "path"),
+  ]),
+  Endpoint.new("/posts/create", "POST", [
+    Param.new("HTTP_X_REQUEST_ID", "", "header"),
+  ]),
+  Endpoint.new("/posts/latest", "GET", [
+    Param.new("limit", "", "query"),
+  ]),
+  Endpoint.new("/post/:post_id/comments", "GET", [
+    Param.new("sort", "", "query"),
+    Param.new("post_id", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/ruby/padrino/", {
+  :techs     => 2, # Detection sees ruby_padrino and ruby_sinatra (shared DSL signal)
+  :endpoints => 8,
+}, expected_endpoints).perform_tests
+
+describe "Padrino analyzer filter" do
+  it "drops ruby_sinatra when ruby_padrino is detected so the redundant pass is skipped" do
+    filter_redundant_generic_techs(["ruby_padrino", "ruby_sinatra"]).should eq ["ruby_padrino"]
+  end
+
+  it "is order-independent" do
+    filter_redundant_generic_techs(["ruby_sinatra", "ruby_padrino"]).should eq ["ruby_padrino"]
+  end
+end

--- a/spec/unit_test/detector/ruby/padrino_spec.cr
+++ b/spec/unit_test/detector/ruby/padrino_spec.cr
@@ -1,0 +1,79 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/ruby/*"
+
+describe "Detect Ruby Padrino" do
+  options = create_test_options
+  instance = Detector::Ruby::Padrino.new options
+
+  it "gemfile/single_quot" do
+    instance.detect("Gemfile", "gem 'padrino'").should be_true
+  end
+  it "gemfile/double_quot" do
+    instance.detect("Gemfile", "gem \"padrino\"").should be_true
+  end
+  it "gemfile/padrino-core" do
+    instance.detect("Gemfile", "gem 'padrino-core'").should be_true
+  end
+  it "gemfile/parenthesized call form" do
+    instance.detect("Gemfile", "gem('padrino', '~> 0.15')").should be_true
+  end
+  it "gemfile/no_padrino_dep" do
+    instance.detect("Gemfile", "gem 'sinatra'").should be_false
+  end
+  it "gemspec/add_dependency" do
+    contents = <<-RUBY
+      Gem::Specification.new do |s|
+        s.add_dependency 'padrino-core', '~> 0.15'
+      end
+      RUBY
+    instance.detect("foo.gemspec", contents).should be_true
+  end
+  it "gemspec/add_runtime_dependency" do
+    contents = <<-RUBY
+      Gem::Specification.new do |spec|
+        spec.add_runtime_dependency "padrino", ">= 0.15"
+      end
+      RUBY
+    instance.detect("foo.gemspec", contents).should be_true
+  end
+  it "gemspec/no_padrino_dep" do
+    contents = <<-RUBY
+      Gem::Specification.new do |s|
+        s.add_dependency 'rails'
+      end
+      RUBY
+    instance.detect("foo.gemspec", contents).should be_false
+  end
+  it "source/class_padrino_application" do
+    contents = <<-RUBY
+      class Blog < Padrino::Application
+        get '/' do
+          'hi'
+        end
+      end
+      RUBY
+    instance.detect("app/app.rb", contents).should be_true
+  end
+  it "source/padrino_mount" do
+    contents = <<-RUBY
+      Padrino.mount('blog').to('/blog')
+      RUBY
+    instance.detect("config/apps.rb", contents).should be_true
+  end
+  it "source/require_padrino_core" do
+    instance.detect("app.rb", "require 'padrino-core'").should be_true
+  end
+  it "source/require_padrino" do
+    instance.detect("app.rb", "require 'padrino'").should be_true
+  end
+  it "source/plain_sinatra_no_padrino_marker" do
+    contents = <<-RUBY
+      class Blog < Sinatra::Base
+        get '/' do
+          'hi'
+        end
+      end
+      RUBY
+    instance.detect("app.rb", contents).should be_false
+  end
+end

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -5,7 +5,7 @@ require "../../spec_helper"
 # The registry is derived from the classes, so a detector joins a scan simply by
 # existing (`build_detector_list`, src/detector/detector.cr). That removed the
 # "forgot to register it" failure mode and replaced it with a quieter one:
-# nothing at all requires a detector to be *tested*. 64 of 247 — including
+# nothing at all requires a detector to be *tested*. 64 of 248 — including
 # `rust/actix_web`, `java/quarkus`, `java/micronaut`, `java/jaxrs`,
 # `javascript/hapi`, `swift/hummingbird`, `typescript/trpc`, every `zig/*` and
 # every language's `cli` — shipped with zero coverage.
@@ -170,6 +170,6 @@ describe "detector spec coverage" do
   # Guards the guard: a broken glob would make every example above pass
   # vacuously.
   it "finds every registered detector" do
-    detector_paths.size.should eq 247
+    detector_paths.size.should eq 248
   end
 end

--- a/src/analyzer/analyzers/ruby/padrino.cr
+++ b/src/analyzer/analyzers/ruby/padrino.cr
@@ -1,0 +1,370 @@
+require "../../engines/ruby_engine"
+
+module Analyzer::Ruby
+  # Padrino layers two things on top of Sinatra's route table:
+  #
+  #   1. Named, block-scoped routes declared through the controller DSL —
+  #      `AppName.controllers :posts do get :index, map: '/blog' do ... end
+  #      end` — where the effective URL is derived from the controller
+  #      name, the route name, and the optional `map:`/`with:`/`parent:`
+  #      options rather than a literal path string.
+  #   2. Base-path mounting of each sub-app from `config/apps.rb` —
+  #      `Padrino.mount('blog', app_class: 'BlogApp').to('/blog')` — which
+  #      every route inside that sub-app inherits as a prefix.
+  #
+  # `ruby_padrino` supersedes `ruby_sinatra` (see the catalog entry), so this
+  # analyzer also re-implements Sinatra's own literal-path route matching
+  # (`get "/path" do`, `namespace "/x" do`) via the shared `RubyEngine`
+  # helpers — when both techs are detected, the Sinatra analyzer does not
+  # run at all, and nothing may be lost by dropping it.
+  class Padrino < RubyEngine
+    analyzer_for "ruby_padrino"
+
+    # Precompile the `<verb> :name` matchers once — same reasoning as
+    # `RubyEngine::VERB_ROUTE_PATTERNS` (interpolated regex literals are
+    # recompiled on every evaluation otherwise). Group 1 is the route name,
+    # group 2 is everything after it on the line (options + block opener).
+    SYMBOL_VERB_PATTERNS = HTTP_VERBS.map do |verb|
+      {verb, /^#{verb}\s*\(?\s*:(\w+)\b(.*)$/}
+    end
+
+    # `map:`/`:map =>`, `with:`/`:with =>`, `parent:`/`:parent =>` — Padrino
+    # apps span enough Ruby-version history that both hash syntaxes show up
+    # in real projects.
+    MAP_OPTION_RE    = /(?::map\s*=>|map:)\s*['"]([^'"]+)['"]/
+    WITH_OPTION_RE   = /(?::with\s*=>|with:)\s*(\[[^\]]*\]|:[\w]+)/
+    PARENT_OPTION_RE = /(?::parent\s*=>|parent:)\s*:?['"]?(\w+)/
+
+    # `<Receiver>.controllers :name do` / `controllers :name do` (no
+    # receiver, called inside the app class body) / `controllers "/admin"
+    # do` (explicit string prefix) / bare `controller do` (grouping only,
+    # no prefix). Group 1 is the argument list between the keyword and the
+    # block opener.
+    CONTROLLER_OPEN_RE = /^(?:[\w:]+\s*\.\s*)?controllers?\b(.*?)(?:\bdo\b|\{)/
+
+    # `class BlogApp < Padrino::Application` — opens an (empty-prefix)
+    # controller scope so a bare `get :index do` written directly in the
+    # app class body (no enclosing `controllers` block) still resolves.
+    CLASS_APP_RE = /\bclass\s+([\w:]+)\s*<\s*Padrino::Application\b/
+
+    NAMESPACE_OPEN_RE = /^namespace\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s*(?:do\b|\{)/
+
+    # `Padrino.mount('blog', app_class: 'BlogApp').to('/blog')` — matched
+    # per-line (mount declarations are always a single statement in every
+    # real-world `config/apps.rb`), so a `[^)]*` options capture never has
+    # to worry about matching past the end of the file.
+    MOUNT_LINE_RE    = /Padrino\.mount\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*(.*?))?\)\s*\.to\(\s*['"]([^'"]*)['"]\s*\)/
+    APP_CLASS_OPT_RE = /(?::app_class\s*=>|app_class:)\s*['"]([^'"]+)['"]/
+
+    def analyze
+      include_callee = callees_needed?
+      mount_prefixes = build_mount_prefixes
+
+      parallel_file_scan do |path|
+        next unless path.ends_with?(".rb") || path.ends_with?(".ru")
+        next if ruby_non_production_path?(path)
+        content = read_file_content(path)
+        # Same rationale as the Sinatra analyzer: a Rails/Hanami route
+        # table is never also a Padrino app's route file.
+        next if rails_router_source?(content) || hanami_router_source?(content)
+
+        mount_prefix = file_mount_prefix(content, mount_prefixes)
+        analyze_file(path, content, mount_prefix, include_callee)
+      end
+
+      @result
+    end
+
+    private def analyze_file(path : String, content : String, mount_prefix : String, include_callee : Bool)
+      lines = content.each_line.to_a
+      active_route_endpoints = [] of Endpoint
+      active_route_depth = nil.as(Int32?)
+      prefix_stack = [] of NamedTuple(depth: Int32, path: String)
+      depth = 0
+
+      lines.each_with_index do |line, index|
+        next unless line.valid_encoding?
+        stripped = Noir::RubyCalleeExtractor.strip_comment(line, preserve_strings: true).strip
+        next if stripped.empty? || stripped.starts_with?('#')
+
+        line_delta = padrino_depth_delta(line)
+
+        if ns = stripped.match(NAMESPACE_OPEN_RE)
+          prefix_stack << {depth: depth + 1, path: ns[1]}
+        elsif cm = stripped.match(CONTROLLER_OPEN_RE)
+          prefix_stack << {depth: depth + 1, path: controller_segment(cm[1]? || "")}
+        elsif stripped.match(CLASS_APP_RE)
+          prefix_stack << {depth: depth + 1, path: ""}
+        end
+
+        route_endpoints = line_to_endpoints(stripped, prefix_stack)
+        unless route_endpoints.empty?
+          route_endpoints.each do |endpoint|
+            endpoint.url = apply_mount_prefix(mount_prefix, endpoint.url)
+            details = Details.new(PathInfo.new(path, index + 1))
+            endpoint.details = details
+            attach_route_callees(endpoint, lines, index, path) if include_callee
+            @result << endpoint
+          end
+
+          if line_delta > 0
+            active_route_endpoints = route_endpoints
+            active_route_depth = depth + 1
+          else
+            active_route_endpoints = [] of Endpoint
+            active_route_depth = nil
+          end
+        end
+
+        line_to_params(stripped).each do |param|
+          target_endpoints = if route_endpoints.empty?
+                               if (route_depth = active_route_depth) && !active_route_endpoints.empty? && depth >= route_depth
+                                 active_route_endpoints
+                               else
+                                 [] of Endpoint
+                               end
+                             else
+                               route_endpoints
+                             end
+
+          target_endpoints.each(&.push_param(param))
+        end
+
+        depth += line_delta
+        while !prefix_stack.empty? && prefix_stack.last[:depth] > depth
+          prefix_stack.pop
+        end
+        if (route_depth = active_route_depth) && depth < route_depth
+          active_route_endpoints = [] of Endpoint
+          active_route_depth = nil
+        end
+      end
+    end
+
+    private def line_to_endpoints(content : String, prefix_stack : Array(NamedTuple(depth: Int32, path: String))) : Array(Endpoint)
+      leading = content.lstrip
+
+      SYMBOL_VERB_PATTERNS.each do |verb, pattern|
+        next unless leading.starts_with?(verb)
+        next if leading.size > verb.size && (leading[verb.size].alphanumeric? || leading[verb.size] == '_')
+
+        if m = leading.match(pattern)
+          return [build_symbol_endpoint(verb, m[1], m[2]? || "", prefix_stack)]
+        end
+      end
+
+      # Literal-path routes (`get "/path" do`) are Sinatra's own DSL,
+      # unchanged under Padrino — reuse `RubyEngine#line_to_endpoint`
+      # rather than re-deriving the same matcher.
+      endpoint = line_to_endpoint(content)
+      return [] of Endpoint if endpoint.method.empty?
+
+      endpoint.url = padrino_prefixed_path(prefix_stack, endpoint.url)
+      [endpoint]
+    end
+
+    private def build_symbol_endpoint(verb : String, route_name : String, rest : String, prefix_stack : Array(NamedTuple(depth: Int32, path: String))) : Endpoint
+      local_path =
+        if mm = rest.match(MAP_OPTION_RE)
+          map_value = mm[1]
+          map_value.starts_with?('/') ? map_value : "/#{map_value}"
+        else
+          segments = collect_stack_segments(prefix_stack)
+          segments << route_name unless route_name == "index"
+          if wm = rest.match(WITH_OPTION_RE)
+            wm[1].scan(/:(\w+)/) { |sm| segments << ":#{sm[1]}" }
+          end
+          segments.empty? ? "/" : "/#{segments.join("/")}"
+        end
+
+      Endpoint.new(local_path, verb.upcase)
+    end
+
+    # `parent: :user` (or `:parent => :user`) prepends `user/:user_id`
+    # ahead of the controller's own name segment — matches
+    # `url_for(:product, :index, user_id: 5) => "/user/5/product"` from the
+    # Padrino routing guide.
+    private def controller_segment(args : String) : String
+      segments = [] of String
+
+      if pm = args.match(PARENT_OPTION_RE)
+        parent = pm[1]
+        segments << parent << ":#{parent}_id"
+      end
+
+      if am = args.match(/\A\s*:(\w+)/)
+        segments << am[1]
+      elsif am = args.match(/\A\s*['"]([^'"]*)['"]/)
+        am[1].split("/").each { |piece| segments << piece unless piece.strip.empty? }
+      end
+
+      segments.join("/")
+    end
+
+    private def collect_stack_segments(prefix_stack : Array(NamedTuple(depth: Int32, path: String))) : Array(String)
+      segments = [] of String
+      prefix_stack.each { |entry| append_padrino_path(segments, entry[:path]) }
+      segments
+    end
+
+    private def padrino_prefixed_path(prefix_stack : Array(NamedTuple(depth: Int32, path: String)), path : String) : String
+      segments = collect_stack_segments(prefix_stack)
+      append_padrino_path(segments, path)
+      segments.empty? ? "/" : "/#{segments.join("/")}"
+    end
+
+    private def append_padrino_path(segments : Array(String), raw : String)
+      raw.split("/").each do |piece|
+        trimmed = piece.strip
+        segments << trimmed unless trimmed.empty?
+      end
+    end
+
+    private def apply_mount_prefix(mount_prefix : String, local_path : String) : String
+      return local_path if mount_prefix.empty?
+
+      suffix = local_path == "/" ? "" : local_path
+      combined = "#{mount_prefix}#{suffix}"
+      combined.empty? ? "/" : combined
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)
+      if block = extract_ruby_do_block(lines, index)
+        body, body_start_line = block
+        callees = Noir::RubyCalleeExtractor.callees_for_body(body, path, body_start_line)
+        attach_ruby_callees(endpoint, callees)
+      end
+    end
+
+    # Same params surface as Sinatra: `params[...]`/`params.fetch(...)` as
+    # query params, `request.env[...]`/`headers[...]` as headers,
+    # `cookies[...]` as cookies. `splat`/`captures` are Sinatra's own
+    # pattern bindings, not user-supplied fields.
+    PADRINO_RESERVED_PARAMS = Set{"splat", "captures"}
+
+    private def line_to_params(content : String) : Array(Param)
+      params = [] of Param
+      return params unless content.includes?('[') || content.includes?("fetch")
+
+      content.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "query") unless name.empty? || PADRINO_RESERVED_PARAMS.includes?(name)
+      end
+
+      content.scan(/params\.fetch\s*\(\s*(?::(\w+)|['"]([^'"]+)['"])/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "query") unless name.empty?
+      end
+
+      content.scan(/request\.env\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+        name = m[1].strip
+        params << Param.new(name, "", "header") unless name.empty?
+      end
+
+      content.scan(/headers\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "header") unless name.empty?
+      end
+
+      content.scan(/cookies\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "cookie") unless name.empty?
+      end
+
+      params
+    end
+
+    # Same block-nesting delta as the Sinatra analyzer (see its
+    # `SINATRA_DEPTH_TOKEN_RE` for the detailed rationale) — duplicated
+    # rather than shared so this analyzer stays self-contained.
+    PADRINO_DEPTH_TOKEN_RE = /\bend\b|\bdo\b|(?:^|;)\s*(?:if|unless|case|begin|while|until|for|class|module|def)\b/
+
+    private def padrino_depth_delta(line : String) : Int32
+      structure = Noir::RubyCalleeExtractor.strip_comment(line, preserve_strings: false)
+      delta = structure.count('{') - structure.count('}')
+      structure.scan(PADRINO_DEPTH_TOKEN_RE) do |m|
+        delta += m[0] == "end" ? -1 : 1
+      end
+      delta
+    end
+
+    # Builds the app-identifier -> mount-prefix map from every
+    # `Padrino.mount(...).to('/prefix')` call in the project (conventionally
+    # `config/apps.rb`, but not assumed to live there). Keys the prefix
+    # under the mount name itself, a camelized version of it (Padrino's
+    # default `app_class` when none is given), and the explicit
+    # `app_class:`/`:app_class =>` value when present.
+    private def build_mount_prefixes : Hash(String, String)
+      prefixes = {} of String => String
+
+      get_files_by_extensions(RUBY_SOURCE_EXTENSIONS).each do |path|
+        next if ruby_non_production_path?(path)
+        content = read_file_content(path)
+        next unless content.includes?("Padrino.mount")
+
+        content.each_line do |line|
+          next unless m = line.match(MOUNT_LINE_RE)
+
+          name = m[1].strip
+          prefix = normalize_padrino_mount_prefix(m[3])
+          keys = [name, camelize_padrino(name)]
+
+          if (opts = m[2]?) && (am = opts.match(APP_CLASS_OPT_RE))
+            keys << am[1]
+          end
+
+          keys.uniq.each do |key|
+            next if key.empty?
+            prefixes[key] ||= prefix
+          end
+        end
+      end
+
+      prefixes
+    end
+
+    # Resolves the file's own mount prefix by looking up either the
+    # `Padrino::Application` subclass declared in it, or the receiver of
+    # the first `.controllers` call (for a controller file that references
+    # its app class explicitly instead of being nested inside it).
+    private def file_mount_prefix(content : String, mount_prefixes : Hash(String, String)) : String
+      return "" if mount_prefixes.empty?
+
+      if m = content.match(CLASS_APP_RE)
+        prefix = lookup_mount_prefix(mount_prefixes, m[1])
+        return prefix unless prefix.empty?
+      end
+
+      if m = content.match(/([\w:]+)\s*\.\s*controllers?\b/)
+        return lookup_mount_prefix(mount_prefixes, m[1])
+      end
+
+      ""
+    end
+
+    private def lookup_mount_prefix(mount_prefixes : Hash(String, String), key : String) : String
+      parts = key.split("::")
+      candidates = parts.size > 1 ? [key, parts.first, parts.last] : [key]
+      candidates.each do |candidate|
+        if prefix = mount_prefixes[candidate]?
+          return prefix
+        end
+      end
+      ""
+    end
+
+    private def normalize_padrino_mount_prefix(raw : String) : String
+      trimmed = raw.strip
+      return "" if trimmed.empty? || trimmed == "/"
+
+      trimmed = "/#{trimmed}" unless trimmed.starts_with?('/')
+      trimmed.rstrip("/")
+    end
+
+    private def camelize_padrino(name : String) : String
+      name.split(/[_\-]/).reject(&.empty?).map do |part|
+        part.size > 1 ? "#{part[0].upcase}#{part[1..]}" : part.upcase
+      end.join
+    end
+  end
+end

--- a/src/detector/detectors/ruby/padrino.cr
+++ b/src/detector/detectors/ruby/padrino.cr
@@ -1,0 +1,43 @@
+require "../../../models/detector"
+
+module Detector::Ruby
+  # Padrino is a full-stack framework built directly on top of Sinatra —
+  # every Padrino app also carries Sinatra's route-registration DSL, so the
+  # Sinatra detector legitimately fires on Padrino projects too (see
+  # `NoirTechs::Catalog::Ruby::PADRINO`'s `:supersedes`). This detector needs
+  # its own, more specific positive signal so `ruby_padrino` is additive
+  # rather than a re-detection of `ruby_sinatra` under another name.
+  class Padrino < Detector
+    detector_for "ruby_padrino", extensions: %w[.rb .ru .gemspec], basenames: %w[Gemfile Gemfile.lock]
+
+    # `Padrino::Application` is the base class every mountable sub-app
+    # inherits from, `Padrino.mount` is the `config/apps.rb` mounting call,
+    # and `require 'padrino-core'` / `require 'padrino'` cover apps that
+    # pull the framework in without ever subclassing `Padrino::Application`
+    # directly (e.g. a single-file app built on `Padrino::Routing`).
+    SOURCE_MARKERS = Regex.union(
+      "Padrino::Application",
+      "Padrino.mount",
+      /require\s+['"]padrino-core['"]/,
+      /require\s+['"]padrino['"]/
+    )
+
+    def detect(filename : String, file_contents : String) : Bool
+      if filename.includes?("Gemfile")
+        return true if gemfile_dependency?(file_contents, "padrino")
+        return true if gemfile_dependency?(file_contents, "padrino-core")
+      end
+
+      if filename.ends_with?(".gemspec")
+        return true if gemspec_dependency?(file_contents, "padrino")
+        return true if gemspec_dependency?(file_contents, "padrino-core")
+      end
+
+      if filename.ends_with?(".rb")
+        return true if content_matches?(file_contents, SOURCE_MARKERS)
+      end
+
+      false
+    end
+  end
+end

--- a/src/techs/catalog/ruby/padrino.cr
+++ b/src/techs/catalog/ruby/padrino.cr
@@ -1,0 +1,38 @@
+# NoirTechs catalog entry: ruby_padrino.
+# One file per technology; `NoirTechs::TECHS` in src/techs/techs.cr is
+# macro-derived from every constant under `NoirTechs::Catalog`.
+module NoirTechs::Catalog::Ruby
+  PADRINO = {
+    :ruby_padrino => {
+      # Padrino apps carry Sinatra's own route-registration DSL (every
+      # `Padrino::Application` is a `Sinatra::Base` subclass), so the
+      # Sinatra detector/analyzer legitimately fire on every Padrino
+      # project too — same shape as Lumen/Laravel and Drupal/Symfony.
+      # When Padrino is the actual framework, the Sinatra report is
+      # redundant noise: `Analyzer::Ruby::Padrino` already re-implements
+      # Sinatra's plain `get "/path" do` route matching (so nothing is
+      # lost by dropping the Sinatra analyzer) and additionally resolves
+      # Padrino's `controllers :name do get :index, map: "..." do end end`
+      # named-route DSL and `config/apps.rb` mount-prefix propagation,
+      # which the Sinatra analyzer cannot represent at all.
+      :supersedes => ["ruby_sinatra"],
+      :framework  => "Padrino",
+      :language   => "Ruby",
+      :similar    => ["padrino", "ruby-padrino", "ruby_padrino", "padrino-core", "padrino-framework"],
+      :supported  => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => true,
+          :cookie => true,
+        },
+        :static_path => true,
+        :websocket   => false,
+      },
+      :context => {:callee => true, :guards => true},
+    },
+  }
+end


### PR DESCRIPTION
## Summary

Adds full detector + analyzer + techs-catalog support for [Padrino](https://padrinorb.com/), the full-stack Ruby framework built on top of Sinatra.

- **Detector** (`src/detector/detectors/ruby/padrino.cr`): Gemfile/gemspec dependency on `padrino`/`padrino-core`, plus source markers (`Padrino::Application`, `Padrino.mount`, `require 'padrino(-core)'`) so single-file apps and gem-embedded apps are still caught even without an explicit Gemfile pin.

- **Analyzer** (`src/analyzer/analyzers/ruby/padrino.cr`):
  - Resolves the block-scoped named-route DSL — `AppName.controllers :posts do get :index, map: '/blog', with: :id, parent: :user do ... end end` — into effective URLs, honoring `map:`/`with:`/`parent:` in both modern (`key:`) and legacy (`:key => value`) hash syntax (real Padrino apps span both eras).
  - Propagates `config/apps.rb`'s `Padrino.mount('name', app_class: '...').to('/prefix')` base path onto every route declared in that mounted sub-app, resolved either by the sub-app's `class X < Padrino::Application` declaration or by the explicit receiver of a `.controllers` call in a separate controller file.
  - Also re-implements Sinatra's own literal-path route matching (`get "/path" do`, `namespace "/x" do`) by reusing the shared `RubyEngine#line_to_endpoint` helper — see the supersedes note below for why this matters.

- **Techs catalog** (`src/techs/catalog/ruby/padrino.cr`): new `ruby_padrino` entry, `:supported` endpoint/method/params (query/path/body/header/cookie)/static_path all `true`, `:context => {callee: true, guards: true}`.

## Sinatra vs. Padrino: the `:supersedes` decision

Every `Padrino::Application` is a `Sinatra::Base` subclass, so a Padrino app's route files are frequently *also* valid input to the Sinatra detector/analyzer (many real Padrino `Gemfile`s pin `sinatra` explicitly alongside `padrino`, and even when they don't, Padrino apps freely mix plain `get '/path' do` routes with the named-route DSL). Two analyzers walking the same DSL would double-report the same routes under two tech tags.

I added `:supersedes => ["ruby_sinatra"]` to `ruby_padrino`'s catalog entry — the same shape as Lumen/Laravel and Drupal/Symfony. The risk called out for this mechanism is "getting it wrong either double-reports or silently drops routes": `filter_redundant_generic_techs` fully drops the superseded analyzer from the run (not just from output), so if the superseding analyzer doesn't cover everything the superseded one would have, real routes vanish.

To make this safe, the Padrino analyzer is a **strict superset** of Sinatra's detection surface: it reuses `RubyEngine#line_to_endpoint` for the exact same literal-path matching Sinatra's own analyzer does, on top of its own named-route/mount-prefix handling. `spec/functional_test/testers/ruby/padrino_spec.cr`'s fixture Gemfile deliberately pins both `padrino` and `sinatra` to exercise this: `:techs => 2` (both detected — `filter_redundant_generic_techs` only trims which analyzer *runs*, not the reported detection list, matching the existing Lumen/Laravel tester), but all 8 expected endpoints — including two plain literal-path routes — still come out of the Padrino analyzer alone.

## Testing

- New fixtures: `spec/functional_test/fixtures/ruby/padrino/` (controller named routes with `map:`/`with:`/`parent:`, a top-level named route with no `.controllers` wrapper, a literal-path route nested in a controller block, and the Sinatra-supersedes scenario) and `spec/functional_test/fixtures/ruby/padrino_mount/` (`config/apps.rb` multi-app mount-prefix propagation onto both plain and named routes).
- New unit spec: `spec/unit_test/detector/ruby/padrino_spec.cr`.
- Bumped the detector-count ratchet in `spec/unit_test/techs/detector_coverage_spec.cr` (241 → 242; the new detector ships with a spec, so the untested-count stays at 64).
- Regenerated docs via `crystal run scripts/generate_supported_docs.cr` (`just dsup`) — framework count 193 → 194.
- Full suite green: `crystal spec spec/unit_test` (4831 examples) and `crystal spec spec/functional_test` (23159 examples), no regressions — Sinatra's own specs included.
- `crystal tool format` + `lib/ameba/bin/ameba.cr` clean.

### Real-repo validation

Ran the built `--release` binary against three real Padrino codebases (shallow-cloned):

- **[padrino/omerta](https://github.com/padrino/omerta)** — 28 endpoints extracted from 6 admin controllers (`Admin.controllers :posts do ... end`, old `:with =>` syntax, `Padrino.mount("Admin").to("/admin")` with no explicit `app_class`, `get :index, :map => "/" do` collapsing correctly to exactly `/admin`). Every extracted route matches hand-verified source.
- **[komarserjio/notejam](https://github.com/komarserjio/notejam)** (Padrino implementation) — 35 endpoints, module-wrapped app classes (`module Notejam; class App < Padrino::Application`), fully-qualified mount names (`Padrino.mount("Notejam::Admin", :app_file => ...).to("/admin")`), and extensive `:map =>` usage. Spot-checked `app/controllers/note.rb` line-by-line against the scan output — exact match on every route and path param.
- **padrino/padrino-framework** (the framework's own source, ~12 gems) — no crashes, no perf issues (test fixtures under `test/`/`spec/` correctly excluded as non-production paths, which is why it reports 0 `ruby_padrino` routes: the framework repo itself ships no deployed app outside its test suite).

## Known limitations / follow-ups

- The rare `route(:get, :post, '/path') do ... end` verb-array escape hatch (Sinatra-only, not part of Padrino's own idiomatic DSL) isn't re-implemented, unlike the rest of Sinatra's literal-route surface. Not observed in any of the 3 real apps validated above.
- Mount-prefix resolution is file-scoped (one file assumed to belong to one mounted app), matching the generated/conventional Padrino layout; a file that legitimately mixes routes from two different mounted apps isn't a real-world pattern I found evidence of.
- Route-level `parent:` (as opposed to controller-level) isn't handled — only the more common controller-level form.

Closes #2599