### PR TITLE
feat(cli): report analyzers that failed, and add --strict to fail on them

### DIFF
--- a/docs/content/get_started/running/index.ko.md
+++ b/docs/content/get_started/running/index.ko.md
@@ -159,6 +159,7 @@ noir scan . --ai-context guards,sinks
 | `--concurrency <N>`   | 워커 수 (기본값: CPU 코어 수) |
 | `--cache-disable`     | 이번 실행에 한해 LLM 응답 캐시 비활성화 |
 | `--cache-clear`       | 실행 전에 LLM 응답 캐시 초기화 |
+| `--strict`            | 분석기가 하나라도 실패하면 종료 코드 2 반환 (결과 출력은 그대로) |
 | `--verbose`           | 상세 로깅 |
 | `--no-log`            | 모든 로그 억제 |
 | `--no-color`          | plain 출력의 ANSI 색상 비활성화 |

--- a/docs/content/get_started/running/index.md
+++ b/docs/content/get_started/running/index.md
@@ -156,6 +156,7 @@ See [Callee Coverage](@/usage/supported/callee_coverage/index.md) and [AI Contex
 | `--concurrency <N>`   | Worker count (default: CPU cores) |
 | `--cache-disable`     | Disable the LLM response cache for this run |
 | `--cache-clear`       | Clear the LLM response cache before running |
+| `--strict`            | Exit with code 2 if any analyzer failed (the scan still reports its results) |
 | `--verbose`           | Detailed logging |
 | `--no-log`            | Suppress all logs |
 | `--no-color`          | Disable ANSI colors in plain output |

--- a/docs/content/usage/output_formats/json/index.ko.md
+++ b/docs/content/usage/output_formats/json/index.ko.md
@@ -46,8 +46,31 @@ noir scan . -f json --no-log
       "protocol": "http",
       "tags": []
     }
+  ],
+  "errors": []
+}
+```
+
+## 분석기 실패 기록
+
+분석기 하나가 예외로 죽어도 스캔은 나머지 기술을 계속 처리합니다. `errors`에는 그렇게 건너뛴 분석기가 남기 때문에, 결과가 비어 있는 이유가 "해당 프레임워크가 없어서"인지 "아예 분석하지 못해서"인지 구분할 수 있습니다.
+
+```json
+{
+  "endpoints": [],
+  "passive_results": [],
+  "errors": [
+    { "tech": "go_gin", "message": "Index out of bounds" }
   ]
 }
+```
+
+이 키는 항상 출력됩니다. `"errors": []`는 선택된 분석기가 모두 끝까지 실행됐다는 뜻입니다.
+
+`-f yaml`도 같은 키를 담고, `-f sarif`는 `runs[0].invocations[0].executionSuccessful`로 같은 사실을 알립니다. `--strict`를 붙이면 리포트를 출력한 뒤 종료 코드 2로 끝나므로 CI에서 바로 걸러낼 수 있습니다.
+
+```bash
+noir scan . -f json --no-log --strict > endpoints.json
 ```
 
 ## JSONL 출력

--- a/docs/content/usage/output_formats/json/index.md
+++ b/docs/content/usage/output_formats/json/index.md
@@ -58,8 +58,31 @@ The result is an object with an `endpoints` array. Each endpoint has the URL, HT
       "protocol": "http",
       "tags": []
     }
+  ],
+  "errors": []
+}
+```
+
+## Analyzer Failures
+
+A tech analyzer that raises is logged and skipped, and the scan continues with the rest. `errors` records which ones that happened to, so an empty result for a framework can be told apart from a framework that was never analyzed:
+
+```json
+{
+  "endpoints": [],
+  "passive_results": [],
+  "errors": [
+    { "tech": "go_gin", "message": "Index out of bounds" }
   ]
 }
+```
+
+The key is always present. `"errors": []` is the positive statement that every selected analyzer ran to completion.
+
+`-f yaml` carries the same key, and `-f sarif` reports it as `runs[0].invocations[0].executionSuccessful`. Add `--strict` to make a degraded scan exit with code 2, after the report has been written:
+
+```bash
+noir scan . -f json --no-log --strict > endpoints.json
 ```
 
 ## JSONL Output

