### PR TITLE
refactor(analyzer): drop dead File.directory? guards from analyzer file loops

### DIFF
--- a/src/analyzer/analyzers/asp/classic.cr
+++ b/src/analyzer/analyzers/asp/classic.cr
@@ -64,7 +64,7 @@ module Analyzer::Asp
     INCLUDE_NAME_RE = /\A(?:lib|partial)\./i
 
     def analyze
-      asp_files = get_files_by_extension(".asp").reject { |path| File.directory?(path) }
+      asp_files = get_files_by_extension(".asp")
       return @result if asp_files.empty?
 
       # Pass 1: every file reachable only via `#include` is a fragment,
@@ -87,8 +87,6 @@ module Analyzer::Asp
       targets = Set(String).new
 
       files.each do |path|
-        next if File.directory?(path)
-
         content = read_file_content(path)
         next unless content.includes?("#include")
 

--- a/src/analyzer/analyzers/aspnet/webforms.cr
+++ b/src/analyzer/analyzers/aspnet/webforms.cr
@@ -109,7 +109,6 @@ module Analyzer::Aspnet
     def analyze
       pages = PAGE_EXTENSIONS.flat_map { |extension| get_files_by_extension(extension) }
         .uniq!
-        .reject { |path| File.directory?(path) }
       return @result if pages.empty?
 
       # These lookups walk the whole file map; resolve them once up front

--- a/src/analyzer/analyzers/clojure/cli.cr
+++ b/src/analyzer/analyzers/clojure/cli.cr
@@ -37,7 +37,6 @@ module Analyzer::Clojure
       endpoints = {} of String => Endpoint
       [".clj", ".cljs", ".cljc"].each do |ext|
         get_files_by_extension(ext).each do |path|
-          next if File.directory?(path)
           next if cli_test_path?(path)
           next unless File.exists?(path)
           begin

--- a/src/analyzer/analyzers/cpp/cli.cr
+++ b/src/analyzer/analyzers/cpp/cli.cr
@@ -85,7 +85,6 @@ module Analyzer::Cpp
 
       EXTS.each do |ext|
         get_files_by_extension(ext).each do |path|
-          next if File.directory?(path)
           next if cpp_test_path?(path)
           next unless File.exists?(path)
 

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -46,7 +46,6 @@ module Analyzer::Cpp
         files = CPP_EXTENSIONS.flat_map { |ext| locator.files_by_extension(ext) }
 
         parallel_analyze(files) do |path|
-          next if File.directory?(path)
           next unless File.exists?(path)
           analyze_file(path, include_callee)
         end

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -62,7 +62,6 @@ module Analyzer::Cpp
         files = CPP_EXTENSIONS.flat_map { |ext| locator.files_by_extension(ext) }
 
         parallel_analyze(files) do |path|
-          next if File.directory?(path)
           next unless File.exists?(path)
           next unless CPP_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
 

--- a/src/analyzer/analyzers/cpp/httplib.cr
+++ b/src/analyzer/analyzers/cpp/httplib.cr
@@ -61,7 +61,6 @@ module Analyzer::Cpp
         files = CPP_EXTENSIONS.flat_map { |ext| locator.files_by_extension(ext) }
 
         parallel_analyze(files) do |path|
-          next if File.directory?(path)
           next unless File.exists?(path)
           # The vendored single-header library defines the Server/Client classes
           # themselves; never scan it for routes (avoids FPs + a big perf hit).

--- a/src/analyzer/analyzers/cpp/oatpp.cr
+++ b/src/analyzer/analyzers/cpp/oatpp.cr
@@ -38,7 +38,6 @@ module Analyzer::Cpp
         files = CPP_EXTENSIONS.flat_map { |ext| locator.files_by_extension(ext) }
 
         parallel_analyze(files) do |path|
-          next if File.directory?(path)
           next unless File.exists?(path)
           analyze_file(path, include_callee)
         end

