### PR TITLE
refactor(analyzer): convert the long-tail splitters to Noir::TopLevelSplit

### DIFF
--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -1,5 +1,6 @@
 require "../../../miniparsers/csharp_callee_extractor"
 require "../../../minilexers/csharp_lexer"
+require "../../../utils/top_level_split"
 
 module Analyzer::CSharp::Common
   # Standard .NET test-source conventions:
@@ -186,64 +187,31 @@ module Analyzer::CSharp::Common
     {signature, index - 1}
   end
 
+  # Inside a string literal commas/brackets are data, not structure — e.g.
+  # a route literal `"/a,b"` or a `new[] { "GET", "POST" }` arg. Single
+  # quotes are NOT a quote style: in C# they wrap a char literal, which
+  # never carries a route, and treating `'` as a quote would let an
+  # apostrophe inside a `"..."`-free fragment swallow the rest of the list.
+  #
+  # `Empties::DropTrailing`, not `DropAll`: the comma branch pushed
+  # `current.to_s.strip` with no emptiness guard, so `(a, , b)` kept its
+  # interior `""`; only the tail was guarded by `unless tail.empty?`.
+  #
+  # File-local because no other splitter combines `Nest::Angle` with
+  # per-kind counters — java/wicket.cr comes closest and shares one depth.
+  SPLIT_PARAMETERS_RULES = Noir::TopLevelSplit::Rules.new(
+    nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+          Noir::TopLevelSplit::Nest::Brace | Noir::TopLevelSplit::Nest::Angle,
+    quotes: "\"",
+    escape: Noir::TopLevelSplit::Escape::InQuotes,
+    strip: true,
+    empties: Noir::TopLevelSplit::Empties::DropTrailing,
+    per_kind: true,
+    clamp: true,
+  )
+
   protected def split_csharp_parameters(param_list : String) : Array(String)
-    params = [] of String
-    current = String::Builder.new
-    generic_depth = 0
-    paren_depth = 0
-    bracket_depth = 0
-    brace_depth = 0
-    in_string = false
-    escaped = false
-
-    param_list.each_char do |char|
-      # Inside a string literal commas/brackets are data, not structure —
-      # e.g. a route literal `"/a,b"` or a `new[] { "GET", "POST" }` arg.
-      if in_string
-        current << char
-        if escaped
-          escaped = false
-        elsif char == '\\'
-          escaped = true
-        elsif char == '"'
-          in_string = false
-        end
-        next
-      end
-
-      case char
-      when '"'
-        in_string = true
-      when '<'
-        generic_depth += 1
-      when '>'
-        generic_depth -= 1 if generic_depth > 0
-      when '('
-        paren_depth += 1
-      when ')'
-        paren_depth -= 1 if paren_depth > 0
-      when '['
-        bracket_depth += 1
-      when ']'
-        bracket_depth -= 1 if bracket_depth > 0
-      when '{'
-        brace_depth += 1
-      when '}'
-        brace_depth -= 1 if brace_depth > 0
-      when ','
-        if generic_depth == 0 && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-          params << current.to_s.strip
-          current = String::Builder.new
-          next
-        end
-      end
-
-      current << char
-    end
-
-    tail = current.to_s.strip
-    params << tail unless tail.empty?
-    params
+    Noir::TopLevelSplit.split(param_list, ',', SPLIT_PARAMETERS_RULES)
   end
 
   # Returns the substring inside the first balanced parameter-list parens of

--- a/src/analyzer/analyzers/dart/dart_helper.cr
+++ b/src/analyzer/analyzers/dart/dart_helper.cr
@@ -1,4 +1,5 @@
 require "../../../utils/path_scope"
+require "../../../utils/top_level_split"
 require "../../../miniparsers/dart_callee_extractor"
 
 module Analyzer::Dart
@@ -211,72 +212,36 @@ module Analyzer::Dart
       nil
     end
 
-    # Split a call's argument list on top-level commas. Each bracket kind
-    # (`()`, `{}`, `[]`, `<>`) gets its own counter so a generic argument
-    # (`Map<String, int>`) and a collection literal (`[a, b]`) both keep
-    # their inner commas, and string literals are skipped so a comma inside
-    # `'a,b'` never splits. The trailing segment is always emitted, so a
+    # Each bracket kind (`()`, `{}`, `[]`, `<>`) gets its own counter so a
+    # generic argument (`Map<String, int>`) and a collection literal
+    # (`[a, b]`) both keep their inner commas, and string literals are
+    # skipped so a comma inside `'a,b'` never splits. Nothing is stripped
+    # and every part is kept, the trailing one included, so a
     # single-argument call yields a one-element array.
