### PR TITLE
refactor(utils): add a shared top-level splitter, convert the C++ analyzers

### DIFF
--- a/spec/unit_test/utils/top_level_split_spec.cr
+++ b/spec/unit_test/utils/top_level_split_spec.cr
@@ -1,0 +1,392 @@
+require "spec"
+require "../../../src/utils/top_level_split"
+
+private alias TLS = Noir::TopLevelSplit
+private alias TLSRules = Noir::TopLevelSplit::Rules
+private alias TLSNest = Noir::TopLevelSplit::Nest
+private alias TLSEscape = Noir::TopLevelSplit::Escape
+private alias TLSEmpties = Noir::TopLevelSplit::Empties
+
+private ALL_BRACKETS = TLSNest::Paren | TLSNest::Bracket | TLSNest::Brace
+
+private def tls_rules(**opts)
+  TLSRules.new(**opts)
+end
+
+describe Noir::TopLevelSplit do
+  describe "basic splitting" do
+    it "splits a flat list" do
+      TLS.split("a,b,c", ',', tls_rules).should eq ["a", "b", "c"]
+    end
+
+    it "strips each part when strip is true" do
+      TLS.split(" a ,  b  , c ", ',', tls_rules(strip: true)).should eq ["a", "b", "c"]
+    end
+
+    it "keeps surrounding whitespace when strip is false" do
+      TLS.split(" a , b ", ',', tls_rules(strip: false, empties: TLSEmpties::Keep))
+        .should eq [" a ", " b "]
+    end
+
+    it "returns the whole input when no delimiter is present" do
+      TLS.split("a b c", ',', tls_rules).should eq ["a b c"]
+    end
+
+    it "handles empty input" do
+      TLS.split("", ',', tls_rules(empties: TLSEmpties::Keep)).should eq [""]
+      TLS.split("", ',', tls_rules(empties: TLSEmpties::DropTrailing)).should eq [] of String
+      TLS.split("", ',', tls_rules(empties: TLSEmpties::DropAll)).should eq [] of String
+    end
+
+    it "handles delimiter-only input" do
+      TLS.split(",", ',', tls_rules(empties: TLSEmpties::Keep)).should eq ["", ""]
+      TLS.split(",,,", ',', tls_rules(empties: TLSEmpties::Keep)).should eq ["", "", "", ""]
+      TLS.split(",,,", ',', tls_rules(empties: TLSEmpties::DropAll)).should eq [] of String
+    end
+  end
+
+  describe "nesting" do
+    it "ignores delimiters inside parentheses" do
+      TLS.split("f(a, b), c", ',', tls_rules).should eq ["f(a, b)", "c"]
+    end
+
+    it "ignores delimiters inside nested calls" do
+      TLS.split("f(a, g(b, c)), d", ',', tls_rules).should eq ["f(a, g(b, c))", "d"]
+    end
+
+    it "ignores delimiters inside brackets and braces" do
+      TLS.split("[1, 2], {3, 4}, 5", ',', tls_rules).should eq ["[1, 2]", "{3, 4}", "5"]
+    end
+
+    it "does not count a bracket kind that is not enabled" do
+      # Angle is off by default, so `a < b` reads as a comparison, not a generic.
+      TLS.split("a < b, c > d", ',', tls_rules).should eq ["a < b", "c > d"]
+    end
+
+    it "counts angle brackets when Nest::Angle is enabled" do
+      angle = tls_rules(nest: ALL_BRACKETS | TLSNest::Angle)
+      TLS.split("Map<String, String> m, x", ',', angle).should eq ["Map<String, String> m", "x"]
+    end
+
+    it "splits generic arguments with GENERICS_ONLY" do
+      TLS.split("String, List<Map<String, Integer>>, int", ',', TLSRules::GENERICS_ONLY)
+        .should eq ["String", " List<Map<String, Integer>>", " int"]
+    end
+
+    it "ignores parens under GENERICS_ONLY because they are not enabled" do
+      TLS.split("f(a, b)", ',', TLSRules::GENERICS_ONLY).should eq ["f(a", " b)"]
+    end
+  end
+
+  describe "per_kind" do
+    it "keeps independent counters when per_kind is true" do
+      # `[` leaves bracket depth at 1; the stray `)` clamps paren depth at 0,
+      # so the comma is still nested and nothing splits.
+      TLS.split("[a)b, c", ',', tls_rules(per_kind: true)).should eq ["[a)b, c"]
+    end
+
+    it "lets one kind cancel another when per_kind is false" do
+      # `[` is +1 and `)` is -1 on the SAME counter, so the comma sees depth 0.
+      TLS.split("[a)b, c", ',', tls_rules(per_kind: false)).should eq ["[a)b", "c"]
+    end
+
+    it "agrees on balanced input regardless of per_kind" do
+      input = "f([1, 2], {3, 4}), g(5, 6)"
+      expected = ["f([1, 2], {3, 4})", "g(5, 6)"]
+      TLS.split(input, ',', tls_rules(per_kind: true)).should eq expected
+      TLS.split(input, ',', tls_rules(per_kind: false)).should eq expected
+    end
+
+    it "differs on a mismatched brace/paren pair" do
+      TLS.split("{a), b", ',', tls_rules(per_kind: true)).should eq ["{a), b"]
+      TLS.split("{a), b", ',', tls_rules(per_kind: false)).should eq ["{a)", "b"]
+    end
+  end
+
+  describe "clamp" do
+    it "ignores a closer at depth zero when clamp is true" do
+      TLS.split(")a, b", ',', tls_rules(clamp: true)).should eq [")a", "b"]
+    end
+
+    it "goes negative and suppresses later splits when clamp is false" do
+      # Depth becomes -1 at `)` and never returns to exactly 0, so the comma
+      # no longer splits.
+      TLS.split(")a, b", ',', tls_rules(clamp: false)).should eq [")a, b"]
+    end
+
+    it "recovers to depth zero only when a matching opener follows" do
+      # `))a, b` sits at -2 and stays nested; `))((a, b` climbs back to exactly
+      # 0 and splits again. Under clamp: true both would have split.
+      TLS.split("))a, b", ',', tls_rules(clamp: false)).should eq ["))a, b"]
+      TLS.split("))((a, b", ',', tls_rules(clamp: false)).should eq ["))((a", "b"]
+      TLS.split("))a, b", ',', tls_rules(clamp: true)).should eq ["))a", "b"]
+    end
+
+    it "clamps per counter when per_kind is also on" do
+      TLS.split("))a, b", ',', tls_rules(clamp: true, per_kind: true)).should eq ["))a", "b"]
+      TLS.split("))a, b", ',', tls_rules(clamp: false, per_kind: true)).should eq ["))a, b"]
+    end
+  end
+
+  describe "quotes" do
+    it "does not split inside a quoted run" do
+      TLS.split("a, \"b, c\", d", ',', tls_rules).should eq ["a", "\"b, c\"", "d"]
+    end
+
+    it "retains the quote characters in the emitted part" do
+      TLS.split("\"x\"", ',', tls_rules).should eq ["\"x\""]
+    end
+
+    it "does not treat brackets inside quotes as nesting" do
+      TLS.split("\"(\", \")\"", ',', tls_rules).should eq ["\"(\"", "\")\""]
+    end
+
+    it "closes a run only with the character that opened it" do
+      TLS.split("\"it's fine\", next", ',', tls_rules).should eq ["\"it's fine\"", "next"]
+    end
+
+    it "treats every configured quote character as an opener" do
+      TLS.split("'a, b', c", ',', tls_rules).should eq ["'a, b'", "c"]
+    end
+
+    it "disables quote handling entirely when quotes is empty" do
+      TLS.split("\"a, b\", c", ',', tls_rules(quotes: "")).should eq ["\"a", "b\"", "c"]
+    end
+
+    it "runs an unterminated quote to end of input" do
+      TLS.split("a, \"b, c", ',', tls_rules).should eq ["a", "\"b, c"]
+    end
+
+    it "keeps an unterminated quote open across brackets" do
+      TLS.split("a, \"b(, c", ',', tls_rules).should eq ["a", "\"b(, c"]
+    end
+
+    it "supports backticks for template literals under Rules::JS" do
+      TLS.split("`/a/${x, y}`, handler", ',', TLSRules::JS).should eq ["`/a/${x, y}`", "handler"]
+    end
+  end
+
+  describe "Escape::None" do
+    it "treats a backslash as an ordinary character inside quotes" do
+      # The run closes at the second `"`, so the following comma splits.
+      TLS.split("\"a\\\", b", ',', tls_rules(escape: TLSEscape::None))
+        .should eq ["\"a\\\"", "b"]
+    end
+
+    it "treats a backslash as an ordinary character outside quotes" do
+      TLS.split("a\\, b", ',', tls_rules(escape: TLSEscape::None)).should eq ["a\\", "b"]
+    end
+
+    it "keeps a trailing backslash" do
+      TLS.split("a\\", ',', tls_rules(escape: TLSEscape::None)).should eq ["a\\"]
+    end
+  end
+
+  describe "Escape::InQuotes" do
+    it "does not close the run on an escaped quote" do
+      TLS.split("\"a\\\"b\", c", ',', tls_rules(escape: TLSEscape::InQuotes))
+        .should eq ["\"a\\\"b\"", "c"]
+    end
+
+    it "retains the backslash in the emitted part" do
+      # Matches every implementation this module replaces: they append the
+      # char and only afterwards decide it was an escape.
+      TLS.split("\"a\\nb\"", ',', tls_rules(escape: TLSEscape::InQuotes)).should eq ["\"a\\nb\""]
+    end
+
+    it "treats an escaped backslash as consumed so the next quote closes" do
+      TLS.split("\"a\\\\\", b", ',', tls_rules(escape: TLSEscape::InQuotes))
+        .should eq ["\"a\\\\\"", "b"]
+    end
+
+    it "leaves a backslash outside quotes ordinary" do
+      TLS.split("a\\, b", ',', tls_rules(escape: TLSEscape::InQuotes)).should eq ["a\\", "b"]
+    end
+
+    it "handles a trailing backslash inside an unterminated run" do
+      TLS.split("a, \"b\\", ',', tls_rules(escape: TLSEscape::InQuotes)).should eq ["a", "\"b\\"]
+    end
+
+    it "handles a trailing backslash at end of input outside quotes" do
+      TLS.split("a, b\\", ',', tls_rules(escape: TLSEscape::InQuotes)).should eq ["a", "b\\"]
+    end
+  end
+
+  describe "Escape::Always" do
+    it "escapes the delimiter outside quotes" do
+      TLS.split("a\\,b, c", ',', tls_rules(escape: TLSEscape::Always)).should eq ["a\\,b", "c"]
+    end
+
+    it "escapes a quote outside quotes so no run opens" do
+      TLS.split("a\\\", b", ',', tls_rules(escape: TLSEscape::Always)).should eq ["a\\\"", "b"]
+    end
+
+    it "escapes a bracket outside quotes so depth is untouched" do
+      TLS.split("a\\(, b", ',', tls_rules(escape: TLSEscape::Always)).should eq ["a\\(", "b"]
+    end
+
+    it "still escapes inside quotes" do
+      TLS.split("\"a\\\"b\", c", ',', tls_rules(escape: TLSEscape::Always))
+        .should eq ["\"a\\\"b\"", "c"]
+    end
+
+    it "keeps a trailing backslash" do
+      TLS.split("a, b\\", ',', tls_rules(escape: TLSEscape::Always)).should eq ["a", "b\\"]
+    end
+  end
+
+  describe "Empties" do
+    it "keeps every empty part under Keep" do
+      TLS.split("a,,b,", ',', tls_rules(empties: TLSEmpties::Keep)).should eq ["a", "", "b", ""]
+    end
+
+    it "drops only the final empty part under DropTrailing" do
+      TLS.split("a,,b,", ',', tls_rules(empties: TLSEmpties::DropTrailing)).should eq ["a", "", "b"]
+    end
+
+    it "drops exactly one trailing empty, not a run of them" do
+      TLS.split("a,,", ',', tls_rules(empties: TLSEmpties::DropTrailing)).should eq ["a", ""]
+    end
+
+    it "leaves a non-empty final part alone under DropTrailing" do
+      TLS.split("a,,b", ',', tls_rules(empties: TLSEmpties::DropTrailing)).should eq ["a", "", "b"]
+    end
+
+    it "drops every empty part under DropAll" do
+      TLS.split(",a,,b,,", ',', tls_rules(empties: TLSEmpties::DropAll)).should eq ["a", "b"]
+    end
+
+    it "treats a whitespace-only part as empty because strip runs first" do
+      TLS.split("a,   ,b", ',', tls_rules(strip: true, empties: TLSEmpties::DropAll))
+        .should eq ["a", "b"]
+      TLS.split("a,   ,b", ',', tls_rules(strip: false, empties: TLSEmpties::DropAll))
+        .should eq ["a", "   ", "b"]
+    end
+
+    it "drops a whitespace-only trailing part under DropTrailing when stripping" do
+      TLS.split("a,  ", ',', tls_rules(strip: true, empties: TLSEmpties::DropTrailing))
+        .should eq ["a"]
+      TLS.split("a,  ", ',', tls_rules(strip: false, empties: TLSEmpties::DropTrailing))
+        .should eq ["a", "  "]
+    end
+  end
+
+  describe "multi-character delimiter" do
+    it "splits on a two-character separator" do
+      TLS.split("a :> b :> c", ":>", tls_rules).should eq ["a", "b", "c"]
+    end
+
+    it "does not fire on a partial match" do
+      TLS.split("a : b :> c", ":>", tls_rules).should eq ["a : b", "c"]
+    end
+
+    it "does not fire on a lone leading character of the separator" do
+      TLS.split("a:b", ":>", tls_rules).should eq ["a:b"]
+    end
+
+    it "handles a separator that itself contains bracket characters" do
+      # `:<|>` carries `<` and `>`; the separator match must win over the
+      # angle-depth bookkeeping or the rest of the input never splits.
+      angle = tls_rules(nest: ALL_BRACKETS | TLSNest::Angle)
+      TLS.split("Get :<|> Post :<|> Put", ":<|>", angle).should eq ["Get", "Post", "Put"]
+    end
+
+    it "ignores a separator inside quotes" do
+      TLS.split("\"a || b\" || c", "||", tls_rules).should eq ["\"a || b\"", "c"]
+    end
+
+    it "ignores a separator nested inside brackets" do
+      TLS.split("f(a || b) || c", "||", tls_rules).should eq ["f(a || b)", "c"]
+    end
+
+    it "finds an overlapping match instead of skipping past it" do
+      # Naively flushing the whole buffered prefix on mismatch would miss the
+      # "aab" that starts at index 1.
+      TLS.split("xaaaby", "aab", tls_rules(strip: false, empties: TLSEmpties::Keep))
+        .should eq ["xa", "y"]
+    end
+
+    it "matches leftmost on a repeated separator character" do
+      TLS.split("a|||b", "||", tls_rules(strip: false, empties: TLSEmpties::Keep))
+        .should eq ["a", "|b"]
+    end
+
+    it "emits an empty part between adjacent separators" do
+      TLS.split("a&&&&b", "&&", tls_rules(strip: false, empties: TLSEmpties::Keep))
+        .should eq ["a", "", "b"]
+    end
+
+    it "leaves a dangling partial separator at end of input in the tail" do
+      TLS.split("a :> b :", ":>", tls_rules(strip: false, empties: TLSEmpties::Keep))
+        .should eq ["a ", " b :"]
+    end
+
+    it "handles input that is only the separator" do
+      TLS.split("||", "||", tls_rules(empties: TLSEmpties::Keep)).should eq ["", ""]
+    end
+
+    it "behaves like the Char overload for a one-character String" do
+      TLS.split("a,b,c", ",", tls_rules).should eq ["a", "b", "c"]
+      TLS.split("f(a, b), c", ",", tls_rules).should eq ["f(a, b)", "c"]
+    end
+
+    it "returns the whole input for an empty separator" do
+      TLS.split(" a,b ", "", tls_rules(strip: true)).should eq ["a,b"]
+      TLS.split(" a,b ", "", tls_rules(strip: false, empties: TLSEmpties::Keep)).should eq [" a,b "]
+    end
+  end
+
+  describe "non-ASCII input" do
+    it "splits Korean arguments correctly" do
+      TLS.split("경로, 처리기, 옵션", ',', tls_rules).should eq ["경로", "처리기", "옵션"]
+    end
+
+    it "does not split a delimiter inside a Korean quoted argument" do
+      TLS.split("\"/한국, 경로\", 처리기", ',', tls_rules).should eq ["\"/한국, 경로\"", "처리기"]
+    end
+
+    it "handles emoji inside a quoted argument" do
+      TLS.split("\"/api/🚀, /b\", handler", ',', tls_rules).should eq ["\"/api/🚀, /b\"", "handler"]
+    end
+
+    it "keeps multi-byte characters intact around nesting" do
+      TLS.split("f(한, 국), 어", ',', tls_rules).should eq ["f(한, 국)", "어"]
+    end
+
+    it "does not desync a multi-character separator after multi-byte text" do
+      TLS.split("한국 || 語 || 🚀", "||", tls_rules).should eq ["한국", "語", "🚀"]
+    end
+
+    it "handles an escaped quote next to multi-byte content" do
+      TLS.split("\"한\\\"국\", 어", ',', tls_rules).should eq ["\"한\\\"국\"", "어"]
+    end
+  end
+
+  describe "Rules::CPP" do
+    it "keeps a whole nested handler call as one argument" do
+      input = "app->Get(\"/users/{id}\", [](const Req &r, Res &s) { s.set(\"a,b\"); })"
+      TLS.split(input, ',', TLSRules::CPP).should eq [input]
+    end
+
+    it "splits an oatpp ENDPOINT macro argument list" do
+      TLS.split("\"GET\", \"/users/{id}\", getUser, PATH(Int32, id)", ',', TLSRules::CPP)
+        .should eq ["\"GET\"", "\"/users/{id}\"", "getUser", "PATH(Int32, id)"]
+    end
+
+    it "drops the trailing empty argument" do
+      TLS.split("\"GET\", \"/a\",", ',', TLSRules::CPP).should eq ["\"GET\"", "\"/a\""]
+    end
+
+    it "keeps an interior empty argument" do
+      TLS.split("\"GET\", , \"/a\"", ',', TLSRules::CPP).should eq ["\"GET\"", "", "\"/a\""]
+    end
+
+    it "does not treat a single quote as a quote character" do
+      TLS.split("'a', 'b'", ',', TLSRules::CPP).should eq ["'a'", "'b'"]
+    end
+
+    it "uses per-kind clamped counters" do
+      TLS.split("[a)b, c", ',', TLSRules::CPP).should eq ["[a)b, c"]
+    end
+  end
+end

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/cpp_callee_extractor"
+require "../../../utils/top_level_split"
 require "wait_group"
 
 module Analyzer::Cpp