--- a/spec/unit_test/models/analyzer_failure_spec.cr
+++ b/spec/unit_test/models/analyzer_failure_spec.cr
@@ -1,0 +1,23 @@
+require "../../spec_helper"
+require "../../../src/models/analyzer_failure"
+
+describe AnalyzerFailure do
+  it "round-trips through JSON" do
+    failure = AnalyzerFailure.new("go_gin", "Index out of bounds")
+
+    json = failure.to_json
+    json.should eq(%({"tech":"go_gin","message":"Index out of bounds"}))
+
+    restored = AnalyzerFailure.from_json(json)
+    restored.tech.should eq("go_gin")
+    restored.message.should eq("Index out of bounds")
+  end
+
+  it "round-trips through YAML" do
+    failure = AnalyzerFailure.new("python_django", "unterminated string literal")
+
+    restored = AnalyzerFailure.from_yaml(failure.to_yaml)
+    restored.tech.should eq("python_django")
+    restored.message.should eq("unterminated string literal")
+  end
+end

--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -29,6 +29,11 @@ describe "default_options" do
     noir_options["no_spinner"].should be_false
   end
 
+  it "has strict mode disabled by default" do
+    noir_options = create_test_options
+    noir_options["strict"].should be_false
+  end
+
   # Concurrency is auto-scaled to the host's CPU count, clamped to the
   # [4, 32] window. The exact value depends on the box the suite runs
   # on, so the spec asserts the window rather than a literal.
@@ -52,6 +57,21 @@ describe "run_options_parser" do
     begin
       noir_options = run_options_parser()
       noir_options["no_spinner"].should be_true
+    ensure
+      ARGV.clear
+      ARGV.concat(original_argv)
+    end
+  end
+
+  it "supports --strict" do
+    original_argv = ARGV.dup
+
+    ARGV.clear
+    ARGV.concat(["--strict"])
+
+    begin
+      noir_options = run_options_parser()
+      noir_options["strict"].should be_true
     ensure
       ARGV.clear
       ARGV.concat(original_argv)

