### PR TITLE
fix(parser): bound AST walk depth and parse time so one file can't kill the scan

### DIFF
--- a/spec/unit_test/analyzer/analyzer_deep_nesting_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_deep_nesting_spec.cr
@@ -1,0 +1,54 @@
+require "../../spec_helper"
+require "../../../src/models/code_locator"
+require "../../../src/analyzer/analyzers/rust/actix_web"
+
+# Walkers that recurse *outside* an `each_named_child` block — on a
+# `field(...)` receiver, or on a child array materialised up front so the
+# walk can look ahead — are invisible to the shared depth guard in
+# `Noir::TreeSitter.each_named_child` and carry their own `depth`
+# parameter instead. These specs pin that: the assertion is just "returns
+# without crashing", because a stack overflow is a hard process abort that
+# no `rescue` upstream can turn into a per-file failure.
+private NEST = 6000
+
+private def with_rust_file(content : String, &)
+  dir = File.tempname("deep_nesting_spec")
+  Dir.mkdir_p(dir)
+  path = File.join(dir, "main.rs")
+  File.write(path, content)
+  begin
+    yield path
+  ensure
+    File.delete(path) if File.exists?(path)
+    Dir.delete(dir) if Dir.exists?(dir)
+  end
+end
+
+describe "deeply nested Rust sources" do
+  options = create_test_options
+
+  it "survives a #{NEST}-link .service() chain (receiver recursion)" do
+    source = String.build do |io|
+      io << "use actix_web::{web, App};\n\nfn app() {\n    App::new()"
+      NEST.times { io << ".service(h)" }
+      io << ";\n}\n"
+    end
+
+    with_rust_file(source) do |path|
+      Analyzer::Rust::ActixWeb.new(options).analyze_file(path)
+    end
+  end
+
+  it "survives #{NEST} nested blocks (attribute/function pair walk)" do
+    source = String.build do |io|
+      io << "fn deep() {\n"
+      NEST.times { io << "if a {\n" }
+      NEST.times { io << "}\n" }
+      io << "}\n"
+    end
+
+    with_rust_file(source) do |path|
+      Analyzer::Rust::ActixWeb.new(options).analyze_file(path)
+    end
+  end
+end

--- a/spec/unit_test/ext/tree_sitter_walk_depth_spec.cr
+++ b/spec/unit_test/ext/tree_sitter_walk_depth_spec.cr
@@ -1,0 +1,61 @@
+require "spec"
+require "../../../src/ext/tree_sitter/tree_sitter"
+
+# `each_named_child` is the descent step practically every AST walker in
+# the tree recurses through, so it is where the recursion bound lives.
+# Without it a source file with thousands of nested syntactic constructs
+# — `((((...))))`, a generated builder chain, machine-emitted code —
+# recursed until the fiber stack ran out. A stack overflow is a hard
+# abort: it takes down the whole scan, and none of the `rescue`s in
+# `parallel_analyze` or `scan_files` can catch it.
+describe "Noir::TreeSitter.each_named_child depth bound" do
+  it "stops descending past MAX_AST_DEPTH" do
+    nest = Noir::TreeSitter::MAX_AST_DEPTH + 500
+    source = "x = #{"(" * nest}1#{")" * nest}\n"
+
+    deepest = 0
+    visit = uninitialized Proc(LibTreeSitter::TSNode, Int32, Nil)
+    visit = ->(node : LibTreeSitter::TSNode, depth : Int32) do
+      deepest = depth if depth > deepest
+      Noir::TreeSitter.each_named_child(node) { |child| visit.call(child, depth + 1) }
+    end
+
+    Noir::TreeSitter.parse_python(source) { |root| visit.call(root, 0) }
+
+    deepest.should be <= Noir::TreeSitter::MAX_AST_DEPTH
+  end
+
+  it "leaves the counter at rest after a walk completes" do
+    source = "x = ((((1))))\n"
+    Noir::TreeSitter.parse_python(source) do |root|
+      Noir::TreeSitter.each_named_child(root) { |child| child }
+    end
+
+    Noir::TreeSitter.walk_depth.should eq(0)
+  end
+
+  it "restores the counter when a walker raises mid-descent" do
+    source = "x = ((((1))))\n"
+
+    expect_raises(Exception, "boom") do
+      Noir::TreeSitter.parse_python(source) do |root|
+        Noir::TreeSitter.each_named_child(root) do |child|
+          Noir::TreeSitter.each_named_child(child) { raise "boom" }
+        end
+      end
+    end
+
+    Noir::TreeSitter.walk_depth.should eq(0)
+  end
+
+  it "still yields every named child of a shallow node" do
+    source = "def f(a, b, c):\n    pass\n"
+
+    top_level = [] of String
+    Noir::TreeSitter.parse_python(source) do |root|
+      Noir::TreeSitter.each_named_child(root) { |c| top_level << Noir::TreeSitter.node_type(c) }
+    end
+
+    top_level.should eq(["function_definition"])
+  end
+end