--- a/src/analyzer/analyzers/crystal/cli.cr
+++ b/src/analyzer/analyzers/crystal/cli.cr
@@ -31,7 +31,6 @@ module Analyzer::Crystal
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".cr").each do |path|
-        next if File.directory?(path)
         next if cli_test_path?(path)
         next unless File.exists?(path)
         begin

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -231,7 +231,6 @@ module Analyzer::Crystal
       actions = Hash(HandlerActionKey, Array(Noir::CrystalCalleeExtractor::Entry)).new
 
       get_files_by_extension(".cr").each do |path|
-        next if File.directory?(path)
         next unless File.exists?(path)
         next if crystal_dependency_path?(path)
 

--- a/src/analyzer/analyzers/csharp/cli.cr
+++ b/src/analyzer/analyzers/csharp/cli.cr
@@ -75,7 +75,6 @@ module Analyzer::CSharp
       endpoints = {} of String => Endpoint
 
       get_files_by_extension(".cs").each do |path|
-        next if File.directory?(path)
         next if Common.csharp_test_path?(base_relative_path(path))
         next unless File.exists?(path)
 

--- a/src/analyzer/analyzers/csharp/signalr.cr
+++ b/src/analyzer/analyzers/csharp/signalr.cr
@@ -64,7 +64,7 @@ module Analyzer::CSharp
       map_hub_types = Set(String).new # types named in MapHub<T>
 
       files = get_files_by_extension(".cs").reject do |path|
-        File.directory?(path) || Common.csharp_test_path?(base_relative_path(path)) || !File.exists?(path)
+        Common.csharp_test_path?(base_relative_path(path)) || !File.exists?(path)
       end
 
       # Pass 1 — routes + mounted types across every file. A hub class and

--- a/src/analyzer/analyzers/dart/cli.cr
+++ b/src/analyzer/analyzers/dart/cli.cr
@@ -30,7 +30,6 @@ module Analyzer::Dart
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".dart").each do |path|
-        next if File.directory?(path)
         next if cli_test_path?(path)
         next unless File.exists?(path)
         begin

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -41,7 +41,6 @@ module Analyzer::Dart
       registrations = [] of Registration
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless path.ends_with?(".dart")
         # `test/integration/*_endpoint_test.dart` exercises endpoints but
         # is not itself a server surface.

--- a/src/analyzer/analyzers/elixir/cli.cr
+++ b/src/analyzer/analyzers/elixir/cli.cr
@@ -23,7 +23,6 @@ module Analyzer::Elixir
       files = get_files_by_extension(".ex") + get_files_by_extension(".exs")
 
       files.each do |path|
-        next if File.directory?(path)
         next if cli_test_path?(path)
         begin
           content = read_file_content(path)

--- a/src/analyzer/analyzers/elixir/phoenix_channel.cr
+++ b/src/analyzer/analyzers/elixir/phoenix_channel.cr
@@ -36,7 +36,7 @@ module Analyzer::Elixir
       modules = [] of ChannelModule
 
       files = get_files_by_extension(".ex").reject do |path|
-        File.directory?(path) || elixir_test_path?(path) || !File.exists?(path)
+        elixir_test_path?(path) || !File.exists?(path)
       end
 
       # Pass 1 — topic↔module declarations from socket modules.

--- a/src/analyzer/analyzers/erlang/cowboy.cr
+++ b/src/analyzer/analyzers/erlang/cowboy.cr
@@ -88,9 +88,7 @@ module Analyzer::Erlang
     end
 
     private def erlang_sources : Array(String)
-      files = get_files_by_extension(".erl") + get_files_by_extension(".hrl")
-      files.reject! { |path| File.directory?(path) }
-      files
+      get_files_by_extension(".erl") + get_files_by_extension(".hrl")
     end
 
     # Erlang requires the module name to match the file name, so the

--- a/src/analyzer/analyzers/erlang/elli.cr
+++ b/src/analyzer/analyzers/erlang/elli.cr
@@ -37,8 +37,6 @@ module Analyzer::Erlang
 
     def analyze
       get_files_by_extension(".erl").each do |path|
-        next if File.directory?(path)
-
         content = read_file_content(path)
         # Every Elli route clause is a `handle(` head; skip files without
         # one before paying for the comment strip.

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -80,7 +80,6 @@ module Analyzer::Fsharp
     def analyze
       include_callee = callees_needed?
       all_files.each do |path|
