### PR TITLE
refactor(analyzer): convert the JavaScript/TypeScript splitters to Noir::TopLevelSplit

### DIFF
--- a/spec/unit_test/utils/top_level_split_spec.cr
+++ b/spec/unit_test/utils/top_level_split_spec.cr
@@ -424,4 +424,59 @@ describe Noir::TopLevelSplit do
       TLS.split("[a)b, c", ',', TLSRules::JAVA).should eq ["[a)b", "c"]
     end
   end
+
+  describe "Rules::JS" do
+    it "splits a decorator argument list and strips each part" do
+      TLS.split("'users/:id', { name: 'x', tags: [1, 2] }", ',', TLSRules::JS)
+        .should eq ["'users/:id'", "{ name: 'x', tags: [1, 2] }"]
+    end
+
+    # Backticks are the axis that separates this preset from JAVA/CPP: a
+    # template literal wraps most JS route strings, and without backtick
+    # quoting the comma inside `${...}` would break the route in half.
+    it "treats a backtick template literal as one quoted run" do
+      TLS.split("`/users/${ids.join(',')}/posts`, handler", ',', TLSRules::JS)
+        .should eq ["`/users/${ids.join(',')}/posts`", "handler"]
+    end
+
+    it "keeps a nested template literal intact" do
+      TLS.split("`${`${x, y}`, z}`, tail", ',', TLSRules::JS)
+        .should eq ["`${`${x, y}`, z}`", "tail"]
+    end
+
+    it "keeps an arrow function with its own parameter list as one part" do
+      TLS.split("'/x', (req, res) => res.send('ok'), next", ',', TLSRules::JS)
+        .should eq ["'/x'", "(req, res) => res.send('ok')", "next"]
+    end
+
+    it "splits a concatenated path expression on plus" do
+      TLS.split("BASE + `/users/${id}`", '+', TLSRules::JS)
+        .should eq ["BASE", "`/users/${id}`"]
+    end
+
+    # DropAll, unlike JAVA's DropTrailing: interior empties vanish too, so a
+    # caller cannot index parts positionally.
+    it "drops interior and trailing empty parts" do
+      TLS.split("a, , b,", ',', TLSRules::JS).should eq ["a", "b"]
+    end
+
+    it "retains a backslash escaping a quote inside a run" do
+      TLS.split("'a\\', b'", ',', TLSRules::JS).should eq ["'a\\', b'"]
+    end
+
+    # The axis that separates this preset from typescript/trpc.cr, whose
+    # file-local rules share one depth counter and would split here.
+    it "uses per-kind clamped depth counters" do
+      TLS.split("[a)b, c", ',', TLSRules::JS).should eq ["[a)b, c"]
+    end
+
+    it "does not count angle brackets, unlike nextjs.cr's file-local rules" do
+      TLS.split("Promise<a, b>", ',', TLSRules::JS).should eq ["Promise<a", "b>"]
+    end
+
+    it "keeps a non-ASCII quoted argument in one part" do
+      TLS.split("'안녕, 세상', handler", ',', TLSRules::JS)
+        .should eq ["'안녕, 세상'", "handler"]
+    end
+  end
 end

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -1,6 +1,7 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
+require "../../../utils/top_level_split"
 
 module Analyzer::Javascript
   class Nestjs < JavascriptEngine
@@ -572,51 +573,7 @@ module Analyzer::Javascript
     end
 
     private def split_top_level(text : String, delimiter : Char) : Array(String)
-      parts = [] of String
-      start = 0
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      quote : Char? = nil
-      escaped = false
-
-      text.each_char_with_index do |char, index|
-        if quote
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            quote = nil
-          end
-          next
-        end
-
-        case char
-        when '\'', '"', '`'
-          quote = char
-        when '('
-          paren_depth += 1
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-        when '['
-          bracket_depth += 1
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-        when '{'
-          brace_depth += 1
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-        else
-          if char == delimiter && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << text[start...index].strip
-            start = index + 1
-          end
-        end
-      end
-
-      parts << text[start..-1].strip
-      parts.reject(&.empty?)
+      Noir::TopLevelSplit.split(text, delimiter, Noir::TopLevelSplit::Rules::JS)
     end
 
     private def process_http_methods(class_content : String, base_paths : Array(String), controller_versions : Array(String), file_path : String, result : Array(Endpoint), include_callee : Bool, controller_start_line : Int32, literal_values : Hash(String, Array(String)))

--- a/src/analyzer/analyzers/javascript/nextjs.cr
+++ b/src/analyzer/analyzers/javascript/nextjs.cr
@@ -2,6 +2,7 @@ require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
 require "../../../miniparsers/import_graph"