--- a/spec/unit_test/miniparser/extractor_recursion_depth_spec.cr
+++ b/spec/unit_test/miniparser/extractor_recursion_depth_spec.cr
@@ -16,8 +16,15 @@ require "../../../src/miniparsers/http4k_extractor_ts"
 require "../../../src/miniparsers/adonisjs_extractor_ts"
 require "../../../src/miniparsers/jvm_lambda_dsl_extractor_ts"
 require "../../../src/miniparsers/kotlin_ktor_route_extractor_ts"
+require "../../../src/miniparsers/go_route_extractor_ts"
 
 private NEST = 3000
+
+# The Go cases below nest inside a single expression rather than one
+# block per level, so each level costs far less stack than a full walker
+# frame — 3000 still fits comfortably. Raised until the unguarded parser
+# actually overflowed, so removing the guard fails the spec.
+private GO_NEST = 20_000
 
 describe "extractor recursion depth bounds" do
   it "Elysia tolerates a 3000-link chained DSL without crashing" do
@@ -76,6 +83,25 @@ describe "extractor recursion depth bounds" do
       nest_methods: Set{"path"},
     )
     Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(body, config)
+  end
+
+  # `string_expr_text` resolves a route/group prefix built out of `+`
+  # concatenation and parentheses. It recurses on the operands via
+  # `field(...)`, not through `each_named_child`, so the shared depth
+  # guard there never sees it — generated Go with a long concatenated
+  # constant used to take the whole scan down with it.
+  it "Go route extractor tolerates a #{GO_NEST}-term string concatenation without crashing" do
+    body = String.build do |io|
+      io << "package main\n\nvar prefix = "
+      GO_NEST.times { |i| io << " + " unless i == 0; io << %("a") }
+      io << "\n\nfunc reg(r *gin.Engine) {\n  r.GET(prefix, h)\n}\n"
+    end
+    Noir::TreeSitterGoRouteExtractor.extract_routes(body)
+  end
+
+  it "Go route extractor tolerates #{GO_NEST} nested parentheses without crashing" do
+    body = "package main\n\nvar prefix = #{"(" * GO_NEST}\"/a\"#{")" * GO_NEST}\n"
+    Noir::TreeSitterGoRouteExtractor.extract_routes(body)
   end
 
   it "Ktor route extractor tolerates 3000 nested route() blocks without crashing" do

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -200,18 +200,28 @@ module Analyzer::Rust
       registrations
     end
 
+    # `depth` bounds the descent. Most of this walk recurses inside
+    # `each_named_child`, whose own guard would catch it, but the
+    # `.service(...)` branch recurses on the *receiver* — one level per
+    # link of an `App::new().service(a).service(b)...` chain, outside any
+    # `each_named_child` block. A generated or adversarial `.rs` file with
+    # thousands of chained links would run the fiber stack out, and a
+    # stack overflow aborts the whole scan rather than failing one file.
     private def collect_service_registrations(node : LibTreeSitter::TSNode,
                                               source : String,
                                               test_regions : Array(Tuple(Int32, Int32)),
                                               file_path : String,
                                               active_prefix : String,
-                                              registrations : Hash(String, Array(String)))
+                                              registrations : Hash(String, Array(String)),
+                                              depth : Int32 = 0)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       if Noir::TreeSitter.node_type(node) == "function_item"
         if name = function_name(node, source)
           if prefixes = lookup_configure_prefixes(name, file_path)
             Noir::TreeSitter.each_named_child(node) do |child|
               prefixes.each do |prefix|
-                collect_service_registrations(child, source, test_regions, file_path, scoped_route_path(active_prefix, prefix), registrations)
+                collect_service_registrations(child, source, test_regions, file_path, scoped_route_path(active_prefix, prefix), registrations, depth + 1)
               end
             end
             return
@@ -237,16 +247,16 @@ module Analyzer::Rust
           if handler_name = service_handler_name(named[0], source)
             push_registration(registrations, handler_name, service_prefix)
           else
