### PR TITLE
refactor(analyzer): convert the Python splitters to Noir::TopLevelSplit

### DIFF
--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -2,6 +2,7 @@ require "../../../miniparsers/python_route_extractor"
 require "../../../miniparsers/python_route_extractor_ts"
 require "../../engines/python_engine"
 require "./python_helper"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   class Bottle < PythonEngine
@@ -342,64 +343,12 @@ module Analyzer::Python
       nil
     end
 
+    # Delegates to the shared splitter; `Rules::PYTHON` reproduces this
+    # file's previous hand-rolled loop exactly (both quote styles, backslash
+    # escapes inside quotes, per-kind clamped depth, no strip, and every
+    # empty part kept so positional indexing of the result stays valid).
     private def split_python_arguments(args : String) : Array(String)
-      parts = [] of String
-      current = String::Builder.new
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      args.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '('
-          paren_depth += 1
-          current << ch
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-          current << ch
-        when '['
-          bracket_depth += 1
-          current << ch
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-          current << ch
-        when '{'
-          brace_depth += 1
-          current << ch
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-          current << ch
-        when ','
-          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON)
     end
 
     # Memoized per keyword — the keyword set is tiny (`path`, `rule`,

--- a/src/analyzer/analyzers/python/cherrypy.cr
+++ b/src/analyzer/analyzers/python/cherrypy.cr
@@ -1,5 +1,6 @@
 require "../../engines/python_engine"
 require "./python_helper"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   class CherryPy < PythonEngine
@@ -627,64 +628,12 @@ module Analyzer::Python
       body.join("\n")
     end
 
+    # Delegates to the shared splitter; `Rules::PYTHON` reproduces this
+    # file's previous hand-rolled loop exactly (both quote styles, backslash
+    # escapes inside quotes, per-kind clamped depth, no strip, and every
+    # empty part kept so positional indexing of the result stays valid).
     private def split_python_arguments(args : ::String) : Array(::String)
-      parts = [] of ::String
-      current = String::Builder.new
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      args.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '('
-          paren_depth += 1
-          current << ch
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-          current << ch
-        when '['
-          bracket_depth += 1
-          current << ch
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-          current << ch
-        when '{'
-          brace_depth += 1
-          current << ch
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-          current << ch
-        when ','
-          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON)
     end
   end
 end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -1,5 +1,6 @@
 require "../../engines/python_engine"
 require "json"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   class Django < PythonEngine
@@ -502,64 +503,10 @@ module Analyzer::Python
       end
     end
 
+    # Same rules as `split_python_arguments`, splitting on `+` instead of `,`
+    # so a concatenated URL-prefix expression breaks into its terms.
     private def split_python_expression_terms(expression : ::String) : Array(::String)
-      parts = [] of ::String
-      current = String::Builder.new
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      expression.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '('
-          paren_depth += 1
-          current << ch
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-          current << ch
-        when '['
-          bracket_depth += 1
-          current << ch
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-          current << ch
-        when '{'
-          brace_depth += 1
-          current << ch
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-          current << ch
-        when '+'
-          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(expression, '+', Noir::TopLevelSplit::Rules::PYTHON)
     end
 
     private def extract_urlpattern_lists(content : ::String) : Hash(::String, ::String)
@@ -1192,64 +1139,12 @@ module Analyzer::Python
       ""
     end
 
+    # Delegates to the shared splitter; `Rules::PYTHON` reproduces this
+    # file's previous hand-rolled loop exactly (both quote styles, backslash
+    # escapes inside quotes, per-kind clamped depth, no strip, and every
+    # empty part kept so positional indexing of the result stays valid).
     private def split_python_arguments(args : ::String) : Array(::String)
-      parts = [] of ::String
-      current = String::Builder.new
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      args.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '('
-          paren_depth += 1
-          current << ch
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-          current << ch
-        when '['
-          bracket_depth += 1
-          current << ch
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-          current << ch
-        when '{'
-          brace_depth += 1
-          current << ch
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-          current << ch
-        when ','
-          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON)
     end
 
     # Extract endpoints from a given file

--- a/src/analyzer/analyzers/python/django_ninja.cr
+++ b/src/analyzer/analyzers/python/django_ninja.cr
@@ -1,4 +1,5 @@
 require "../../engines/python_engine"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   # Django Ninja is a FastAPI-inspired REST framework that plugs into
@@ -698,50 +699,13 @@ module Analyzer::Python
       nil
     end
 
+    # Delegates to the shared splitter. `Rules::PYTHON_SHARED_DEPTH`, not
+    # `Rules::PYTHON`: this loop counted `(`, `[` and `{` on ONE depth
+    # counter, which is observable on the unbalanced fragments the route
+    # regexes actually hand it — `"[a)b, c"` splits here, but would not
+    # under per-kind counters.
     private def split_python_arguments(args : ::String) : Array(::String)