+    #
+    # File-local rather than a `Rules` preset: it is the only splitter in
+    # the tree that counts `<>` and also keeps every part unstripped, so a
+    # central name would have exactly one user.
+    SPLIT_ARGS_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace | Noir::TopLevelSplit::Nest::Angle,
+      quotes: "\"'",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: false,
+      empties: Noir::TopLevelSplit::Empties::Keep,
+      per_kind: true,
+      clamp: true,
+    )
+
+    # Split a call's argument list on top-level commas.
     #
     # Note: `Serverpod#split_top_level_commas` is deliberately NOT this
     # method — it tracks only `<`/`(` on one shared counter and is not
-    # string-aware, matching the narrower shapes it parses.
+    # string-aware, matching the narrower shapes it parses. It goes through
+    # the same shared splitter with its own `Rules`, so the difference is
+    # now two constants to compare rather than two loops to diff.
     def split_top_level_args(text : String) : Array(String)
-      result = [] of String
-      chars = text.chars
-      depth_paren = 0
-      depth_brace = 0
-      depth_bracket = 0
-      depth_angle = 0
-      start = 0
-      i = 0
-      in_string = false
-      string_quote = '\0'
-
-      while i < chars.size
-        c = chars[i]
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
-          next
-        end
-
-        case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-        when '('
-          depth_paren += 1
-        when ')'
-          depth_paren -= 1 if depth_paren > 0
-        when '{'
-          depth_brace += 1
-        when '}'
-          depth_brace -= 1 if depth_brace > 0
-        when '['
-          depth_bracket += 1
-        when ']'
-          depth_bracket -= 1 if depth_bracket > 0
-        when '<'
-          depth_angle += 1
-        when '>'
-          depth_angle -= 1 if depth_angle > 0
-        when ','
-          if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << chars[start...i].join
-            start = i + 1
-          end
-        else
-          # ignore
-        end
-        i += 1
-      end
-      result << chars[start..].join if start <= chars.size
-      result
+      Noir::TopLevelSplit.split(text, ',', SPLIT_ARGS_RULES)
     end
 
     # Matches a bare handler reference (`_createUser`, `auth.handler`)

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/dart_callee_extractor"
+require "../../../utils/top_level_split"
 require "./dart_helper"
 
 module Analyzer::Dart
@@ -322,34 +323,29 @@ module Analyzer::Dart
       last
     end
 
+    # Serverpod's argument lists carry Dart generics (`Future<List<Foo>>`) and
+    # call expressions, and nothing else nests: this splitter sees method
+    # signatures, never string literals, so quote handling stays off.
+    #
+    # `Nest::Paren | Nest::Angle` with `per_kind: false` is the whole of the
+    # old body's depth model — one counter incremented by `<` and `(` alike
+    # and decremented by `>` and `)`, with `[]` and `{}` inert. Those are two
+    # orthogonal choices in `Rules` (`nest` picks which characters count,
+    # `per_kind` picks how many counters exist), which is why this reads as a
+    # plain preset despite earlier surveys in this series calling the
+    # combination inexpressible.
+    SPLIT_COMMAS_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Angle,
+      quotes: "",
+      escape: Noir::TopLevelSplit::Escape::None,
+      strip: false,
+      empties: Noir::TopLevelSplit::Empties::Keep,
+      per_kind: false,
+      clamp: true,
+    )
+
     private def split_top_level_commas(text : String) : Array(String)