-            collect_service_registrations(named[0], source, test_regions, file_path, service_prefix, registrations)
+            collect_service_registrations(named[0], source, test_regions, file_path, service_prefix, registrations, depth + 1)
           end
 
-          collect_service_registrations(receiver, source, test_regions, file_path, active_prefix, registrations) if receiver
+          collect_service_registrations(receiver, source, test_regions, file_path, active_prefix, registrations, depth + 1) if receiver
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        collect_service_registrations(child, source, test_regions, file_path, active_prefix, registrations)
+        collect_service_registrations(child, source, test_regions, file_path, active_prefix, registrations, depth + 1)
       end
     end
 
@@ -301,7 +311,10 @@ module Analyzer::Rust
                                                 active_prefix : String,
                                                 base : String,
                                                 glob_contexts : Array(String),
-                                                regs : Array(NamedTuple(base: String, ref: String, prefix: String)))
+                                                regs : Array(NamedTuple(base: String, ref: String, prefix: String)),
+                                                depth : Int32 = 0)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       if Noir::TreeSitter.node_type(node) == "call_expression"
         return if RustEngine.inside_test_region?(node, test_regions)
 
@@ -329,16 +342,16 @@ module Analyzer::Rust
               end
             end
           else
-            collect_qualified_registrations(arg, source, test_regions, service_prefix, base, glob_contexts, regs)
+            collect_qualified_registrations(arg, source, test_regions, service_prefix, base, glob_contexts, regs, depth + 1)
           end
 
-          collect_qualified_registrations(receiver, source, test_regions, active_prefix, base, glob_contexts, regs) if receiver
+          collect_qualified_registrations(receiver, source, test_regions, active_prefix, base, glob_contexts, regs, depth + 1) if receiver
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        collect_qualified_registrations(child, source, test_regions, active_prefix, base, glob_contexts, regs)
+        collect_qualified_registrations(child, source, test_regions, active_prefix, base, glob_contexts, regs, depth + 1)
       end
     end
 

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -34,6 +34,23 @@ module Analyzer::Swift
     # is router-like.
     ROUTER_EXTENSION_PATTERN = /\bextension\s+(?:RoutesBuilder|Router)\b/
 
+    # Gate for `register_router_params`. All three patterns it runs require
+    # one of these three words, so a line without any of them cannot
+    # contribute a receiver and does not need to be matched at all.
+    #
+    # That pattern opens with an unanchored `([A-Za-z_]\w*)`, so PCRE2 tries
+    # it at every offset of the subject and backtracks the greedy `\w*` on
+    # each one — quadratic in the line length. Up to roughly half a megabyte
+    # the JIT absorbs it; past that the JIT stack overflows, PCRE2 falls back
+    # to the interpreter, and the cost becomes visible all at once: a
+    # 600 KB single-line `.swift` file (generated code, a vendored bundle)
+    # took 75 s in this one `scan` where 300 KB took milliseconds.
+    #
+    # A literal union is a plain memchr-class search with no backtracking, and
+    # since the full pattern requires one of these three words the gate cannot
+    # change what is found.
+    ROUTER_TYPE_RE = Regex.union("RoutesBuilder", "Router", "Application")
+
     # `route_definition?` runs on every scanned line (route detection, param
     # lookahead, body-boundary checks). One precompiled `Regex.union` scan
     # (PCRE2 JIT) replaces six naive `String#includes?` char scans; union
@@ -277,6 +294,8 @@ module Analyzer::Swift
     private def register_router_params(lines : Array(String), prefix_by_receiver : Hash(String, String))
       lines.each do |line|
         stripped = code_line(line)
+        next unless stripped.matches?(ROUTER_TYPE_RE)
+
         stripped.scan(ROUTER_PARAM_PATTERN) do |match|
           prefix_by_receiver[match[1]] ||= ""
         end

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -434,7 +434,17 @@ module Analyzer::Rust
     # comments). This matches how `#[get(...)] async fn handler` is
     # laid out in the AST — both are top-level siblings, not parent /
     # child.