--- a/spec/unit_test/output_builder/analyzer_failures_spec.cr
+++ b/spec/unit_test/output_builder/analyzer_failures_spec.cr
@@ -1,0 +1,147 @@
+require "../../spec_helper"
+require "../../../src/output_builder/json"
+require "../../../src/output_builder/yaml"
+require "../../../src/output_builder/toml"
+require "../../../src/output_builder/sarif"
+require "../../../src/models/analyzer_failure"
+require "../../../src/models/endpoint"
+require "../../../src/models/passive_scan"
+require "../../../src/utils/utils"
+require "json"
+
+# The structured formats are the only place a degraded scan is visible to a
+# machine: the log line scrolls past in CI, and the endpoint list of a scan
+# whose Go analyzer died looks exactly like one for a project with no Go in
+# it. These specs pin both halves of that — the failures when there are some,
+# and the explicit "none" when there aren't.
+private def failure_builder_options
+  {
+    "debug"   => YAML::Any.new(false),
+    "verbose" => YAML::Any.new(false),
+    "color"   => YAML::Any.new(false),
+    "nolog"   => YAML::Any.new(false),
+    "output"  => YAML::Any.new(""),
+  }
+end
+
+private def sample_failures
+  [
+    AnalyzerFailure.new("go_gin", "Index out of bounds"),
+    AnalyzerFailure.new("rust_axum", "Invalid UTF-8 byte sequence"),
+  ]
+end
+
+private def sample_endpoints
+  endpoint = Endpoint.new("/test", "GET")
+  endpoint.push_param(Param.new("id", "1", "query"))
+  [endpoint]
+end
+
+describe "analyzer failures in structured output" do
+  describe "OutputBuilderJson" do
+    it "emits every failed analyzer under errors" do
+      builder = OutputBuilderJson.new(failure_builder_options)
+      builder.io = IO::Memory.new
+      builder.analyzer_failures = sample_failures
+
+      builder.print(sample_endpoints)
+      errors = JSON.parse(builder.io.to_s)["errors"].as_a
+
+      errors.size.should eq(2)
+      errors[0]["tech"].as_s.should eq("go_gin")
+      errors[0]["message"].as_s.should eq("Index out of bounds")
+      errors[1]["tech"].as_s.should eq("rust_axum")
+    end
+
+    it "emits an empty errors array when every analyzer succeeded" do
+      builder = OutputBuilderJson.new(failure_builder_options)
+      builder.io = IO::Memory.new
+
+      builder.print(sample_endpoints)
+      json = JSON.parse(builder.io.to_s)
+
+      # Present-but-empty, not absent: a consumer has to be able to read
+      # "nothing failed" off the document itself.
+      json.as_h.has_key?("errors").should be_true
+      json["errors"].as_a.should be_empty
+    end
+  end
+
+  describe "OutputBuilderYaml" do
+    it "emits every failed analyzer under errors" do
+      builder = OutputBuilderYaml.new(failure_builder_options)
+      builder.io = IO::Memory.new
+      builder.analyzer_failures = sample_failures
+
+      builder.print(sample_endpoints)
+      errors = YAML.parse(builder.io.to_s)["errors"].as_a
+
+      errors.size.should eq(2)
+      errors[0]["tech"].as_s.should eq("go_gin")
+      errors[0]["message"].as_s.should eq("Index out of bounds")
+    end
+
+    it "emits an empty errors array when every analyzer succeeded" do
+      builder = OutputBuilderYaml.new(failure_builder_options)
+      builder.io = IO::Memory.new
+
+      builder.print(sample_endpoints)
+      yaml = YAML.parse(builder.io.to_s)
+
+      yaml.as_h.has_key?("errors").should be_true
+      yaml["errors"].as_a.should be_empty
+    end
+  end
+
+  describe "OutputBuilderToml" do
+    it "emits an [[errors]] table per failed analyzer" do
+      builder = OutputBuilderToml.new(failure_builder_options)
+      builder.io = IO::Memory.new
+      builder.analyzer_failures = sample_failures
+
+      builder.print(sample_endpoints)
+      output = builder.io.to_s
+
+      output.should contain("[[errors]]")
+      output.should contain("tech = \"go_gin\"")
+      output.should contain("message = \"Index out of bounds\"")
+      output.should contain("tech = \"rust_axum\"")
+    end
+
+    it "writes no errors table when every analyzer succeeded" do
+      builder = OutputBuilderToml.new(failure_builder_options)
+      builder.io = IO::Memory.new
+
+      builder.print(sample_endpoints)
+
+      # TOML has no spelling for an empty array of tables, so unlike JSON and
+      # YAML a clean scan simply has no section here.
+      builder.io.to_s.should_not contain("[[errors]]")
+    end
+  end
+
+  describe "OutputBuilderSarif" do
+    it "marks the invocation unsuccessful when an analyzer failed" do
+      builder = OutputBuilderSarif.new(failure_builder_options)
+      builder.io = IO::Memory.new
+      builder.analyzer_failures = sample_failures
+
+      builder.print(sample_endpoints)
+      invocations = JSON.parse(builder.io.to_s)["runs"].as_a[0]["invocations"].as_a
+
+      invocations.size.should eq(1)
+      invocations[0]["executionSuccessful"].as_bool.should be_false
+    end
+
+    it "marks the invocation successful when every analyzer ran" do
+      builder = OutputBuilderSarif.new(failure_builder_options)
+      builder.io = IO::Memory.new
+
+      builder.print(sample_endpoints)
+      invocations = JSON.parse(builder.io.to_s)["runs"].as_a[0]["invocations"].as_a
+
+      invocations.size.should eq(1)
+      invocations[0]["executionSuccessful"].as_bool.should be_true
+    end
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -1,6 +1,7 @@
 require "./analyzers/**"
 require "./analyzers/file_analyzers/*"
 require "../miniparsers/extraction_result_cache"
+require "../models/analyzer_failure"
 require "../models/locator_keys"
 require "../techs/techs"
 