-      parts = [] of ::String
-      current = String::Builder.new
-      depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      args.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '(', '[', '{'
-          depth += 1
-          current << ch
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-          current << ch
-        when ','
-          if depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON_SHARED_DEPTH)
     end
 
     # A NinjaAPI / Router instance and everything discovered about it.

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -1,4 +1,5 @@
 require "../../engines/python_engine"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   class Falcon < PythonEngine
@@ -290,50 +291,13 @@ module Analyzer::Python
       extract_keyword_string(args, "prefix") || args[0]?.try { |arg| Helper.extract_python_string(arg) }
     end
 
+    # Delegates to the shared splitter. `Rules::PYTHON_SHARED_DEPTH`, not
+    # `Rules::PYTHON`: this loop counted `(`, `[` and `{` on ONE depth
+    # counter, which is observable on the unbalanced fragments the route
+    # regexes actually hand it — `"[a)b, c"` splits here, but would not
+    # under per-kind counters.
     private def split_python_arguments(args : ::String) : Array(::String)
-      parts = [] of ::String
-      current = String::Builder.new
-      depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      args.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '(', '[', '{'
-          depth += 1
-          current << ch
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-          current << ch
-        when ','
-          if depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON_SHARED_DEPTH)
     end
 
     # Memoized per keyword — the keyword set is tiny (`prefix`) but this

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -1,4 +1,5 @@
 require "../../engines/python_engine"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   class FastAPI < PythonEngine
@@ -1167,48 +1168,14 @@ module Analyzer::Python
       parts
     end
 
+    # Delegates to the shared splitter. `Rules::PYTHON_SHARED_DEPTH`, not
+    # `Rules::PYTHON`: this loop counted `(`, `[` and `{` on ONE depth
+    # counter, which is observable on the unbalanced fragments the route
+    # regexes actually hand it. The two wrappers above stay local — the
+    # `nil`-on-single-part contract of `split_python_expression` is a FastAPI
+    # call-site convention, not a splitting rule.
     private def split_python_top_level(input : ::String, delimiter : Char) : Array(::String)
-      parts = [] of ::String
-      start = 0
-      depth = 0
-      in_quote = nil
-      escaped = false
-      index = 0
-      # `String#[]` walks from the start on every call for non-ASCII
-      # content, so indexing `input` directly inside this while loop was
-      # O(n^2); `chars` gives O(1) random access instead. The
-      # `input[start...index]` slices below stay on `input` — they only
-      # run once per delimiter found, not once per character.
-      chars = input.chars
-      while index < chars.size
-        ch = chars[index]
-        if in_quote
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-        else
-          case ch
-          when '\'', '"'
-            in_quote = ch
-          when '(', '[', '{'
-            depth += 1
-          when ')', ']', '}'
-            depth -= 1 if depth > 0
-          else
-            if ch == delimiter && depth == 0
-              parts << input[start...index]
-              start = index + 1
-            end
-          end
-        end
-        index += 1
-      end
-      parts << input[start..]
-      parts
+      Noir::TopLevelSplit.split(input, delimiter, Noir::TopLevelSplit::Rules::PYTHON_SHARED_DEPTH)
     end
 
     private def static_route_path(path : ::String) : ::String

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -1,4 +1,5 @@
 require "../../engines/python_engine"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   class Pyramid < PythonEngine
@@ -309,64 +310,12 @@ module Analyzer::Python
       nil
     end
 
+    # Delegates to the shared splitter; `Rules::PYTHON` reproduces this
+    # file's previous hand-rolled loop exactly (both quote styles, backslash
+    # escapes inside quotes, per-kind clamped depth, no strip, and every
+    # empty part kept so positional indexing of the result stays valid).
     private def split_python_arguments(args : String) : Array(String)
-      parts = [] of String
-      current = String::Builder.new
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      args.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '('
-          paren_depth += 1
-          current << ch
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-          current << ch
-        when '['
-          bracket_depth += 1
-          current << ch
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-          current << ch
-        when '{'
-          brace_depth += 1
-          current << ch
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-          current << ch
-        when ','
-          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON)
     end
 
     # Memoized per keyword — the keyword set is tiny (`name`) but this

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -2,6 +2,7 @@ require "../../../miniparsers/python_route_extractor"
 require "../../../miniparsers/python_route_extractor_ts"
 require "../../engines/python_engine"
 require "./python_helper"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   class Sanic < PythonEngine
@@ -622,64 +623,12 @@ module Analyzer::Python
       nil
     end
 
