### PR TITLE
feat(analyzer): detect Oak routes in Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The inventory feeds three audiences:
 
 ## What Noir does
 
-- **Endpoint extraction.** Static analysis across [204 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
+- **Endpoint extraction.** Static analysis across [205 frameworks](https://owasp-noir.github.io/noir/usage/supported/language_and_frameworks/). Returns endpoints, parameters, headers, cookies, and the source files they came from.
 - **LLM fallback.** Hand unsupported frameworks (or one-off custom routing) to OpenAI / Ollama / etc. when static rules don't apply.
 - **Output for the next stage.** JSON, YAML, OpenAPI, SARIF, cURL, Postman, HTML — whichever format the next tool in the pipeline reads.
 - **DAST integration.** Pipe directly into ZAP, Burp Suite, Caido or Gori as a proxy target, or export OpenAPI for them to import.

--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 204개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
+description = "코드 속 모든 엔드포인트를 찾아냅니다. Noir는 29개 언어와 205개 프레임워크의 소스를 정적 분석하여 섀도우 API를 드러내고 공격 표면을 그립니다."
 template = "landing"
 +++
 
@@ -91,7 +91,7 @@ template = "landing"
         <p>플러그인도, 언어별 설정도 없는 단일 바이너리입니다. 정적 규칙이 놓친 프레임워크는 LLM이 대신 처리합니다.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">언어</span></span>
-          <span><span class="stat-val">204</span><span class="stat-key">프레임워크</span></span>
+          <span><span class="stat-val">205</span><span class="stat-key">프레임워크</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "OWASP Noir"
-description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 204 frameworks, exposing shadow APIs and mapping the attack surface."
+description = "Hunt every endpoint in your code. Noir statically analyses source across 29 languages and 205 frameworks, exposing shadow APIs and mapping the attack surface."
 template = "landing"
 +++
 
@@ -89,7 +89,7 @@ template = "landing"
         <p>One binary, no plugins and no per-language setup. Frameworks the static rules miss fall back to an LLM.</p>
         <div class="stat-row">
           <span><span class="stat-val">29</span><span class="stat-key">Languages</span></span>
-          <span><span class="stat-val">204</span><span class="stat-key">Frameworks</span></span>
+          <span><span class="stat-val">205</span><span class="stat-key">Frameworks</span></span>
         </div>
       </div>
     </article>

--- a/docs/content/usage/supported/callee_coverage/index.ko.md
+++ b/docs/content/usage/supported/callee_coverage/index.ko.md
@@ -37,7 +37,7 @@ JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는
 | Groovy | Grails |
 | Haskell | Scotty, Servant, Yesod |
 | Java | Apache Struts 2, Apache Wicket, Armeria, Dropwizard, Helidon MP, Helidon SE, JAX-RS, JDK HttpServer, Javalin, Micronaut, Play Framework, Quarkus, Spark Java, Spring, Vert.x |
-| JavaScript | AdonisJS, Apollo Server, Astro, Elysia, Express, Fastify, Feathers, Fresh, Hapi, Hono, Koa, NestJS, Next.js, Nitro, NuxtJS, Remix, Restify, SvelteKit |
+| JavaScript | AdonisJS, Apollo Server, Astro, Elysia, Express, Fastify, Feathers, Fresh, Hapi, Hono, Koa, NestJS, Next.js, Nitro, NuxtJS, Oak, Remix, Restify, SvelteKit |
 | Kotlin | Ktor, Spring, http4k |
 | Lua | Lapis, lor |
 | PHP | CakePHP, CodeIgniter, Hyperf, Laminas, Laravel, Lumen, Phalcon, Pure, Slim, Symfony, ThinkPHP, Yii2 |

--- a/docs/content/usage/supported/callee_coverage/index.md
+++ b/docs/content/usage/supported/callee_coverage/index.md
@@ -37,7 +37,7 @@ This matrix lists frameworks where Noir supports per-endpoint callee extraction.
 | Groovy | Grails |
 | Haskell | Scotty, Servant, Yesod |
 | Java | Apache Struts 2, Apache Wicket, Armeria, Dropwizard, Helidon MP, Helidon SE, JAX-RS, JDK HttpServer, Javalin, Micronaut, Play Framework, Quarkus, Spark Java, Spring, Vert.x |
-| JavaScript | AdonisJS, Apollo Server, Astro, Elysia, Express, Fastify, Feathers, Fresh, Hapi, Hono, Koa, NestJS, Next.js, Nitro, NuxtJS, Remix, Restify, SvelteKit |
+| JavaScript | AdonisJS, Apollo Server, Astro, Elysia, Express, Fastify, Feathers, Fresh, Hapi, Hono, Koa, NestJS, Next.js, Nitro, NuxtJS, Oak, Remix, Restify, SvelteKit |
 | Kotlin | Ktor, Spring, http4k |
 | Lua | Lapis, lor |
 | PHP | CakePHP, CodeIgniter, Hyperf, Laminas, Laravel, Lumen, Phalcon, Pure, Slim, Symfony, ThinkPHP, Yii2 |

--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -3096,6 +3096,33 @@ sort_by = "weight"
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Oak</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Remix</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -3096,6 +3096,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Oak</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip on">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Remix</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>

--- a/spec/functional_test/fixtures/javascript/oak/main.ts
+++ b/spec/functional_test/fixtures/javascript/oak/main.ts
@@ -1,0 +1,42 @@
+import { Application, Router } from "@oak/oak";
+
+const router = new Router();
+
+router.get("/users", (ctx) => {
+  ctx.response.body = { users: [] };
+});
+
+router.post("/users", async (ctx) => {
+  const { name, email } = await ctx.request.body.json();
+  ctx.response.body = { name, email };
+});
+
+router.get("/users/:id", (ctx) => {
+  ctx.response.body = { id: ctx.params.id };
+});
+
+router.put("/users/:id", async (ctx) => {
+  const { name } = await ctx.request.body.json();
+  ctx.response.body = { id: ctx.params.id, name };
+});
+
+router.delete("/users/:id", (ctx) => {
+  ctx.response.status = 204;
+});
+
+router.get("/search", (ctx) => {
+  const q = ctx.request.url.searchParams.get("q");
+  ctx.response.body = { q };
+});
+
+router.get("/profile", async (ctx) => {
+  const token = ctx.request.headers.get("x-api-key");
+  const session = await ctx.cookies.get("session");
+  ctx.response.body = { token, session };
+});
+
+const app = new Application();
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen({ port: 8000 });

--- a/spec/functional_test/fixtures/javascript/oak_nested_mount/app.ts
+++ b/spec/functional_test/fixtures/javascript/oak_nested_mount/app.ts
@@ -1,0 +1,8 @@
+import { Application } from "@oak/oak";
+import router from "./routes/index.ts";
+
+const app = new Application();
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen({ port: 8000 });

--- a/spec/functional_test/fixtures/javascript/oak_nested_mount/routes/articles_router.ts
+++ b/spec/functional_test/fixtures/javascript/oak_nested_mount/routes/articles_router.ts
@@ -1,0 +1,10 @@
+import { Router } from "@oak/oak";
+
+const router = new Router();
+
+router.get("/articles", (ctx) => {});
+router.get("/articles/:slug", (ctx) => {
+  const slug = ctx.params.slug;
+});
+
+export default router;

--- a/spec/functional_test/fixtures/javascript/oak_nested_mount/routes/index.ts
+++ b/spec/functional_test/fixtures/javascript/oak_nested_mount/routes/index.ts
@@ -1,0 +1,14 @@
+import { Router } from "@oak/oak";
+import users from "./users_router.ts";
+import articles from "./articles_router.ts";
+
+// Aggregate sub-routers into `api` (no prefix), then mount `api` under
+// /api via the Oak `.routes()` middleware chain.
+const api = new Router();
+api.use(users.routes());
+api.use(articles.routes());
+
+const router = new Router();
+router.use("/api", api.routes(), api.allowedMethods());
+
+export default router;

--- a/spec/functional_test/fixtures/javascript/oak_nested_mount/routes/users_router.ts
+++ b/spec/functional_test/fixtures/javascript/oak_nested_mount/routes/users_router.ts
@@ -1,0 +1,9 @@
+import { Router } from "@oak/oak";
+
+const router = new Router();
+
+router.post("/users", (ctx) => {});
+router.post("/users/login", (ctx) => {});
+router.get("/user", (ctx) => {});
+
+export default router;

--- a/spec/functional_test/fixtures/javascript/oak_url_import/main.ts
+++ b/spec/functional_test/fixtures/javascript/oak_url_import/main.ts
@@ -1,0 +1,17 @@
+import { Application, Router } from "https://deno.land/x/oak@v12.6.1/mod.ts";
+
+const router = new Router({ prefix: "/api/v1" });
+
+router.get("/status", (ctx) => {
+  ctx.response.body = { status: "ok" };
+});
+
+router.get("/items/:itemId", (ctx) => {
+  ctx.response.body = { itemId: ctx.params.itemId };
+});
+
+const app = new Application();
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen({ port: 8001 });

--- a/spec/functional_test/testers/javascript/oak_nested_mount_spec.cr
+++ b/spec/functional_test/testers/javascript/oak_nested_mount_spec.cr
@@ -1,0 +1,23 @@
+require "../../func_spec.cr"
+
+# Oak routers mount sub-routers through a `.routes()`/`.allowedMethods()`
+# middleware chain, same shape as koa-router:
+#   api.use(usersRouter.routes())        // usersRouter imported from another file
+#   router.use('/api', api.routes(), api.allowedMethods())
+# Every sub-router's route must inherit the `/api` prefix even though the
+# sub-routers live in separate files and `api`/`router` are local
+# aggregators with no backing file.
+expected_endpoints = [
+  Endpoint.new("/api/users", "POST"),
+  Endpoint.new("/api/users/login", "POST"),
+  Endpoint.new("/api/user", "GET"),
+  Endpoint.new("/api/articles", "GET"),
+  Endpoint.new("/api/articles/:slug", "GET", [
+    Param.new("slug", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/oak_nested_mount/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/oak_spec.cr
+++ b/spec/functional_test/testers/javascript/oak_spec.cr
@@ -1,0 +1,31 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/users", "GET"),
+  Endpoint.new("/users", "POST", [
+    Param.new("name", "", "json"),
+    Param.new("email", "", "json"),
+  ]),
+  Endpoint.new("/users/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/users/:id", "PUT", [
+    Param.new("id", "", "path"),
+    Param.new("name", "", "json"),
+  ]),
+  Endpoint.new("/users/:id", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/search", "GET", [
+    Param.new("q", "", "query"),
+  ]),
+  Endpoint.new("/profile", "GET", [
+    Param.new("x-api-key", "", "header"),
+    Param.new("session", "", "cookie"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/oak/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/oak_url_import_spec.cr
+++ b/spec/functional_test/testers/javascript/oak_url_import_spec.cr
@@ -1,0 +1,15 @@
+require "../../func_spec.cr"
+
+# Legacy `https://deno.land/x/oak@vX.Y.Z/mod.ts` import style, plus the
+# `new Router({ prefix: '/x' })` constructor recipe.
+expected_endpoints = [
+  Endpoint.new("/api/v1/status", "GET"),
+  Endpoint.new("/api/v1/items/:itemId", "GET", [
+    Param.new("itemId", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/oak_url_import/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/detector/javascript/oak_spec.cr
+++ b/spec/unit_test/detector/javascript/oak_spec.cr
@@ -1,0 +1,78 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/javascript/*"
+
+describe "Detect JS Oak" do
+  options = create_test_options
+  instance = Detector::Javascript::Oak.new options
+
+  it "jsr_import_single_quot" do
+    instance.detect("main.ts", "import { Router } from '@oak/oak'").should be_true
+  end
+
+  it "jsr_import_double_quot" do
+    instance.detect("main.ts", "import { Router } from \"@oak/oak\"").should be_true
+  end
+
+  it "jsr_bare_specifier_single_quot" do
+    instance.detect("main.ts", "import { Router } from 'jsr:@oak/oak'").should be_true
+  end
+
+  it "jsr_bare_specifier_double_quot" do
+    instance.detect("main.ts", "import { Router } from \"jsr:@oak/oak\"").should be_true
+  end
+
+  it "require_style" do
+    instance.detect("main.ts", "const { Router } = require(\"@oak/oak\")").should be_true
+  end
+
+  it "deno_land_url_unversioned" do
+    instance.detect("main.ts", "import { Router } from \"https://deno.land/x/oak/mod.ts\"").should be_true
+  end
+
+  it "deno_land_url_versioned" do
+    instance.detect("main.ts", "import { Router } from \"https://deno.land/x/oak@v12.6.1/mod.ts\"").should be_true
+  end
+
+  it "deno_land_url_no_protocol" do
+    instance.detect("main.ts", "import { Router } from \"deno.land/x/oak/mod.ts\"").should be_true
+  end
+
+  it "deno_json_import_map" do
+    content = %({"imports": {"@oak/oak": "jsr:@oak/oak@^17.1.0"}})
+    instance.detect("deno.json", content).should be_true
+  end
+
+  it "deno_jsonc_import_map" do
+    content = %({"imports": {"oak/": "https://deno.land/x/oak@v12.6.1/"}})
+    instance.detect("deno.jsonc", content).should be_true
+  end
+
+  it "import_map_json" do
+    content = %({"imports": {"@oak/oak": "jsr:@oak/oak@^17.1.0"}})
+    instance.detect("import_map.json", content).should be_true
+  end
+
+  it "js_extension" do
+    instance.detect("main.js", "import { Router } from \"@oak/oak\";").should be_true
+  end
+
+  it "not_oak" do
+    instance.detect("main.ts", "import { Router } from 'koa-router'").should be_false
+  end
+
+  it "not_oak_deno_land_other_package" do
+    instance.detect("main.ts", "import { serve } from \"https://deno.land/std/http/server.ts\"").should be_false
+  end
+
+  it "no_signal_no_match" do
+    instance.detect("main.ts", "console.log('hello world')").should be_false
+  end
+
+  it "package_json_without_signal" do
+    instance.detect("package.json", %({"name": "some-app"})).should be_false
+  end
+
+  it "unrelated_extension" do
+    instance.detect("main.py", "from oak import Router").should be_false
+  end
+end

--- a/spec/unit_test/models/locator_ownership_spec.cr
+++ b/spec/unit_test/models/locator_ownership_spec.cr
@@ -124,7 +124,8 @@ describe "locator key ownership" do
   # to *read* them back, which is the whole point of the namespace. A writer is a
   # file that mints and then pushes, and a push of a minted key takes a local
   # variable rather than a `LocatorKeys::` constant. That pair is what identifies
-  # `koa.cr` and `express/router_mount_scanner.cr`, and it is the check the
+  # `koa.cr`, `oak.cr`, and `express/router_mount_scanner.cr` — all three resolve
+  # cross-file router mount prefixes the same way — and it is the check the
   # `analyzer/javascript/express` owner failed.
   it "writes namespace keys only from the owning subsystem" do
     namespace = Noir::LocatorKeys::EXPRESS_ROUTER_PREFIX
@@ -143,7 +144,7 @@ describe "locator key ownership" do
 
     # Guards this example specifically: if the minting helper is renamed, the
     # scan would find no writers and pass while checking nothing.
-    writers.size.should eq 2
+    writers.size.should eq 3
   end
 
   # Guards the guards. Every example above is a source scan, so a broken glob or

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -5,7 +5,7 @@ require "../../spec_helper"
 # The registry is derived from the classes, so a detector joins a scan simply by
 # existing (`build_detector_list`, src/detector/detector.cr). That removed the
 # "forgot to register it" failure mode and replaced it with a quieter one:
-# nothing at all requires a detector to be *tested*. 64 of 252 — including
+# nothing at all requires a detector to be *tested*. 64 of 253 — including
 # `rust/actix_web`, `java/quarkus`, `java/micronaut`, `java/jaxrs`,
 # `javascript/hapi`, `swift/hummingbird`, `typescript/trpc`, every `zig/*` and
 # every language's `cli` — shipped with zero coverage.
@@ -170,6 +170,6 @@ describe "detector spec coverage" do
   # Guards the guard: a broken glob would make every example above pass
   # vacuously.
   it "finds every registered detector" do
-    detector_paths.size.should eq 252
+    detector_paths.size.should eq 253
   end
 end

--- a/src/analyzer/analyzers/javascript/oak.cr
+++ b/src/analyzer/analyzers/javascript/oak.cr
@@ -1,0 +1,298 @@
+require "../../engines/javascript_engine"
+require "../../../miniparsers/js_route_extractor"
+require "../../../miniparsers/import_graph"
+require "../../../models/code_locator"
+require "../../../utils/url_path"
+
+module Analyzer::Javascript
+  # Oak's Router API is deliberately close to Koa's — `router.get(path,
+  # handler)`, `:param` path syntax, a `ctx` handed to every handler — so
+  # this analyzer largely mirrors `Analyzer::Javascript::Koa`: both share
+  # `Noir::JSRouteExtractor` for verb-call extraction, path-param scanning,
+  # and callee attachment. See `js_route_extractor.cr`'s `:oak` entry in
+  # `SHARED_EXTRACTOR_FRAMEWORK_MARKERS` — it, and the Oak-specific
+  # ctx.request.* param patterns added alongside it, are what make reuse
+  # possible.
+  #
+  # Two shapes Oak supports that the shared JSParser already resolves with
+  # no framework-specific code here:
+  #
+  #   * `new Router({ prefix: '/api/v1' })` — the constructor-level prefix
+  #     is generic in `JSParser#scan_router_constructor_prefixes` (keyed on
+  #     any `Router`-named constructor, not a specific framework).
+  #   * `parent.use('/prefix', child.routes())` mounted **within the same
+  #     file** — the generic same-file router-mount scan in
+  #     `JSParser#parse_routes` handles this already (it only needs `child`
+  #     to appear as a bare identifier inside the `.use(...)` call, and
+  #     `child.routes()` still exposes `child` as that identifier).
+  #
+  # What the shared parser can't do — because it operates on one file's
+  # token stream — is a router assembled in one file and mounted with a
+  # prefix in another. `resolve_oak_mount_prefixes` below handles that
+  # cross-file case, the same way `Koa#resolve_koa_mount_prefixes` does.
+  class Oak < JavascriptEngine
+    analyzer_for "js_oak"
+
+    def analyze
+      result = [] of Endpoint
+      include_callee = callees_needed?
+
+      resolve_oak_mount_prefixes
+
+      parallel_file_scan([".ts", ".js", ".mjs"]) do |path|
+        begin
+          content = read_file_content(path)
+          next if Noir::JSRouteExtractor.other_shared_extractor_framework?(content, :oak)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
+            include_callees: include_callee)
+          parser_endpoints.each do |endpoint|
+            if endpoint.details.code_paths.empty?
+              endpoint.details = Details.new(PathInfo.new(path))
+            end
+
+            if endpoint.url.includes?(":")
+              endpoint.url.scan(/:(\w+)/) do |m|
+                if m.size > 0
+                  param = Param.new(m[1], "", "path")
+                  endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
+                end
+              end
+            end
+            result << endpoint
+          end
+        rescue e
+          logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
+          analyze_with_regex(path, result)
+        end
+      end
+
+      result
+    end
+
+    # Resolve cross-file Oak router mount prefixes and seed them into
+    # CodeLocator under each imported child router's file key — the same
+    # trick `Koa#resolve_koa_mount_prefixes` uses. A common Oak layout
+    # aggregates sub-routers from separate files:
+    #
+    #   // routes/users.ts
+    #   const router = new Router();
+    #   router.get("/", handler);
+    #   export default router;
+    #
+    #   // routes/index.ts
+    #   import users from "./users.ts";
+    #   const router = new Router();
+    #   router.use("/users", users.routes());
+    #
+    # so `routes/users.ts`'s routes need the `/users` prefix even though
+    # the mounting line lives in a different file.
+    private def resolve_oak_mount_prefixes
+      locator = CodeLocator.instance
+      boundary = @base_path
+
+      all_files.each do |path|
+        next unless [".ts", ".js", ".mjs", ".cjs"].any? { |ext| path.ends_with?(ext) }
+        content = read_file_content(path)
+        # Cheap gate: the mount chain always pairs `.use(` with `.routes(`.
+        next unless content.includes?(".use(") && content.includes?(".routes(")
+        next if Noir::JSRouteExtractor.minified_content?(content)
+
+        # Map local identifiers to the router file they import. Oak
+        # projects are ESM-only in the overwhelming majority of cases
+        # (`import x from "./x.ts"`), but a `require(...)` scan is kept
+        # too — cheap, and harmless if it never matches.
+        imports = Hash(String, String).new
+        record_import = ->(var : String, spec : String) do
+          resolved = Noir::ImportGraph.resolve_relative_import(path, spec, boundary: boundary)
+          imports[var] = resolved if resolved
+        end
+        content.scan(/(?:const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |m|
+          record_import.call(m[1], m[2]) if m.size >= 3
+        end
+        content.scan(/import\s+(\w+)\s+from\s+['"]([^'"]+)['"]/) do |m|
+          record_import.call(m[1], m[2]) if m.size >= 3
+        end
+
+        # Collect mount edges: parent.use('/prefix', child[.routes()]) and
+        # the no-prefix parent.use(child[.routes()]). The `.routes()`
+        # suffix on `child` is optional — a sub-router file may export
+        # the pre-called `router.routes()` directly, in which case the
+        # mount site sees a bare identifier. Unlike koa-router, Oak's
+        # `.use()` on a router routinely takes a third argument
+        # (`child.allowedMethods()`), so — unlike the plain koa-router
+        # regex — neither pattern requires the call to close right after
+        # `child`.
+        edges = [] of Tuple(String, String, String)
+        content.scan(/(\w+)\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)(?:\.routes\s*\(\s*\))?/) do |m|
+          edges << {m[1], m[2], m[3]} if m.size >= 4
+        end
+        content.scan(/(\w+)\.use\s*\(\s*(\w+)(?:\.routes\s*\(\s*\))?/) do |m|
+          edges << {m[1], "", m[2]} if m.size >= 3
+        end
+        next if edges.empty?
+
+        prefixes = resolve_mount_edge_prefixes(edges)
+
+        prefixes.each do |router_var, router_prefixes|
+          file = imports[router_var]?
+          next unless file
+          key = Analyzer::Javascript::ExpressConstants.file_key(File.expand_path(file))
+          router_prefixes.each do |prefix|
+            next if prefix.empty?
+            locator.push(key, prefix) unless locator.all(key).includes?(prefix)
+          end
+        end
+      rescue e
+        logger.debug "oak mount prefix resolution failed for #{path}: #{e.message}"
+      end
+    end
+
+    # Resolve every router variable's mount prefix(es) from the edge list.
+    # A variable that is never mounted into another (a root aggregator like
+    # the exported `router`) carries the empty prefix; children inherit the
+    # parent's prefix joined with the edge's own prefix. Iterated to a
+    # fixpoint so a two-level chain (root -> api -> child) fully resolves.
+    private def resolve_mount_edge_prefixes(edges : Array(Tuple(String, String, String))) : Hash(String, Array(String))
+      children = edges.map { |_, _, child| child }.to_set
+      prefixes = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
+
+      # Seed roots (never a mount target) with the empty prefix.
+      edges.each do |parent, _, _|
+        prefixes[parent] << "" if !children.includes?(parent) && prefixes[parent].empty?
+      end
+
+      max_iterations = 16
+      iterations = 0
+      changed = true
+      while changed && iterations < max_iterations
+        changed = false
+        iterations += 1
+        edges.each do |parent, prefix, child|
+          # Propagate only from a resolved parent (a seeded root or an
+          # already-resolved child). Defaulting an unresolved parent to ""
+          # would leak a wrong prefix (`/sub` instead of `/api/sub`).
+          parent_prefixes = prefixes[parent]?
+          next if parent_prefixes.nil? || parent_prefixes.empty?
+          parent_prefixes.each do |pp|
+            combined = if pp.empty?
+                         prefix
+                       elsif prefix.empty?
+                         pp
+                       else
+                         Noir::URLPath.join(pp, prefix)
+                       end
+            unless prefixes[child].includes?(combined)
+              prefixes[child] << combined
+              changed = true
+            end
+          end
+        end
+      end
+
+      prefixes
+    end
+
+    private def analyze_with_regex(path : String, result : Array(Endpoint))
+      file_content = read_file_content(path)
+      # Regex fallback for when the JSParser trips over a file (rare, but
+      # more likely on Deno/TS sources that lean on newer TS syntax).
+      # Covers router.get('/path', ...) / router.post(...) / ... and the
+      # constructor-level `new Router({ prefix: '/x' })` recipe — the
+      # cross-file `.use('/prefix', child.routes())` mount chain is
+      # already resolved ahead of time by `resolve_oak_mount_prefixes`
+      # and read back through `CodeLocator`, same as the primary path.
+
+      router_prefixes = {} of String => String
+
+      file_content.scan(/const\s+(\w+)\s*=\s*new\s+Router\(\s*{\s*prefix:\s*['"]([^'"]+)['"]\s*}?\s*\)/) do |match|
+        router_prefixes[match[1]] = match[2]
+      end
+
+      file_content.scan(/(\w+)\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)\.routes\(\s*\)/) do |match|
+        parent_router = match[1]
+        prefix = match[2]
+        child_router_name = match[3]
+
+        base_prefix = router_prefixes.fetch(parent_router, "")
+        router_prefixes[child_router_name] = File.join(base_prefix, prefix)
+      end
+
+      locator = CodeLocator.instance
+      lookup_key = Analyzer::Javascript::ExpressConstants.file_key(File.expand_path(path))
+      file_prefixes = locator.all(lookup_key)
+
+      file_content.scan(/(?:(\w+)\.|app\.)(get|post|put|delete|del|patch|options|head|all)\s*\(\s*['"]([^'"]+)['"]/) do |match|
+        router_var = match[1]
+        http_method = Noir::JSRouteExtractor.normalize_http_method(match[2])
+        route_path = match[3]
+
+        current_prefix = ""
+        if router_var && router_prefixes.has_key?(router_var)
+          current_prefix = router_prefixes[router_var]
+        elsif !file_prefixes.empty?
+          current_prefix = file_prefixes.first
+        end
+
+        full_path = File.join(current_prefix, route_path)
+        full_path = "/" if full_path.empty?
+        full_path = "/#{full_path}" unless full_path.starts_with?('/')
+
+        endpoint = Endpoint.new(full_path, http_method)
+        endpoint.details = Details.new(PathInfo.new(path, 1))
+
+        route_path.scan(/:(\w+)/) do |m|
+          if m.size > 0 && !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
+            endpoint.push_param(Param.new(m[1], "", "path"))
+          end
+        end
+
+        extract_oak_params_from_content(file_content, router_var || "app", match[2], route_path, endpoint)
+
+        unless result.any? { |e| e.url == full_path && e.method == http_method }
+          result << endpoint
+        end
+      end
+    end
+
+    # Extract parameters from an Oak handler body, for the regex-fallback
+    # path only — the primary path gets these for free through
+    # `Noir::JSRouteExtractor.extract_params_from_context`, which already
+    # carries the Oak-specific ctx.request.* patterns.
+    private def extract_oak_params_from_content(content : String, router_name : String, method : String, path : String, endpoint : Endpoint)
+      handler_pattern = /#{Regex.escape(router_name)}\.#{method}\s*\(\s*['"]#{Regex.escape(path)}['"][^{]*\{([^}]*(?:\{[^}]*\})*[^}]*)\}/m
+
+      match = content.match(handler_pattern)
+      return unless match && match.size > 1
+
+      handler_body = match[1]
+      return if handler_body.empty?
+
+      handler_body.scan(/ctx\.request\.url\.searchParams\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |m|
+        endpoint.push_param(Param.new(m[1], "", "query")) if m.size > 0
+      end
+
+      handler_body.scan(/(?:const|let|var)\s*\{\s*([^}]+)\s*\}\s*=\s*await\s+ctx\.request\.body\.json\s*\(/) do |m|
+        if m.size > 0
+          m[1].split(",").map(&.strip).each do |param|
+            clean_param = param.split("=").first.strip.split(":").first.strip
+            endpoint.push_param(Param.new(clean_param, "", "json")) unless clean_param.empty?
+          end
+        end
+      end
+
+      handler_body.scan(/ctx\.request\.headers\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |m|
+        endpoint.push_param(Param.new(m[1], "", "header")) if m.size > 0
+      end
+
+      handler_body.scan(/ctx\.cookies\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |m|
+        endpoint.push_param(Param.new(m[1], "", "cookie")) if m.size > 0
+      end
+
+      handler_body.scan(/ctx\.params\.(\w+)/) do |m|
+        if m.size > 0 && !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
+          endpoint.push_param(Param.new(m[1], "", "path"))
+        end
+      end
+    end
+  end
+end

--- a/src/detector/detectors/javascript/oak.cr
+++ b/src/detector/detectors/javascript/oak.cr
@@ -1,0 +1,42 @@
+require "../../../models/detector"
+
+module Detector::Javascript
+  class Oak < Detector
+    detector_for "js_oak",
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      basenames: %w[package.json deno.json deno.jsonc import_map.json]
+
+    MANIFEST_BASENAMES = %w[package.json deno.json deno.jsonc import_map.json]
+
+    # Oak ships no package.json of its own — it's a Deno-native
+    # framework — so the reliable signal is the import specifier
+    # itself:
+    #   * the JSR package, `import { Router } from "@oak/oak"`,
+    #     including the bare `jsr:@oak/oak` specifier form.
+    #   * the legacy URL import,
+    #     `import { Router } from "https://deno.land/x/oak@v.../mod.ts"`
+    #     (any version, any subpath — the bare "deno.land/x/oak"
+    #     substring covers all of them).
+    # Both forms are quoted strings rather than anchored to `from`/
+    # `require(` so the same signal also fires inside a Deno import map
+    # (`deno.json`/`deno.jsonc`/`import_map.json`), where the specifier
+    # is a bare JSON key/value: `"imports": { "@oak/oak": "jsr:@oak/
+    # oak@^17.1.0" }` or `"oak/": "https://deno.land/x/oak@v12.6.1/"`.
+    SIGNAL = Regex.union(
+      /["']@oak\/oak["']/,
+      /["']jsr:@oak\/oak["']/,
+      /["'](?:https?:\/\/)?deno\.land\/x\/oak(?:[@\/][^"']*)?["']/,
+    )
+
+    def detect(filename : String, file_contents : String) : Bool
+      base = File.basename(filename)
+      return content_matches?(file_contents, SIGNAL) if MANIFEST_BASENAMES.includes?(base)
+
+      return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") ||
+                          filename.ends_with?(".cjs") || filename.ends_with?(".jsx") ||
+                          filename.ends_with?(".ts") || filename.ends_with?(".tsx")
+
+      content_matches?(file_contents, SIGNAL)
+    end
+  end
+end

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -544,6 +544,8 @@ module Noir
       "from \"polka\"", "from 'polka'",
       "from \"h3\"", "from 'h3'",
       "from \"@nestjs/", "from '@nestjs/",
+      "from \"@oak/oak\"", "from '@oak/oak'",
+      "deno.land/x/oak",
     ]
 
     # Path-level evidence that a file is a mock-server fixture.
@@ -743,6 +745,18 @@ module Noir
         "require(\"restify\")", "require('restify')",
         "from \"restify-router\"", "from 'restify-router'",
         "require(\"restify-router\")", "require('restify-router')",
+      ],
+      # Oak is Deno-native and ships no package.json, so its import
+      # evidence is the specifier itself: the JSR package (`@oak/oak`,
+      # optionally through a bare `jsr:` specifier) or the legacy URL
+      # import (`https://deno.land/x/oak@vX.Y.Z/mod.ts`). The bare
+      # "deno.land/x/oak" substring covers every versioned/unversioned
+      # URL form without needing to enumerate them.
+      :oak => [
+        "from \"@oak/oak\"", "from '@oak/oak'",
+        "from \"jsr:@oak/oak", "from 'jsr:@oak/oak",
+        "require(\"@oak/oak\")", "require('@oak/oak')",
+        "deno.land/x/oak",
       ],
     }
 
@@ -1234,6 +1248,17 @@ module Noir
           end
         end
       end
+
+      # Oak-style: const { X } = await ctx.request.body.json()
+      handler_body.scan(/(?:const|let|var)\s*\{\s*([^}]+)\s*\}\s*=\s*await\s+ctx\.request\.body\.json\s*\(/) do |match|
+        if match.size > 0
+          params = match[1].split(",").map(&.strip)
+          params.each do |param|
+            clean_param = clean_destructured_param(param)
+            endpoint.push_param(Param.new(clean_param, "", "json")) unless clean_param.empty?
+          end
+        end
+      end
     end
 
     def self.extract_query_params(handler_body : String, endpoint : Endpoint)
@@ -1296,6 +1321,13 @@ module Noir
           endpoint.push_param(Param.new(match[1], "", "query"))
         end
       end
+
+      # Oak/Fetch-API-style: ctx.request.url.searchParams.get('param')
+      handler_body.scan(/ctx\.request\.url\.searchParams\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+        if match.size > 0
+          endpoint.push_param(Param.new(match[1], "", "query"))
+        end
+      end
     end
 
     def self.extract_header_params(handler_body : String, endpoint : Endpoint)
@@ -1338,6 +1370,14 @@ module Noir
         endpoint.push_param(Param.new(match[1], "", "header")) if match.size > 0
       end
       handler_body.scan(/\w+\.req\.header\s*\(\s*([A-Za-z_$]\w*)\s*\)/) do |match| # c.req.header(CONST) — unresolved
+        push_unresolved_param(endpoint, match[1], "header") if match.size > 0
+      end
+
+      # Oak/Fetch-API-style: ctx.request.headers.get('x-token')
+      handler_body.scan(/ctx\.request\.headers\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+        endpoint.push_param(Param.new(match[1], "", "header")) if match.size > 0
+      end
+      handler_body.scan(/ctx\.request\.headers\.get\s*\(\s*([A-Za-z_$]\w*)\s*\)/) do |match| # unresolved
         push_unresolved_param(endpoint, match[1], "header") if match.size > 0
       end
     end

--- a/src/techs/catalog/javascript/oak.cr
+++ b/src/techs/catalog/javascript/oak.cr
@@ -1,0 +1,26 @@
+# NoirTechs catalog entry: js_oak.
+# One file per technology; `NoirTechs::TECHS` in src/techs/techs.cr is
+# macro-derived from every constant under `NoirTechs::Catalog`.
+module NoirTechs::Catalog::Javascript
+  OAK = {
+    :js_oak => {
+      :framework => "Oak",
+      :language  => "JavaScript",
+      :similar   => ["oak", "deno-oak", "js-oak", "@oak/oak"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => true,
+          :cookie => true,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+      :context => {:callee => true, :guards => true},
+    },
+  }
+end


### PR DESCRIPTION
## Summary

Adds full detector/analyzer/techs-catalog support for [Oak](https://jsr.io/@oak/oak), the de-facto Express/Koa-style HTTP middleware framework for Deno, closing #2597 (part of umbrella #2589).

Oak's `Router` API is deliberately close to Koa's (`router.get(path, handler)`, `:param` path syntax, a `ctx` handed to every handler), so the analyzer reuses `Noir::JSRouteExtractor` the same way `Analyzer::Javascript::Koa` does rather than duplicating extraction logic.

## What's included

- **Detector** (`src/detector/detectors/javascript/oak.cr`): matches both Deno import styles —
  - JSR: `import { Router } from "@oak/oak"` (including the bare `jsr:@oak/oak` specifier)
  - Legacy URL: `import { Router } from "https://deno.land/x/oak@vX.Y.Z/mod.ts"` (any version/subpath)
  - The signal is a quoted-string match rather than anchored to `from`/`require(`, so it also fires from a Deno import map (`deno.json`/`deno.jsonc`/`import_map.json`) where the specifier is a bare JSON key/value.
- **Shared extractor** (`src/miniparsers/js_route_extractor.cr`):
  - `:oak` joins `SHARED_EXTRACTOR_FRAMEWORK_MARKERS` (same list Express/Fastify/Koa/Hono/Restify are in). This list programmatically derives the cross-framework exclusion (`other_shared_extractor_framework?`), so a Koa project is never misread as Oak or vice versa — same guarantee the #2417-2432 project-scoping campaign put in place for the other frameworks in that list.
  - Oak's own markers were also added to `HTTP_SERVER_LIBRARY_MARKERS` (the test-stub-exemption list).
  - Oak-specific `ctx.request.*` param idioms — the Fetch-API-flavored `ctx.request.url.searchParams.get()`, `ctx.request.headers.get()`, and `await ctx.request.body.json()` destructuring — are added alongside Koa's `ctx.*` patterns in the shared query/header/body param scanners.
- **Analyzer** (`src/analyzer/analyzers/javascript/oak.cr`):
  - Two things Oak supports needed **zero** Oak-specific code because the shared `JSParser` already resolves them generically:
    - `new Router({ prefix: '/x' })` — `JSParser#scan_router_constructor_prefixes` is keyed on any `Router`-named constructor, not a specific framework (confirmed via the existing `koa_constructor_prefix_recipe` fixture, which exercises the same code path).
    - Same-file `parent.use('/prefix', child.routes())` mounts — `JSParser`'s same-file router-mount scan only needs `child` to appear as a bare identifier inside `.use(...)`.
  - `resolve_oak_mount_prefixes` handles the one thing the file-scoped `JSParser` can't: a router assembled in one file and mounted with a prefix in another. It mirrors `Koa#resolve_koa_mount_prefixes`, relaxed to tolerate Oak's `.routes(), child.allowedMethods()` trailing arg (koa-router's `.use()` never takes a third arg; Oak's routinely does).
  - A regex fallback (`analyze_with_regex`) mirrors Koa's, for the (rare) case the JSParser trips on a file.
- **Techs catalog** (`src/techs/catalog/javascript/oak.cr`): query/path/body/header/cookie params and callees marked supported. `static_path` and `websocket` are left off — Oak has no single-call idiom to detect them the way `express.static()` gives Express/Koa; would need dedicated work as a follow-up.
- **Tests**: unit detector spec (17 cases covering both import styles, import-map matching, and negative cases against Koa/other Deno packages) + 3 functional fixture/tester pairs — basic routes+params (JSR import), the legacy URL import + constructor-prefix recipe, and a cross-file nested-router mount (mirrors `koa_nested_mount`).

## Oak-vs-Koa disambiguation

Handled entirely by `SHARED_EXTRACTOR_FRAMEWORK_MARKERS`: each framework in that map gets an automatically-derived "does this file show definitive evidence of a *different* shared-extractor framework, with none of my own?" exclusion. Adding `:oak` to the map means Koa's own exclusion list picks up Oak's markers for free (and vice versa) — no hand-written cross-check needed. Full unit + functional suites pass with zero regressions, including every existing Koa fixture.

## Validation against a real repo

Shallow-cloned [`asad-devx/deno-api-starter-oak`](https://github.com/asad-devx/deno-api-starter-oak) (oak `v5.0.0`, legacy URL import, array-based `[middleware, handler]` route registrations with spread args — a good stress test since it's an older/unusual Oak shape):

```
$ noir scan /tmp/oak-validate --only-techs js_oak -f json --no-log
```

7 of 8 real routes extracted correctly (`POST /login`, `POST /register`, `POST /token`, `GET /users`, `GET|PUT|DELETE /users/:id`) with correct method, URL, and path params, zero cross-framework leakage. The one miss is `router.get("", ...)` (empty-string root path) — a pre-existing `JSParser` limitation shared by every framework using this extractor (its route-path filter drops non-`/`-prefixed empty paths before the leading-slash normalization step runs), not Oak-specific, and out of scope for this PR.

Also validated against a second real project using a custom `deno.json` import-map alias (`"@oak": "https://deno.land/x/oak@v16.0.0/mod.ts"`) to confirm detection fires correctly off the manifest even when source files use a bespoke alias — confirmed 0 false positives (that project's own routing convention is a fully custom declarative object table, not `router.get()` calls, so it's outside any static analyzer's reach without bespoke handling).

## Test plan

- [x] `crystal spec spec/unit_test` — 4852 examples, 0 failures
- [x] `crystal spec spec/functional_test` — 23227 examples, 0 failures (no Koa regressions)
- [x] `shards build --release --no-debug --production` succeeds
- [x] `just check` (format + Ameba) — 2159 files inspected, 0 failures
- [x] `just dsup` — regenerated docs included (195 frameworks, up from 194)
- [x] Validated against two real Oak/Deno repos (see above)

## Known limitations / follow-ups

- `static_path` / `websocket` not marked supported in the techs catalog — no standardized single-call idiom to detect them yet.
- Empty-string root path (`router.get("", handler)`) is dropped — shared `JSParser` limitation across all frameworks using it, not Oak-specific.
- Older Oak API (`ctx.request.body()` as a method call returning `{type, value}`, pre-v12) isn't covered by the body-param extraction — only the current `ctx.request.body.json()` shape is. This is a param-extraction miss only (routes/paths still extract correctly); no false positives result.