+require "../../../utils/top_level_split"
 
 module Analyzer::Javascript
   class Nextjs < JavascriptEngine
@@ -600,33 +601,31 @@ module Analyzer::Javascript
       end
     end
 
+    # Unlike every other JS/TS splitter this one has NO quote handling at all,
+    # counts `<` `>` as nesting, and neither strips nor drops empty parts —
+    # reproduced verbatim from the body it replaces.
+    #
+    # The two callers explain the shape: `exported_alias_for_method` passes the
+    # inside of an `export { a, b as c }` clause and
+    # `extract_server_action_params` passes a TypeScript parameter list, so
+    # generics have to nest (`{ params }: { params: Promise<{ id: string }> }`)
+    # but neither input can contain a string literal. Both strip each part and
+    # skip the empties themselves.
+    SPLIT_TOP_LEVEL_COMMAS_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace | Noir::TopLevelSplit::Nest::Angle,
+      quotes: "",
+      escape: Noir::TopLevelSplit::Escape::None,
+      strip: false,
+      empties: Noir::TopLevelSplit::Empties::Keep,
+      per_kind: false,
+      clamp: true,
+    )
+
     # Split a comma-separated string at top-level commas only (ignoring those inside
     # braces, brackets, parens, or angle brackets).
     private def split_top_level_commas(s : String) : Array(String)
-      parts = [] of String
-      depth = 0
-      buffer = String::Builder.new
-      s.each_char do |c|
-        case c
-        when '{', '[', '(', '<'
-          depth += 1
-          buffer << c
-        when '}', ']', ')', '>'
-          depth -= 1 if depth > 0
-          buffer << c
-        when ','
-          if depth == 0
-            parts << buffer.to_s
-            buffer = String::Builder.new
-          else
-            buffer << c
-          end
-        else
-          buffer << c
-        end
-      end
-      parts << buffer.to_s
-      parts
+      Noir::TopLevelSplit.split(s, ',', SPLIT_TOP_LEVEL_COMMAS_RULES)
     end
 
     # Extract only simple top-level identifiers from a flat destructure body.

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -1,5 +1,6 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
+require "../../../utils/top_level_split"
 
 module Analyzer::Javascript
   # Remix v2 is filesystem-routed under `app/routes/`. The route URL
@@ -159,34 +160,27 @@ module Analyzer::Javascript
       url == "/" ? "/" : url.sub(/\/+$/, "")
     end
 
+    # `[...]` is the only thing that nests in a Remix flat-route filename, and
+    # a filename has no string literals, so quote handling is off — a route
+    # named `it's.tsx` would otherwise open a quoted run and never split.
+    # Empties are kept and parts are not stripped because `normalize_segment`
+    # and the caller decide what an empty segment means; a filename cannot
+    # contain leading or trailing whitespace worth trimming anyway.
+    FLAT_SEGMENT_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Bracket,
+      quotes: "",
+      escape: Noir::TopLevelSplit::Escape::None,
+      strip: false,
+      empties: Noir::TopLevelSplit::Empties::Keep,
+      per_kind: false,
+      clamp: true,
+    )
+
     # Split a dot-flat Remix route name on segment separators, treating a
     # `.` inside an escaped `[...]` group as a literal (e.g.
     # `jokes[.]rss` is ONE segment whose URL is `/jokes.rss`, not two).
     private def split_flat_segments(name : String) : Array(String)
-      segments = [] of String
-      current = String::Builder.new
-      depth = 0
-      name.each_char do |ch|
-        case ch
-        when '['
-          depth += 1
-          current << ch
-        when ']'
-          depth -= 1 if depth > 0
-          current << ch
-        when '.'
-          if depth == 0
-            segments << current.to_s
-            current = String::Builder.new
-          else
-            current << ch
-          end
-        else
-          current << ch
-        end
-      end
-      segments << current.to_s
-      segments
+      Noir::TopLevelSplit.split(name, '.', FLAT_SEGMENT_RULES)
     end
 
     # Unescape `[...]` literals (the brackets are removed; their contents

--- a/src/analyzer/analyzers/typescript/loopback.cr
+++ b/src/analyzer/analyzers/typescript/loopback.cr
@@ -1,6 +1,7 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
+require "../../../utils/top_level_split"
 
 module Analyzer::Typescript
   # LoopBack 4 (`@loopback/rest`) routes controller methods with OpenAPI
@@ -320,51 +321,7 @@ module Analyzer::Typescript
     end
 
     private def split_top_level(text : String, delimiter : Char) : Array(String)