-        next if File.directory?(path)
         next unless path.ends_with?(".fs") || path.ends_with?(".fsx")
         # Skip .NET test conventions: `/tests/` and `/test/`
         # parent dirs, and `*Tests.fs` filenames. Giraffe's own

--- a/src/analyzer/analyzers/gleam/wisp.cr
+++ b/src/analyzer/analyzers/gleam/wisp.cr
@@ -111,7 +111,7 @@ module Analyzer::Gleam
     @contents = {} of String => String
 
     def analyze
-      gleam_files = get_files_by_extension(".gleam").reject! { |path| File.directory?(path) }
+      gleam_files = get_files_by_extension(".gleam")
       return @result if gleam_files.empty?
 
       build_module_index(gleam_files)

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -39,7 +39,6 @@ module Analyzer::Go
       chi_dirs = Set(String).new
 
       get_files_by_extension(".go").each do |scan_path|
-        next if File.directory?(scan_path)
         begin
           dir = File.dirname(scan_path)
           package_files[dir] ||= [] of String

--- a/src/analyzer/analyzers/go/cli.cr
+++ b/src/analyzer/analyzers/go/cli.cr
@@ -152,7 +152,6 @@ module Analyzer::Go
       endpoints = {} of String => Endpoint
 
       get_files_by_extension(".go").each do |path|
-        next if File.directory?(path)
         next if GoEngine.go_test_file?(base_relative_path(path))
         next unless File.exists?(path)
 

--- a/src/analyzer/analyzers/go/connect_rpc.cr
+++ b/src/analyzer/analyzers/go/connect_rpc.cr
@@ -74,7 +74,6 @@ module Analyzer::Go
     # `connect.NewXxxHandler(XxxProcedure, ...)` constructor.
     private def discover_connect_go_endpoints(seen_urls : Set(String))
       get_files_by_extension(".go").each do |path|
-        next if File.directory?(path)
         next if GoEngine.go_test_file?(base_relative_path(path))
         begin
           content = read_file_content(path)
@@ -127,7 +126,6 @@ module Analyzer::Go
       mounts = {} of ServiceMountKey => ServiceMount
       begin
         get_files_by_extension(".go").each do |path|
-          next if File.directory?(path)
           next if GoEngine.go_test_file?(base_relative_path(path))
           base_path = configured_base_for(path)
           content = read_file_content(path)

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -29,7 +29,6 @@ module Analyzer::Go
         # twins on `GoCalleeExtractor`.
         file_contents = Hash(String, String).new
         go_files.each do |fp|
-          next if File.directory?(fp)
           next if GoEngine.go_test_file?(base_relative_path(fp))
           begin
             file_contents[fp] = read_file_content(fp)

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -31,7 +31,6 @@ module Analyzer::Go
       # twins on `GoCalleeExtractor`.
       file_contents = Hash(String, String).new
       get_files_by_extension(".go").each do |fp|
-        next if File.directory?(fp)
         begin
           file_contents[fp] = read_file_content(fp)
         rescue IO::Error

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -67,7 +67,6 @@ module Analyzer::Go
       file_contents_cache = Hash(String, String).new
 
       get_files_by_extension(".go").each do |scan_path|
-        next if File.directory?(scan_path)
         next if GoEngine.go_test_file?(base_relative_path(scan_path))
         begin
           dir = File.dirname(scan_path)

--- a/src/analyzer/analyzers/go/kratos.cr
+++ b/src/analyzer/analyzers/go/kratos.cr
@@ -51,7 +51,6 @@ module Analyzer::Go
     def analyze
       file_contents = Hash(String, String).new
       get_files_by_extension(".go").each do |fp|
-        next if File.directory?(fp)
         begin
           file_contents[fp] = read_file_content(fp)
         rescue IO::Error