-    protected def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
+    # `depth` bounds the descent. The recursive call sits *outside* the
+    # `each_named_child` block (children are materialised first so
+    # `find_paired_function` can look ahead), so the depth guard inside
+    # `each_named_child` has already unwound by the time we recurse and
+    # cannot see this walk. A `.rs` file nesting thousands of blocks deep
+    # — generated code, or a hand-built stress case — would otherwise run
+    # the fiber stack out, and a stack overflow aborts the process rather
+    # than failing the one file.
+    protected def each_routing_pair(node : LibTreeSitter::TSNode, depth : Int32 = 0, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       named = [] of LibTreeSitter::TSNode
       Noir::TreeSitter.each_named_child(node) { |c| named << c }
       named.each_with_index do |child, idx|
@@ -442,7 +452,7 @@ module Analyzer::Rust
           pair_function = find_paired_function(named, idx + 1)
           block.call(child, pair_function) if pair_function
         end
-        each_routing_pair(child, &block)
+        each_routing_pair(child, depth + 1, &block)
       end
     end
 

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -46,6 +46,8 @@ lib LibTreeSitter
   fun ts_parser_delete(parser : TSParser)
   fun ts_parser_set_language(parser : TSParser, language : TSLanguage) : Bool
   fun ts_parser_parse_string(parser : TSParser, old_tree : TSTree, string : LibC::Char*, length : LibC::UInt) : TSTree
+  fun ts_parser_set_timeout_micros(parser : TSParser, timeout_micros : UInt64)
+  fun ts_parser_reset(parser : TSParser)
 
   # ----- Tree / node -----
   fun ts_tree_delete(tree : TSTree)
@@ -209,6 +211,26 @@ module Noir::TreeSitter
     end
   end
 
+  # Wall-clock ceiling for a single `ts_parser_parse_string` call.
+  #
+  # tree-sitter's error recovery is quadratic on badly-malformed input: a
+  # 200 KB single line of unterminated string literals in a `.go` file
+  # spends minutes inside `ts_parser__recover` before returning. Nothing
+  # in noir can interrupt that — the parse is one blocking C call, so the
+  # scan simply stops, with no output and no way to tell which file did
+  # it. Files are capped at `MediaFilter::MAX_FILE_SIZE` (10 MB) and a
+  # well-formed file that size parses in well under a second, so ten
+  # seconds is ~100x headroom over any legitimate input while still
+  # bounding the pathological case.
+  #
+  # On expiry the parse returns null and `parse` raises, which the
+  # per-file rescue in `parallel_analyze` / `scan_files` logs at debug —
+  # one file dropped instead of the whole run.
+  PARSE_TIMEOUT_MICROS = begin
+    ms = ENV["NOIR_PARSE_TIMEOUT_MS"]?.try(&.strip.to_u64?)
+    (ms && ms > 0 ? ms : 10_000_u64) * 1000_u64
+  end
+
   # Parses `source` with the given `language` and yields the root
   # `LibTreeSitter::TSNode`. The parser is checked out from a per-language
   # pool and returned when the block exits; the tree is freed in the
@@ -216,8 +238,16 @@ module Noir::TreeSitter
   def self.parse(source : String, language : LibTreeSitter::TSLanguage, &)
     parser = checkout_parser(language)
     begin
+      LibTreeSitter.ts_parser_set_timeout_micros(parser, PARSE_TIMEOUT_MICROS)
       tree = LibTreeSitter.ts_parser_parse_string(parser, Pointer(Void).null.as(LibTreeSitter::TSTree), source.to_unsafe, source.bytesize.to_u32)
-      raise "ts_parser_parse_string returned null" if tree.null?
+      if tree.null?
+        # A halted parser holds the partial parse so the next call can
+        # resume it. We never resume — the parser goes straight back to
+        # the shared pool — so reset it, or the next unrelated file
+        # inherits this one's state.
+        LibTreeSitter.ts_parser_reset(parser)
+        raise "ts_parser_parse_string returned null (timed out after #{PARSE_TIMEOUT_MICROS // 1000}ms, or out of memory)"
+      end
       begin
         yield LibTreeSitter.ts_tree_root_node(tree)
       ensure
@@ -299,25 +329,70 @@ module Noir::TreeSitter
   # exact same named children in the same order.
   NAMED_CHILD_CURSOR_THRESHOLD = 8
 
+  # Nesting level of the `each_named_child` calls currently on this
+  # thread's stack — the descent depth of whatever AST walk is running.
+  #
+  # Thread-local rather than a plain class variable so two walks running
+  # on different threads (the MT runtime, or two analyzers under
+  # `parallel_analyze`) cannot corrupt each other's count.
+  #
+  # Every frame saves the value it found and restores it in an `ensure`,
+  # so the counter only ever *over*-estimates: a fiber that suspends
+  # mid-walk (a `logger` write inside a walker block) leaves its depth
+  # standing, and a walk that starts on the same thread meanwhile is
+  # bounded more tightly than it needed to be. That direction is the safe
+  # one — it can truncate a pathological walk early, never overrun the
+  # stack — and it costs one integer per node instead of per-fiber
+  # storage.
+  @[ThreadLocal]
+  @@walk_depth = 0
+
+  # Descent depth of the AST walk currently running on this thread.
+  # Exposed for specs; not part of the public API contract.
+  def self.walk_depth : Int32
+    @@walk_depth
+  end
+
   # Iterates named children without allocating an array.
+  #
+  # Yields nothing once the walk has descended `MAX_AST_DEPTH` levels.
+  # Practically every extractor in the tree descends by recursing inside
+  # this block, so bounding it here bounds all of them at once: the
+  # alternative is threading a `depth` parameter through ~300 hand-rolled
+  # walkers and remembering to do it in the next one. A source file with
+  # thousands of nested syntactic constructs (`((((...))))`, chained
+  # builders, generated code) otherwise recurses until the fiber stack
+  # runs out, and a stack overflow is a hard abort — it kills the whole
+  # scan, not just the file, and no `rescue` in `parallel_analyze` can
+  # catch it. Walkers that thread their own `depth` against
+  # `MAX_AST_DEPTH` still cut earlier and more precisely; this is the
+  # backstop for the ones that don't.
   #
   # The cursor path lives in a separate `@[NoInline]` method on purpose:
   # these extractors recurse through `each_named_child`'s block, so any
-  # local this method reserves (notably the 32-byte `TSTreeCursor` and
-  # the `ensure` machinery) is paid at every recursion level. Keeping the
-  # cursor out of this frame preserves the tiny original frame for the
-  # common narrow-node path, so deeply nested inputs don't overflow the
-  # stack (guarded by spec/unit_test/miniparser/extractor_recursion_depth_spec).
+  # local this method reserves (notably the 32-byte `TSTreeCursor`) is
+  # paid at every recursion level. Keeping the cursor out of this frame
+  # preserves the small original frame for the common narrow-node path,
+  # so legitimate deep input stays well inside the stack (guarded by
+  # spec/unit_test/miniparser/extractor_recursion_depth_spec).
   def self.each_named_child(node : LibTreeSitter::TSNode, &)
     count = LibTreeSitter.ts_node_named_child_count(node)
     return if count == 0
 
-    if count <= NAMED_CHILD_CURSOR_THRESHOLD
-      count.times do |i|
-        yield LibTreeSitter.ts_node_named_child(node, i.to_u32)
+    depth = @@walk_depth
+    return if depth >= MAX_AST_DEPTH
+    @@walk_depth = depth + 1
+
+    begin
+      if count <= NAMED_CHILD_CURSOR_THRESHOLD
+        count.times do |i|
+          yield LibTreeSitter.ts_node_named_child(node, i.to_u32)
+        end
+      else
+        each_named_child_via_cursor(node) { |child| yield child }
       end
-    else
-      each_named_child_via_cursor(node) { |child| yield child }
+    ensure
+      @@walk_depth = depth
     end
   end
 

--- a/src/miniparsers/go_route_extractor_ts/core.cr
+++ b/src/miniparsers/go_route_extractor_ts/core.cr
@@ -1492,9 +1492,19 @@ module Noir
       first_named_child(node)
     end
 
+    # `depth` bounds the descent: this walks operand-by-operand through
+    # `+` chains and parentheses, which nest one AST level per term. It
+    # recurses on `field`/`first_named_child` rather than through
+    # `each_named_child`, so the shared guard there does not see it and a
+    # generated Go file — a 20k-term string concatenation, `((((...))))`
+    # — would run the fiber stack out. A stack overflow aborts the whole
+    # process, so the scan dies rather than the file.
     private def string_expr_text(node : LibTreeSitter::TSNode,
                                  source : String,
-                                 values : Hash(String, String)) : String?
+                                 values : Hash(String, String),
+                                 depth : Int32 = 0) : String?
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       case Noir::TreeSitter.node_type(node)
       when "interpreted_string_literal", "raw_string_literal"
         decode_string_literal(node, source)