-      parts = [] of String
-      start = 0
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      quote : Char? = nil
-      escaped = false
-
-      text.each_char_with_index do |char, index|
-        if quote
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            quote = nil
-          end
-          next
-        end
-
-        case char
-        when '\'', '"', '`'
-          quote = char
-        when '('
-          paren_depth += 1
-        when ')'
-          paren_depth -= 1 if paren_depth > 0
-        when '['
-          bracket_depth += 1
-        when ']'
-          bracket_depth -= 1 if bracket_depth > 0
-        when '{'
-          brace_depth += 1
-        when '}'
-          brace_depth -= 1 if brace_depth > 0
-        else
-          if char == delimiter && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-            parts << text[start...index].strip
-            start = index + 1
-          end
-        end
-      end
-
-      parts << text[start..-1].strip
-      parts.reject(&.empty?)
+      Noir::TopLevelSplit.split(text, delimiter, Noir::TopLevelSplit::Rules::JS)
     end
 
     private def push_unique_param(endpoint : Endpoint, param : Param)

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -1,6 +1,7 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
+require "../../../utils/top_level_split"
 
 module Analyzer::Typescript
   class TRPC < Analyzer::Javascript::JavascriptEngine
@@ -723,42 +724,25 @@ module Analyzer::Typescript
       nil
     end
 
+    # `Rules::JS` except that one depth counter is shared by `()`, `[]` and
+    # `{}` instead of one per kind — this file's copy tracked a single `depth`
+    # where nestjs.cr and loopback.cr tracked three. Only observable on the
+    # unbalanced fragments these actually receive: on `"[a)b, c"` the shared
+    # counter reads `)` as closing the `[` and splits, where `Rules::JS`
+    # stays at bracket depth 1 and returns one part.
+    SPLIT_TOP_LEVEL_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace,
+      quotes: "\"'`",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: true,
+      empties: Noir::TopLevelSplit::Empties::DropAll,
+      per_kind: false,
+      clamp: true,
+    )
+
     private def split_top_level(text : String, delimiter : Char) : Array(String)
-      parts = [] of String
-      start = 0
-      depth = 0
-      quote : Char? = nil
-      escaped = false
-
-      text.each_char_with_index do |char, index|
-        if quote
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            quote = nil
-          end
-          next
-        end
-
-        case char
-        when '\'', '"', '`'
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        else
-          if char == delimiter && depth == 0
-            parts << text[start...index].strip
-            start = index + 1
-          end
-        end
-      end
-
-      parts << text[start..-1].strip
-      parts.reject(&.empty?)
+      Noir::TopLevelSplit.split(text, delimiter, SPLIT_TOP_LEVEL_RULES)
     end
 
     private def skip_top_level_to_comma(chars : Array(Char), start : Int32) : Int32

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -213,12 +213,31 @@ module Noir
 
       # JavaScript/TypeScript object-literal and argument lists.
       # Serves analyzer/analyzers/javascript/nestjs.cr and
-      # analyzer/analyzers/typescript/loopback.cr `split_top_level`. Backticks
-      # are quote characters because template literals wrap most route
-      # strings; missing them merges a whole `${...}` route into one part.
+      # analyzer/analyzers/typescript/loopback.cr `split_top_level`, which are
+      # byte-identical and are called with both `,` and `+`. Backticks are
+      # quote characters because template literals wrap most route strings;
+      # missing them merges a whole `${...}` route into one part.
       #