--- a/src/analyzer/analyzers/groovy/cli.cr
+++ b/src/analyzer/analyzers/groovy/cli.cr
@@ -65,7 +65,6 @@ module Analyzer::Groovy
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".groovy").each do |path|
-        next if File.directory?(path)
         next if cli_test_path?(path)
         next unless File.exists?(path)
         begin

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -93,7 +93,6 @@ module Analyzer::Groovy
     def analyze
       include_callee = callees_needed?
       all_files.each do |path|
-        next if File.directory?(path)
         next unless path.ends_with?(".groovy")
 
         content = read_file_content(path)

--- a/src/analyzer/analyzers/haskell/cli.cr
+++ b/src/analyzer/analyzers/haskell/cli.cr
@@ -57,7 +57,6 @@ module Analyzer::Haskell
       endpoints = {} of String => Endpoint
       [".hs", ".lhs"].each do |ext|
         get_files_by_extension(ext).each do |path|
-          next if File.directory?(path)
           next if cli_test_path?(path)
           next unless File.exists?(path)
           begin

--- a/src/analyzer/analyzers/haskell/scotty.cr
+++ b/src/analyzer/analyzers/haskell/scotty.cr
@@ -33,7 +33,6 @@ module Analyzer::Haskell
       handler_bodies = include_callee ? build_handler_bodies : HandlerBodies.new
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless haskell_source?(path)
 
         content = read_file_content(path)
@@ -51,7 +50,6 @@ module Analyzer::Haskell
       handlers = HandlerBodies.new
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless haskell_source?(path)
 
         Noir::HaskellCalleeExtractor.function_bodies(read_file_content(path), path).each do |body|

--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -23,7 +23,6 @@ module Analyzer::Haskell
       server_bindings = include_callee ? build_server_bindings : ServerBindings.new
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless haskell_source?(path)
 
         content = read_file_content(path)
@@ -76,7 +75,6 @@ module Analyzer::Haskell
       handlers = HandlerBodies.new
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless haskell_source?(path)
 
         Noir::HaskellCalleeExtractor.function_bodies(read_file_content(path), path).each do |body|
@@ -97,7 +95,6 @@ module Analyzer::Haskell
       bindings = ServerBindings.new
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless haskell_source?(path)
 
         extract_server_binding_targets(read_file_content(path)).each do |entry|

--- a/src/analyzer/analyzers/haskell/yesod.cr
+++ b/src/analyzer/analyzers/haskell/yesod.cr
@@ -20,8 +20,6 @@ module Analyzer::Haskell
       handler_bodies = include_callee ? build_handler_bodies : HandlerBodies.new
 
       all_files.each do |path|
-        next if File.directory?(path)
-
         if route_file?(path)
           # The expanded path canonicalizes the dedup key only. Reporting it
           # as well recorded an absolute machine path in `code_paths`, while
@@ -72,7 +70,6 @@ module Analyzer::Haskell
       handlers = HandlerBodies.new
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless haskell_source?(path)
 
         Noir::HaskellCalleeExtractor.function_bodies(read_file_content(path), path).each do |body|

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -46,7 +46,6 @@ module Analyzer::Java
                 begin
                   path = channel.receive?
                   break if path.nil?
-                  next if File.directory?(path)
                   next if JavaEngine.test_path?(base_relative_path(path))
 
                   if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))

--- a/src/analyzer/analyzers/java/cli.cr
+++ b/src/analyzer/analyzers/java/cli.cr
@@ -80,7 +80,6 @@ module Analyzer::Java
       endpoints = {} of String => Endpoint
 
       get_files_by_extension(".java").each do |path|
-        next if File.directory?(path)
         next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
 

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -48,7 +48,6 @@ module Analyzer::Java
                 begin
                   path = channel.receive?
                   break if path.nil?
-                  next if File.directory?(path)
 
                   relative_path = get_relative_path(configured_base_for(path), path)
 

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -80,7 +80,6 @@ module Analyzer::Java
                 begin
                   path = channel.receive?
                   break if path.nil?
-                  next if File.directory?(path)
                   next if JavaEngine.test_path?(base_relative_path(path))
 
                   if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -459,7 +459,6 @@ module Analyzer::Javascript
       main_files = [] of String
 
       @all_files.each do |file|