@@ -1504,13 +1514,13 @@ module Noir
         left = Noir::TreeSitter.field(node, "left")
         right = Noir::TreeSitter.field(node, "right")
         return unless left && right
-        left_text = string_expr_text(left, source, values)
-        right_text = string_expr_text(right, source, values)
+        left_text = string_expr_text(left, source, values, depth + 1)
+        right_text = string_expr_text(right, source, values, depth + 1)
         return unless left_text && right_text
         "#{left_text}#{right_text}"
       when "parenthesized_expression"
         child = first_named_child(node)
-        child ? string_expr_text(child, source, values) : nil
+        child ? string_expr_text(child, source, values, depth + 1) : nil
       end
     end
 


### PR DESCRIPTION
## What

A source file with thousands of nested syntactic constructs took the **whole scan** down with a stack overflow. Unlike every other per-file failure, that is a hard process abort — the rescues in `parallel_analyze` / `scan_files` never see it, so the run ends with no output and no hint which file did it.

Fuzzing the analyzers over adversarial corpora reproduced it in `rust/actix_web`, `rust/axum`, `rust/gotham`, `go/huma` and more. Each one was only visible after the previous crasher was excluded, because whichever analyzer got there first killed the process.

Minimal repro (a real actix-web project with one deeply nested expression):

