### PR TITLE
chore(deps): give every runtime dependency a version constraint

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -17,20 +17,36 @@ targets:
     main: src/noir.cr
 
 # Project Dependencies
+#
+# Every entry carries a version constraint. `shard.lock` pins the exact
+# revisions used to build this repo, but the lock is not what a consumer
+# resolves against: a shard that depends on noir, or any checkout without a
+# lock, resolves from the constraints below and would otherwise take whatever
+# tag happens to be newest. For a tool that ships an SBOM, the dependency
+# range belongs in the manifest, not only in the lockfile.
+#
+# Pre-1.0 shards use `~> 0.y.z` (admits patch releases only), since by
+# convention a 0.x minor bump is where the breaking change lands. Post-1.0
+# shards use `~> x.y`, which admits non-breaking minor releases.
 dependencies:
   acp:
     github: hahwul/acp.cr
+    version: ~> 0.2.0
   crest:
     github: mamantoha/crest
     version: ~> 1.4.0
   har:
     github: NeuraLegion/har
+    version: ~> 1.2
   http_proxy:
     github: mamantoha/http_proxy
+    version: ~> 0.15.0
   sarif:
     github: hahwul/sarif.cr
+    version: ~> 0.2.0
   toml:
     github: crystal-community/toml.cr
+    version: ~> 0.8.0
 
 # Development Dependencies
 development_dependencies:


### PR DESCRIPTION
## Summary

Five of the six runtime dependencies had no `version:` at all — only `github:`.

```yaml
acp:        { github: hahwul/acp.cr }              # no constraint
har:        { github: NeuraLegion/har }            # no constraint
http_proxy: { github: mamantoha/http_proxy }       # no constraint
sarif:      { github: hahwul/sarif.cr }            # no constraint
toml:       { github: crystal-community/toml.cr }  # no constraint
crest:      { version: ~> 1.4.0 }                  # the only pinned one
```

`shard.lock` pins exact revisions for builds *of this repo*, but the lock is not what a consumer resolves against. A shard that depends on noir, or any checkout without a lock, resolves from the manifest and takes whatever tag is newest at that moment.

## This is already happening

Resolving today's manifest with no lock present picks a different `acp` than the one we ship:

```console
$ shards install --without-development   # manifest on main
I: Installing acp (0.3.0)          # <- lock says 0.2.0
I: Installing http-client-digest_auth (0.6.0)
I: Installing http_proxy (0.15.1)
I: Installing crest (1.4.1)
I: Installing har (1.2.0)
I: Installing sarif (0.2.0)
I: Installing toml (0.8.1)
```

With the constraints added, the same lockless resolve reproduces the committed lock exactly:

```console
$ shards install --without-development   # manifest with this PR
I: Installing acp (0.2.0)          # <- matches shard.lock
I: Installing http-client-digest_auth (0.6.0)
I: Installing http_proxy (0.15.1)
I: Installing crest (1.4.1)
I: Installing har (1.2.0)
I: Installing sarif (0.2.0)
I: Installing toml (0.8.1)
```

For a tool that publishes an SBOM on every release, the supported dependency range belongs in the manifest, not only in the lockfile.

## Constraint policy

Written into a comment above the block so the next added dependency follows it:

- **Pre-1.0 shards** get `~> 0.y.z` (patch releases only) — by convention a 0.x minor bump is where the breaking change lands.
- **Post-1.0 shards** get `~> x.y` — admits non-breaking minor releases.

`crest` already had `~> 1.4.0` and is **left as-is**. Widening it is a separate decision with its own testing, since upstream has moved on to 1.8.1.

The `ameba` development dependency deliberately keeps `branch: master`. CI runs the lock-pinned build on purpose — see the comment on the `lint` job, which explains that tracking the action's own image pulled in an unreleased rule set and failed CI on already-merged code. A `version:` constraint would resolve to a released build with a different rule set, which is the thing that comment is protecting against.

## Test plan

- `shards install` in-repo → `shard.lock` **byte-identical** (`git diff shard.lock` empty), same eight resolved shards
- Lockless resolve in a scratch directory → matches the committed lock exactly (output above)
- `shards.nix` needs no regeneration: `crystal2nix` derives it from `shard.lock`, which is unchanged
- `typos .` → clean

No source files are touched, and this repo's own build resolves to the same revisions it did before.