### PR TITLE
refactor(analyzer): convert the Java splitters to Noir::TopLevelSplit

### DIFF
--- a/spec/unit_test/utils/top_level_split_spec.cr
+++ b/spec/unit_test/utils/top_level_split_spec.cr
@@ -389,4 +389,39 @@ describe Noir::TopLevelSplit do
       TLS.split("[a)b, c", ',', TLSRules::CPP).should eq ["[a)b, c"]
     end
   end
+
+  describe "Rules::JAVA" do
+    it "splits an annotation argument list and strips each part" do
+      TLS.split("value = \"/users/{id}\", method = RequestMethod.GET", ',', TLSRules::JAVA)
+        .should eq ["value = \"/users/{id}\"", "method = RequestMethod.GET"]
+    end
+
+    it "keeps a nested lambda handler as one argument" do
+      input = "\"/a\", ctx -> { ctx.json(map(\"x\", 1)); }"
+      TLS.split(input, ',', TLSRules::JAVA).should eq ["\"/a\"", "ctx -> { ctx.json(map(\"x\", 1)); }"]
+    end
+
+    it "splits a concatenated path expression on plus" do
+      TLS.split("BASE + \"/users\" + suffix", '+', TLSRules::JAVA)
+        .should eq ["BASE", "\"/users\"", "suffix"]
+    end
+
+    it "drops a trailing empty part but keeps an interior one" do
+      TLS.split("a, , b,", ',', TLSRules::JAVA).should eq ["a", "", "b"]
+    end
+
+    it "treats a single quote as a quote character, unlike Rules::CPP" do
+      TLS.split("sep(','), x", ',', TLSRules::JAVA).should eq ["sep(',')", "x"]
+    end
+
+    # The axis that separates this preset from quarkus.cr and wicket.cr, which
+    # add Nest::Angle: here a generic argument list breaks apart at its comma.
+    it "does not count angle brackets, so a generic type splits" do
+      TLS.split("Map<String, Integer> m", ',', TLSRules::JAVA).should eq ["Map<String", "Integer> m"]
+    end
+
+    it "uses one shared clamped depth across bracket kinds" do
+      TLS.split("[a)b, c", ',', TLSRules::JAVA).should eq ["[a)b", "c"]
+    end
+  end
 end

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -5,6 +5,7 @@ require "../../../miniparsers/java_callee_extractor"
 require "../../../miniparsers/java_parameter_extractor_ts"
 require "../../../miniparsers/java_route_extractor_ts"
 require "../../../utils/url_path"
+require "../../../utils/top_level_split"
 
 module Analyzer::Java
   class Armeria < Analyzer
@@ -401,45 +402,10 @@ module Analyzer::Java
       matches.size == 1 ? matches.first : nil
     end
 
+    # Same rules as `split_top_level_args`, splitting on `+` instead of `,` so
+    # a concatenated path expression breaks into its terms.
     private def split_top_level_concat(expr : String) : Array(String)
-      parts = [] of String
-      start = 0
-      depth = 0
-      in_string = false
-      quote = '\0'
-      escape = false
-
-      expr.each_char_with_index do |char, index|
-        if in_string
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == quote
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"', '\''
-          in_string = true
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        when '+'
-          next unless depth == 0
-
-          parts << expr[start...index].strip
-          start = index + 1
-        end
-      end
-
-      tail = expr[start..]?.to_s.strip
-      parts << tail unless tail.empty?
-      parts
+      Noir::TopLevelSplit.split(expr, '+', Noir::TopLevelSplit::Rules::JAVA)
     end
 
     private def strip_wrapping_parentheses(expr : String) : String
@@ -597,45 +563,12 @@ module Analyzer::Java
       name.split(/[.$]/).last
     end
 
+    # Delegates to the shared splitter; `Rules::JAVA` reproduces this file's
+    # previous hand-rolled loop exactly (both quote styles, backslash escapes
+    # inside quotes, one clamped depth shared by `()`/`[]`/`{}`, each part
+    # stripped, interior empties kept and a trailing empty dropped).
     private def split_top_level_args(expr : String) : Array(String)