@@ -384,57 +385,11 @@ module Analyzer::Cpp
       normalize_handler_target(raw_handler)
     end
 
+    # Delegates to the shared splitter; `Rules::CPP` reproduces this file's
+    # previous hand-rolled loop exactly (double quotes only, backslash escapes
+    # inside quotes, per-kind clamped depth, trailing empty dropped).
     private def split_top_level_args(raw : String) : Array(String)
-      args = [] of String
-      current = String::Builder.new
-      paren_depth = 0
-      brace_depth = 0
-      bracket_depth = 0
-      in_string = false
-      escaped = false
-
-      raw.each_char do |char|
-        if in_string
-          current << char
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == '"'
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"'
-          in_string = true
-        when '('
-          paren_depth += 1
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-        when '{'
-          brace_depth += 1
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-        when '['
-          bracket_depth += 1
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-        when ','
-          if paren_depth == 0 && brace_depth == 0 && bracket_depth == 0
-            args << current.to_s.strip
-            current = String::Builder.new
-            next
-          end
-        end
-
-        current << char
-      end
-
-      tail = current.to_s.strip
-      args << tail unless tail.empty?
-      args
+      Noir::TopLevelSplit.split(raw, ',', Noir::TopLevelSplit::Rules::CPP)
     end
 
     private def callees_for_handler(content : String, path : String, handler_target : HandlerTarget) : Array(Noir::CppCalleeExtractor::Entry)