```rust
use actix_web::{get, App, HttpServer, Responder};

#[get("/hello")]
async fn hello() -> impl Responder { "hi" }

fn deep() -> i32 { ((((… 6000 levels …)))) }
```

```
$ noir scan ./demo
Stack overflow (e.g., infinite or very deep recursion)
[…] *Analyzer::Rust::ActixWeb#collect_service_registrations […]
```

## How

**One central bound.** The shared descent step is `Noir::TreeSitter.each_named_child` — nearly every walker in the tree recurses inside its block. Bounding it there bounds all ~300 hand-rolled walkers at once, including the ones not written yet, instead of threading a `depth` parameter through each. The counter is thread-local and restored in an `ensure`, so it only ever *over*-estimates: the direction that truncates a pathological walk early rather than overrunning the stack.

**Three walkers recurse outside that block** and carry their own `depth`:

| Walker | Why the shared guard misses it |
| --- | --- |
| `ActixWeb#collect_service_registrations` / `#collect_qualified_registrations` | recurse on the `field(...)` receiver — one level per link of `App::new().service(a).service(b)…` |
| `RustEngine#each_routing_pair` | materialises children up front so `find_paired_function` can look ahead, then recurses after the block has unwound |
| `TreeSitterGoRouteExtractor#string_expr_text` | walks `+`-concatenation operands and parentheses via `field` / `first_named_child` |

## Two adjacent input-driven hangs, same family

- **`swift/vapor`** — `ROUTER_PARAM_PATTERN` opens with an unanchored `([A-Za-z_]\w*)`, so PCRE2 retries it at every offset and backtracks the greedy `\w*` on each. Past ~512 KB the JIT stack overflows and PCRE2 falls back to the interpreter: a 600 KB single-line `.swift` file spent **75 s** in that one `scan` where 300 KB took milliseconds. Now gated on a literal union every match must contain — provably output-preserving.
- **tree-sitter's own error recovery** is quadratic on badly-malformed input; a 200 KB line of unterminated string literals in a `.go` file spends minutes inside `ts_parser__recover`. That is one blocking C call nothing on our side can interrupt, so `parse` sets a 10 s ceiling (`NOIR_PARSE_TIMEOUT_MS`) — ~100x headroom over any legitimate file under the 10 MB cap — and resets the halted parser before returning it to the pool.

## Verification

- `crystal spec spec/unit_test spec/functional_test` — 28 629 examples, 0 failures.
- Output **byte-identical** to `main` on the full fixture corpus with all 250 techs forced; fixture-scan wall clock unchanged within noise (1.16 s → 1.09 s avg over 8 runs).
- New specs are real regression tests — each one crashes the suite when its guard is removed:
  - `spec/unit_test/ext/tree_sitter_walk_depth_spec.cr`
  - `spec/unit_test/analyzer/analyzer_deep_nesting_spec.cr`
  - two Go cases added to `spec/unit_test/miniparser/extractor_recursion_depth_spec.cr`
- Every adversarial corpus used to find these now exits 0 (nested parens / braces / blocks / generics / closures / builder chains / concatenations across `.rs .go .java .kt .js .ts .py` plus deep OAS/YAML/JSON/XML specs).

## Known, not fixed here

`fsharp/giraffe` probes ~7 `\G`-anchored patterns at **every character offset**, so a 2 MB `.fs` file costs ~12 s. That is honest linear work with a large constant, not a blowup — worth a follow-up, out of scope for a crash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)