### PR TITLE
feat(analyzer): detect Helidon routes in Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The inventory feeds three audiences:
 
 ## What Noir does
 
-- **Endpoint extraction.** Static analysis across [200 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
+- **Endpoint extraction.** Static analysis across [202 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
 - **LLM fallback.** Hand unsupported frameworks (or one-off custom routing) to OpenAI / Ollama / etc. when static rules don't apply.
 - **Output for the next stage.** JSON, YAML, OpenAPI, SARIF, cURL, Postman, HTML — whichever format the next tool in the pipeline reads.
 - **DAST integration.** Pipe directly into ZAP, Burp Suite, Caido or Gori as a proxy target, or export OpenAPI for them to import.

--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 200개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
+description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 202개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
 template = "landing"
 +++
 
@@ -91,7 +91,7 @@ template = "landing"
         <p>플러그인도, 언어별 설정도 없는 단일 바이너리입니다. 정적 규칙이 놓친 프레임워크는 LLM이 대신 처리합니다.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">언어</span></span>
-          <span><span class="stat-val">200</span><span class="stat-key">프레임워크</span></span>
+          <span><span class="stat-val">202</span><span class="stat-key">프레임워크</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 200 frameworks, exposing shadow APIs and mapping the attack surface."
+description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 202 frameworks, exposing shadow APIs and mapping the attack surface."
 template = "landing"
 +++
 
@@ -89,7 +89,7 @@ template = "landing"
         <p>One binary, no plugins and no per-language setup. Frameworks the static rules miss fall back to an LLM.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">Languages</span></span>
-          <span><span class="stat-val">200</span><span class="stat-key">Frameworks</span></span>
+          <span><span class="stat-val">202</span><span class="stat-key">Frameworks</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/usage/supported/callee_coverage/index.ko.md
+++ b/docs/content/usage/supported/callee_coverage/index.ko.md
@@ -36,7 +36,7 @@ JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는
 | Go | Beego, Chi, Echo, Fiber, Gin, GoFrame, Gorilla Mux, Goyave, Hertz, Huma, Iris, Kratos, PocketBase, fasthttp, go-restful, go-zero, httprouter, net/http |
 | Groovy | Grails |
 | Haskell | Scotty, Servant, Yesod |
-| Java | Apache Struts 2, Apache Wicket, Armeria, Dropwizard, JAX-RS, JDK HttpServer, Javalin, Micronaut, Play Framework, Quarkus, Spark Java, Spring, Vert.x |
+| Java | Apache Struts 2, Apache Wicket, Armeria, Dropwizard, Helidon MP, Helidon SE, JAX-RS, JDK HttpServer, Javalin, Micronaut, Play Framework, Quarkus, Spark Java, Spring, Vert.x |
 | JavaScript | AdonisJS, Apollo Server, Astro, Elysia, Express, Fastify, Fresh, Hapi, Hono, Koa, NestJS, Next.js, Nitro, NuxtJS, Remix, Restify, SvelteKit |
 | Kotlin | Ktor, Spring, http4k |
 | Lua | Lapis, lor |

--- a/docs/content/usage/supported/callee_coverage/index.md
+++ b/docs/content/usage/supported/callee_coverage/index.md
@@ -36,7 +36,7 @@ This matrix lists frameworks where Noir supports per-endpoint callee extraction.
 | Go | Beego, Chi, Echo, Fiber, Gin, GoFrame, Gorilla Mux, Goyave, Hertz, Huma, Iris, Kratos, PocketBase, fasthttp, go-restful, go-zero, httprouter, net/http |
 | Groovy | Grails |
 | Haskell | Scotty, Servant, Yesod |
-| Java | Apache Struts 2, Apache Wicket, Armeria, Dropwizard, JAX-RS, JDK HttpServer, Javalin, Micronaut, Play Framework, Quarkus, Spark Java, Spring, Vert.x |
+| Java | Apache Struts 2, Apache Wicket, Armeria, Dropwizard, Helidon MP, Helidon SE, JAX-RS, JDK HttpServer, Javalin, Micronaut, Play Framework, Quarkus, Spark Java, Spring, Vert.x |
 | JavaScript | AdonisJS, Apollo Server, Astro, Elysia, Express, Fastify, Fresh, Hapi, Hono, Koa, NestJS, Next.js, Nitro, NuxtJS, Remix, Restify, SvelteKit |
 | Kotlin | Ktor, Spring, http4k |
 | Lua | Lapis, lor |

--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -2281,6 +2281,60 @@ sort_by = "weight"
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Helidon MP</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Helidon SE</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">JAX-RS</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -2281,6 +2281,60 @@ Each card below lists a framework's supported features. **Route** covers endpoin
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Helidon MP</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Helidon SE</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">JAX-RS</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/spec/functional_test/fixtures/java/helidon_mp/pom.xml
+++ b/spec/functional_test/fixtures/java/helidon_mp/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>4.2.1</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.examples.quickstart</groupId>
+    <artifactId>helidon-quickstart-mp</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.health</groupId>
+            <artifactId>helidon-microprofile-health</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/spec/functional_test/fixtures/java/helidon_mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/spec/functional_test/fixtures/java/helidon_mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -1,0 +1,43 @@
+package io.helidon.examples.quickstart.mp;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * A simple JAX-RS resource to greet you. No Helidon import appears
+ * anywhere in this file — matches Helidon's own quickstart-mp, whose
+ * MP runtime is pulled in solely through `pom.xml`.
+ */
+@Path("/greet")
+public class GreetResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public GreetingMessage getDefaultMessage(@QueryParam("lang") String lang) {
+        return new GreetingMessage("Hello " + lang);
+    }
+
+    @Path("/{name}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public GreetingMessage getMessage(@PathParam("name") String name,
+                                      @HeaderParam("X-Trace-Id") String traceId) {
+        return new GreetingMessage(name);
+    }
+
+    @Path("/greeting")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateGreeting(GreetingMessage message) {
+        return Response.status(Response.Status.NO_CONTENT).build();
+    }
+}

--- a/spec/functional_test/fixtures/java/helidon_mp/src/main/java/io/helidon/examples/quickstart/mp/GreetingMessage.java
+++ b/spec/functional_test/fixtures/java/helidon_mp/src/main/java/io/helidon/examples/quickstart/mp/GreetingMessage.java
@@ -1,0 +1,21 @@
+package io.helidon.examples.quickstart.mp;
+
+public class GreetingMessage {
+
+    private String message;
+
+    public GreetingMessage() {
+    }
+
+    public GreetingMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/spec/functional_test/fixtures/java/helidon_se/src/main/java/io/helidon/examples/quickstart/se/AdminService.java
+++ b/spec/functional_test/fixtures/java/helidon_se/src/main/java/io/helidon/examples/quickstart/se/AdminService.java
@@ -1,0 +1,15 @@
+package io.helidon.examples.quickstart.se;
+
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+
+public class AdminService implements HttpService {
+
+    private static final String STATUS_PATH = "/status";
+
+    @Override
+    public void routing(HttpRules rules) {
+        rules.get(STATUS_PATH, (req, res) -> res.send("admin-ok"))
+             .delete("/cache/{cacheId}", (req, res) -> res.send("cleared"));
+    }
+}

--- a/spec/functional_test/fixtures/java/helidon_se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/spec/functional_test/fixtures/java/helidon_se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -1,0 +1,39 @@
+package io.helidon.examples.quickstart.se;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+public class GreetService implements HttpService {
+
+    @Override
+    public void routing(HttpRules rules) {
+        rules.get("/", this::getDefaultMessageHandler)
+             .get("/{name}", this::getMessageHandler)
+             .put("/greeting", this::updateGreetingHandler)
+             .register("/admin", new AdminService());
+    }
+
+    private void getDefaultMessageHandler(ServerRequest request, ServerResponse response) {
+        String lang = request.query().first("lang").orElse("en");
+        response.send("Hello " + lang);
+    }
+
+    private void getMessageHandler(ServerRequest request, ServerResponse response) {
+        String name = request.path().pathParameters().get("name");
+        String trace = request.headers().get(HeaderNames.create("X-Trace-Id")).value();
+        response.send(name + trace);
+    }
+
+    private void updateGreetingHandler(ServerRequest request, ServerResponse response) {
+        GreetingUpdate update = request.content().as(GreetingUpdate.class);
+        String session = request.headers().cookies().get("session");
+        response.status(204).send();
+    }
+
+    static class GreetingUpdate {
+        public String greeting;
+    }
+}

--- a/spec/functional_test/fixtures/java/helidon_se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/spec/functional_test/fixtures/java/helidon_se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -1,0 +1,25 @@
+package io.helidon.examples.quickstart.se;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+
+public final class Main {
+
+    private Main() {
+    }
+
+    public static void main(String[] args) {
+        WebServer server = WebServer.builder()
+                .routing(Main::routing)
+                .build()
+                .start();
+
+        System.out.println("WEB server is up! http://localhost:" + server.port());
+    }
+
+    static void routing(HttpRouting.Builder routing) {
+        routing.get("/health", (req, res) -> res.send("OK"))
+               .any("/ping", (req, res) -> res.send("pong"))
+               .register("/greet", new GreetService());
+    }
+}

--- a/spec/functional_test/testers/java/helidon_mp_spec.cr
+++ b/spec/functional_test/testers/java/helidon_mp_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/greet", "GET", [
+    Param.new("lang", "", "query"),
+  ]),
+  Endpoint.new("/greet/{name}", "GET", [
+    Param.new("X-Trace-Id", "", "header"),
+    Param.new("name", "", "path"),
+  ]),
+  Endpoint.new("/greet/greeting", "PUT", [
+    Param.new("message", "", "json"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/java/helidon_mp/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/java/helidon_se_spec.cr
+++ b/spec/functional_test/testers/java/helidon_se_spec.cr
@@ -1,0 +1,26 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/health", "GET"),
+  Endpoint.new("/ping", "ANY"),
+  Endpoint.new("/greet/", "GET", [
+    Param.new("lang", "", "query"),
+  ]),
+  Endpoint.new("/greet/{name}", "GET", [
+    Param.new("X-Trace-Id", "", "header"),
+    Param.new("name", "", "path"),
+  ]),
+  Endpoint.new("/greet/greeting", "PUT", [
+    Param.new("session", "", "cookie"),
+    Param.new("body", "GreetingUpdate", "json"),
+  ]),
+  Endpoint.new("/greet/admin/status", "GET"),
+  Endpoint.new("/greet/admin/cache/{cacheId}", "DELETE", [
+    Param.new("cacheId", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/java/helidon_se/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/detector/java/helidon_mp_spec.cr
+++ b/spec/unit_test/detector/java/helidon_mp_spec.cr
@@ -1,0 +1,23 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/java/*"
+
+describe "Detect Java Helidon MP" do
+  options = create_test_options
+  instance = Detector::Java::HelidonMp.new options
+
+  it "Main.java" do
+    instance.detect("Main.java", "import io.helidon.microprofile.server.Server;").should be_true
+  end
+
+  it "pom.xml" do
+    instance.detect("pom.xml", "<artifactId>helidon-microprofile-core</artifactId>\n<groupId>io.helidon.microprofile.bundles</groupId>").should be_true
+  end
+
+  it "build.gradle" do
+    instance.detect("build.gradle", "implementation 'io.helidon.microprofile.bundles:helidon-microprofile-core'").should be_true
+  end
+
+  it "plain JAX-RS resource without a Helidon import" do
+    instance.detect("GreetResource.java", "import jakarta.ws.rs.Path;").should be_false
+  end
+end

--- a/spec/unit_test/detector/java/helidon_se_spec.cr
+++ b/spec/unit_test/detector/java/helidon_se_spec.cr
@@ -1,0 +1,23 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/java/*"
+
+describe "Detect Java Helidon SE" do
+  options = create_test_options
+  instance = Detector::Java::HelidonSe.new options
+
+  it "HttpService.java" do
+    instance.detect("GreetService.java", "import io.helidon.webserver.http.HttpService;").should be_true
+  end
+
+  it "HttpRouting.java" do
+    instance.detect("Main.java", "import io.helidon.webserver.http.HttpRouting;").should be_true
+  end
+
+  it "unrelated.java" do
+    instance.detect("Application.java", "import org.springframework.boot.SpringApplication;").should be_false
+  end
+
+  it "non-java file" do
+    instance.detect("pom.xml", "io.helidon.webserver").should be_false
+  end
+end

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -5,7 +5,7 @@ require "../../spec_helper"
 # The registry is derived from the classes, so a detector joins a scan simply by
 # existing (`build_detector_list`, src/detector/detector.cr). That removed the
 # "forgot to register it" failure mode and replaced it with a quieter one:
-# nothing at all requires a detector to be *tested*. 64 of 248 — including
+# nothing at all requires a detector to be *tested*. 64 of 250 — including
 # `rust/actix_web`, `java/quarkus`, `java/micronaut`, `java/jaxrs`,
 # `javascript/hapi`, `swift/hummingbird`, `typescript/trpc`, every `zig/*` and
 # every language's `cli` — shipped with zero coverage.
@@ -170,6 +170,6 @@ describe "detector spec coverage" do
   # Guards the guard: a broken glob would make every example above pass
   # vacuously.
   it "finds every registered detector" do
-    detector_paths.size.should eq 248
+    detector_paths.size.should eq 250
   end
 end

--- a/src/analyzer/analyzers/java/helidon_mp.cr
+++ b/src/analyzer/analyzers/java/helidon_mp.cr
@@ -1,0 +1,248 @@
+require "../../../models/analyzer"
+require "../../engines/java_engine"
+require "../../../miniparsers/jaxrs_extractor_ts"
+require "../../../miniparsers/import_graph"
+require "../../../utils/url_path"
+
+module Analyzer::Java
+  # Helidon MP is MicroProfile: routes are plain JAX-RS
+  # (`@Path`/`@GET`/`@POST`/...) resource classes, exactly like Quarkus
+  # or vanilla Jersey/RESTEasy. There is no Helidon-specific routing
+  # shape to walk here, so — mirroring how `Analyzer::Java::Quarkus`
+  # handles the same situation — this analyzer just drives the shared
+  # `TreeSitterJaxRsExtractor` against files in project roots that carry
+  # a Helidon MP marker, so results are reported as "Helidon" rather
+  # than the generic `java_jaxrs` tech. `Analyzer::Java::JaxRs` treats
+  # `io.helidon.microprofile` as a derivative marker (see
+  # `JaxRs::DERIVATIVE_MARKERS`) so the same routes aren't also emitted
+  # under `java_jaxrs`.
+  class HelidonMp < Analyzer
+    analyzer_for "java_helidon_mp"
+
+    JAVA_EXTENSION     = "java"
+    HELIDON_MP_MARKERS = ["io.helidon.microprofile"]
+    alias ApplicationBaseKey = Tuple(String, String)
+
+    def analyze
+      include_callee = callees_needed?
+      dto_builder = Noir::TreeSitterJavaDtoIndex.new
+      bean_cache = Hash(String, Hash(String, Array(Param))).new
+      source_cache = Hash(String, String).new
+      custom_verb_cache = Hash(String, Hash(String, String)).new
+
+      file_list = all_files()
+      helidon_mp_roots = helidon_mp_project_roots_for(file_list)
+      application_base_paths = application_base_paths_for(file_list, helidon_mp_roots)
+
+      file_list.each do |path|
+        next if JavaEngine.test_path?(base_relative_path(path))
+        next unless File.exists?(path)
+        next unless path.ends_with?(".#{JAVA_EXTENSION}")
+        next unless helidon_mp_roots.includes?(project_root_for(path))
+
+        content = read_file_content(path)
+        next unless jaxrs_source?(content)
+
+        Noir::TreeSitter.parse_java(content) do |root|
+          package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
+          next if package_name.empty?
+
+          imports = Noir::TreeSitterJavaParameterExtractor.extract_imports_from(root, content)
+          dto_index = dto_builder.build_for_with_root(path, content, root)
+          bean_index = bean_index_for(path, content, package_name, bean_cache, imports,
+            Noir::TreeSitterJaxRsExtractor.extract_bean_fields_from(root, content))
+          subresource_sources = subresource_sources_for(path, content, package_name, source_cache, imports,
+            Noir::TreeSitterJaxRsExtractor.extract_class_names_from(root, content))
+          custom_verb_annotations = custom_verb_index_for(path, content, package_name, custom_verb_cache, imports,
+            Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations_from(root, content))
+          application_base_path = application_base_path_for(path, package_name, application_base_paths)
+
+          Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources,
+            custom_verb_annotations: custom_verb_annotations, include_callees: include_callee).each do |route|
+            line = route.line + 1
+            details = Details.new(PathInfo.new(route.file_path || path, line))
+            endpoint = Endpoint.new(Noir::URLPath.join_trimmed(application_base_path, route.path), route.verb, route.params, details)
+            endpoint.protocol = route.protocol
+            route.callees.each do |name, callee_line|
+              endpoint.push_callee(Callee.new(name, path: route.file_path || path, line: callee_line))
+            end
+            @result << endpoint
+          end
+        end
+      end
+
+      Fiber.yield
+      @result
+    end
+
+    JAXRS_SOURCE_RE = Regex.union("jakarta.ws.rs", "javax.ws.rs")
+
+    private def jaxrs_source?(content : String) : Bool
+      content.matches?(JAXRS_SOURCE_RE)
+    end
+
+    private def helidon_mp_project_roots_for(file_list : Array(String)) : Set(String)
+      roots = Set(String).new
+
+      file_list.each do |path|
+        next if JavaEngine.test_path?(base_relative_path(path))
+        next unless File.exists?(path)
+        next unless helidon_mp_manifest_path?(path) || path.ends_with?(".#{JAVA_EXTENSION}")
+
+        content = read_file_content(path)
+        roots << project_root_for(path) if HELIDON_MP_MARKERS.any? { |marker| content.includes?(marker) }
+      end
+
+      roots
+    end
+
+    private def helidon_mp_manifest_path?(path : String) : Bool
+      basename = File.basename(path)
+      basename == "pom.xml" || basename == "build.gradle" || basename == "build.gradle.kts"
+    end
+
+    private def application_base_paths_for(file_list : Array(String), helidon_mp_roots : Set(String)) : Hash(ApplicationBaseKey, String)
+      base_paths = Hash(ApplicationBaseKey, String).new
+
+      file_list.each do |path|
+        next if JavaEngine.test_path?(base_relative_path(path))
+        next unless File.exists?(path)
+        next unless path.ends_with?(".#{JAVA_EXTENSION}")
+        next unless helidon_mp_roots.includes?(project_root_for(path))
+
+        content = read_file_content(path)
+        next unless content.includes?("ApplicationPath")
+        next unless jaxrs_source?(content)
+
+        Noir::TreeSitter.parse_java(content) do |root|
+          package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
+          next if package_name.empty?
+          project_root = project_root_for(path)
+          key = {project_root, package_name}
+          next if base_paths.has_key?(key)
+
+          if base_path = Noir::TreeSitterJaxRsExtractor.extract_application_path_from(root, content)
+            base_paths[key] = base_path
+          end
+        end
+      end
+
+      base_paths
+    end
+
+    private def application_base_path_for(path : String,
+                                          package_name : String,
+                                          base_paths : Hash(ApplicationBaseKey, String)) : String
+      project_root = project_root_for(path)
+      keys = base_paths.keys.select { |key| key[0] == project_root }
+      keys.sort_by!(&.[1].size)
+      keys.reverse_each do |key|
+        base_package = key[1]
+        next unless package_name == base_package || package_name.starts_with?("#{base_package}.")
+        return base_paths[key]
+      end
+      ""
+    end
+
+    private def project_root_for(path : String) : String
+      ["/src/main/java/", "/src/"].each do |marker|
+        if index = path.index(marker)
+          return path[...index]
+        end
+      end
+
+      # A manifest file (`pom.xml`, `build.gradle`) at the module root
+      # has no `/src/...` marker to slice on, so it falls back to the
+      # raw configured base — which, unlike the marker-sliced form
+      # above, may carry a trailing slash depending on how `-b` was
+      # passed. Strip it so this root compares equal to the
+      # marker-derived root for `.java` files in the same module.
+      configured_base_for(path).rstrip('/')
+    end
+
+    private def bean_index_for(path : String,
+                               content : String,
+                               package_name : String,
+                               cache : Hash(String, Hash(String, Array(Param))),
+                               imports : Array(Noir::ImportGraph::ImportRef)? = nil,
+                               current_file_beans : Hash(String, Array(Param))? = nil) : Hash(String, Array(Param))
+      result = Hash(String, Array(Param)).new
+      resolved_imports = imports || Noir::TreeSitterJavaParameterExtractor.extract_imports(content)
+
+      Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
+        beans = cache[file] ||= begin
+          if file == path && current_file_beans
+            current_file_beans
+          else
+            body = file == path ? content : read_file_content(file)
+            Noir::TreeSitterJaxRsExtractor.extract_bean_fields(body)
+          end
+        rescue IO::Error
+          {} of String => Array(Param)
+        end
+
+        beans.each { |name, params| result[name] ||= params }
+      end
+
+      result
+    end
+
+    private def custom_verb_index_for(path : String,
+                                      content : String,
+                                      package_name : String,
+                                      cache : Hash(String, Hash(String, String)),
+                                      imports : Array(Noir::ImportGraph::ImportRef)? = nil,
+                                      current_file_verbs : Hash(String, String)? = nil) : Hash(String, String)
+      result = Hash(String, String).new
+      resolved_imports = imports || Noir::TreeSitterJavaParameterExtractor.extract_imports(content)
+
+      Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
+        verbs = cache[file] ||= begin
+          if file == path && current_file_verbs
+            current_file_verbs
+          else
+            body = file == path ? content : read_file_content(file)
+            if jaxrs_source?(body)
+              Noir::TreeSitterJaxRsExtractor.extract_custom_verb_annotations(body)
+            else
+              Hash(String, String).new
+            end
+          end
+        rescue IO::Error
+          Hash(String, String).new
+        end
+
+        verbs.each { |name, verb| result[name] ||= verb }
+      end
+
+      result
+    end
+
+    private def subresource_sources_for(path : String,
+                                        content : String,
+                                        package_name : String,
+                                        cache : Hash(String, String),
+                                        imports : Array(Noir::ImportGraph::ImportRef)? = nil,
+                                        current_file_class_names : Array(String)? = nil) : Hash(String, Noir::TreeSitterJaxRsExtractor::SourceEntry)
+      result = Hash(String, Noir::TreeSitterJaxRsExtractor::SourceEntry).new
+      resolved_imports = imports || Noir::TreeSitterJavaParameterExtractor.extract_imports(content)
+
+      Noir::ImportGraph.related_files(path, package_name, resolved_imports, JAVA_EXTENSION) do |file|
+        body = cache[file] ||= begin
+          file == path ? content : read_file_content(file)
+        rescue IO::Error
+          ""
+        end
+        next if body.empty?
+        next unless jaxrs_source?(body)
+
+        class_names = file == path && current_file_class_names ? current_file_class_names : Noir::TreeSitterJaxRsExtractor.extract_class_names(body)
+        class_names.each do |name|
+          result[name] ||= {file, body}
+        end
+      end
+
+      result
+    end
+  end
+end

--- a/src/analyzer/analyzers/java/helidon_se.cr
+++ b/src/analyzer/analyzers/java/helidon_se.cr
@@ -1,0 +1,163 @@
+require "../../../models/analyzer"
+require "../../engines/java_engine"
+require "../../../miniparsers/helidon_se_extractor_ts"
+require "../../../utils/url_path"
+
+module Analyzer::Java
+  # Helidon SE's routing table is composed two ways at once: inline verb
+  # calls directly on a `HttpRouting.Builder`/`HttpRules`, and modular
+  # `HttpService` classes mounted elsewhere via
+  # `builder.register("/prefix", new SomeService())`. The second shape —
+  # one `HttpService` per resource, wired up from a separate `Main`
+  # class — is what every Helidon-published quickstart/example uses, so
+  # getting only the first shape right would miss the prefix on nearly
+  # every real route.
+  #
+  # `TreeSitterHelidonSeExtractor` reports the two shapes per file:
+  # verb calls tagged by their enclosing class, and `.register(...)`
+  # edges tagged by (enclosing class, target class). This analyzer
+  # aggregates both across every Helidon-marked file in a project root
+  # and resolves the resulting mount graph — classes are matched by
+  # simple name, root-scoped, the same approximation the JAX-RS
+  # analyzer's bean/subresource indices and the Micronaut analyzer's
+  # interface-route index already make for cross-file linkage.
+  class HelidonSe < Analyzer
+    analyzer_for "java_helidon_se"
+
+    JAVA_EXTENSION = "java"
+
+    # `io.helidon.webserver` covers the `HttpRouting`/`HttpService`/
+    # `HttpRules`/`WebServer` types across Helidon 2.x-4.x — a class
+    # that implements `HttpService` or builds a `HttpRouting.Builder`
+    # necessarily imports (or fully-qualifies) something under this
+    # package, so a single substring check is a genuine positive
+    # signal rather than "any Java file with `.get(...)` calls".
+    HELIDON_SE_MARKER_RE = Regex.union("io.helidon.webserver")
+
+    alias Route = Noir::TreeSitterHelidonSeExtractor::Route
+    alias RegisterEdge = Noir::TreeSitterHelidonSeExtractor::RegisterEdge
+
+    def analyze
+      include_callee = callees_needed?
+
+      # project_root => class_name => [(Route, file_path)]
+      routes_by_root = Hash(String, Hash(String, Array(Tuple(Route, String)))).new
+      # project_root => [RegisterEdge]
+      edges_by_root = Hash(String, Array(RegisterEdge)).new
+
+      all_files().each do |path|
+        next if JavaEngine.test_path?(base_relative_path(path))
+        next unless File.exists?(path)
+        next unless path.ends_with?(".#{JAVA_EXTENSION}")
+
+        content = read_file_content(path)
+        next unless content_matches?(content, HELIDON_SE_MARKER_RE)
+
+        result = Noir::TreeSitterHelidonSeExtractor.extract(content, include_callees: include_callee)
+        next if result.routes.empty? && result.edges.empty?
+
+        root = project_root_for(path)
+        routes_for_root = routes_by_root[root] ||= Hash(String, Array(Tuple(Route, String))).new
+        result.routes.each do |route|
+          (routes_for_root[route.class_name] ||= [] of Tuple(Route, String)) << {route, path}
+        end
+        (edges_by_root[root] ||= [] of RegisterEdge).concat(result.edges)
+      end
+
+      routes_by_root.each do |root, routes_by_class|
+        prefixes = resolve_prefixes(routes_by_class.keys, edges_by_root[root]? || [] of RegisterEdge)
+
+        routes_by_class.each do |class_name, entries|
+          class_prefixes = prefixes[class_name]? || Set{""}
+
+          entries.each do |entry|
+            route, path = entry
+            params = params_for(route)
+            line = route.line + 1
+
+            class_prefixes.each do |prefix|
+              details = Details.new(PathInfo.new(path, line))
+              endpoint = Endpoint.new(Noir::URLPath.join_trimmed(prefix, route.path), route.verb, params, details)
+              endpoint.protocol = route.protocol
+              route.callees.each do |callee_entry|
+                name, callee_line = callee_entry
+                endpoint.push_callee(Callee.new(name, path: path, line: callee_line))
+              end
+              @result << endpoint
+            end
+          end
+        end
+      end
+
+      Fiber.yield
+      @result
+    end
+
+    private def params_for(route : Route) : Array(Param)
+      params = [] of Param
+      route.query_params.each { |name| params << Param.new(name, "", "query") }
+      route.header_params.each { |name| params << Param.new(name, "", "header") }
+      route.cookie_params.each { |name| params << Param.new(name, "", "cookie") }
+      if route.has_body?
+        params << Param.new("body", route.body_type || "", "json")
+      end
+      params
+    end
+
+    # Resolve, per class, every prefix it's reachable at by following
+    # `.register(prefix, new Target())` edges from root mounts (classes
+    # that are never themselves a register target — the composer that
+    # wires everything to the `WebServer`). A class untouched by any
+    # edge (including one that's a target nobody ever reached) falls
+    # back to the empty prefix rather than silently dropping its
+    # routes — matches the rest of noir's "best-effort over dropped"
+    # posture when cross-file linkage can't be fully resolved.
+    private def resolve_prefixes(classes_with_routes : Array(String), edges : Array(RegisterEdge)) : Hash(String, Set(String))
+      prefixes = Hash(String, Set(String)).new
+      targets = edges.map(&.target_class).to_set
+
+      classes_with_routes.each do |name|
+        prefixes[name] = Set{""} unless targets.includes?(name)
+      end
+      edges.each do |edge|
+        prefixes[edge.source_class] ||= Set{""} unless targets.includes?(edge.source_class)
+      end
+
+      # Bounded fixed-point over a typically tiny graph; the bound (not
+      # a bare `changed`-flag loop) keeps a register() cycle from
+      # spinning forever while still giving every realistic nesting
+      # depth room to converge.
+      (edges.size + 8).times do
+        changed = false
+        edges.each do |edge|
+          next unless source_prefixes = prefixes[edge.source_class]?
+          target_prefixes = prefixes[edge.target_class] ||= Set(String).new
+
+          source_prefixes.each do |source_prefix|
+            joined = Noir::URLPath.join_trimmed(source_prefix, edge.prefix)
+            next if target_prefixes.includes?(joined)
+            target_prefixes << joined
+            changed = true
+          end
+        end
+        break unless changed
+      end
+
+      classes_with_routes.each do |name|
+        existing = prefixes[name]?
+        prefixes[name] = Set{""} if existing.nil? || existing.empty?
+      end
+
+      prefixes
+    end
+
+    private def project_root_for(path : String) : String
+      marker = "/src/main/java/"
+      if index = path.index(marker)
+        path[...index]
+      else
+        File.dirname(path)
+      end
+    end
+  end
+end

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -124,13 +124,22 @@ module Analyzer::Java
       base_paths
     end
 
+    # Manifest basenames a derivative framework can *only* show up in.
+    # Helidon MP's own quickstart is the concrete case: its JAX-RS
+    # resource classes carry no `io.helidon` import at all — the
+    # runtime is pulled in solely via `pom.xml`'s
+    # `io.helidon.microprofile.*` dependencies, so a `.java`-only scan
+    # would never see the marker and JAX-RS would double-count those
+    # routes under `java_jaxrs` too.
+    DERIVATIVE_MANIFEST_BASENAMES = Set{"pom.xml", "build.gradle", "build.gradle.kts"}
+
     private def derivative_project_roots_for(file_list : Array(String)) : Set(String)
       roots = Set(String).new
 
       file_list.each do |path|
         next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
-        next unless path.ends_with?(".#{JAVA_EXTENSION}")
+        next unless path.ends_with?(".#{JAVA_EXTENSION}") || DERIVATIVE_MANIFEST_BASENAMES.includes?(File.basename(path))
 
         content = read_file_content(path)
         roots << project_root_for(path) if claimed_by_derivative?(content)
@@ -171,7 +180,14 @@ module Analyzer::Java
         end
       end
 
-      configured_base_for(path)
+      # A manifest file (`pom.xml`, `build.gradle` — see
+      # `DERIVATIVE_MANIFEST_BASENAMES`) at the module root has no
+      # `/src/...` marker to slice on, so it falls back to the raw
+      # configured base — which, unlike the marker-sliced form above,
+      # may carry a trailing slash depending on how `-b` was passed.
+      # Strip it so this root compares equal to the marker-derived
+      # root for `.java` files in the same module.
+      configured_base_for(path).rstrip('/')
     end
 
     private def web_xml_base_paths_for(file_list : Array(String),
@@ -342,7 +358,9 @@ module Analyzer::Java
     # Frameworks that ride on JAX-RS but ship their own analyzer.
     # Listing them here keeps the JAX-RS analyzer the fallback for
     # vanilla Jersey / RESTEasy resources without double-counting.
-    DERIVATIVE_MARKERS    = ["io.quarkus", "io.dropwizard"]
+    # `io.helidon.microprofile` routes to `Analyzer::Java::HelidonMp`,
+    # which drives this same extractor under the `java_helidon_mp` tech.
+    DERIVATIVE_MARKERS    = ["io.quarkus", "io.dropwizard", "io.helidon.microprofile"]
     DERIVATIVE_MARKERS_RE = Regex.union(DERIVATIVE_MARKERS)
 
     private def claimed_by_derivative?(content : String) : Bool

--- a/src/detector/detectors/java/helidon_mp.cr
+++ b/src/detector/detectors/java/helidon_mp.cr
@@ -1,0 +1,26 @@
+require "../../../models/detector"
+
+module Detector::Java
+  class HelidonMp < Detector
+    detector_for "java_helidon_mp",
+      extensions: %w[.java pom.xml build.gradle build.gradle.kts]
+
+    # Helidon MP resource classes are frequently plain JAX-RS with no
+    # direct Helidon import — the MP runtime is pulled in only via the
+    # build manifest (or a bootstrap `Main` calling
+    # `io.helidon.microprofile.server.Server`). So this checks both:
+    # a `.java` file that references the MP runtime directly, or a
+    # build manifest declaring a `io.helidon.microprofile` dependency.
+    def detect(filename : String, file_contents : String) : Bool
+      if filename.ends_with?(".java")
+        return file_contents.includes?("io.helidon.microprofile")
+      end
+
+      if filename.includes?("pom.xml") || filename.includes?("build.gradle") || filename.includes?("build.gradle.kts")
+        return file_contents.includes?("io.helidon.microprofile")
+      end
+
+      false
+    end
+  end
+end

--- a/src/detector/detectors/java/helidon_se.cr
+++ b/src/detector/detectors/java/helidon_se.cr
@@ -1,0 +1,17 @@
+require "../../../models/detector"
+
+module Detector::Java
+  class HelidonSe < Detector
+    detector_for "java_helidon_se", extensions: %w[.java]
+
+    # A class that implements `HttpService` or builds a
+    # `HttpRouting.Builder` necessarily imports (or fully qualifies)
+    # something under `io.helidon.webserver` — true across Helidon
+    # 2.x-4.x, so this single substring check is a real positive
+    # signal rather than "any Java file with `.get(...)` calls".
+    def detect(filename : String, file_contents : String) : Bool
+      return false unless filename.ends_with?(".java")
+      file_contents.includes?("io.helidon.webserver")
+    end
+  end
+end

--- a/src/detector/detectors/java/jaxrs.cr
+++ b/src/detector/detectors/java/jaxrs.cr
@@ -5,9 +5,9 @@ module Detector::Java
     detector_for "java_jaxrs", extensions: %w[.java]
 
     # Frameworks that ride on JAX-RS but ship their own detector.
-    # Quarkus / Dropwizard projects should report as that specific
-    # framework, not as plain JAX-RS.
-    DERIVATIVE_MARKERS = ["io.quarkus", "io.dropwizard"]
+    # Quarkus / Dropwizard / Helidon MP projects should report as that
+    # specific framework, not as plain JAX-RS.
+    DERIVATIVE_MARKERS = ["io.quarkus", "io.dropwizard", "io.helidon.microprofile"]
 
     # `derivative_project?` answers a project-wide question — "does any
     # Java file under this root pull in Quarkus/Dropwizard?" — whose
@@ -40,11 +40,21 @@ module Detector::Java
       end
     end
 
+    # Manifest basenames a derivative framework can *only* show up in.
+    # Helidon MP's own quickstart is the concrete case: its JAX-RS
+    # resource classes carry no `io.helidon` import at all — the
+    # runtime is pulled in solely via `pom.xml`'s
+    # `io.helidon.microprofile.*` dependencies, so a `.java`-only scan
+    # would never see the marker and this detector would double-report
+    # both `java_jaxrs` and `java_helidon_mp` for the same project.
+    DERIVATIVE_MANIFEST_GLOBS = %w[pom.xml build.gradle build.gradle.kts]
+
     private def compute_derivative_project(root : String) : Bool
       java_glob = File.join(root, "src/main/java/**/*.java")
       fallback_glob = File.join(root, "**/*.java")
       candidates = Dir.glob(java_glob)
       candidates = Dir.glob(fallback_glob) if candidates.empty?
+      candidates += DERIVATIVE_MANIFEST_GLOBS.map { |name| File.join(root, name) }
 
       locator = CodeLocator.instance
       candidates.any? do |path|

--- a/src/miniparsers/helidon_se_extractor_ts.cr
+++ b/src/miniparsers/helidon_se_extractor_ts.cr
@@ -1,0 +1,545 @@
+require "../utils/url_path"
+require "../ext/tree_sitter/tree_sitter"
+require "./java_callee_extractor"
+require "./java_route_extractor_ts"
+require "../models/endpoint"
+
+module Noir
+  # Tree-sitter-backed walker for Helidon SE's functional routing DSL.
+  #
+  # Helidon SE has two route-registration shapes that both have to be
+  # covered:
+  #
+  #   1. Inline verb calls directly on a `HttpRouting.Builder` /
+  #      `HttpRules` receiver: `routing.get("/x", (req, res) -> ...)`,
+  #      chained or nested inside a lambda passed to `.routing(...)`.
+  #   2. Modular services: a class `implements HttpService` overrides
+  #      `routing(HttpRules rules)` with its own verb calls, and is
+  #      mounted elsewhere via `someBuilder.register("/prefix", new
+  #      MyService())`. The quickstart/example apps published by the
+  #      Helidon project overwhelmingly use this shape — `Main`
+  #      composes routing by registering one `HttpService` per
+  #      resource, in a totally separate class (often a separate
+  #      file).
+  #
+  # Shape 2 is genuinely cross-class (and often cross-file), so this
+  # extractor does not try to resolve the full prefix here. Instead it
+  # reports, per file:
+  #
+  #   * `routes`  — every verb call found, tagged with the *simple*
+  #     name of its immediately enclosing class (empty prefix).
+  #   * `edges`   — every `.register(prefix, new Target())` call
+  #     found, tagged with the enclosing class that issued the call
+  #     and the (simple) class name of the target service.
+  #
+  # The analyzer aggregates `routes`/`edges` across every Helidon file
+  # in a project root and resolves the prefix graph there (classes are
+  # matched by simple name, project-root scoped — the same
+  # approximation `TreeSitterMicronautExtractor`'s interface-route
+  # index and `TreeSitterJvmLambdaDslExtractor`'s method-reference
+  # index already make).
+  module TreeSitterHelidonSeExtractor
+    extend self
+
+    # Helidon's fluent verb API: `HttpRules`/`HttpRouting.Builder` both
+    # expose the same method names. `any` matches every HTTP method —
+    # kept as the literal "ANY" verb, same convention as Ring/Compojure/
+    # Pedestal/Wisp/Cowboy in this codebase rather than exploding it into
+    # one endpoint per concrete verb.
+    VERB_METHODS = {
+      "get"     => "GET",
+      "post"    => "POST",
+      "put"     => "PUT",
+      "delete"  => "DELETE",
+      "head"    => "HEAD",
+      "options" => "OPTIONS",
+      "patch"   => "PATCH",
+      "trace"   => "TRACE",
+      "any"     => "ANY",
+    }
+
+    struct Route
+      getter class_name : String
+      getter verb : String
+      getter path : String
+      getter line : Int32
+      getter query_params : Array(String)
+      getter header_params : Array(String)
+      getter cookie_params : Array(String)
+      getter body_type : String?
+      getter? has_body : Bool
+      # 1-hop callees out of the handler body; `path` is attached by the
+      # analyzer. Each tuple is (callee_name, line_1_based).
+      getter callees : Array(Tuple(String, Int32))
+      getter protocol : String
+
+      def initialize(@class_name, @verb, @path, @line, @query_params, @header_params,
+                     @cookie_params, @body_type, @has_body, @callees, @protocol = "http")
+      end
+    end
+
+    # `someBuilder.register(prefix, new Target())` (or the no-prefix
+    # `register(new Target())` overload, where `prefix` is `""`).
+    # `source_class` is the simple name of the class the `.register`
+    # call is lexically inside; `target_class` is the simple name of the
+    # mounted `HttpService`.
+    struct RegisterEdge
+      getter source_class : String
+      getter prefix : String
+      getter target_class : String
+
+      def initialize(@source_class, @prefix, @target_class)
+      end
+    end
+
+    struct FileResult
+      getter routes : Array(Route)
+      getter edges : Array(RegisterEdge)
+
+      def initialize(@routes, @edges)
+      end
+    end
+
+    def extract(source : String, *, include_callees : Bool = false) : FileResult
+      routes = [] of Route
+      edges = [] of RegisterEdge
+
+      Noir::TreeSitter.parse_java(source) do |root|
+        constants = TreeSitterJavaRouteExtractor.extract_string_constants_from(root, source)
+        method_bodies = method_body_index(root, source)
+        walk(root, source, "", constants, method_bodies, routes, edges, 0, include_callees)
+      end
+
+      FileResult.new(routes, edges)
+    end
+
+    # Helidon path-parameter syntax: `{name}`, `{name:regex}` (typed /
+    # regex-constrained segment) and `{+name}` (matches multiple path
+    # segments). All three name the same logical parameter — normalize
+    # down to the plain `{name}` the rest of noir (and the shared
+    # path-parameter optimizer pass) expects.
+    def normalize_path(path : String) : String
+      path.gsub(/\{\+?([^{}:]+)(?::[^{}]*)?\}/) { "{#{$~[1].strip}}" }
+    end
+
+    # ---- traversal ----------------------------------------------------
+
+    private def walk(node : LibTreeSitter::TSNode,
+                     source : String,
+                     current_class : String,
+                     constants : Hash(String, String),
+                     method_bodies : Hash(String, LibTreeSitter::TSNode),
+                     routes : Array(Route),
+                     edges : Array(RegisterEdge),
+                     depth : Int32,
+                     include_callees : Bool)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+      ty = Noir::TreeSitter.node_type(node)
+
+      if ty == "class_declaration"
+        name = type_identifier_text(node, source)
+        new_class = name.empty? ? current_class : name
+        Noir::TreeSitter.each_named_child(node) do |child|
+          walk(child, source, new_class, constants, method_bodies, routes, edges, depth + 1, include_callees)
+        end
+        return
+      end
+
+      if ty == "method_invocation"
+        name = method_invocation_method_name(node, source)
+        if verb = VERB_METHODS[name]?
+          emit_route(node, source, verb, current_class, constants, method_bodies, routes, include_callees)
+        elsif name == "register"
+          emit_register_edges(node, source, current_class, constants, edges)
+        end
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, source, current_class, constants, method_bodies, routes, edges, depth + 1, include_callees)
+      end
+    end
+
+    # `routing.get("/x", handler)` / `rules.get("/x", handler)`. Requires
+    # a resolvable string path plus a second (handler) argument — this
+    # is what tells a genuine route call apart from unrelated 1-arg
+    # `.get(...)` calls that collide on method name (`Optional#get()`,
+    # `Map#get(key)`, `List#get(index)`): those never carry a string
+    # literal first argument *and* a second argument at the same time.
+    private def emit_route(call : LibTreeSitter::TSNode,
+                           source : String,
+                           verb : String,
+                           current_class : String,
+                           constants : Hash(String, String),
+                           method_bodies : Hash(String, LibTreeSitter::TSNode),
+                           routes : Array(Route),
+                           include_callees : Bool)
+      args = argument_list_node(call)
+      return unless args
+      return if LibTreeSitter.ts_node_named_child_count(args) < 2
+
+      path_arg = first_string_argument(call, source, constants)
+      return unless path_arg
+
+      full_path = normalize_path(path_arg)
+      line = Noir::TreeSitter.node_start_row(call)
+
+      query_params = [] of String
+      header_params = [] of String
+      cookie_params = [] of String
+      body_type : String? = nil
+      has_body = false
+      callees = [] of Tuple(String, Int32)
+
+      body = lambda_body_in_args(call) || method_reference_body_in_args(call, source, method_bodies)
+      if body
+        scan_handler(body, source, 0) do |kind, value|
+          case kind
+          when :query  then query_params << value
+          when :header then header_params << value
+          when :cookie then cookie_params << value
+          when :body   then has_body = true
+          when :body_typed
+            body_type = value
+            has_body = true
+          end
+        end
+
+        if include_callees
+          Noir::JavaCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
+            name, _path, line_no = entry
+            callees << {name, line_no}
+          end
+        end
+      end
+
+      routes << Route.new(current_class, verb, full_path, line, query_params, header_params,
+        cookie_params, body_type, has_body, callees)
+    end
+
+    # `builder.register("/prefix", new Service())`,
+    # `builder.register(new Service())`, and the multi-service overloads
+    # (`register(prefix, new A(), new B())`). Any argument the extractor
+    # can't resolve to a concrete `HttpService` type (a bare identifier,
+    # a lambda/method-reference supplier, …) is silently skipped — the
+    # dominant real-world shape is `new ServiceClass(...)` and that's
+    # what's covered here.
+    private def emit_register_edges(call : LibTreeSitter::TSNode,
+                                    source : String,
+                                    current_class : String,
+                                    constants : Hash(String, String),
+                                    edges : Array(RegisterEdge))
+      args = argument_list_node(call)
+      return unless args
+
+      children = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(args) { |child| children << child }
+      return if children.empty?
+
+      prefix = ""
+      service_children = children
+      if Noir::TreeSitter.node_type(children[0]) == "string_literal"
+        if resolved = resolve_string_value(children[0], source, constants)
+          prefix = resolved
+          service_children = children[1..]
+        end
+      end
+
+      service_children.each do |arg|
+        next unless target = service_class_name(arg, source)
+        edges << RegisterEdge.new(current_class, prefix, target)
+      end
+    end
+
+    private def service_class_name(node : LibTreeSitter::TSNode, source : String) : String?
+      case Noir::TreeSitter.node_type(node)
+      when "object_creation_expression"
+        type_node = Noir::TreeSitter.field(node, "type")
+        return unless type_node
+        simple_type_name(Noir::TreeSitter.node_text(type_node, source))
+      when "method_reference"
+        text = Noir::TreeSitter.node_text(node, source)
+        return unless text.ends_with?("::new")
+        simple_type_name(text[0...-5])
+      end
+    end
+
+    private def simple_type_name(text : String) : String?
+      name = text.strip
+      return if name.empty?
+      if lt = name.index('<')
+        name = name[...lt].strip
+      end
+      if dot = name.rindex('.')
+        name = name[(dot + 1)..]
+      end
+      name.empty? ? nil : name
+    end
+
+    # ---- handler-body parameter scan -----------------------------------
+
+    # Helidon's request accessors nest one level deeper than Javalin's
+    # flat `ctx.xxxParam(...)` — `req.query().get("name")`,
+    # `req.headers().cookies().get("name")`,
+    # `req.headers().get(HeaderNames.create("Name"))`,
+    # `req.content().as(Foo.class)`. Matched structurally on the
+    # *receiver* chain's tail call name rather than a fixed variable
+    # name, so it survives whatever the request parameter is called.
+    private def scan_handler(node : LibTreeSitter::TSNode,
+                             source : String,
+                             depth : Int32,
+                             &block : Symbol, String ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+      if Noir::TreeSitter.node_type(node) == "method_invocation"
+        name = method_invocation_method_name(node, source)
+        receiver = Noir::TreeSitter.field(node, "object")
+
+        if receiver && QUERY_ACCESSORS.includes?(name) && chain_tail?(receiver, source, "query")
+          if value = first_string_argument(node, source, EMPTY_CONSTANTS)
+            block.call(:query, value)
+          end
+        elsif receiver && COOKIE_ACCESSORS.includes?(name) && chain_tail?(receiver, source, "cookies")
+          if value = first_string_argument(node, source, EMPTY_CONSTANTS)
+            block.call(:cookie, value)
+          end
+        elsif receiver && HEADER_ACCESSORS.includes?(name) && chain_tail?(receiver, source, "headers")
+          if value = header_name_argument(node, source)
+            block.call(:header, value)
+          end
+        elsif receiver && name == "as" && chain_tail?(receiver, source, "content")
+          if type = first_class_literal_type(node, source)
+            block.call(:body_typed, type)
+          else
+            block.call(:body, "")
+          end
+        end
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        scan_handler(child, source, depth + 1, &block)
+      end
+    end
+
+    EMPTY_CONSTANTS  = {} of String => String
+    QUERY_ACCESSORS  = Set{"get", "first", "all", "contains"}
+    COOKIE_ACCESSORS = Set{"get", "first", "all", "getAll", "contains"}
+    HEADER_ACCESSORS = Set{"get", "first", "value", "contains"}
+
+    # True when `node` is (or ends in) a zero-arg call named `method` —
+    # i.e. `node`'s own text is `<...>.method()` or bare `method()`.
+    # Used to confirm `req.query().get(...)` / `req.headers().cookies()
+    # .get(...)` / `req.content().as(...)` without caring what the
+    # request variable itself is named.
+    private def chain_tail?(node : LibTreeSitter::TSNode, source : String, method : String) : Bool
+      return false unless Noir::TreeSitter.node_type(node) == "method_invocation"
+      Noir::TreeSitter.node_text(node, source).ends_with?(".#{method}()") ||
+        Noir::TreeSitter.node_text(node, source) == "#{method}()"
+    end
+
+    # `req.headers().get(HeaderNames.create("Name"))` — the header-name
+    # argument is a typed `HeaderName`, not a raw string. Known
+    # constants (`HeaderNames.CONTENT_TYPE`, …) can't be resolved to
+    # their literal wire name without a lookup table, so only the
+    # explicit `HeaderNames.create("...")` / `HeaderNames.createFromLowercase("...")`
+    # constructor form is supported.
+    private def header_name_argument(call : LibTreeSitter::TSNode, source : String) : String?
+      args = argument_list_node(call)
+      return unless args
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "method_invocation"
+        name = method_invocation_method_name(arg, source)
+        next unless name == "create" || name == "createFromLowercase"
+        if value = first_string_argument(arg, source, EMPTY_CONSTANTS)
+          return value
+        end
+      end
+      nil
+    end
+
+    private def first_class_literal_type(call : LibTreeSitter::TSNode, source : String) : String?
+      args = argument_list_node(call)
+      return unless args
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "class_literal"
+        Noir::TreeSitter.each_named_child(arg) do |child|
+          if Noir::TreeSitter.node_type(child) == "type_identifier"
+            return Noir::TreeSitter.node_text(child, source)
+          end
+        end
+      end
+      nil
+    end
+
+    # ---- shared shape helpers (Java call/string plumbing) --------------
+    #
+    # These mirror the equivalent private helpers in
+    # `TreeSitterJvmLambdaDslExtractor` — Crystal's `private def` is
+    # file-scoped, so they can't be shared directly; kept minimal since
+    # Helidon has no `nest`/`crud`/router-receiver concepts to carry.
+
+    private def method_invocation_method_name(call : LibTreeSitter::TSNode, source : String) : String
+      if name_node = Noir::TreeSitter.field(call, "name")
+        return Noir::TreeSitter.node_text(name_node, source)
+      end
+
+      result = ""
+      Noir::TreeSitter.each_named_child(call) do |child|
+        ty = Noir::TreeSitter.node_type(child)
+        case ty
+        when "identifier"
+          result = Noir::TreeSitter.node_text(child, source)
+        when "argument_list"
+          break
+        end
+      end
+      result
+    end
+
+    private def type_identifier_text(decl : LibTreeSitter::TSNode, source : String) : String
+      name_node = Noir::TreeSitter.field(decl, "name")
+      return "" unless name_node
+      Noir::TreeSitter.node_text(name_node, source)
+    end
+
+    private def argument_list_node(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(call) do |child|
+        return child if Noir::TreeSitter.node_type(child) == "argument_list"
+      end
+      nil
+    end
+
+    private def first_string_argument(call : LibTreeSitter::TSNode,
+                                      source : String,
+                                      constants : Hash(String, String)) : String?
+      args = argument_list_node(call)
+      return unless args
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        case Noir::TreeSitter.node_type(arg)
+        when "string_literal", "identifier", "field_access", "scoped_identifier", "binary_expression", "parenthesized_expression"
+          if value = resolve_string_value(arg, source, constants)
+            return value
+          end
+        end
+      end
+      nil
+    end
+
+    private def resolve_string_value(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     constants : Hash(String, String),
+                                     depth = 0) : String?
+      return if depth > 16
+
+      case Noir::TreeSitter.node_type(node)
+      when "string_literal"
+        decode_string_literal(node, source)
+      when "identifier", "field_access", "scoped_identifier"
+        resolve_constant_reference(Noir::TreeSitter.node_text(node, source), constants)
+      when "binary_expression"
+        return unless Noir::TreeSitter.node_text(node, source).includes?("+")
+        left = Noir::TreeSitter.field(node, "left")
+        right = Noir::TreeSitter.field(node, "right")
+        return unless left && right
+        left_value = resolve_string_value(left, source, constants, depth + 1)
+        right_value = resolve_string_value(right, source, constants, depth + 1)
+        return unless left_value && right_value
+        "#{left_value}#{right_value}"
+      when "parenthesized_expression"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          if value = resolve_string_value(child, source, constants, depth + 1)
+            return value
+          end
+        end
+      end
+    end
+
+    private def resolve_constant_reference(name : String, constants : Hash(String, String)) : String?
+      if resolved = constants[name]?
+        return resolved
+      end
+
+      suffix = ".#{name}"
+      matches = constants.compact_map do |key, value|
+        key.ends_with?(suffix) ? value : nil
+      end.uniq!
+      matches.size == 1 ? matches.first : nil
+    end
+
+    private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String
+      buf = String.build do |io|
+        Noir::TreeSitter.each_named_child(node) do |child|
+          if Noir::TreeSitter.node_type(child) == "string_fragment"
+            io << Noir::TreeSitter.node_text(child, source)
+          end
+        end
+      end
+      return buf unless buf.empty?
+      raw = Noir::TreeSitter.node_text(node, source)
+      raw.size >= 2 && raw.starts_with?('"') && raw.ends_with?('"') ? raw[1..-2] : raw
+    end
+
+    # Pull the lambda's body (`block` or expression) out of the call's
+    # argument list. Returns nil if no lambda is passed.
+    private def lambda_body_in_args(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      args = argument_list_node(call)
+      return unless args
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "lambda_expression"
+        Noir::TreeSitter.each_named_child(arg) do |child|
+          ty = Noir::TreeSitter.node_type(child)
+          next if ty == "identifier" || ty == "formal_parameters" || ty == "inferred_parameters"
+          return child
+        end
+      end
+      nil
+    end
+
+    private def method_reference_body_in_args(call : LibTreeSitter::TSNode,
+                                              source : String,
+                                              method_bodies : Hash(String, LibTreeSitter::TSNode)) : LibTreeSitter::TSNode?
+      args = argument_list_node(call)
+      return unless args
+
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "method_reference"
+
+        method_name = Noir::TreeSitter.node_text(arg, source).split("::").last?.to_s
+        next if method_name.empty?
+
+        if body = method_bodies[method_name]?
+          return body
+        end
+      end
+
+      nil
+    end
+
+    private def method_body_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
+      bodies = Hash(String, LibTreeSitter::TSNode).new
+
+      walk_method_declarations(root) do |method|
+        name_node = Noir::TreeSitter.field(method, "name")
+        body = Noir::TreeSitter.field(method, "body")
+        next unless name_node && body
+
+        name = Noir::TreeSitter.node_text(name_node, source)
+        bodies[name] ||= body
+      end
+
+      bodies
+    end
+
+    private def walk_method_declarations(node : LibTreeSitter::TSNode, depth : Int32 = 0, &block : LibTreeSitter::TSNode ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+      if Noir::TreeSitter.node_type(node) == "method_declaration"
+        block.call(node)
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_method_declarations(child, depth + 1, &block)
+      end
+    end
+  end
+end

--- a/src/techs/catalog/java/helidon.cr
+++ b/src/techs/catalog/java/helidon.cr
@@ -1,0 +1,63 @@
+# NoirTechs catalog entries: java_helidon_se, java_helidon_mp.
+# One file per technology; `NoirTechs::TECHS` in src/techs/techs.cr is
+# macro-derived from every constant under `NoirTechs::Catalog`.
+#
+# Helidon ships two unrelated routing models under one project, so it
+# gets two techs rather than one — same precedent as
+# `csharp_aspnet_mvc` / `csharp_aspnet_core_mvc`:
+#
+#   * SE  — the functional `HttpRouting`/`HttpService` builder DSL,
+#     walked by a dedicated tree-sitter analyzer
+#     (`Analyzer::Java::HelidonSe`). Query/header/cookie/body params
+#     are scanned from the handler body; path params come from the
+#     shared `{name}` optimizer pass.
+#   * MP  — MicroProfile: plain JAX-RS resource classes. There is no
+#     Helidon-specific routing shape here, so `Analyzer::Java::HelidonMp`
+#     just drives the shared JAX-RS extractor (same relationship
+#     Quarkus has to JAX-RS) — the fuller JAX-RS param surface
+#     (matrix/form/etc.) applies.
+module NoirTechs::Catalog::Java
+  HELIDON_SE = {
+    :java_helidon_se => {
+      :framework => "Helidon SE",
+      :language  => "Java",
+      :similar   => ["helidon", "helidon-se", "helidon_se", "java-helidon-se", "java_helidon_se"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => true,
+          :cookie => true,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+      :context => {:callee => true},
+    },
+  }
+
+  HELIDON_MP = {
+    :java_helidon_mp => {
+      :framework => "Helidon MP",
+      :language  => "Java",
+      :similar   => ["helidon-mp", "helidon_mp", "java-helidon-mp", "java_helidon_mp"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => true,
+          :cookie => true,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+      :context => {:callee => true},
+    },
+  }
+end


### PR DESCRIPTION
## Summary

Adds detector + analyzer + techs-catalog coverage for Helidon (Oracle's cloud-native Java framework), both routing flavors.

**Helidon SE** (new coverage — the functional builder DSL, no annotations):
- New tree-sitter walker `Noir::TreeSitterHelidonSeExtractor` (`src/miniparsers/helidon_se_extractor_ts.cr`) covers `HttpRouting.Builder`/`HttpRules` verb calls (`routing.get("/x", handler)`, chained, `.any()` → `"ANY"` verb).
- The dominant real-world shape — one `HttpService` per resource, mounted from a separate composer class via `builder.register("/prefix", new SomeService())` — is what every Helidon-published quickstart/example uses. This is genuinely cross-class (often cross-file), so the extractor reports routes tagged by their enclosing class plus `.register(...)` edges per file; `Analyzer::Java::HelidonSe` (`src/analyzer/analyzers/java/helidon_se.cr`) aggregates both across a project root and resolves the mount-prefix graph (bounded fixed-point, classes matched by simple name — the same approximation the JAX-RS/Micronaut analyzers already make for cross-file linkage). A class untouched by the graph falls back to the empty prefix rather than dropping its routes.
- Query/header/cookie/body params are scanned from the handler body (`req.query().get(...)`, `req.headers().get(HeaderNames.create(...))`, `req.headers().cookies().get(...)`, `req.content().as(X.class)`); path params come from the existing `{name}`-in-URL optimizer pass. Helidon's `{name:regex}` and `{+name}` path syntax normalize down to plain `{name}`.
- Gated on a genuine positive signal: a file must contain `io.helidon.webserver` (true across Helidon 2.x–4.x for anything that builds routing or implements `HttpService`) — not "any Java file with `.get(...)` calls".

**Helidon MP** (detector-only reuse, as the issue anticipated): Helidon MP is plain JAX-RS/MicroProfile — `@Path`/`@GET`/etc. resource classes, with no Helidon-specific routing shape to walk. `noir`'s analyzer registry is a strict 1:1 tech→analyzer map (confirmed in `src/analyzer/analyzer.cr` — a tech can't "point at" another tech's analyzer directly), so — mirroring the existing `Analyzer::Java::Quarkus` precedent for the same situation — `Analyzer::Java::HelidonMp` is a thin analyzer that just drives the shared `TreeSitterJaxRsExtractor` under its own `java_helidon_mp` tech, scoped to project roots carrying a Helidon MP marker. Helidon's own `helidon-quickstart-mp` has **no Helidon import anywhere in its resource classes** — the MP runtime is pulled in solely through `pom.xml`'s `io.helidon.microprofile.*` dependencies — so both the new detector and the project-root scoping check manifest files (`pom.xml`/`build.gradle`/`build.gradle.kts`), not just `.java` content. `Analyzer::Java::JaxRs` / `Detector::Java::JaxRs` now also treat `io.helidon.microprofile` as a derivative marker (checked against manifest files too) so the same routes aren't double-reported under `java_jaxrs`.

**Techs catalog**: two techs, `java_helidon_se` and `java_helidon_mp` (`src/techs/catalog/java/helidon.cr`) — split rather than one shared tech, matching the existing `csharp_aspnet_mvc`/`csharp_aspnet_core_mvc` precedent for one project with two unrelated routing models that warrant reporting separately.

## Validation against real Helidon apps

Shallow-cloned `helidon-io/helidon-examples` into `/tmp/helidon-validate` and ran the built `bin/noir` against it:

- `examples/quickstarts/helidon-quickstart-se` → `GET /greet/`, `PUT /greet/greeting` (body `JsonObject`), `GET /greet/{name}` (path `name`) — matches the file's own documented curl examples exactly (the `/greet/` trailing slash is intentional: an explicit `rules.get("/", ...)` carries its own `/` segment, same composition rule `URLPath.join_absorbing`'s doc comment already describes for Spring).
- `examples/quickstarts/helidon-quickstart-mp` → `GET /greet`, `GET /greet/{name}` (header `X-Trace-Id`, path `name`), `PUT /greet/greeting` (body `message`) — matches exactly, tagged `java_helidon_mp` (not `java_jaxrs`).
- `examples/metrics/http-status-count-se` (three services composed from one `Main`, including a `.register(HttpStatusMetricService.create())` no-path metrics hook that correctly contributes nothing) → both `/greet/*` and `/simple-greet/*` resolve with correct prefixes, no leakage from the metrics-only service.
- Full `examples/` sweep (~40 independent Helidon modules, 791 `.java` files) → 268 endpoints (192 `java_helidon_se`, 64 `java_helidon_mp`), 0.42s, no crashes, no `java_jaxrs` cross-tagging anywhere in the monorepo.

## Testing

- New functional-test fixtures: `spec/functional_test/fixtures/java/helidon_se/` (3-class app exercising register-based 2-level nesting, `.any()`, query/header/cookie/body param scanning, path params) and `spec/functional_test/fixtures/java/helidon_mp/` (JAX-RS resource + manifest-only Helidon signal, mirroring the real quickstart-mp shape), with matching testers.
- New unit detector specs for both new detectors.
- `crystal spec spec/unit_test` (4844 examples) and `crystal spec spec/functional_test` (23215 examples): all green, no regressions.
- `crystal tool format --check` and `ameba` (project lint): clean.
- `just dsup`: regenerated docs included (196 frameworks, up from 194).
- `shards build --release --no-debug --production`: clean.

## Limitations / follow-ups for a human reviewer

- Helidon SE prefix resolution matches `.register()` targets by simple class name, root-scoped — same approximation JAX-RS/Micronaut already use for cross-file linkage; two same-named service classes in one project root would cross-wire (not seen in the real examples repo).
- `.register(supplier)` forms other than `new Service(...)` / `Service::new` (a local variable, a lambda supplier) aren't resolved — the dominant real-world shape is covered.
- Header params require the `HeaderNames.create("...")` constructor form; well-known typed constants (`HeaderNames.CONTENT_TYPE`, etc.) aren't mapped to their wire name (would need a lookup table) and are skipped — app-specific custom headers (the more interesting case for attack-surface discovery) are the ones actually covered.
- Helidon SE's `HttpRoute.builder().path(...).methods(...).handler(...)` advanced multi-method form and WebSocket support are out of scope for this pass.

Closes #2591