-      args = [] of String
-      start = 0
-      depth = 0
-      in_string = false
-      quote = '\0'
-      escape = false
-
-      expr.each_char_with_index do |char, index|
-        if in_string
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == quote
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"', '\''
-          in_string = true
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        when ','
-          next unless depth == 0
-
-          args << expr[start...index].strip
-          start = index + 1
-        end
-      end
-
-      tail = expr[start..]?.to_s.strip
-      args << tail unless tail.empty?
-      args
+      Noir::TopLevelSplit.split(expr, ',', Noir::TopLevelSplit::Rules::JAVA)
     end
 
     # True when absolute_offset falls inside a string/comment per mask.

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -4,6 +4,7 @@ require "../../../miniparsers/jaxrs_extractor_ts"
 require "../../../miniparsers/import_graph"
 require "yaml"
 require "../../../utils/url_path"
+require "../../../utils/top_level_split"
 
 module Analyzer::Java
   # Dropwizard ships Jersey under the hood, so JAX-RS resource
@@ -328,51 +329,13 @@ module Analyzer::Java
       base == "/" ? "/*" : "#{base.rstrip('/')}/*"
     end
 
+    # Delegates to the shared splitter. This file's copy was written against a
+    # `String::Builder` where armeria's and vertx's slice by index, but the two
+    # forms are observably identical — `Rules::JAVA` reproduces both (one
+    # clamped depth shared by `()`/`[]`/`{}`, both quote styles, backslash
+    # escapes inside quotes, stripped parts, trailing empty dropped).
     private def split_top_level_args(source : String) : Array(String)
-      args = [] of String
-      current = String::Builder.new
-      depth = 0
-      quote : Char? = nil
-      escaped = false
-
-      source.each_char do |char|
-        if quote
-          current << char
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            quote = nil
-          end
-          next
-        end
-
-        case char
-        when '"', '\''
-          quote = char
-          current << char
-        when '(', '{', '['
-          depth += 1
-          current << char
-        when ')', '}', ']'
-          depth -= 1 if depth > 0
-          current << char
-        when ','
-          if depth == 0
-            args << current.to_s.strip
-            current = String::Builder.new
-          else
-            current << char
-          end
-        else
-          current << char
-        end
-      end
-
-      tail = current.to_s.strip
-      args << tail unless tail.empty?
-      args
+      Noir::TopLevelSplit.split(source, ',', Noir::TopLevelSplit::Rules::JAVA)
     end
 
     private def string_literal_value(expression : String) : String?

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -5,6 +5,7 @@ require "../../../miniparsers/jaxrs_extractor_ts"
 require "../../../miniparsers/import_graph"
 require "yaml"
 require "../../../utils/url_path"
+require "../../../utils/top_level_split"
 
 module Analyzer::Java
   # Quarkus is JAX-RS-flavoured, so this analyzer just drives the
@@ -572,45 +573,27 @@ module Analyzer::Java
       content[(open_idx + 1)...close_idx]
     end
 
+    # `Rules::JAVA` plus `Nest::Angle`, on the same shared depth counter. Not
+    # the shared `Rules::JAVA` preset: this splitter runs on a JAX-RS resource
+    # method's parameter list, where `Map<String, List<Integer>>` is one
+    # parameter and must not break in two. The cost is that a `<` used as a
+    # comparison — `f(a < b, c)` — raises the depth and swallows the comma,
+    # which cannot happen in a parameter list. File-local because quarkus is
+    # the only splitter with exactly this combination; wicket also counts
+    # angles but takes only `"` as a quote.
+    SPLIT_ARGS_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace | Noir::TopLevelSplit::Nest::Angle,
+      quotes: "\"'",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: true,
+      empties: Noir::TopLevelSplit::Empties::DropTrailing,
+      per_kind: false,
+      clamp: true,
+    )
+
     private def split_top_level_args(source : String) : Array(String)
-      args = [] of String
-      start = 0
-      depth = 0
-      in_string = false
-      quote = '\0'
-      escape = false
-
-      source.each_char_with_index do |char, index|
-        if in_string
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == quote
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"', '\''
-          in_string = true
-          quote = char
-        when '(', '[', '{', '<'
-          depth += 1
-        when ')', ']', '}', '>'
-          depth -= 1 if depth > 0
-        when ','
-          next unless depth == 0
-
-          args << source[start...index].strip
-          start = index + 1
-        end
-      end
-
-      tail = source[start..]?.to_s.strip
-      args << tail unless tail.empty?
-      args
+      Noir::TopLevelSplit.split(source, ',', SPLIT_ARGS_RULES)
     end
 
     private def parameter_variable_name(arg : String) : String

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -6,6 +6,7 @@ require "../../../utils/spring_property_path"
 require "../../engines/java_engine"
 require "../../../utils/path_scope"
 require "../../../utils/url_path"