-      parts = [] of String
-      # `String#[]` re-walks from byte 0 on every call once the source
-      # contains any multi-byte char, turning this scan O(n^2); index a
-      # materialized Array(Char) instead (O(1) per access).
-      chars = text.chars
-      depth = 0
-      start = 0
-      i = 0
-      while i < chars.size
-        c = chars[i]
-        case c
-        when '<', '('
-          depth += 1
-        when '>', ')'
-          depth -= 1 if depth > 0
-        when ','
-          if depth == 0
-            parts << chars[start...i].join
-            start = i + 1
-          end
-        else
-          # ignore
-        end
-        i += 1
-      end
-      parts << chars[start..].join
-      parts
+      Noir::TopLevelSplit.split(text, ',', SPLIT_COMMAS_RULES)
     end
 
     private def emit_endpoint(path : String,

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -1,5 +1,6 @@
 require "../../engines/elixir_engine"
 require "../../../utils/url_path"
+require "../../../utils/top_level_split"
 
 module Analyzer::Elixir
   class Phoenix < ElixirEngine
@@ -676,52 +677,14 @@ module Analyzer::Elixir
       end
     end
 
+    # Split an Elixir macro argument list on top-level commas.
+    #
+    # `Rules::SHARED_DEPTH_RAW` verbatim: one shared depth over `()`, `[]`
+    # and `{}`, both quote styles, nothing stripped and every part kept —
+    # `parse_macro_call_args` indexes positionally, so an interior empty
+    # has to hold its slot.
     private def split_top_level_commas(text : String) : Array(String)
-      parts = [] of String
-      buffer = String::Builder.new
-      depth = 0
-      in_string = false
-      escaped = false
-      quote = '\0'
-
-      text.each_char do |char|
-        if in_string
-          buffer << char
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '"', '\''
-          in_string = true
-          quote = char
-          buffer << char
-        when '(', '[', '{'
-          depth += 1
-          buffer << char
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-          buffer << char
-        when ','
-          if depth == 0
-            parts << buffer.to_s
-            buffer = String::Builder.new
-          else
-            buffer << char
-          end
-        else
-          buffer << char
-        end
-      end
-
-      parts << buffer.to_s
-      parts
+      Noir::TopLevelSplit.split(text, ',', Noir::TopLevelSplit::Rules::SHARED_DEPTH_RAW)
     end
 
     private def endpoints_from_route_macro(invocation : RouteMacroInvocation,

--- a/src/analyzer/analyzers/erlang/cowboy.cr
+++ b/src/analyzer/analyzers/erlang/cowboy.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "./erlang_helper"
+require "../../../utils/top_level_split"
 require "set"
 
 module Analyzer::Erlang
@@ -337,61 +338,35 @@ module Analyzer::Erlang
       end
     end
 
+    # `Rules::JAVA` except that a closer at depth 0 is NOT clamped: the
+    # bare `depth -= 1` of the body this replaces drives depth negative on
+    # a fragment that closes a bracket the caller's regex already sliced
+    # away (`")x, y"`), which suppresses every later split. Preserved
+    # verbatim because it is observable on exactly the unbalanced input
+    # `each_qs_field` hands over.
+    #
+    # The original pushed interior parts unstripped and dropped the tail
+    # only when `tail.strip.empty?`, then ran `parts.map(&.strip)` over
+    # everything. That is `strip: true` + `Empties::DropTrailing`: the
+    # emptiness test is on the stripped tail either way.
+    #
+    # File-local because cowboy is the only splitter combining
+    # `clamp: false` with stripping.
+    SPLIT_TOP_LEVEL_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace,
+      quotes: "\"'",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: true,
+      empties: Noir::TopLevelSplit::Empties::DropTrailing,
+      per_kind: false,
+      clamp: false,
+    )
+
     # Splits an Erlang tuple/list body on its top-level commas, ignoring
     # commas nested in strings, quoted atoms, tuples, lists or binaries.
     private def split_top_level(body : String) : Array(String)
-      parts = [] of String
-      current = String::Builder.new
-      depth = 0
-      i = 0
-      chars = body.chars
-
-      while i < chars.size
-        c = chars[i]
-
-        if c == '"' || c == '\''
-          quote = c
-          current << c
-          i += 1
-          while i < chars.size
-            ch = chars[i]
-            if ch == '\\' && i + 1 < chars.size
-              current << ch
-              current << chars[i + 1]
-              i += 2
-              next
-            end
-            current << ch
-            i += 1
-            break if ch == quote
-          end
-          next
-        end
-
-        case c
-        when '{', '[', '('
-          depth += 1
-          current << c
-        when '}', ']', ')'
-          depth -= 1
-          current << c
-        when ','
-          if depth == 0
-            parts << current.to_s
-            current = String::Builder.new
-          else
-            current << c
-          end
-        else
-          current << c
-        end
-
-        i += 1
-      end
-
-      tail = current.to_s
-      parts << tail unless tail.strip.empty?
-      parts.map(&.strip)
+      Noir::TopLevelSplit.split(body, ',', SPLIT_TOP_LEVEL_RULES)
     end
   end
 end

--- a/src/analyzer/analyzers/php/laminas.cr
+++ b/src/analyzer/analyzers/php/laminas.cr
@@ -1,4 +1,5 @@
 require "../../engines/php_engine"
+require "../../../utils/top_level_split"
 
 module Analyzer::Php
   class Laminas < PhpEngine
@@ -400,47 +401,34 @@ module Analyzer::Php
       methods.empty? ? HTTP_METHODS : methods
     end
 
-    # Byte-level scan for O(1) positional access instead of `String#[](Int)`,
-    # which is O(n) on strings containing multi-byte characters and turns a
-    # single call into O(n^2) — see `find_matching_delimiter` below for the
-    # same fix applied elsewhere in this file.
+    # `Rules::SHARED_DEPTH_RAW` with a trailing empty dropped, then a
+    # `strip` applied by this method rather than by the splitter.
+    #
+    # The order matters and is not cosmetic. The body this replaces
+    # stripped each part as it pushed it, but decided whether to emit the
+    # tail from the RAW slice (`if start < size`), so `f(a, )` kept a final
+    # `""` while `f(a,)` did not. Stripping inside the splitter would test
+    # the stripped tail and drop both. Splitting raw and stripping
+    # afterwards reproduces the original exactly.
+    #
+    # The old scan walked bytes to dodge `String#[](Int)`; the shared
+    # splitter is a single forward `each_char` pass, so it is O(n) on any
+    # input without needing the byte detour. Every delimiter, quote and
+    # bracket involved is ASCII and UTF-8 continuation bytes are all
+    # >= 0x80, so the two scans see the same split points.
+    SPLIT_ARGS_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace,
+      quotes: "\"'",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: false,
+      empties: Noir::TopLevelSplit::Empties::DropTrailing,
+      per_kind: false,
+      clamp: true,
+    )
+
     private def split_top_level_args(content : String) : Array(String)