-        next if File.directory?(file)
         next unless ExpressConstants::JS_EXTENSIONS.any? { |ext| file.ends_with?(ext) }
         next unless @base_paths.any? { |base| Noir::PathScope.under_root?(file, base) }
         main_files << file

--- a/src/analyzer/analyzers/kotlin/cli.cr
+++ b/src/analyzer/analyzers/kotlin/cli.cr
@@ -59,7 +59,6 @@ module Analyzer::Kotlin
       endpoints = {} of String => Endpoint
 
       get_files_by_extension(".kt").each do |path|
-        next if File.directory?(path)
         next if KotlinEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path)
 

--- a/src/analyzer/analyzers/lua/cli.cr
+++ b/src/analyzer/analyzers/lua/cli.cr
@@ -35,7 +35,6 @@ module Analyzer::Lua
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".lua").each do |path|
-        next if File.directory?(path)
         next if cli_test_path?(path)
         next unless File.exists?(path)
         begin

--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -47,7 +47,6 @@ module Analyzer::Lua
       include_callee = callees_needed?
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless path.ends_with?(".lua") || path.ends_with?(".moon")
         # Skip Busted / OpenResty spec files. Lapis's own
         # `spec/**/*_spec.moon` and `spec_openresty/`/`spec_cqueues/`

--- a/src/analyzer/analyzers/lua/lor.cr
+++ b/src/analyzer/analyzers/lua/lor.cr
@@ -78,7 +78,6 @@ module Analyzer::Lua
     private def collect_files : Array(String)
       result = [] of String
       all_files.each do |path|
-        next if File.directory?(path)
         next unless path.ends_with?(".lua") || path.ends_with?(".moon")
         next if lor_test_path?(path)
         result << path

--- a/src/analyzer/analyzers/perl/cli.cr
+++ b/src/analyzer/analyzers/perl/cli.cr
@@ -43,7 +43,6 @@ module Analyzer::Perl
       endpoints = {} of String => Endpoint
       [".pl", ".pm"].each do |ext|
         get_files_by_extension(ext).each do |path|
-          next if File.directory?(path)
           next if cli_test_path?(path)
           next unless File.exists?(path)
           begin

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -116,7 +116,6 @@ module Analyzer::Perl
       callees = ControllerCalleeIndex.new
 
       all_files.each do |path|
-        next if File.directory?(path)
         ext = File.extname(path)
         next unless ext == ".pl" || ext == ".pm" || ext == ".psgi" || ext == ".t"
         next if perl_test_path?(path, ext)

--- a/src/analyzer/analyzers/php/cli.cr
+++ b/src/analyzer/analyzers/php/cli.cr
@@ -80,7 +80,6 @@ module Analyzer::Php
       endpoints = {} of String => Endpoint
 
       get_files_by_extension(".php").each do |path|
-        next if File.directory?(path)
         next if PhpEngine.test_path?(base_relative_path(path))
 
         begin

--- a/src/analyzer/analyzers/r/plumber.cr
+++ b/src/analyzer/analyzers/r/plumber.cr
@@ -28,7 +28,7 @@ module Analyzer::R
 
     def analyze
       r_files = get_files_by_extension(".R") + get_files_by_extension(".r")
-      r_files = r_files.uniq.reject! { |path| File.directory?(path) }
+      r_files = r_files.uniq
       return @result if r_files.empty?
 
       r_files.each do |path|

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -80,7 +80,6 @@ module Analyzer::Ruby
       all_files.each do |path|
         next unless path.ends_with?(".rb")
         next if ruby_non_production_path?(path)
-        next if File.directory?(path)
         content = read_file_content(path)
         # Only base-class definitions (`Grape::API`) and aggregators
         # (`mount`) feed the index; plain route files inherit from a custom

--- a/src/analyzer/analyzers/ruby/webrick.cr
+++ b/src/analyzer/analyzers/ruby/webrick.cr
@@ -87,7 +87,6 @@ module Analyzer::Ruby
       all_files.each do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
         next if ruby_non_production_path?(path)