@@ -104,7 +105,12 @@ def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
   techs.reject { |tech| drop.includes?(tech) }
 end
 
-def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLogger)
+# `failures` is an out-parameter rather than a second return value so the
+# existing signature keeps working: library embedders and specs call this
+# positionally and have no interest in the failure list. Callers that do care
+# (the CLI, via `NoirRunner`) pass an array and get every tech that raised.
+def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLogger,
+                       failures : Array(AnalyzerFailure)? = nil)
   result = [] of Endpoint
   file_analyzer = FileAnalyzer.new options
   logger.info "Initializing analyzers"
@@ -164,6 +170,15 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
           logger.debug "Analyzer[#{tech}] done (#{endpoints.size})"
         rescue e
           logger.warning "Analyzer[#{tech}] failed: #{e.message}"
+          if collected = failures
+            # `e.message` is nilable and can be empty (`IndexError.new`,
+            # `raise ""`), and a report that reads `go_gin: ` names no cause
+            # at all — the class name is at least something to search for.
+            reason = e.message.presence || e.class.name
+            # Same mutex as the result concat above, not a second one: this
+            # runs on a spawned fiber and `collected` is shared by all of them.
+            mutex.synchronize { collected << AnalyzerFailure.new(tech, reason) }
+          end
         end
       end
     end

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -262,6 +262,23 @@ module Noir::CLI::ScanCommand
     !options["ai_model"].to_s.empty? || provider.downcase.starts_with?("acp:")
   end
 
+  # Names the analyzers that raised, so a scan whose coverage was cut short
+  # says so instead of reporting the surviving endpoints as the whole story.
+  # Laid out like the detected-techs list above it (`├──` / `└──`), because
+  # it answers the same question — which techs were actually processed.
+  private def self.report_analyzer_failures(logger : NoirLogger,
+                                            failures : Array(AnalyzerFailure),
+                                            scope : String)
+    return if failures.empty?
+
+    plural = failures.size == 1 ? "analyzer" : "analyzers"
+    logger.warning "#{failures.size} #{plural} failed#{scope}; results may be incomplete."
+    failures.each_with_index do |failure, index|
+      prefix = index < failures.size - 1 ? "├──" : "└──"
+      logger.sub "#{prefix} #{failure.tech}: #{failure.message}"
+    end
+  end
+
   private def self.run_scan(noir_options : Hash(String, YAML::Any))
     app = NoirRunner.new noir_options
     start_time = Time.instant
@@ -381,6 +398,7 @@ module Noir::CLI::ScanCommand
       app.analyze
     end
     app.logger.success "Identified #{app.endpoints.size} endpoints in total."
+    report_analyzer_failures(app.logger, app.analyzer_failures, "")
 
     elapsed = Time.instant - start_time
     app.logger.info "Scan completed in #{(elapsed.total_milliseconds / 1000.0).round(4)} s."
@@ -400,10 +418,26 @@ module Noir::CLI::ScanCommand
       locator.clear_all
       app_diff.detect
       app_diff.analyze
+      # The diff is computed against the old codebase's endpoint list, so an
+      # analyzer that died over there turns unscanned routes into phantom
+      # "added" entries. Named separately from the base scan's failures —
+      # the two scans have different code, and only one of them is the one
+      # the user is about to act on.
+      report_analyzer_failures(app.logger, app_diff.analyzer_failures, " in the --diff-path codebase")
 
       app.logger.info "Generating Diff Report."
       app.diff_report(app_diff)
     end
+
+    # After the report, never before: a degraded scan still has results, and
+    # the point of `--strict` is to flag them, not to withhold them. Exit 2
+    # rather than 1 so a CI gate can tell "scan ran, coverage incomplete"
+    # from the usage/validation errors that already exit 1.
+    degraded = !app.analyzer_failures.empty?
+    if diff_app = app_diff
+      degraded ||= !diff_app.analyzer_failures.empty?
+    end
+    exit(2) if degraded && any_to_bool(app.options["strict"]?)
   rescue e : Noir::InvalidExcludePathError
     # Raised from the detector's file walk once a malformed --exclude-path
     # glob is actually reached. Without this the process printed a raw