-      args = [] of String
-      bytes = content.to_slice
-      start = 0
-      i = 0
-      depth = 0
-      in_string = false
-      quote = 0_u8
-      escaped = false
-      size = bytes.size
-
-      while i < size
-        byte = bytes[i]
-        if in_string
-          if escaped
-            escaped = false
-          elsif byte == BYTE_BACKSLASH
-            escaped = true
-          elsif byte == quote
-            in_string = false
-          end
-        elsif byte == BYTE_SQUOTE || byte == BYTE_DQUOTE
-          in_string = true
-          quote = byte
-        elsif byte == BYTE_LBRACKET || byte == BYTE_LPAREN || byte == BYTE_LBRACE
-          depth += 1
-        elsif byte == BYTE_RBRACKET || byte == BYTE_RPAREN || byte == BYTE_RBRACE
-          depth -= 1 if depth > 0
-        elsif byte == BYTE_COMMA && depth == 0
-          args << String.new(bytes[start...i]).strip
-          start = i + 1
-        end
-        i += 1
-      end
-
-      args << String.new(bytes[start...size]).strip if start < size
-      args
+      Noir::TopLevelSplit.split(content, ',', SPLIT_ARGS_RULES).map(&.strip)
     end
 
     private def parse_top_level_entries(content : String) : Array(PhpArrayEntry)

--- a/src/analyzer/analyzers/php/wordpress.cr
+++ b/src/analyzer/analyzers/php/wordpress.cr
@@ -1,4 +1,5 @@
 require "../../engines/php_engine"
+require "../../../utils/top_level_split"
 
 module Analyzer::Php
   # WordPress attack-surface extractor.
@@ -328,47 +329,39 @@ module Analyzer::Php
       nil
     end
 
+    # `Rules::SHARED_DEPTH_RAW` with a trailing empty dropped and, like
+    # erlang/cowboy.cr, WITHOUT clamping: the body this replaces closed
+    # brackets with a bare `depth -= 1`, so a fragment beginning with a
+    # closer (`")x, y"`) drives depth negative and stops splitting. That is
+    # observable on the regex-sliced input this actually receives, so it is
+    # preserved rather than normalised.
+    #
+    # File-local because wordpress is the only splitter pairing
+    # `clamp: false` with unstripped parts.
+    SPLIT_ARGS_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace,
+      quotes: "\"'",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: false,
+      empties: Noir::TopLevelSplit::Empties::DropTrailing,
+      per_kind: false,
+      clamp: false,
+    )
+
     # Split a PHP argument list on top-level commas, ignoring commas
     # nested inside (), [], {} or quoted strings. Only the first two
     # arguments are needed, but splitting fully keeps the logic simple.