-        next if File.directory?(path)
         next unless File.exists?(path)
 
         content = read_file_content(path)

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -283,7 +283,6 @@ module Analyzer::Rust
     private def build_cross_file_scope_registrations : Array(NamedTuple(base: String, ref: String, prefix: String))
       regs = [] of NamedTuple(base: String, ref: String, prefix: String)
       all_files.each do |path|
-        next if File.directory?(path)
         next unless File.exists?(path) && File.extname(path) == ".rs"
         next if RustEngine.test_path?(base_relative_path(path))
         base = configured_base_for(path)
@@ -411,7 +410,6 @@ module Analyzer::Rust
     private def build_configure_fn_prefix : Array(NamedTuple(base: String, ref: String, prefix: String, source_path: String))
       result = [] of NamedTuple(base: String, ref: String, prefix: String, source_path: String)
       all_files.each do |fpath|
-        next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)
@@ -515,7 +513,6 @@ module Analyzer::Rust
 
       aliases = {} of String => String
       all_files.each do |fpath|
-        next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(base_relative_path(fpath))
         read_file_content(fpath).scan(/\bpub\s+use\s+([^;{}]+?)\s+as\s+([A-Za-z_]\w*)\s*;/) do |m|
@@ -944,7 +941,6 @@ module Analyzer::Rust
 
       entries = [] of GlobalFunctionEntry
       all_files.each do |fpath|
-        next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(base_relative_path(fpath))
         src = read_file_content(fpath)

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -1234,7 +1234,6 @@ module Analyzer::Rust
       edges = Hash(NestScopedKey, Array(NestEdge)).new
 
       all_files.each do |fpath|
-        next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(base_relative_path(fpath))
         src = read_file_content(fpath)
@@ -1497,7 +1496,6 @@ module Analyzer::Rust
       fn_routes = Hash(UtoipaScopedKey, Array(Tuple(String, String?))).new
 
       all_files.each do |fpath|
-        next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)

--- a/src/analyzer/analyzers/rust/cli.cr
+++ b/src/analyzer/analyzers/rust/cli.cr
@@ -62,7 +62,6 @@ module Analyzer::Rust
       endpoints = {} of String => Endpoint
 
       get_files_by_extension(".rs").each do |path|
-        next if File.directory?(path)
         next if RustEngine.test_path?(base_relative_path(path))
 
         begin

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -113,7 +113,6 @@ module Analyzer::Rust
       mounts = [] of MountEntry
 
       all_files.each do |path|
-        next if File.directory?(path)
         next unless File.exists?(path) && File.extname(path) == ".rs"
         next if RustEngine.test_path?(base_relative_path(path))
         base = configured_base_for(path)

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -84,7 +84,6 @@ module Analyzer::Rust
     private def build_global_handler_info : Hash(ScopedNameKey, HandlerInfo)
       info = {} of ScopedNameKey => HandlerInfo
       all_files.each do |fpath|
-        next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)
@@ -649,7 +648,6 @@ module Analyzer::Rust
       edges = Hash(ScopedNameKey, Array(PrefixEdge)).new
       pushed = Set(ScopedNameKey).new
       all_files.each do |fpath|
-        next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)
@@ -797,7 +795,6 @@ module Analyzer::Rust
       consts = {} of ScopedNameKey => String
       pattern = /(?:const|static)\s+([A-Z_][A-Z0-9_]*)\s*:\s*&(?:'static\s+)?str\s*=\s*"([^"]*)"/
       all_files.each do |fpath|
-        next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(base_relative_path(fpath))
         base = configured_base_for(fpath)

--- a/src/analyzer/analyzers/scala/cli.cr
+++ b/src/analyzer/analyzers/scala/cli.cr
@@ -70,7 +70,6 @@ module Analyzer::Scala
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".scala").each do |path|
-        next if File.directory?(path)
         next if cli_test_path?(path)
         next unless File.exists?(path)
         begin

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -48,7 +48,6 @@ module Analyzer::Scala
     private def build_mount_prefixes : Hash(String, String)
       map = {} of String => String
       all_files.each do |path|
-        next if File.directory?(path)
         next unless File.exists?(path) && File.extname(path) == ".scala"
         next if scalatra_test_path?(path)
         begin