--- a/src/analyzer/analyzers/cpp/httplib.cr
+++ b/src/analyzer/analyzers/cpp/httplib.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/cpp_callee_extractor"
+require "../../../utils/top_level_split"
 
 module Analyzer::Cpp
   # cpp-httplib (yhirose/cpp-httplib) — a header-only HTTP/HTTPS server & client
@@ -236,50 +237,11 @@ module Analyzer::Cpp
       endpoint.push_param(param)
     end
 
+    # Delegates to the shared splitter; `Rules::CPP` reproduces this file's
+    # previous hand-rolled loop exactly (double quotes only, backslash escapes
+    # inside quotes, per-kind clamped depth, trailing empty dropped).
     private def split_top_level_args(raw : String) : Array(String)
-      args = [] of String
-      current = String::Builder.new
-      paren = 0
-      brace = 0
-      bracket = 0
-      in_string = false
-      escaped = false
-
-      raw.each_char do |char|
-        if in_string
-          current << char
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == '"'
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"' then in_string = true
-        when '(' then paren += 1
-        when ')' then paren -= 1 if paren > 0
-        when '{' then brace += 1
-        when '}' then brace -= 1 if brace > 0
-        when '[' then bracket += 1
-        when ']' then bracket -= 1 if bracket > 0
-        when ','
-          if paren == 0 && brace == 0 && bracket == 0
-            args << current.to_s.strip
-            current = String::Builder.new
-            next
-          end
-        end
-
-        current << char
-      end
-
-      tail = current.to_s.strip
-      args << tail unless tail.empty?
-      args
+      Noir::TopLevelSplit.split(raw, ',', Noir::TopLevelSplit::Rules::CPP)
     end
   end
 end