+    # Delegates to the shared splitter; `Rules::PYTHON` reproduces this
+    # file's previous hand-rolled loop exactly (both quote styles, backslash
+    # escapes inside quotes, per-kind clamped depth, no strip, and every
+    # empty part kept so positional indexing of the result stays valid).
     private def split_python_arguments(args : ::String) : Array(::String)
-      parts = [] of ::String
-      current = String::Builder.new
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      args.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '('
-          paren_depth += 1
-          current << ch
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-          current << ch
-        when '['
-          bracket_depth += 1
-          current << ch
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-          current << ch
-        when '{'
-          brace_depth += 1
-          current << ch
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-          current << ch
-        when ','
-          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON)
     end
 
     private def find_function_def(lines : Array(::String), function_name : ::String) : Int32?

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -1,4 +1,5 @@
 require "../../engines/python_engine"
+require "../../../utils/top_level_split"
 
 module Analyzer::Python
   class Starlette < PythonEngine
@@ -633,64 +634,12 @@ module Analyzer::Python
       reference.matches?(/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/) ? reference : ""
     end
 
+    # Delegates to the shared splitter; `Rules::PYTHON` reproduces this
+    # file's previous hand-rolled loop exactly (both quote styles, backslash
+    # escapes inside quotes, per-kind clamped depth, no strip, and every
+    # empty part kept so positional indexing of the result stays valid).
     private def split_python_arguments(args : ::String) : Array(::String)
-      parts = [] of ::String
-      current = String::Builder.new
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_quote : Char? = nil
-      escaped = false
-
-      args.each_char do |ch|
-        if in_quote
-          current << ch
-          if escaped
-            escaped = false
-          elsif ch == '\\'
-            escaped = true
-          elsif ch == in_quote
-            in_quote = nil
-          end
-          next
-        end
-
-        case ch
-        when '\'', '"'
-          in_quote = ch
-          current << ch
-        when '('
-          paren_depth += 1
-          current << ch
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-          current << ch
-        when '['
-          bracket_depth += 1
-          current << ch
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-          current << ch
-        when '{'
-          brace_depth += 1
-          current << ch
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-          current << ch
-        when ','
-          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-
-      parts << current.to_s
-      parts
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON)
     end
 
     private def normalize_receiver(receiver : ::String) : ::String

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -139,16 +139,18 @@ module Noir
       )
 
       # Python call-argument lists and expression terms.
-      # Serves the four byte-identical `split_python_arguments` clones in
-      # analyzer/analyzers/python/{django,starlette,bottle,pyramid}.cr plus
-      # django.cr `split_python_expression_terms`. Note these deliberately do
-      # NOT strip and keep every empty part — callers strip themselves and
-      # some index positionally, so an interior empty must hold its slot.
+      # Serves the six byte-identical `split_python_arguments` clones in
+      # analyzer/analyzers/python/{bottle,cherrypy,django,pyramid,sanic,
+      # starlette}.cr plus django.cr `split_python_expression_terms` (same
+      # body, `+` instead of `,`). Note these deliberately do NOT strip and
+      # keep every empty part — callers strip themselves and some index
+      # positionally, so an interior empty must hold its slot.
       #
       # Near misses that need their own `Rules` when converted:
-      #   fastapi.cr `split_python_top_level`  -> per_kind: false
-      #   flask.cr   `split_python_call_args`  -> Escape::Always, strip: true,
-      #                                           Empties::DropAll
+      #   flask.cr  `split_python_call_args`  -> Escape::Always, strip: true,
+      #                                          Empties::DropAll, and one
+      #                                          counter shared by `[`/`{`
+      #                                          only — not expressible here.
       PYTHON = new(
         nest: Nest::Paren | Nest::Bracket | Nest::Brace,
         quotes: "\"'",
@@ -156,6 +158,27 @@ module Noir
         strip: false,
         empties: Empties::Keep,
         per_kind: true,
+        clamp: true,
+      )
+
+      # `PYTHON` with one shared depth counter instead of per-kind counters.
+      # Serves analyzer/analyzers/python/{django_ninja,falcon}.cr
+      # `split_python_arguments` and fastapi.cr `split_python_top_level`.
+      #
+      # A named preset rather than three inline `Rules.new(...)` literals
+      # because the split is not a per-file accident: the Python analyzers
+      # genuinely disagree on `per_kind`, and keeping the two variants
+      # adjacent is what makes that disagreement — and the fact that it is
+      # only observable on unbalanced input — legible. Three copies of the
+      # same seven-argument literal in three files is exactly the drift this
+      # module exists to end.
+      PYTHON_SHARED_DEPTH = new(
+        nest: Nest::Paren | Nest::Bracket | Nest::Brace,
+        quotes: "\"'",
+        escape: Escape::InQuotes,
+        strip: false,
+        empties: Empties::Keep,
+        per_kind: false,
         clamp: true,
       )
 