+    #
+    # The empty-input guard is the old tail condition
+    # `if start <= args.size - 1 || parts.empty?`, whose `|| parts.empty?`
+    # arm fires for exactly one input: `""`, which yielded `[""]` and not
+    # `[]`. `Empties::DropTrailing` can only return `[]` for that same
+    # input, so restoring it here is exact — and cheaper than a fourth
+    # `Empties` case for one caller.
     private def split_top_level_args(args : String) : Array(String)
-      parts = [] of String
-      depth = 0
-      in_string = false
-      quote = '\0'
-      escaped = false
-      start = 0
-      args.each_char_with_index do |char, i|
-        if in_string
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            in_string = false
-          end
-          next
-        end
-
-        case char
-        when '\'', '"'
-          in_string = true
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1
-        when ','
-          if depth == 0
-            parts << args[start...i]
-            start = i + 1
-          end
-        else
-          # no-op
-        end
-      end
-      parts << args[start..] if start <= args.size - 1 || parts.empty?
-      parts
+      parts = Noir::TopLevelSplit.split(args, ',', SPLIT_ARGS_RULES)
+      parts.empty? ? [""] : parts
     end
 
     # ASCII delimiters for the paren matcher below (mirrors PhpEngine's

--- a/src/analyzer/analyzers/python/django_ninja.cr
+++ b/src/analyzer/analyzers/python/django_ninja.cr
@@ -699,13 +699,13 @@ module Analyzer::Python
       nil
     end
 
-    # Delegates to the shared splitter. `Rules::PYTHON_SHARED_DEPTH`, not
+    # Delegates to the shared splitter. `Rules::SHARED_DEPTH_RAW`, not
     # `Rules::PYTHON`: this loop counted `(`, `[` and `{` on ONE depth
     # counter, which is observable on the unbalanced fragments the route
     # regexes actually hand it — `"[a)b, c"` splits here, but would not
     # under per-kind counters.
     private def split_python_arguments(args : ::String) : Array(::String)
-      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON_SHARED_DEPTH)
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::SHARED_DEPTH_RAW)
     end
 
     # A NinjaAPI / Router instance and everything discovered about it.

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -291,13 +291,13 @@ module Analyzer::Python
       extract_keyword_string(args, "prefix") || args[0]?.try { |arg| Helper.extract_python_string(arg) }
     end
 
-    # Delegates to the shared splitter. `Rules::PYTHON_SHARED_DEPTH`, not
+    # Delegates to the shared splitter. `Rules::SHARED_DEPTH_RAW`, not
     # `Rules::PYTHON`: this loop counted `(`, `[` and `{` on ONE depth
     # counter, which is observable on the unbalanced fragments the route
     # regexes actually hand it — `"[a)b, c"` splits here, but would not
     # under per-kind counters.
     private def split_python_arguments(args : ::String) : Array(::String)
-      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON_SHARED_DEPTH)
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::SHARED_DEPTH_RAW)
     end
 
     # Memoized per keyword — the keyword set is tiny (`prefix`) but this

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -1168,14 +1168,14 @@ module Analyzer::Python
       parts
     end
 
-    # Delegates to the shared splitter. `Rules::PYTHON_SHARED_DEPTH`, not
+    # Delegates to the shared splitter. `Rules::SHARED_DEPTH_RAW`, not
     # `Rules::PYTHON`: this loop counted `(`, `[` and `{` on ONE depth
     # counter, which is observable on the unbalanced fragments the route
     # regexes actually hand it. The two wrappers above stay local — the
     # `nil`-on-single-part contract of `split_python_expression` is a FastAPI
     # call-site convention, not a splitting rule.
     private def split_python_top_level(input : ::String, delimiter : Char) : Array(::String)
-      Noir::TopLevelSplit.split(input, delimiter, Noir::TopLevelSplit::Rules::PYTHON_SHARED_DEPTH)
+      Noir::TopLevelSplit.split(input, delimiter, Noir::TopLevelSplit::Rules::SHARED_DEPTH_RAW)
     end
 
     private def static_route_path(path : ::String) : ::String

--- a/src/analyzer/analyzers/specification/typespec.cr
+++ b/src/analyzer/analyzers/specification/typespec.cr
@@ -1,4 +1,5 @@
 require "../../engines/specification_engine"
+require "../../../utils/top_level_split"
 require "uri"
 
 module Analyzer::Specification
@@ -549,40 +550,30 @@ module Analyzer::Specification
         pos
       end
 