--- a/src/analyzer/analyzers/cpp/oatpp.cr
+++ b/src/analyzer/analyzers/cpp/oatpp.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/cpp_callee_extractor"
+require "../../../utils/top_level_split"
 
 module Analyzer::Cpp
   # oat++ (oatpp) — routes are declared inside an `ApiController` subclass with
@@ -174,50 +175,11 @@ module Analyzer::Cpp
       endpoint.push_param(param)
     end
 
+    # Delegates to the shared splitter; `Rules::CPP` reproduces this file's
+    # previous hand-rolled loop exactly (double quotes only, backslash escapes
+    # inside quotes, per-kind clamped depth, trailing empty dropped).
     private def split_top_level_args(raw : String) : Array(String)
-      args = [] of String
-      current = String::Builder.new
-      paren = 0
-      brace = 0
-      bracket = 0
-      in_string = false
-      escaped = false
-
-      raw.each_char do |char|
-        if in_string
-          current << char
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == '"'
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"' then in_string = true
-        when '(' then paren += 1
-        when ')' then paren -= 1 if paren > 0
-        when '{' then brace += 1
-        when '}' then brace -= 1 if brace > 0
-        when '[' then bracket += 1
-        when ']' then bracket -= 1 if bracket > 0
-        when ','
-          if paren == 0 && brace == 0 && bracket == 0
-            args << current.to_s.strip
-            current = String::Builder.new
-            next
-          end
-        end
-
-        current << char
-      end
-
-      tail = current.to_s.strip
-      args << tail unless tail.empty?
-      args
+      Noir::TopLevelSplit.split(raw, ',', Noir::TopLevelSplit::Rules::CPP)
     end
   end
 end

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -1,0 +1,392 @@
+module Noir
+  # Splits a delimited list at the top nesting level, respecting quoted runs
+  # and (optionally) backslash escapes.
+  #
+  # This replaces ~44 hand-rolled copies of the same loop spread across
+  # `src/analyzer/analyzers/`, `src/analyzer/engines/` and `src/miniparsers/`,
+  # 19 of which were byte-identical to a sibling. A quote- or escape-handling
+  # bug used to need 44 separate fixes; the copies had already drifted along
+  # seven independent axes (see `Rules`), so "just pick one and inline it"
+  # would have changed detection for whichever analyzers lost their variant.
+  #
+  # Implementation note — why a single forward pass into a `String::Builder`
+  # and not `text[i]` / `text[start...index]`:
+  # `String#[](Int)` and char-range slicing are O(index) the moment a string
+  # contains one multi-byte UTF-8 codepoint, because Crystal has to walk the
+  # bytes to find the char boundary. Several of the copies being replaced
+  # here indexed per char inside a `while` loop, making them O(n^2) on any
+  # source file with a Korean comment or an emoji in a string literal, and at
+  # least one carried a comment about materializing `.chars` up front to work
+  # around exactly that. A splitter only ever moves forward, so `each_char`
+  # plus one `String::Builder` per part is O(n) with no random access at all,
+  # no `.chars` array, and no ASCII-vs-UTF-8 dispatch.
+  #
+  # This is deliberately NOT the `single_byte?` / `Bytes`-vs-`Array(Char)`
+  # dispatch used by `Noir::JSLiteralScanner`. That pattern exists there for
+  # `find_matching_*`, which must random-access from an arbitrary index and so
+  # genuinely needs an indexable source. A forward-only splitter does not, and
+  # paying for the dispatch (plus a full `.chars` materialization on non-ASCII
+  # input) would be strictly slower than just iterating.
+  module TopLevelSplit
+    extend self
+
+    # Bracket kinds whose depth suppresses splitting. Callers enable only the
+    # kinds their language actually nests: C++ argument lists must count
+    # `< >` as comparison operators, not generics, or `f(a < b, c)` loses a
+    # part, while a Java generic-signature splitter counts nothing else.
+    @[Flags]
+    enum Nest
+      Paren   # ( )
+      Bracket # [ ]
+      Brace   # { }
+      Angle   # < >
+    end
+
+    # How a backslash is treated.
+    #
+    # `InQuotes` consumes the backslash AND the following character as part of
+    # the quoted run, and RETAINS the backslash in the emitted part — verified
+    # against the implementations being replaced (e.g. drogon/httplib/oatpp
+    # `split_top_level_args`, which append the char first and only then decide
+    # whether it was an escape). Callers re-parse the literal themselves, so
+    # stripping the backslash here would have silently changed every route
+    # string that contained an escaped quote.
+    enum Escape
+      None     # backslash is an ordinary character, even inside quotes
+      InQuotes # backslash escapes the next char only inside a quoted run
+      Always   # backslash escapes the next char everywhere
+    end
+
+    # What happens to parts that are empty after `strip`.
+    enum Empties
+      Keep         # every part is emitted, empties included
+      DropTrailing # a final empty part is dropped; interior empties survive
+      DropAll      # every empty part is dropped
+    end
+
+    # The seven axes along which the hand-rolled copies differed.
+    struct Rules
+      # Bracket kinds that contribute depth.
+      getter nest : Nest
+
+      # Characters that open and close a quoted run. A run is closed by the
+      # same character that opened it, so `"'"` + `"\""` in one string handles
+      # both quote styles without letting `"it's"` open an apostrophe run.
+      # `""` disables quote handling entirely.
+      getter quotes : String
+
+      # Backslash policy; see `Escape`.
+      getter escape : Escape
+
+      # Whether each part is `strip`ped. Applied BEFORE the `Empties` policy,
+      # so a whitespace-only part counts as empty.
+      getter? strip : Bool
+
+      # Empty-part policy; see `Empties`.
+      getter empties : Empties
+
+      # true  => an independent depth counter per bracket kind
+      # false => one shared depth across all enabled kinds
+      #
+      # Configurable rather than fixed because it is observable on UNBALANCED
+      # input, which is what these splitters actually receive: every caller
+      # hands them a regex-sliced fragment, not a parsed expression. On
+      # `"[a)b, c"` a shared counter reads `[` as +1 and `)` as -1 and splits
+      # at the comma; per-kind counters leave the bracket depth at 1 and emit
+      # one part. Normalizing to either value would have moved endpoints in
+      # whichever group lost.
+      getter? per_kind : Bool
+
+      # true  => a closer at depth 0 is ignored (`d -= 1 if d > 0`)
+      # false => depth is allowed to go negative
+      #
+      # Same reasoning as `per_kind`. Most replaced sites clamp, but three do
+      # a bare `depth -= 1` — erlang/cowboy.cr `split_top_level`,
+      # php/wordpress.cr `split_top_level_args`, and engines/cfml_engine.cr
+      # `split_arguments` (the last one is easy to miss: it is on the shared
+      # engine, not an analyzer, so a survey scoped to `analyzers/` reports
+      # only two). On a fragment that
+      # closes a bracket opened in a prefix the regex already discarded (e.g.
+      # `")x, y"`) that is the difference between one part and two. Splitting
+      # requires depth EXACTLY 0, so a negative depth suppresses every
+      # remaining split rather than re-enabling them.
+      getter? clamp : Bool
+
+      def initialize(
+        @nest : Nest = Nest::Paren | Nest::Bracket | Nest::Brace,
+        @quotes : String = "\"'",
+        @escape : Escape = Escape::InQuotes,
+        @strip : Bool = true,
+        @empties : Empties = Empties::DropTrailing,
+        @per_kind : Bool = false,
+        @clamp : Bool = true,
+      )
+      end
+
+      # C++ call-argument lists.
+      # Serves: analyzer/analyzers/cpp/{drogon,httplib,oatpp}.cr
+      # `split_top_level_args`. Double quotes only (C++ single quotes are char
+      # literals and never wrap a route), per-kind counters and clamping both
+      # taken verbatim from those three bodies, `<>` deliberately NOT counted.
+      CPP = new(
+        nest: Nest::Paren | Nest::Bracket | Nest::Brace,
+        quotes: "\"",
+        escape: Escape::InQuotes,
+        strip: true,
+        empties: Empties::DropTrailing,
+        per_kind: true,
+        clamp: true,
+      )
+
+      # Python call-argument lists and expression terms.
+      # Serves the four byte-identical `split_python_arguments` clones in
+      # analyzer/analyzers/python/{django,starlette,bottle,pyramid}.cr plus
+      # django.cr `split_python_expression_terms`. Note these deliberately do
+      # NOT strip and keep every empty part — callers strip themselves and
+      # some index positionally, so an interior empty must hold its slot.
+      #
+      # Near misses that need their own `Rules` when converted:
+      #   fastapi.cr `split_python_top_level`  -> per_kind: false
+      #   flask.cr   `split_python_call_args`  -> Escape::Always, strip: true,
+      #                                           Empties::DropAll
+      PYTHON = new(
+        nest: Nest::Paren | Nest::Bracket | Nest::Brace,
+        quotes: "\"'",
+        escape: Escape::InQuotes,
+        strip: false,
+        empties: Empties::Keep,
+        per_kind: true,
+        clamp: true,
+      )
+
+      # Java annotation and call-argument lists.
+      # Serves analyzer/analyzers/java/{vertx,dropwizard,armeria}.cr
+      # `split_top_level_args` / `split_top_level_concat`. One shared depth is
+      # unanimous across the Java splitters, unlike Python and JS.
+      #
+      # Near misses that need their own `Rules` when converted:
+      #   quarkus.cr `split_top_level_args`   -> nest also includes Angle
+      #   spring.cr  `split_top_level_concat` -> quotes "\"", Empties::DropAll
+      JAVA = new(
+        nest: Nest::Paren | Nest::Bracket | Nest::Brace,
+        quotes: "\"'",
+        escape: Escape::InQuotes,
+        strip: true,
+        empties: Empties::DropTrailing,
+        per_kind: false,
+        clamp: true,
+      )
+
+      # JavaScript/TypeScript object-literal and argument lists.
+      # Serves analyzer/analyzers/javascript/nestjs.cr and
+      # analyzer/analyzers/typescript/loopback.cr `split_top_level`. Backticks
+      # are quote characters because template literals wrap most route
+      # strings; missing them merges a whole `${...}` route into one part.
+      #
+      # Near misses that need their own `Rules` when converted:
+      #   typescript/trpc.cr `split_top_level` -> per_kind: false
+      JS = new(
+        nest: Nest::Paren | Nest::Bracket | Nest::Brace,
+        quotes: "\"'`",
+        escape: Escape::InQuotes,
+        strip: true,
+        empties: Empties::DropAll,
+        per_kind: true,
+        clamp: true,
+      )
+
+      # Generic/type-argument lists: angle brackets only, no quote handling.
+      # Serves the three byte-identical `split_top_level_commas` clones in
+      # miniparsers/{java_route,jaxrs,micronaut}_extractor_ts.cr, which run on
+      # an already-extracted generic parameter list where `(`/`{` cannot
+      # legally appear and a stray `"` would swallow the rest of the
+      # signature. They keep empties and do not strip.
+      GENERICS_ONLY = new(
+        nest: Nest::Angle,
+        quotes: "",
+        escape: Escape::None,
+        strip: false,
+        empties: Empties::Keep,
+        per_kind: false,
+        clamp: true,
+      )
+    end
+
+    # Splits `text` on every occurrence of `delimiter` that sits at depth 0 and
+    # outside a quoted run.
+    def split(text : String, delimiter : Char, rules : Rules) : Array(String)
+      split_impl(text, [delimiter], rules)
+    end
+
+    # Multi-character separator variant. Only a separator run that sits
+    # ENTIRELY at depth 0 and outside quotes splits, so `":>"` does not fire on
+    # a bare `":"` and `"||"` inside `f(a || b)` is invisible.
+    #
+    # The delimiter itself must not contain a quote character or a backslash;
+    # every real separator (`":>"`, `":<|>"`, `"||"`, `"&&"`) is punctuation.
+    def split(text : String, delimiter : String, rules : Rules) : Array(String)
+      chars = delimiter.chars
+      return apply_empties([rules.strip? ? text.strip : text], rules) if chars.empty?
+      split_impl(text, chars, rules)
+    end
+
+    private def split_impl(text : String, delim : Array(Char), rules : Rules) : Array(String)
+      cur = Cursor.new(rules)
+      multi = delim.size > 1
+      first = delim[0]
+
+      text.each_char do |ch|
+        # Inside a quoted run nothing else can happen: no depth change, no
+        # split, no new quote. This branch is first because it is also the
+        # cheapest, and quoted route strings are where the delimiter character
+        # most often appears.
+        if quote = cur.quote
+          cur.current << ch
+          if cur.escaped?
+            cur.escaped = false
+          elsif ch == '\\' && !rules.escape.none?
+            cur.escaped = true
+          elsif ch == quote
+            cur.quote = nil
+          end
+          next
+        end
+
+        if cur.escaped?
+          cur.current << ch
+          cur.escaped = false
+          next
+        end
+
+        if ch == '\\' && rules.escape.always?
+          cur.flush_pending
+          cur.current << ch
+          cur.escaped = true
+          next
+        end
+
+        if cur.top_level?
+          if multi
+            # Buffer the run while it is still a prefix of the delimiter. On a
+            # mismatch release only the FIRST buffered char and retry the rest,
+            # which is what makes `"aab"` findable inside `"aaab"`; releasing
+            # the whole buffer would skip past the real match.
+            cur.pending << ch
+            while (pending = cur.pending).size > 0
+              if prefix_of?(pending, delim)
+                if pending.size == delim.size
+                  pending.clear
+                  cur.emit
+                end
+                break
+              end
+              cur.consume(pending.shift)
+            end
+            next
+          elsif ch == first
+            cur.emit
+            next
+          end
+        end
+
+        cur.consume(ch)
+      end
+
+      cur.flush_pending
+      cur.emit
+      apply_empties(cur.parts, rules)
+    end
+
+    private def prefix_of?(buffer : Array(Char), delim : Array(Char)) : Bool
+      return false if buffer.size > delim.size
+      buffer.each_with_index do |ch, i|
+        return false if ch != delim[i]
+      end
+      true
+    end
+
+    private def apply_empties(parts : Array(String), rules : Rules) : Array(String)
+      case rules.empties
+      in Empties::Keep
+        parts
+      in Empties::DropTrailing
+        parts.pop if !parts.empty? && parts.last.empty?
+        parts
+      in Empties::DropAll
+        parts.reject!(&.empty?)
+      end
+    end
+
+    # Mutable scan state. A class rather than a bundle of locals so the
+    # delimiter-mismatch path can hand a buffered char back to the same
+    # ordinary-consumption code the main loop uses, instead of duplicating the
+    # depth/quote bookkeeping in two places.
+    private class Cursor
+      OPENERS = {'(', '[', '{', '<'}
+
+      getter parts = [] of String
+      getter pending = [] of Char
+      property current = String::Builder.new
+      property quote : Char? = nil
+      property? escaped = false
+
+      @depths = StaticArray(Int32, 4).new(0)
+
+      def initialize(@rules : Rules)
+      end
+
+      # In shared-depth mode only slot 0 is ever touched, so the same all-zero
+      # test serves both `per_kind` settings.
+      def top_level? : Bool
+        @depths[0] == 0 && @depths[1] == 0 && @depths[2] == 0 && @depths[3] == 0
+      end
+
+      def emit : Nil
+        part = @current.to_s
+        part = part.strip if @rules.strip?
+        @parts << part
+        @current = String::Builder.new
+      end
+
+      def flush_pending : Nil
+        while (buffered = @pending).size > 0
+          consume(buffered.shift)
+        end
+      end
+
+      def consume(ch : Char) : Nil
+        # Only reachable with a quote open when a delimiter containing a quote
+        # character stranded a partial match (documented as unsupported); the
+        # char still lands verbatim in the part so nothing is lost.
+        if @quote
+          @current << ch
+          return
+        end
+
+        if @rules.quotes.includes?(ch)
+          @quote = ch
+        elsif slot = nest_slot(ch)
+          index = @rules.per_kind? ? slot : 0
+          if OPENERS.includes?(ch)
+            @depths[index] += 1
+          elsif @rules.clamp?
+            @depths[index] -= 1 if @depths[index] > 0
+          else
+            @depths[index] -= 1
+          end
+        end
+
+        @current << ch
+      end
+
+      private def nest_slot(ch : Char) : Int32?
+        case ch
+        when '(', ')' then @rules.nest.paren? ? 0 : nil
+        when '[', ']' then @rules.nest.bracket? ? 1 : nil
+        when '{', '}' then @rules.nest.brace? ? 2 : nil
+        when '<', '>' then @rules.nest.angle? ? 3 : nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