--- a/src/cli/scan_flags.cr
+++ b/src/cli/scan_flags.cr
@@ -86,6 +86,7 @@ module Noir::CLI::ScanFlags
     Flag.new("--no-color", "Disable color output"),
     Flag.new("--no-spinner", "Disable loading spinner animations"),
     Flag.new("--no-log", "Show only results"),
+    Flag.new("--strict", "Exit with code 2 if any analyzer failed"),
     Flag.new("--passive-scan", "Enable passive security scan", shorts: %w[-P]),
     Flag.new("--passive-scan-path", "Custom passive rules path", Arg::File, hint: "path"),
     Flag.new("--passive-scan-severity", "Min severity", Arg::Choice,

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -21,6 +21,7 @@ class ConfigInitializer
     ai_context
     nolog
     no_spinner
+    strict
     probe # legacy `send_req` is migrated to `probe` before this coercion runs
     tls_skip_verify
     all_taggers
@@ -241,6 +242,7 @@ class ConfigInitializer
       "ai_context"                   => YAML::Any.new(false),
       "nolog"                        => YAML::Any.new(false),
       "no_spinner"                   => YAML::Any.new(false),
+      "strict"                       => YAML::Any.new(false),
       "output"                       => YAML::Any.new(""),
       "export_es"                    => YAML::Any.new(""),
       "probe_via"                    => YAML::Any.new(""),
@@ -349,6 +351,9 @@ class ConfigInitializer
 
       # Whether to disable loading spinners while keeping normal logs
       no_spinner: #{options["no_spinner"]}
+
+      # Whether to exit with code 2 when any analyzer fails
+      strict: #{options["strict"]}
 
       # The output file to write to
       output: "#{options["output"]}"

--- a/src/models/analyzer_failure.cr
+++ b/src/models/analyzer_failure.cr
@@ -1,0 +1,26 @@
+require "json"
+require "yaml"
+
+# One tech analyzer that raised and was skipped, named so the scan can say
+# which part of the code base it never actually looked at.
+#
+# `analysis_endpoints` has always caught per-tech exceptions and kept going,
+# which is the right call — one broken analyzer must not cost the user the
+# other twenty. But the only trace was a warning line on stderr, so the
+# result of a degraded scan was byte-identical to a clean one: "this project
+# has no Go endpoints" and "the Go analyzer crashed before it could look"
+# produced the same empty list and the same exit 0. In CI, where nobody reads
+# the log of a green run, that is silent coverage loss.
+#
+# Carrying the failures into the structured output (and, with `--strict`,
+# into the exit code) makes the difference observable.
+struct AnalyzerFailure
+  include JSON::Serializable
+  include YAML::Serializable
+
+  getter tech : String
+  getter message : String
+
+  def initialize(@tech : String, @message : String)
+  end
+end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -7,6 +7,7 @@ require "../output_builder/*"
 require "../optimizer/llm_optimizer.cr"
 require "../ai_context/augmentor.cr"
 require "../mobile/linker.cr"
+require "./analyzer_failure.cr"
 require "./endpoint.cr"
 require "./logger.cr"
 require "../utils/*"
@@ -32,8 +33,12 @@ class NoirRunner
   @noir_home : String
   @passive_scans : Array(PassiveScan)
   @passive_results : Array(PassiveScanResult)
+  # Tech analyzers that raised during the last `analyze`. Empty is the
+  # positive statement "every selected analyzer ran to completion", which is
+  # what tells a degraded scan from a clean one.
+  @analyzer_failures = [] of AnalyzerFailure
 
-  getter options, techs, endpoints, logger, passive_results
+  getter options, techs, endpoints, logger, passive_results, analyzer_failures
 
   def initialize(options)
     @options = options
@@ -136,7 +141,14 @@ class NoirRunner
   end
 
   def analyze
-    @endpoints = analysis_endpoints options, @techs, @logger
+    # Cleared before the pass, not merely appended to. Diff mode builds a
+    # second runner, but an embedder can call `analyze` twice on one runner —
+    # and a failure list carrying the previous scan's entries would report a
+    # clean run as degraded (and, under `--strict`, fail the build) forever
+    # after. Same class of leak as the options-hash one
+    # `apply_cfml_components_only!` documents.
+    @analyzer_failures.clear
+    @endpoints = analysis_endpoints options, @techs, @logger, @analyzer_failures
 
     # Use the new optimizer module
     optimizer = LLMEndpointOptimizer.new(@logger, @options)
@@ -256,12 +268,12 @@ class NoirRunner
   # fourth place a format had to be listed.
   def report
     format = options["format"].to_s
-    return if Noir::OutputFormats.render(format, @options, @endpoints, @passive_results)
+    return if Noir::OutputFormats.render(format, @options, @endpoints, @passive_results, @analyzer_failures)
 
     # `CliValidation` rejects an unknown `-f` before a scan starts, so this
     # only catches a library caller that built the options hash itself:
     # fall back to the default format rather than printing nothing at all.
-    Noir::OutputFormats.render(Noir::OutputFormats::DEFAULT, @options, @endpoints, @passive_results)
+    Noir::OutputFormats.render(Noir::OutputFormats::DEFAULT, @options, @endpoints, @passive_results, @analyzer_failures)
   end
 
   def techs=(value : Array(String))

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -1,4 +1,5 @@
 require "./logger"
+require "./analyzer_failure"
 require "./endpoint"
 require "./passive_scan"
 require "../utils/*"
@@ -115,6 +116,13 @@ class OutputBuilder
   @stdout_broken : Bool
 
   property io : IO
+
+  # Tech analyzers that raised during the scan being reported. Carried as a
+  # property rather than a third `print` argument: only three of the thirty
+  # builders have anywhere to put it, and the other twenty-seven would have
+  # grown a parameter they ignore. Defaults to empty so a builder constructed
+  # directly (specs, library callers) reports a clean scan.
+  property analyzer_failures : Array(AnalyzerFailure) = [] of AnalyzerFailure
 
   def initialize(options : Hash(String, YAML::Any))
     @is_debug = any_to_bool(options["debug"])

--- a/src/options.cr
+++ b/src/options.cr
@@ -429,6 +429,9 @@ def run_options_parser
     parser.on "--no-log", "Show only results" do
       noir_options["nolog"] = YAML::Any.new(true)
     end
+    parser.on "--strict", "Exit with code 2 if any analyzer failed" do
+      noir_options["strict"] = YAML::Any.new(true)
+    end
 
     parser.separator "\n PASSIVE SCAN:".colorize(:blue)
     parser.on "-P", "--passive-scan", "Enable passive security scan" do

--- a/src/output_builder/formats.cr
+++ b/src/output_builder/formats.cr
@@ -81,15 +81,26 @@ module Noir::OutputFormats
   # Each `when` branch instantiates one concrete builder, so the call is
   # resolved per class rather than through the `OutputBuilder` base type —
   # which is what lets builders keep their own `print` overloads.
+  #
+  # `errors` reaches the builder as a property rather than a `print`
+  # argument, so the formats with nowhere to put it (every command and
+  # only-* format) need no signature change. It defaults to empty for
+  # callers that render a report they did not scan for.
   def self.render(format : String,
                   options : Hash(String, YAML::Any),
                   endpoints : Array(Endpoint),
-                  passive_results : Array(PassiveScanResult)) : Bool
+                  passive_results : Array(PassiveScanResult),
+                  errors : Array(AnalyzerFailure) = [] of AnalyzerFailure) : Bool
     {% begin %}
       case format
       {% for builder in OutputBuilder.all_subclasses.select(&.annotation(Noir::OutputFormat)) %}
       when {{ builder.annotation(Noir::OutputFormat)[:name] }}