+      # Angle brackets nest because TypeSpec generics (`Response<Widget>`)
+      # reach this splitter; single quotes do not quote because TypeSpec
+      # string literals are double-quoted only.
+      #
+      # Nothing is stripped and a trailing empty is dropped — that is the
+      # old `parts << text[start..] if start < text.size` tail guard, which
+      # skipped the tail exactly when the last character was a top-level
+      # delimiter (and on the empty string).
+      #
+      # File-local: it is the only splitter with this combination, and the
+      # only spec-format one at all.
+      SPLIT_TOP_LEVEL_RULES = Noir::TopLevelSplit::Rules.new(
+        nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+              Noir::TopLevelSplit::Nest::Brace | Noir::TopLevelSplit::Nest::Angle,
+        quotes: "\"",
+        escape: Noir::TopLevelSplit::Escape::InQuotes,
+        strip: false,
+        empties: Noir::TopLevelSplit::Empties::DropTrailing,
+        per_kind: false,
+        clamp: true,
+      )
+
       private def split_top_level(text : String, delim : Char) : Array(String)
-        parts = [] of String
-        depth = 0
-        in_string = false
-        start = 0
-        i = 0
-        while i < text.size
-          c = text[i]
-          if in_string
-            if c == '\\' && i + 1 < text.size
-              i += 2
-              next
-            elsif c == '"'
-              in_string = false
-            end
-          else
-            case c
-            when '"'
-              in_string = true
-            when '(', '{', '[', '<'
-              depth += 1
-            when ')', '}', ']', '>'
-              depth -= 1 if depth > 0
-            else
-              if c == delim && depth == 0
-                parts << text[start...i]
-                start = i + 1
-              end
-            end
-          end
-          i += 1
-        end
-        parts << text[start..] if start < text.size
-        parts
+        Noir::TopLevelSplit.split(text, delim, SPLIT_TOP_LEVEL_RULES)
       end
     end
   end

--- a/src/analyzer/engines/cfml_engine.cr
+++ b/src/analyzer/engines/cfml_engine.cr
@@ -1,5 +1,6 @@
 require "../../models/analyzer"
 require "../../utils/utils.cr"
+require "../../utils/top_level_split"
 
 module Analyzer::Cfml
   # Shared CFML parsing layer.
@@ -157,52 +158,36 @@ module Analyzer::Cfml
       names
     end
 
+    # `Rules::JAVA` with `Empties::DropAll` and, like erlang/cowboy.cr and
+    # php/wordpress.cr, WITHOUT clamping: the body this replaces closed
+    # brackets with a bare `depth -= 1`, so an argument slice that opens on
+    # a closer drives depth negative and suppresses every later split.
+    # Observable on the unbalanced fragments the CFML regexes hand over, so
+    # it is preserved rather than normalised.
+    #
+    # Escaping is `\\`-based, which is what the old body did and is NOT how
+    # CFML escapes a quote — CFML doubles it (`"say ""hi"""`), the way
+    # `matching_delimiter` below already handles. Reproduced verbatim here;
+    # correcting it changes where arguments split and belongs in its own
+    # change.
+    #
+    # File-local because this is the only splitter pairing `clamp: false`
+    # with `DropAll`.
+    SPLIT_ARGUMENTS_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace,
+      quotes: "\"'",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: true,
+      empties: Noir::TopLevelSplit::Empties::DropAll,
+      per_kind: false,
+      clamp: false,
+    )
+
     # Split on commas at nesting depth zero, so a comma inside a default
     # value or a nested call does not start a new argument.
     protected def split_arguments(raw : String) : Array(String)
-      chunks = [] of String
-      current = String::Builder.new
-      depth = 0
-      quote = nil.as(Char?)
-      escape = false
-
-      raw.each_char do |char|
-        if quote
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == quote
-            quote = nil
-          end
-          current << char
-          next
-        end
-
-        case char
-        when '"', '\''
-          quote = char
-          current << char
-        when '(', '[', '{'
-          depth += 1
-          current << char
-        when ')', ']', '}'
-          depth -= 1
-          current << char
-        when ','
-          if depth == 0
-            chunks << current.to_s
-            current = String::Builder.new
-          else
-            current << char
-          end
-        else
-          current << char
-        end
-      end
-
-      chunks << current.to_s
-      chunks.map(&.strip).reject(&.empty?)
+      Noir::TopLevelSplit.split(raw, ',', SPLIT_ARGUMENTS_RULES)
     end
 
     # Arguments of a CFML function call: positional ones keyed "0", "1",

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -105,11 +105,11 @@ module Noir
       # php/wordpress.cr `split_top_level_args`, and engines/cfml_engine.cr
       # `split_arguments` (the last one is easy to miss: it is on the shared
       # engine, not an analyzer, so a survey scoped to `analyzers/` reports