An audit of `src/` found **44 hand-rolled implementations** of the same routine: walk a string, track nesting depth and quote state, split on a delimiter that sits at depth 0 outside quotes. They live under `analyzers/`, `engines/` and `miniparsers/` as `split_top_level`, `split_top_level_args`, `split_python_arguments`, `split_top_level_commas`, `split_arguments`, …

**19 of them are byte-identical to a sibling.** The largest clone clusters:

| Group | Count |
|---|---|
| Python `split_python_arguments` (bottle/cherrypy/django/pyramid/sanic/starlette) | 6 |
| C++ `split_top_level_args` (drogon/httplib/oatpp) | 3 |
| JS offset-returning (express/feathers/hono) | 3 |
| TS miniparser `<>`-only (java_route/jaxrs/micronaut) | 3 |
| flask/quart, nestjs/loopback | 2 + 2 |

A bug in quote or escape handling has to be found and fixed 44 times. Several copies are also quietly O(n²) on non-ASCII input, because they slice by char index inside the loop — one of them carries a comment about working around exactly that with a `.chars` array.

## This PR

Introduces `Noir::TopLevelSplit` and converts **one group** — the three byte-identical C++ bodies — as proof. The rest follow in later PRs, one equivalence class at a time. Net −121 lines in the analyzers.