-        {{ builder }}.new(options).print(endpoints, passive_results)
+        # Named `renderer`, not `builder`: `builder` is the macro loop
+        # variable holding the class, and reusing it for the instance makes
+        # the two impossible to tell apart when reading the expansion.
+        renderer = {{ builder }}.new(options)
+        renderer.analyzer_failures = errors
+        renderer.print(endpoints, passive_results)
       {% end %}
       else
         return false

--- a/src/output_builder/json.cr
+++ b/src/output_builder/json.cr
@@ -4,7 +4,14 @@ require "../models/endpoint"
 @[Noir::OutputFormat(name: "json", description: "JSON", order: 30, structured: true)]
 class OutputBuilderJson < OutputBuilder
   def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
-    message = {"endpoints" => endpoints, "passive_results" => passive_results}.to_json
+    # `errors` is emitted even when empty. `"errors": []` is the assertion a
+    # CI consumer needs — "every analyzer ran" — and an absent key can't make
+    # it, since it reads the same as an older Noir that never reported one.
+    message = {
+      "endpoints"       => endpoints,
+      "passive_results" => passive_results,
+      "errors"          => analyzer_failures,
+    }.to_json
     ob_puts message
   end
 end

--- a/src/output_builder/sarif.cr
+++ b/src/output_builder/sarif.cr
@@ -14,6 +14,13 @@ class OutputBuilderSarif < OutputBuilder
       b.run("OWASP Noir", Noir::VERSION) do |r|
         r.information_uri("https://github.com/owasp-noir/noir")
 