-      # Near misses that need their own `Rules` when converted:
-      #   typescript/trpc.cr `split_top_level` -> per_kind: false
+      # Three more JS/TS sites each disagree on one to four axes and carry a
+      # file-local `Rules` constant rather than a preset here, each being the
+      # only user of its variant:
+      #   typescript/trpc.cr  `split_top_level`        -> per_kind: false
+      #   javascript/nextjs.cr `split_top_level_commas` -> no quotes, no
+      #                                          escape, nest adds Angle,
+      #                                          strip: false, Empties::Keep
+      #   javascript/remix.cr `split_flat_segments`    -> Nest::Bracket only,
+      #                                          no quotes, strip: false,
+      #                                          Empties::Keep, delimiter `.`
+      #
+      # NOT converted — javascript/express/router_mount_scanner.cr
+      # `split_at_top_level_commas` agrees with this preset on every axis
+      # except escaping, which it does with `prev_char != '\\'` instead of an
+      # escape flag. That misreads `"a\\"` as an unterminated string (the
+      # escaped backslash is taken as escaping the closing quote), so no
+      # `Escape` value reproduces it and converting would change where it
+      # splits. The three `split_top_level_args` copies in
+      # javascript/{express,feathers,hono}.cr are likewise left alone: they
+      # return `{part, offset}` tuples, and this module returns only strings.
       JS = new(
         nest: Nest::Paren | Nest::Bracket | Nest::Brace,
         quotes: "\"'`",


### PR DESCRIPTION
## Summary

Fourth step of the splitter consolidation (#2617 C++, #2618 Python, #2619 Java). Five sites converted.

**−178 / +143 lines.**

`nestjs` and `loopback` are byte-identical and are `Rules::JS` as it already stood. Backticks earn their place in that preset here: JS template literals wrap most route strings, and without them a whole `${...}` route merges into one part.

Three sites diverge and keep a **file-local `Rules` constant**, each being the only user of its variant — `trpc` (one shared depth), `nextjs` (no quotes, no escape, counts angle brackets, keeps empties), and `remix` (below). Same standard as #2619's quarkus/wicket/spring, as opposed to #2618's `PYTHON_SHARED_DEPTH`, which earned a central preset by serving three sites.

## Two findings the site list did not predict

**1. A fifth member of the family that no survey had named** — `javascript/remix.cr:165` `split_flat_segments`. It splits a dot-flat Remix route filename on `.` with `[...]` nesting (so `jokes[.]rss` is one segment). Converted.

Quote handling must be **off** for it, and that is not cosmetic: a route file named `it's.tsx` would otherwise open a quoted run that never closes and swallow every following segment.

**2. `express/router_mount_scanner.cr:1038` `split_at_top_level_commas` is not convertible.** It agrees with `Rules::JS` on nesting, per-kind, clamp and quote characters, but does escaping with a lookback rather than a state flag:

```crystal
if ch == in_string && prev_char != '\\'
```

On `"a\\", b` the escaped backslash is taken as escaping the closing quote, so the string never terminates and the comma never splits. No `Escape` value reproduces this. The harness confirms it — old returns one part, `Escape::InQuotes` returns two; **5 mismatches over the corpus, every one of that shape**.

Left as-is: this series reproduces behavior rather than correcting it, and a silent fix here would move endpoints. It is now documented on the `JS` preset as a known defect rather than an oversight — worth its own PR, with its own before/after evidence.

The `split_top_level_args` copies in express/feathers/hono stay out for a structural reason: they return `{part, offset}` tuples and this module returns strings only. They wait on `split_spans`.

## Equivalence proof

Five distinct old bodies against their replacements, **28,966 inputs**:

- 2,596 lines harvested from 305 JS/TS fixture files, plus their inner paren-slices — the shape callers actually pass
- 78 handcrafted: template literals including nested `` `${`${x, y}`, z}` ``, object and array literals, arrow-function arguments, unbalanced fragments, unterminated and escaped quotes of all three kinds, interior (`a,,b`) and trailing (`a,b,`) empties, CJK and emoji inside quoted arguments
- 25,000 seeded-random strings over an alphabet with all three quote characters, backslash, `< >` and `${}`

```
BODY A (nestjs/loopback) delim=',': 0 mismatches / 28966
BODY A (nestjs/loopback) delim='+': 0 mismatches / 28966
BODY B (trpc)            delim=',': 0 mismatches / 28966
BODY C (nextjs)          delim=',': 0 mismatches / 28966
BODY D (remix)           delim='.': 0 mismatches / 28966
```

The constants used in the harness were verified identical to those written into the source files. Harness was a throwaway and is not in the diff.

## Test plan

- `crystal spec spec/unit_test` → **5051 examples, 0 failures** (5041 + 10 new)
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** — unchanged
- Real binary, baseline built before any edit: `fixtures/javascript` and `fixtures/typescript` endpoint sets both identical before/after
- `crystal tool format --check src/ spec/` → clean
- `ameba` on the 7 touched files → `7 inspected, 0 failures`
- `typos .` → clean

## New coverage

`describe "Rules::JS"` (10 examples), mirroring the existing `Rules::CPP` and `Rules::JAVA` blocks. Pins backtick template literals including nested interpolation, `DropAll` dropping interior empties, per-kind depth (the axis separating the preset from trpc), angle brackets *not* being counted (the axis separating it from nextjs), escape retention, and non-ASCII.

## Remaining in the series

dart, elixir, erlang (cowboy), php (laminas, wordpress), csharp, `engines/cfml_engine.cr`; the multi-char-delimiter pair (servant, traefik) which will be the first real users of the `String` overload; typespec. Then `split_spans` for the offset-returning group, which still needs a design pass.

`specification/apache_httpd.cr` `split_args` is out of scope permanently — it is a shell-style tokenizer with no nesting that strips quote characters out of its output, a different algorithm entirely.