+require "../../../utils/top_level_split"
 require "yaml"
 
 module Analyzer::Java
@@ -1105,42 +1106,25 @@ module Analyzer::Java
       nil
     end
 
+    # `Rules::JAVA` minus the single-quote quote style, and dropping EVERY
+    # empty part rather than only a trailing one — the old body ended in
+    # `.map(&.strip).reject(&.empty?)`, so `"a" + + "b"` yielded two terms, not
+    # three. Both matter to the caller, which concatenates the terms it gets
+    # back into a route path. File-local because spring is the only splitter
+    # with this combination.
+    SPLIT_CONCAT_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace,
+      quotes: "\"",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: true,
+      empties: Noir::TopLevelSplit::Empties::DropAll,
+      per_kind: false,
+      clamp: true,
+    )
+
     private def split_top_level_concat(expression : String) : Array(String)
-      parts = [] of String
-      start = 0
-      depth = 0
-      in_string = false
-      escape = false
-
-      expression.each_char_with_index do |char, index|
-        if in_string
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == '"'
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"'
-          in_string = true
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        when '+'
-          if depth.zero?
-            parts << expression[start...index]
-            start = index + 1
-          end
-        end
-      end
-
-      parts << expression[start..]
-      parts.map(&.strip).reject(&.empty?)
+      Noir::TopLevelSplit.split(expression, '+', SPLIT_CONCAT_RULES)
     end
 
     private def strip_wrapping_parentheses(expression : String) : String

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -4,6 +4,7 @@ require "../../../miniparsers/java_callee_extractor"
 require "../../../miniparsers/java_route_extractor_ts"
 require "wait_group"
 require "../../../utils/url_path"
+require "../../../utils/top_level_split"
 
 module Analyzer::Java
   class Vertx < Analyzer
@@ -644,45 +645,16 @@ module Analyzer::Java
       split_top_level(args, ',')
     end
 
+    # Delegates to the shared splitter; `Rules::JAVA` reproduces this file's
+    # previous hand-rolled loop exactly (both quote styles, backslash escapes
+    # inside quotes, one clamped depth shared by `()`/`[]`/`{}`, each part
+    # stripped, interior empties kept and a trailing empty dropped). Called
+    # with `,` through the wrapper above and with `+` from
+    # `resolve_route_path_arg`; the old `case`-on-`separator` put the separator
+    # branch last, so neither of those values could ever shadow a quote or
+    # bracket branch and the parameterization is faithful.
     private def split_top_level(expr : String, separator : Char) : Array(String)
-      parts = [] of String
-      start = 0
-      depth = 0
-      in_string = false
-      quote = '\0'
-      escape = false
-
-      expr.each_char_with_index do |char, index|
-        if in_string
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == quote
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"', '\''
-          in_string = true
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        when separator
-          next unless depth == 0
-
-          parts << expr[start...index].strip
-          start = index + 1
-        end
-      end
-
-      tail = expr[start..]?.to_s.strip
-      parts << tail unless tail.empty?
-      parts
+      Noir::TopLevelSplit.split(expr, separator, Noir::TopLevelSplit::Rules::JAVA)
     end
 
     private def resolve_route_path_arg(raw_arg : String, constants : Hash(String, String), depth = 0) : String?

--- a/src/analyzer/analyzers/java/wicket.cr
+++ b/src/analyzer/analyzers/java/wicket.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../engines/java_engine"
 require "../../../miniparsers/java_route_extractor_ts"
 require "../../../miniparsers/java_callee_extractor"
+require "../../../utils/top_level_split"
 
 module Analyzer::Java
   class Wicket < Analyzer
@@ -702,43 +703,25 @@ module Analyzer::Java
       after < content.size && content[after] == '('
     end
 