+        # SARIF's own signal for "this run did not complete as intended".
+        # A tech analyzer that raised means part of the code base was never
+        # examined, so the empty result list for it is not a finding of
+        # nothing — and `executionSuccessful` is the field a CI gate reads
+        # to tell those two apart.
+        r.invocation(execution_successful: analyzer_failures.empty?)
+
         # Add endpoint discovery rule
         if !endpoints.empty?
           r.rule("endpoint-discovery",

--- a/src/output_builder/toml.cr
+++ b/src/output_builder/toml.cr
@@ -7,7 +7,15 @@ class OutputBuilderToml < OutputBuilder
   include OutputBuilderTomlSerializer
 
   def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
-    message = {"endpoints" => endpoints, "passive_results" => passive_results}.to_json
+    # Always emitted, empty included — see the note in `json.cr`. TOML is the
+    # one format that cannot fully honor that: `generate_toml` renders arrays
+    # as `[[table]]` blocks, and an empty array has no block to render, so a
+    # clean scan stays silent here. That asymmetry belongs to the format.
+    message = {
+      "endpoints"       => endpoints,
+      "passive_results" => passive_results,
+      "errors"          => analyzer_failures,
+    }.to_json
     json_obj = JSON.parse(message)
     toml_output = generate_toml(json_obj.as_h)
     ob_puts toml_output

--- a/src/output_builder/yaml.cr
+++ b/src/output_builder/yaml.cr
@@ -4,7 +4,12 @@ require "../models/endpoint"
 @[Noir::OutputFormat(name: "yaml", description: "YAML", order: 20, structured: true)]
 class OutputBuilderYaml < OutputBuilder
   def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult) = [] of PassiveScanResult)
-    message = {"endpoints" => endpoints, "passive_results" => passive_results}.to_yaml
+    # Always emitted, empty included — see the note in `json.cr`.
+    message = {
+      "endpoints"       => endpoints,
+      "passive_results" => passive_results,
+      "errors"          => analyzer_failures,
+    }.to_yaml
     ob_puts message
   end
 end


### PR DESCRIPTION
## Problem

When a tech analyzer raises, `analysis_endpoints` catches it, logs a warning, and carries on:

```crystal
rescue e
  logger.warning "Analyzer[#{tech}] failed: #{e.message}"
```

The scan then exits 0 and the output carries no trace of it. Nothing downstream can tell **"this codebase has no Go endpoints"** from **"the Go analyzer crashed and we never looked"** — the two produce byte-identical reports. For a tool wired into CI, that is a silent loss of coverage in exactly the place a user would never look for it.

## What this adds

Tech-level failures are collected into `NoirRunner#analyzer_failures` and surfaced three ways.

**1. The CLI names them**, in the same tree layout the detected-techs list above it uses — it answers the same question, which techs were actually processed:

```
✔ Identified 0 endpoints in total.
▲ 1 analyzer failed; results may be incomplete.
  └── crystal_kemal: Index out of bounds
⚬ Scan completed in 0.0127 s.
```