### PR DESCRIPTION
## Summary

Second step of the splitter consolidation begun in #2617. Nine Python analyzers stop carrying their own copy of the top-level split loop.

**−534 / +92 lines.**

## What was converted

**Six byte-identical bodies** — `bottle`, `cherrypy`, `django`, `pyramid`, `sanic`, `starlette` each held the same 58-line `split_python_arguments`. `Rules::PYTHON` already described them exactly (it was derived from these sites), though its doc comment named only four of the six; that is corrected here.

`django.cr` `split_python_expression_terms` is the same body with `+` in place of `,` — same rules, different delimiter argument.

**Three sites with one shared depth counter** — `django_ninja`, `falcon` and `fastapi` count `(`, `[` and `{` on a single counter where the six above keep one per kind.

## Why `PYTHON_SHARED_DEPTH` is a preset, not three inline literals

Three copies of the same seven-argument `Rules.new(...)` in three files is exactly the drift this module exists to end. More usefully, placing it next to `PYTHON` is what makes the disagreement legible: a reader now sees that the Python analyzers genuinely split on `per_kind`, and that the difference is only observable on the unbalanced fragments the route regexes actually hand these functions.

`fastapi`'s two wrappers stay local — `split_python_expression` returns `nil` when it produced a single part, which is a FastAPI call-site convention rather than a splitting rule.

## flask / quart: still out, but for a different reason than recorded

Both are untouched. The blocker is their **counter grouping**: `(` has its own counter while `[` `]` `{` `}` share a second. That is neither `per_kind: true` nor `per_kind: false`, so converting them needs a grouping axis that does not exist yet.

The *other* blocker previously recorded for them — "two independent quote booleans, so `\"it's` opens both quote kinds" — **turns out not to be real**, and the follow-up note in #2617 is wrong on this point. Both guard blocks `next`:

```crystal
if single_quote
  single_quote = false if ch == '\''
  current << ch
  next          # <- the case below is unreachable while either flag is set
end
if double_quote
  ...
  next
end
case ch
when '\'' then single_quote = true
when '"'  then double_quote = true
```

so at most one flag can ever be true, and the pair is equivalent to a single `in_quote : Char?`. If flask/quart are ever converted, the axis to add is per-kind *grouping*, not anything about quotes.

## Equivalence proof

Verbatim copies of all four distinct old implementations were run against their replacements over the same corpus before any old body was deleted:

- 70 handcrafted edge cases — unbalanced fragments, escaped and unterminated quotes, interior empties (`a,,b`) and trailing empties (`a,b,`), decorators with keyword args, Korean/emoji inside quoted arguments
- 1,679 comma- and plus-bearing lines harvested from `spec/functional_test/fixtures/python/**`
- 25,000 seeded-random strings over `( ) [ ] { } " ' \ , + = / : a b 한 국 🚀 space`

```
tier1 split_python_arguments (PYTHON)          inputs=26749 mismatches=0
django split_python_expression_terms           inputs=26749 mismatches=0
django_ninja/falcon (shared depth)             inputs=26749 mismatches=0
fastapi split_python_top_level ','             inputs=26749 mismatches=0
fastapi split_python_top_level '+'             inputs=26749 mismatches=0
fastapi split_python_expression ',' / '+'      inputs=26749 mismatches=0
cross: fastapi ',' == django_ninja ','         inputs=26749 mismatches=0
```

Re-run against the shipped `Rules::PYTHON_SHARED_DEPTH` constant rather than a local literal — same result. The harness was a throwaway and is not in the diff.

## Test plan

- `crystal spec spec/unit_test` → **5034 examples, 0 failures** (unchanged — this PR adds no examples; the shared splitter's 76 specs landed in #2617)
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** — unchanged. The Python fixtures are the largest fixture group in the repo and the direct regression signal here.
- `./bin/noir -b spec/functional_test/fixtures/python -f json --no-log` before vs after → **419 endpoints, identical sets**
- `crystal tool format --check src/ spec/` → clean
- `ameba` on the 10 touched files → `10 inspected, 0 failures`
- `typos .` → clean

## Remaining in the series

`javascript`/`typescript` (nestjs, loopback, trpc), `java` (vertx, dropwizard, armeria, quarkus, spring, wicket), the `<>`-only miniparser trio, dart, elixir, erlang, php, haskell, specification. Plus `split_spans` for the express/feathers/hono offset-returning group, which needs a design pass first — the `String::Builder` core has no char offsets.