+    # `Rules::JAVA` plus `Nest::Angle` and minus the single-quote quote style.
+    # Both divergences are load-bearing here: `mountPage("/x", Foo.class)` and
+    # `MyPage<T>` both reach this splitter, so angles must nest, while a Java
+    # `'c'` char literal never wraps a mount path and treating `'` as a quote
+    # would let an apostrophe inside a string swallow the rest of the list.
+    # File-local because wicket is the only splitter with this combination.
+    SPLIT_ARGUMENTS_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace | Noir::TopLevelSplit::Nest::Angle,
+      quotes: "\"",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: true,
+      empties: Noir::TopLevelSplit::Empties::DropTrailing,
+      per_kind: false,
+      clamp: true,
+    )
+
     private def split_arguments(args : String) : Array(String)
-      parts = [] of String
-      start = 0
-      depth = 0
-      in_string = false
-      escape = false
-
-      args.each_char_with_index do |char, index|
-        if in_string
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == '"'
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"'
-          in_string = true
-        when '(', '[', '{', '<'
-          depth += 1
-        when ')', ']', '}', '>'
-          depth -= 1 if depth > 0
-        when ','
-          if depth.zero?
-            parts << args[start...index].strip
-            start = index + 1
-          end
-        end
-      end
-
-      tail = args[start..]?.try(&.strip)
-      parts << tail if tail && !tail.empty?
-      parts
+      Noir::TopLevelSplit.split(args, ',', SPLIT_ARGUMENTS_RULES)
     end
 
     private def class_literal_name(argument : String?) : String?

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -1,4 +1,5 @@
 require "../utils/url_path"
+require "../utils/top_level_split"
 require "../ext/tree_sitter/tree_sitter"
 require "./extraction_result_cache"
 require "../models/endpoint"
@@ -457,25 +458,13 @@ module Noir
       end
     end
 
+    # Delegates to the shared splitter. `Rules::GENERICS_ONLY` reproduces this
+    # file's previous hand-rolled loop exactly: only `<` and `>` contribute
+    # depth (clamped at 0), quotes and backslashes are ordinary characters, no
+    # part is stripped and every empty part is kept. The caller strips and
+    # skips empties itself.
     private def split_top_level_commas(text : String) : Array(String)
-      parts = [] of String
-      start = 0
-      depth = 0
-      text.each_char_with_index do |char, index|
-        case char
-        when '<'
-          depth += 1
-        when '>'
-          depth -= 1 if depth > 0
-        when ','
-          if depth == 0
-            parts << text[start...index]
-            start = index + 1
-          end
-        end
-      end
-      parts << text[start..]
-      parts
+      Noir::TopLevelSplit.split(text, ',', Noir::TopLevelSplit::Rules::GENERICS_ONLY)
     end
 
     private def strip_generic_arguments(text : String) : String

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -1,4 +1,5 @@
 require "../utils/url_path"
+require "../utils/top_level_split"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./java_callee_extractor"
@@ -659,25 +660,13 @@ module Noir
       end
     end
 
+    # Delegates to the shared splitter. `Rules::GENERICS_ONLY` reproduces this
+    # file's previous hand-rolled loop exactly: only `<` and `>` contribute
+    # depth (clamped at 0), quotes and backslashes are ordinary characters, no
+    # part is stripped and every empty part is kept. The caller strips and
+    # skips empties itself.
     private def split_top_level_commas(text : String) : Array(String)
-      parts = [] of String
-      start = 0
-      depth = 0
-      text.each_char_with_index do |char, index|
-        case char
-        when '<'
-          depth += 1
-        when '>'
-          depth -= 1 if depth > 0
-        when ','
-          if depth == 0
-            parts << text[start...index]
-            start = index + 1
-          end
-        end
-      end
-      parts << text[start..]
-      parts
+      Noir::TopLevelSplit.split(text, ',', Noir::TopLevelSplit::Rules::GENERICS_ONLY)
     end
 
     private def strip_generic_arguments(text : String) : String

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -1,4 +1,5 @@
 require "../utils/url_path"
+require "../utils/top_level_split"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./java_callee_extractor"
@@ -505,25 +506,13 @@ module Noir
       names
     end
 
+    # Delegates to the shared splitter. `Rules::GENERICS_ONLY` reproduces this
+    # file's previous hand-rolled loop exactly: only `<` and `>` contribute
+    # depth (clamped at 0), quotes and backslashes are ordinary characters, no
+    # part is stripped and every empty part is kept. The caller strips and
+    # skips empties itself.
     private def split_top_level_commas(text : String) : Array(String)