Deliberately small: the `Rules` axes chosen here govern ~40 more call sites, so this is the PR to get them wrong in.

## Why seven axes instead of one canonical behavior

The copies genuinely differ, and two of the differences look like bugs but are not:

> **`per_kind` and `clamp` are only observable on unbalanced input** — and unbalanced input is exactly what these functions receive, since every caller hands them a regex-sliced fragment rather than a parsed expression.

On `"[a)b, c"` a shared depth counter reads `)` as −1 and splits at the comma; per-kind counters leave bracket depth at 1 and emit one part. Normalizing to either value would have moved endpoints in whichever group lost. Three sites decrement without a floor — `erlang/cowboy.cr`, `php/wordpress.cr`, and `engines/cfml_engine.cr` — so `clamp` stays configurable too. (That third one is easy to miss: it is on the shared engine rather than an analyzer, so a survey scoped to `analyzers/` reports only two.)

The other five axes: nest set, quote characters, backslash policy, `strip`, and empty-part policy.

## Implementation note

Single `each_char` pass accumulating into a `String::Builder` — O(n), no index arithmetic, no slicing.

It deliberately does **not** copy the `single_byte?` `Bytes`-vs-`Array(Char)` dispatch from `utils/js_literal_scanner.cr`. That pattern exists for `find_matching_*`, which needs random access from an arbitrary index. A splitter only ever moves forward, so the dispatch would be complexity with no payoff.