--- a/src/analyzer/analyzers/swift/cli.cr
+++ b/src/analyzer/analyzers/swift/cli.cr
@@ -35,7 +35,6 @@ module Analyzer::Swift
       endpoints = {} of String => Endpoint
 
       get_files_by_extension(".swift").each do |path|
-        next if File.directory?(path)
         next if SwiftEngine.swift_test_path?(base_relative_path(path))
         next unless File.exists?(path)
 

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -925,7 +925,7 @@ module Analyzer::Swift
 
     private def swift_source_files : Array(String)
       all_files.select do |path|
-        File.exists?(path) && !File.directory?(path) &&
+        File.exists?(path) &&
           File.extname(path) == ".swift" &&
           !swift_test_path?(path) && !swift_vendor_path?(path)
       end

--- a/src/analyzer/analyzers/zig/cli.cr
+++ b/src/analyzer/analyzers/zig/cli.cr
@@ -69,7 +69,6 @@ module Analyzer::Zig
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".zig").each do |path|
-        next if File.directory?(path)
         next if cli_test_path?(path)
         next unless File.exists?(path)
         begin


### PR DESCRIPTION
## Summary

`all_files` is `CodeLocator`'s `FILE_MAP`. Its only writer is `CodeLocator#register_file`, and the only caller of that is the detector walk in `src/detector/detector.cr`, which sits behind `next unless info.file?` on a `File.info?(full_path, follow_symlinks: false)`. Directories are pushed onto the traversal stack and never registered — and symlinks, FIFOs, sockets and devices are dropped at the same line.

`src/models/analyzer.cr` already documents this at its own worker loop:

```crystal
# No `File.directory?` guard — `all_files` comes from
# `file_map`, which the detector only fills with regular
# files.
```

58 analyzers carried the guard anyway. **70 of them could never be true.** Each costs a `stat(2)` per file per analyzer on every scan — on a monorepo with a dozen selected techs that is a real syscall tax for a constant `false` — and each one tells the next reader that directories can turn up in a file loop, which they cannot.

## What was removed

Only guards whose path provenance is `FILE_MAP`: `all_files`, `get_files_by_extension(s)`, `CodeLocator#files_by_extension`, a channel fed from `all_files`, or a local array filtered from one of those.

Most were plain `next if File.directory?(path)` deletions. Eight were expression-level (`.reject { … }` chains, or a `File.directory?(path) ||` term inside a larger predicate); in those the remaining boolean logic is untouched — `File.exists?` checks in `swift/hummingbird.cr`, `csharp/signalr.cr` and `elixir/phoenix_channel.cr` all stay.

## What was deliberately kept

| Site | Why |
|---|---|
| `java/quarkus.cr`, `kotlin/spring.cr`, `go_engine.cr` | `Dir.glob` results — these really do yield directories |
| `express/router_mount_scanner.cr`, `zig/jetzig.cr`, `haskell/yesod.cr` | import / config path resolution, not scan candidates |
| `python/django.cr` | constructor validation of `@basepath` / `@filepath` |
| `llm_analyzers/unified_ai.cr` | paths come from `filter_paths_with_llm`; the file's own comment notes the model sometimes echoes directories back |

## Incidental fix

`gleam/wisp.cr` called `reject!` directly on the array returned by `get_files_by_extension`, which is CodeLocator's **live cached extension index** — an in-place mutation of shared cache state, harmless only because the predicate never matched. A repo-wide grep confirms it was the only site doing this, and it is now gone.

## Test plan

Every removed predicate was constant-false, so detection output is unchanged by construction.

- `crystal tool format --check src/ spec/` → clean
- `crystal run lib/ameba/bin/ameba.cr -- <58 files>` → `58 inspected, 0 failures`
- `typos .` → clean
- `shards build` → OK, `./bin/noir --version` → `1.2.1`
- `crystal spec spec/unit_test` → **4946 examples, 0 failures, 0 errors, 0 pending**
- `crystal spec spec/functional_test` → **23906 examples, 0 failures, 0 errors, 0 pending**