-      parts = [] of String
-      start = 0
-      depth = 0
-      text.each_char_with_index do |char, index|
-        case char
-        when '<'
-          depth += 1
-        when '>'
-          depth -= 1 if depth > 0
-        when ','
-          if depth == 0
-            parts << text[start...index]
-            start = index + 1
-          end
-        end
-      end
-      parts << text[start..]
-      parts
+      Noir::TopLevelSplit.split(text, ',', Noir::TopLevelSplit::Rules::GENERICS_ONLY)
     end
 
     private def strip_generic_arguments(text : String) : String

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -183,12 +183,23 @@ module Noir
       )
 
       # Java annotation and call-argument lists.
-      # Serves analyzer/analyzers/java/{vertx,dropwizard,armeria}.cr
-      # `split_top_level_args` / `split_top_level_concat`. One shared depth is
-      # unanimous across the Java splitters, unlike Python and JS.
+      # Serves four sites in analyzer/analyzers/java/: armeria.cr
+      # `split_top_level_args` AND `split_top_level_concat` (same body, `+`
+      # instead of `,`), dropwizard.cr `split_top_level_args`, and vertx.cr
+      # `split_top_level`, which takes the separator as a parameter and is
+      # called with both `,` and `+`. Note dropwizard's copy was written
+      # against a `String::Builder` and the other three against index slices;
+      # they are nevertheless observably identical, unbalanced input included.
+      # One shared depth is unanimous across the Java splitters, unlike Python
+      # and JS.
       #
-      # Near misses that need their own `Rules` when converted:
+      # Three Java sites each disagree with this preset on one or two axes and
+      # so carry a file-local `Rules` constant rather than a preset here — each
+      # is used by exactly one splitter, so naming them centrally would put
+      # three single-use constants in this file:
       #   quarkus.cr `split_top_level_args`   -> nest also includes Angle
+      #   wicket.cr  `split_arguments`        -> nest also includes Angle,
+      #                                          quotes "\"" only
       #   spring.cr  `split_top_level_concat` -> quotes "\"", Empties::DropAll
       JAVA = new(
         nest: Nest::Paren | Nest::Bracket | Nest::Brace,
@@ -218,12 +229,13 @@ module Noir
         clamp: true,
       )
 
-      # Generic/type-argument lists: angle brackets only, no quote handling.
+      # Type lists: angle brackets only, no quote handling.
       # Serves the three byte-identical `split_top_level_commas` clones in