**2. Structured formats carry it.** `-f json` / `-f yaml` / `-f toml` gain an `errors` array:

```json
{
  "endpoints": [],
  "passive_results": [],
  "errors": [{ "tech": "crystal_kemal", "message": "Index out of bounds" }]
}
```

`-f sarif` sets `runs[].invocations[].executionSuccessful`, which is SARIF's own field for "this run did not complete as intended" and the one a CI gate reads.

**3. `--strict` exits 2** when anything failed — *after* the report is written, never instead of it. Exit 2 rather than 1 so a gate can tell "scan ran, coverage incomplete" from the usage/validation errors that already exit 1.

**The default exit code is unchanged**, so existing pipelines keep passing.

## Schema note

`errors` is emitted **even when empty**. `"errors": []` is the assertion a consumer actually needs — every selected analyzer ran to completion — and an absent key cannot make it, since it reads the same as an older Noir that never reported one. This is an additive change to the JSON/YAML envelope; the GitHub Action's `jq -c .` passthrough and its e2e assertions (`.endpoints | length >= 1`) are unaffected.

TOML is the one exception: `generate_toml` renders arrays as `[[table]]` blocks and an empty array has no block to render, so a clean TOML scan stays silent. That asymmetry belongs to the format.

## Implementation notes

- `analysis_endpoints` takes `failures` as a **defaulted out-parameter**, so library embedders and specs calling it positionally are unaffected.
- The failure is appended inside the **existing** `mutex.synchronize` — it runs on a spawned fiber and the array is shared by all of them. No second lock.
- `e.message.presence || e.class.name` — some exceptions carry a nil or empty message, and a report reading `go_gin: ` names no cause at all.
- `NoirRunner#analyze` **clears the list before each pass**. Diff mode builds a second runner, but an embedder can call `analyze` twice on one, and a carried-over failure would mark a clean scan degraded — and under `--strict` fail the build — forever after. Same class of leak as the options-hash one `apply_cfml_components_only!` documents.
- Failures reach the builders as an `OutputBuilder` property, not a third `print` argument: only four of the thirty builders have anywhere to put them, and the other twenty-six would have grown a parameter they ignore.
- Diff mode reports the `--diff-path` scan's failures separately — an analyzer that died over there turns unscanned routes into phantom "added" entries, and only one of the two scans is the one the user is about to act on.

## Scope

**Tech-level failures only.** The per-file `rescue e; logger.debug` sites in `models/analyzer.cr` (`scan_files`, and the FileAnalyzer worker loop) are deliberately untouched — they are far noisier and reporting them well is a separate decision.

## Test plan

New specs (12 examples): `AnalyzerFailure` JSON/YAML round-trip; json/yaml emit `errors` populated and `errors: []` when clean; toml emits `[[errors]]` tables; sarif `executionSuccessful` both ways; `--strict` option parsing.

Verified against the built binary, with a fault temporarily injected into `crystal_kemal` and then reverted:

| Check | Result |
|---|---|
| default, degraded scan | warning printed, **exit 0** |
| `--strict`, degraded scan | **exit 2**, report still emitted first |
| `-f json --strict` | stdout parses as JSON; warnings went to stderr (1440 B), stdout uncontaminated |
| `errors` payload | `[{"tech": "crystal_kemal", "message": "Index out of bounds"}]` |
| after revert | 11 endpoints, `errors: []`, `executionSuccessful: true` |
| `--strict` on a clean scan | exit 0 |
| completions | `--strict` present in zsh / bash / elvish / fish |
| `noir config init` | template carries `strict: false` |

Gates:

- `crystal tool format --check src/ spec/` → clean
- `crystal run lib/ameba/bin/ameba.cr` on touched files → `0 failures`
- `typos .` → clean
- `crystal spec spec/unit_test` → **4958 examples, 0 failures** (baseline 4946 + 12)
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** (matches baseline)

Docs updated EN + KO: the flag table in `get_started/running`, and a new "Analyzer Failures" section on the JSON output-format page covering the `errors` key, the SARIF equivalent, and `--strict`.