## Presets

`CPP`, `PYTHON`, `JAVA`, `JS`, `GENERICS_ONLY` — field values read off the real implementations, not guessed. Each documents the sites it serves *and* the near-misses that will need their own `Rules`: `fastapi` differs from the other Python splitters only in `per_kind`; `quarkus` from the other Java ones only by counting angle brackets.

`split_spans`, the offset-returning variant express/feathers/hono need, is **absent on purpose**. The Builder design has no char offsets, and the "start offset of the current part" is non-obvious once a multi-char delimiter buffers a pending prefix. That is a design decision belonging to its own PR.

## Equivalence proof

Before the old bodies were deleted, the previous drogon implementation and `TopLevelSplit.split(_, ',', Rules::CPP)` were run over the same corpus:

- 57 hand-written adversarial inputs (unbalanced fragments, escaped quotes, nested calls, empty parts, non-ASCII)
- ~521 argument lists and comma-bearing lines harvested from `spec/functional_test/fixtures/cpp/**`
- 50,000 seeded-random strings over the alphabet `, ( ) [ ] { } " \ space a b 한 🚀 ' < >`

**`corpus=50578 unique=44207 mismatches=0`**

The harness was a throwaway and is not in the diff.

## Test plan

- New: `spec/unit_test/utils/top_level_split_spec.cr`, **76 examples** — every `Escape` mode (including a backslash before a quote and a trailing backslash), every `Empties` mode (interior vs trailing), `per_kind` both ways on mismatched input, `clamp: false` producing negative depth, `quotes: ""`, unterminated quote runs, the multi-char delimiter overload with a partial-match near-miss, non-ASCII inside quoted arguments, and degenerate inputs.
- `crystal spec spec/unit_test` → **5022 examples, 0 failures** (4946 + 76)
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** — unchanged, and the C++ fixtures are the direct regression signal
- `./bin/noir -b spec/functional_test/fixtures/cpp -f json --no-log` compared against a baseline captured before any edit → identical endpoint sets
- `crystal tool format --check src/ spec/` → clean
- `crystal run lib/ameba/bin/ameba.cr` on the 5 touched files → `5 inspected, 0 failures`
- `typos .` → clean

## Follow-ups for the rest of the series

Recorded here so they are not rediscovered 40 call sites later:

1. **`DropAll` vs `DropTrailing` is frequently misread.** Several sites *look* like `DropAll` (`parts << x unless x.empty?` at the tail) but push interior parts unconditionally — that is `DropTrailing`. Check both push sites, not just the tail.
2. **`quotes : String` cannot express two real variants.** `flask.cr` uses two independent booleans, so `"it's` opens both quote kinds. `express/router_mount_scanner.cr` detects escapes with a `prev_char != '\\'` lookback, which is genuinely wrong on a literal `\\` before a quote — converting it is a *fix*, not a refactor, and should be flagged as such.
3. **`per_kind : Bool` is not expressive enough for two sites.** `flask.cr` shares one counter between `[]` and `{}` but keeps `()` separate; `serverpod.cr` shares `<` and `(`.
4. **Multi-char delimiters must not contain a quote character or backslash.** The quote/escape branches run before delimiter matching. Every real separator is punctuation, so this is a documented constraint rather than a limitation in practice.