-      # miniparsers/{java_route,jaxrs,micronaut}_extractor_ts.cr, which run on
-      # an already-extracted generic parameter list where `(`/`{` cannot
-      # legally appear and a stray `"` would swallow the rest of the
-      # signature. They keep empties and do not strip.
+      # miniparsers/{java_route,jaxrs,micronaut}_extractor_ts.cr. All three run
+      # on the tail of an `implements` clause with the class body already
+      # truncated at `{`, so only generic arguments can nest and a stray `"`
+      # would swallow the rest of the type list. They keep empties and do not
+      # strip; every caller strips each part itself and skips the empties.
       GENERICS_ONLY = new(
         nest: Nest::Angle,
         quotes: "",


### PR DESCRIPTION
## Summary

Third step of the splitter consolidation (#2617 C++, #2618 Python). Nine more sites stop carrying their own top-level split loop.

**−330 / +162 lines.**

## What was converted

**Four sites are `Rules::JAVA` as it already stood** — armeria's `split_top_level_args` *and* `split_top_level_concat` (same body, `+` instead of `,`), dropwizard's `split_top_level_args`, and vertx's `split_top_level`, which takes the separator as a parameter and is called with both.

This is where the preset starts paying for itself: **vertx alone has ~15 call sites and wicket ~13**, and every one is untouched because the private wrapper stayed.

**Three sites keep a file-local `Rules` constant** — quarkus (adds `Angle`), wicket (adds `Angle`, drops the single-quote style), spring (`+`, `"` only, `Empties::DropAll`).

**Three `<>`-only miniparser clones** (java_route, jaxrs, micronaut `split_top_level_commas`) move to `Rules::GENERICS_ONLY`.

## Why file-local constants and not new presets

Each is used by exactly one splitter, and **no two of them agree** — quarkus and wicket both add angle brackets but disagree on quotes; spring adds neither. Three central presets would be three single-use constants sitting in a file nothing else references them from.

This is deliberately the opposite call from #2618's `PYTHON_SHARED_DEPTH`, where three sites shared one variant and putting it next to `PYTHON` made a real disagreement legible. `Rules::JAVA`'s doc comment now lists all three divergences and says where they live.

## Two things the hypothesis got wrong

**1. dropwizard is a different implementation, not just another copy.** I grouped it with armeria/vertx as an expected clone. armeria and vertx slice by index (`expr[start...index].strip`); dropwizard accumulates into a `String::Builder` and carries an explicit `else current << char` arm. The rules turn out identical — but that had to be *proved*, so the harness ran a direct `armeria(s, ',') == dropwizard(s)` cross-check across the whole corpus.

**2. `GENERICS_ONLY`'s doc comment described the wrong input.** It claimed the three clones run on "an already-extracted generic parameter list". They do not — all three are called from `implemented_interface_names` on `header.match(/\bimplements\s+(.+)\z/m)[1]`, after the class body has been truncated at `{`. It is an `implements` *type list* that happens to contain generics. The comment's conclusion (`(` and `{` cannot appear) still holds, and now for a stated reason.

## One constraint worth knowing about

vertx's old `case char ... when separator` put the separator branch **after** the quote and bracket arms, so a separator of `"` or `(` would have been shadowed. Both real call sites pass `,` (`:644`) and `+` (`:703`), neither of which collides, so forwarding the parameter to the shared splitter is faithful. Noted on the method so the next person to add a caller knows.

Two other things that looked like divergences and were not: spring's trailing `.map(&.strip).reject(&.empty?)` is exactly `strip: true` + `Empties::DropAll`, not a third policy; wicket's `tail.try(&.strip)` + `if tail && !tail.empty?` is exactly `DropTrailing`.

## Equivalence proof

Six distinct old bodies against their replacements, **26,630 inputs**:

- 82 handcrafted cases — generics (`Map<String, List<Integer>>`), `f(a < b, c > d)` where the angles are comparisons rather than generics, Java char literals `','` and `'\''`, unbalanced fragments, unterminated/escaped quotes, interior vs trailing empties, non-ASCII inside quotes
- 1,548 lines harvested from every file under `spec/functional_test/fixtures/{java,kotlin}` — each candidate line plus its first `(...)` interior, which is the shape the route regexes actually hand these functions
- 25,000 seeded-random strings over an alphabet including `<`, `>`, `+`, quotes and backslash

```
A armeria/vertx ',': 0    A armeria/vertx '+': 0    B dropwizard: 0
C quarkus: 0              D wicket: 0               E spring: 0
F miniparsers: 0          X armeria-vs-dropwizard: 0
```

Harness was a throwaway and is not in the diff.

## Test plan

- `crystal spec spec/unit_test` → **5041 examples, 0 failures** (5034 + 7 new)
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** — unchanged
- Real binary, baseline built from `origin/main` before any edit:
  - `fixtures/java` → **412 endpoints**, raw JSON diff before/after → identical
  - `fixtures/kotlin` → **98 endpoints**, identical (kotlin matters — the JVM extractors are shared)
- `crystal tool format --check src/ spec/` → clean
- `ameba` on the 10 touched source files → `10 inspected, 0 failures`
- `typos .` → clean

## New coverage

`Rules::JAVA` and `Rules::GENERICS_ONLY` are put into service here and had no preset-level spec, so a `describe "Rules::JAVA"` block (7 examples) is added mirroring the existing `Rules::CPP` one. It pins the axis that separates the preset from quarkus/wicket: `Map<String, Integer> m` splits into `["Map<String", "Integer> m"]` under `JAVA`, because angles are not counted.

## Remaining in the series

javascript/typescript (nestjs, loopback, trpc), dart, elixir, erlang, php (laminas, wordpress), haskell (servant), specification (traefik, typespec), csharp, and `engines/cfml_engine.cr`. Plus `split_spans` for the express/feathers/hono offset-returning group, which still needs a design pass — the `String::Builder` core has no char offsets.