-      # only two). On a fragment that
-      # closes a bracket opened in a prefix the regex already discarded (e.g.
-      # `")x, y"`) that is the difference between one part and two. Splitting
-      # requires depth EXACTLY 0, so a negative depth suppresses every
-      # remaining split rather than re-enabling them.
+      # only two). On a fragment that closes a bracket opened in a prefix
+      # the regex already discarded (e.g. `")x, y"`) that is the difference
+      # between one part and two. Splitting requires depth EXACTLY 0, so a
+      # negative depth suppresses every remaining split rather than
+      # re-enabling them.
       getter? clamp : Bool
 
       def initialize(
@@ -163,16 +163,22 @@ module Noir
 
       # `PYTHON` with one shared depth counter instead of per-kind counters.
       # Serves analyzer/analyzers/python/{django_ninja,falcon}.cr
-      # `split_python_arguments` and fastapi.cr `split_python_top_level`.
+      # `split_python_arguments`, fastapi.cr `split_python_top_level` and
+      # elixir/elixir_phoenix.cr `split_top_level_commas`.
       #
-      # A named preset rather than three inline `Rules.new(...)` literals
+      # A named preset rather than four inline `Rules.new(...)` literals
       # because the split is not a per-file accident: the Python analyzers
       # genuinely disagree on `per_kind`, and keeping the two variants
       # adjacent is what makes that disagreement — and the fact that it is
-      # only observable on unbalanced input — legible. Three copies of the
-      # same seven-argument literal in three files is exactly the drift this
+      # only observable on unbalanced input — legible. Four copies of the
+      # same seven-argument literal in four files is exactly the drift this
       # module exists to end.
-      PYTHON_SHARED_DEPTH = new(
+      #
+      # Named for the shape and not for Python because it turned out not to
+      # be a Python idiom at all: Phoenix's splitter, written independently
+      # in another language, agrees on all seven axes. It was
+      # `PYTHON_SHARED_DEPTH` while Python was its only user.
+      SHARED_DEPTH_RAW = new(
         nest: Nest::Paren | Nest::Bracket | Nest::Brace,
         quotes: "\"'",
         escape: Escape::InQuotes,


### PR DESCRIPTION
## Summary

Fifth step of the splitter consolidation (#2617 C++, #2618 Python, #2619 Java, #2620 JS/TS). **Nine sites across eight languages** — dart (helper + serverpod), elixir, erlang, php (laminas + wordpress), csharp, the shared CFML engine, and typespec.

**−411 / +241 lines.**

This group was mostly a question of *which sites are expressible at all*. Three earlier claims in this series turned out to be wrong.

## Three corrections

**1. `erlang/cowboy.cr` — reported as having a strip/empties combination no `Rules` could reproduce**, because `parts.map(&.strip)` runs *after* the empty-tail check. It does not: the tail is tested with `tail.strip.empty?` and every part ends up stripped anyway, so it is exactly `strip: true` + `Empties::DropTrailing`. (Its `clamp: false` *is* real — bare `depth -= 1`.)

**2. `php/wordpress.cr` — reported to need a fourth `Empties` case** for its tail guard `parts << args[start..] if start <= args.size - 1 || parts.empty?`. Worked case by case:

| input | result |
|---|---|
| `""` | `[""]` |
| `","` | `[""]` |
| `"a,"` | `["a"]` |
| `"a,,"` | `["a", ""]` |

That is `DropTrailing` for every input except `""` — and `DropTrailing` can only return `[]` for `""`. So `parts.empty? ? [""] : parts` in the wrapper is exactly equivalent. Inventing a fourth enum case for one caller would have been worse.

**3. `dart/serverpod.cr` — listed as inexpressible** because it "shares one counter between `<` and `(` while ignoring `[]{}`". That conflates two orthogonal axes: **`nest` picks which characters count, `per_kind` picks how many counters exist.** `Nest::Paren | Nest::Angle` with `per_kind: false` is precisely that behavior. Proven over the same corpus and converted here.

## The laminas trap

Worth naming because it would have been an easy silent regression. The old body stripped each part as it pushed, but decided the tail from the **raw** slice (`if start < size`):

| input | old | naive `strip: true` + `DropTrailing` |
|---|---|---|
| `"a, "` | `["a", ""]` | `["a"]` |
| `" "` | `[""]` | `[]` |

So it now splits **raw** with `DropTrailing` and strips in the wrapper.

Its byte scan is equivalent to a char scan here — every delimiter, quote and bracket is ASCII, and UTF-8 continuation bytes are all `>= 0x80`, so neither can collide. Both are O(n), so this is a dedup, **not** a speedup; the comment says so rather than claiming a win.

## Preset changes

`elixir/elixir_phoenix.cr`'s rules are byte-for-byte the preset #2618 added, so it uses it rather than adding a fourth copy of the same seven-argument literal.

The preset is renamed **`PYTHON_SHARED_DEPTH` → `SHARED_DEPTH_RAW`**: a Phoenix analyzer referring to `Rules::PYTHON_*` misleads anyone who has not opened `top_level_split.cr`. Its doc comment keeps the "`PYTHON` with one shared counter" framing so the deliberate `per_kind` disagreement between the Python analyzers stays legible, and records why the name changed. Three Python call sites updated mechanically; the python endpoint set is verified identical.

The other seven sites are each the only user of their variant and keep a **file-local `Rules` constant**, per the standard set in #2619.

## Two latent bugs found and deliberately NOT fixed

Both documented at the constant so they read as known rather than overlooked:

1. **`engines/cfml_engine.cr` `split_arguments` handles `\` escapes, but CFML escapes a quote by doubling it** — which `matching_delimiter`, *in the same file*, already gets right. So `resources( except = "a""b,c" )` splits mid-literal today. Fixing it moves argument boundaries and needs its own PR with fixture evidence.
2. **`specification/typespec.cr`'s old body let its structural `case` arms win over the delimiter test**, so calling it with `'<'` would never split; after conversion the delimiter is checked first. Unreachable today — the one call site passes `','` — but it matters if a second caller appears.

`specification/apache_httpd.cr` `split_args` stays permanently out of scope, re-confirmed: it *deletes* quote characters from its output and drops backslashes, which no `Rules` value can express.

## Equivalence proof

All nine bodies against their replacements, **44,003 inputs**: every line of every fixture under `{dart,elixir,erlang,php,csharp,cfml,specification,python}` plus each line's inner bracket slice, ~120 handcrafted edges (leading closers `")x, y"` / `"]x, y"` / `"}x, y"` / `"<x, y"`, interior/trailing/lone/empty delimiters, escaped and unterminated quotes, CFML doubled quotes `"a""b"`, CJK/emoji/accented text inside quoted args), and 25,000 seeded-random strings.

```
dart 0    elixir 0    cowboy 0    laminas 0    wordpress 0
csharp 0  cfml 0      typespec ',' 0    typespec ';' 0    serverpod 0
```

all over 44,003. Harness was a throwaway and is not in the diff.

## Test plan

- `crystal spec spec/unit_test` → **5051 examples, 0 failures** — unchanged
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** — unchanged
- Real binary, endpoint counts identical before and after for every affected tree:

| lang | endpoints | | lang | endpoints |
|---|---|---|---|---|
| dart | 106 | | cfml | 105 |
| elixir | 80 | | specification | 291 |
| erlang | 13 | | python | 419 |
| php | 250 | | aspnet | 10 |
| csharp | 160 | | asp | 6 |

`aspnet`/`asp` are included because `csharp/common.cr` is shared across the .NET analyzers; `python` because of the preset rename; `dart` in full because four analyzers call `dart_helper`.

- `crystal tool format --check src/ spec/` → clean
- `ameba` on the touched files → 0 failures
- `typos .` → clean

## Side effects

Removes typespec's O(n²) `text[i]`-inside-a-`while` scan and serverpod's `.chars` materialization, both as consequences of the conversion rather than as separate changes.

## Remaining in the series

The multi-char-delimiter pair (`haskell/servant.cr`, `specification/traefik.cr`) — the first real users of the `String` delimiter overload, which currently has specs but no production caller. Then `split_spans` for the offset-returning group (express, feathers, hono, `js_http_route_extractor`), which needs a design pass: the `String::Builder` core has no char offsets.

Separately, `express/router_mount_scanner.cr`'s `prev_char != '\\'` escape lookback (documented in #2620) is a real defect worth its own PR.