### PR TITLE
refactor(analyzer): convert the multi-char-delimiter splitters to Noir::TopLevelSplit

### DIFF
--- a/spec/unit_test/utils/top_level_split_spec.cr
+++ b/spec/unit_test/utils/top_level_split_spec.cr
@@ -336,6 +336,112 @@ describe Noir::TopLevelSplit do
     end
   end
 
+  # The `String`-delimiter overload had unit coverage but no production caller
+  # until haskell/servant.cr (`,` / `:>` / `:<|>`) and
+  # specification/traefik.cr (`||` / `&&`) were converted. These exercise the
+  # buffering paths those two rule sets actually reach.
+  describe "multi-character delimiter, production rule sets" do
+    servant = tls_rules(
+      nest: ALL_BRACKETS,
+      quotes: "\"",
+      escape: TLSEscape::InQuotes,
+      strip: true,
+      empties: TLSEmpties::DropAll,
+      per_kind: true,
+      clamp: true,
+    )
+    traefik = tls_rules(
+      nest: TLSNest::Paren,
+      quotes: "",
+      escape: TLSEscape::None,
+      strip: true,
+      empties: TLSEmpties::DropAll,
+      per_kind: false,
+      clamp: true,
+    )
+
+    it "emits a late-failing partial match verbatim" do
+      # Three of the four separator characters match before the fourth fails;
+      # the buffered `:<|` must land in the part, not be dropped.
+      TLS.split("a :<| b :<|> c", ":<|>", servant).should eq ["a :<| b", "c"]
+    end
+
+    it "retries a late-failing partial match against a real match" do
+      # `:<|` fails at `:`, and the retry must find the `:<|>` that starts one
+      # character later rather than skipping the whole buffer past it.
+      TLS.split("a :<|:<|> b", ":<|>", servant).should eq ["a :<|", "b"]
+    end
+
+    it "keeps a trailing partial separator in the tail" do
+      TLS.split("a :> b :", ":>", servant).should eq ["a", "b :"]
+      TLS.split("a :<|> b :<|", ":<|>", servant).should eq ["a", "b :<|"]
+      TLS.split("a || b |", "||", traefik).should eq ["a", "b |"]
+    end
+
+    it "does not confuse two separators sharing a leading character" do
+      # Servant calls the same splitter with `:>` and `:<|>`; each call must
+      # see only its own separator.
+      api = "\"users\" :> Get '[JSON] [User] :<|> \"posts\" :> Post '[JSON] Post"
+      TLS.split(api, ":<|>", servant)
+        .should eq ["\"users\" :> Get '[JSON] [User]", "\"posts\" :> Post '[JSON] Post"]
+      TLS.split("\"users\" :> Get '[JSON] [User]", ":>", servant)
+        .should eq ["\"users\"", "Get '[JSON] [User]"]
+    end
+
+    it "treats separator angle brackets as ordinary characters when Angle is off" do
+      # `:<|>` carries `<` and `>`; with `Nest::Angle` disabled they must not
+      # touch the depth counters, or a buffered `<` would suppress later splits.
+      TLS.split("A :<|> B :<|> C", ":<|>", servant).should eq ["A", "B", "C"]
+      TLS.split("a < b :> c > d", ":>", servant).should eq ["a < b", "c > d"]
+    end
+
+    it "does not split a servant separator inside a promoted list or parens" do
+      TLS.split("\"a\" :> (X :<|> Y) :<|> Z", ":<|>", servant).should eq ["\"a\" :> (X :<|> Y)", "Z"]
+      TLS.split("Get '[JSON] [Map A B] :<|> Z", ":<|>", servant).should eq ["Get '[JSON] [Map A B]", "Z"]
+    end
+
+    it "keeps a servant separator inside a double-quoted segment" do
+      TLS.split("Summary \"does a :<|> b\" :<|> Z", ":<|>", servant)
+        .should eq ["Summary \"does a :<|> b\"", "Z"]
+    end
+
+    it "leaves backticks and quotes inert in a traefik rule" do
+      # `quotes: ""` is load-bearing: Traefik matcher arguments use backticks
+      # and may contain lone quotes, so any quote handling would swallow the
+      # rest of the rule.
+      TLS.split("Host(`a.com`) && (PathPrefix(`/x`) || PathPrefix(`/y`))", "&&", traefik)
+        .should eq ["Host(`a.com`)", "(PathPrefix(`/x`) || PathPrefix(`/y`))"]
+      TLS.split("Path(`/it's`) || Path(`/\"q\"`)", "||", traefik)
+        .should eq ["Path(`/it's`)", "Path(`/\"q\"`)"]
+    end
+
+    it "hides a traefik separator nested in matcher arguments" do
+      TLS.split("Header(`X-A`, `a||b`) || Path(`/x`)", "||", traefik)
+        .should eq ["Header(`X-A`, `a||b`)", "Path(`/x`)"]
+      TLS.split("Query(`a=1&&b=2`) && Path(`/y`)", "&&", traefik)
+        .should eq ["Query(`a=1&&b=2`)", "Path(`/y`)"]
+    end
+
+    it "does not count regexp brackets in a traefik rule" do
+      TLS.split("HostRegexp(`{sub:[a-z]+}.a.com`) && PathPrefix(`/v1`)", "&&", traefik)
+        .should eq ["HostRegexp(`{sub:[a-z]+}.a.com`)", "PathPrefix(`/v1`)"]
+    end
+
+    it "drops interior and edge empties for both rule sets" do
+      TLS.split("a :> :> b", ":>", servant).should eq ["a", "b"]
+      TLS.split(":> a :>", ":>", servant).should eq ["a"]
+      TLS.split("|| a || || b ||", "||", traefik).should eq ["a", "b"]
+      TLS.split("", ":<|>", servant).should eq [] of String
+      TLS.split("&&", "&&", traefik).should eq [] of String
+    end
+
+    it "does not desync a multi-character separator after multi-byte matchers" do
+      TLS.split("Host(`한국.com`) && Path(`/🚀`)", "&&", traefik)
+        .should eq ["Host(`한국.com`)", "Path(`/🚀`)"]
+      TLS.split("한국 :<|> 語 :<|> 🚀", ":<|>", servant).should eq ["한국", "語", "🚀"]
+    end
+  end
+
   describe "non-ASCII input" do
     it "splits Korean arguments correctly" do
       TLS.split("경로, 처리기, 옵션", ',', tls_rules).should eq ["경로", "처리기", "옵션"]

--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/haskell_callee_extractor"
+require "../../../utils/top_level_split"
 require "set"
 
 module Analyzer::Haskell
@@ -800,70 +801,37 @@ module Analyzer::Haskell
       depth == 0
     end
 
+    # Servant type-level API operators. Double quotes only: Haskell's `'` is a
+    # tick on promoted constructors (`'[JSON]`) and a primed identifier suffix,
+    # never a string delimiter, so treating it as a quote would swallow the
+    # rest of every `Get '[JSON] X`. `<>` are deliberately NOT counted as a
+    # nest kind even though `:<|>` contains both: Haskell writes no angle
+    # generics, and counting them would leave the separator's own `<` on the
+    # depth counter and suppress every later split. Per-kind clamped counters
+    # and `Empties::DropAll` are taken verbatim from the loop this replaces
+    # (three independent `*_depth` variables, each `-= 1 if > 0`, and a final
+    # `.map(&.strip).reject(&.empty?)`), both of which are observable on the
+    # unbalanced fragments the recursive callers hand it.
+    SPLIT_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace,
+      quotes: "\"",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: true,
+      empties: Noir::TopLevelSplit::Empties::DropAll,
+      per_kind: true,
+      clamp: true,
+    )
+
     # This is the hottest splitter in the file -- called (and recursed into,
     # via flatten_route_segments/distribute_route) on expanded Servant API
-    # bodies that can run up to MAX_EXPANSION_BYTES. `String#[](Int)` re-walks
-    # from byte 0 to locate a character index whenever the string isn't
-    # single-byte-optimizable (any non-ASCII content: accented path segments,
-    # unicode string literals, etc.), so indexing `input` by character inside
-    # a `while i < size` loop was O(n^2) on such input. Materialize the chars
-    # once (O(n)) and index the Array(Char) instead, which is O(1) per lookup;
-    # slices are joined back to String only when a part/segment is emitted.
+    # bodies that can run up to MAX_EXPANSION_BYTES. The hand-rolled loop this
+    # replaces materialized `input.chars` up front purely to dodge the O(n^2)
+    # that per-character `String#[](Int)` costs on non-ASCII input;
+    # `Noir::TopLevelSplit` is forward-only and needs neither the array nor the
+    # random access.
     private def split_top_level(input : String, separator : String) : Array(String)
-      parts = [] of String
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      chars = input.chars
-      sep_chars = separator.chars
-      start = 0
-      i = 0
-      sep_size = sep_chars.size
-
-      while i < chars.size
-        c = chars[i]
-        if c == '"'
-          i += 1
-          while i < chars.size && chars[i] != '"'
-            i += 1 if chars[i] == '\\' && i + 1 < chars.size
-            i += 1
-          end
-          i += 1 if i < chars.size
-          next
-        end
-
-        if c == '('
-          paren_depth += 1
-        elsif c == ')'
-          paren_depth -= 1 if paren_depth > 0
-        elsif c == '['
-          bracket_depth += 1
-        elsif c == ']'
-          bracket_depth -= 1 if bracket_depth > 0
-        elsif c == '{'
-          brace_depth += 1
-        elsif c == '}'
-          brace_depth -= 1 if brace_depth > 0
-        elsif paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 && matches_at?(chars, i, sep_chars)
-          parts << chars[start...i].join
-          i += sep_size
-          start = i
-          next
-        end
-
-        i += 1
-      end
-
-      parts << chars[start..].join
-      parts.map(&.strip).reject(&.empty?)
-    end
-
-    private def matches_at?(chars : Array(Char), index : Int32, sep : Array(Char)) : Bool
-      return false if index + sep.size > chars.size
-      sep.size.times do |k|
-        return false if chars[index + k] != sep[k]
-      end
-      true
+      Noir::TopLevelSplit.split(input, separator, SPLIT_RULES)
     end
   end
 end

--- a/src/analyzer/analyzers/specification/traefik.cr
+++ b/src/analyzer/analyzers/specification/traefik.cr
@@ -1,4 +1,5 @@
 require "../../engines/specification_engine"
+require "../../../utils/top_level_split"
 require "set"
 
 module Analyzer::Specification
@@ -195,41 +196,28 @@ module Analyzer::Specification
       values
     end
 
+    # Traefik router rules: `Host(`a.com`) && (PathPrefix(`/x`) ||
+    # PathPrefix(`/y`))`. `quotes: ""` is load-bearing — matcher arguments are
+    # written with backticks, single quotes and double quotes interchangeably
+    # and routinely contain unbalanced ones (`Path(`/it's`)`, a regexp with a
+    # lone quote), so any quote handling at all would swallow the rest of the
+    # rule and lose every alternative after it. Only `()` nests; `[]`/`{}`
+    # appear inside `HostRegexp` character classes and repetition counts, where
+    # counting them would be actively wrong. No escape handling: the replaced
+    # loop had none, and a `\` in a matcher regexp is a regexp escape, not a
+    # string escape.
+    SPLIT_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren,
+      quotes: "",
+      escape: Noir::TopLevelSplit::Escape::None,
+      strip: true,
+      empties: Noir::TopLevelSplit::Empties::DropAll,
+      per_kind: false,
+      clamp: true,
+    )
+
     private def split_top_level(input : String, delimiter : String) : Array(String)
-      parts = [] of String
-      current = ""
-      depth = 0
-      i = 0
-
-      while i < input.size
-        ch = input[i]
-        if ch == '('
-          depth += 1
-          current += ch.to_s
-          i += 1
-          next
-        elsif ch == ')'
-          depth -= 1 if depth > 0
-          current += ch.to_s
-          i += 1
-          next
-        end
-
-        # `i` is a CHAR index (input[i]); use char-based slicing, not byte_slice,
-        # so a multi-byte char before a `||` doesn't desync delimiter detection.
-        if depth == 0 && input[i, delimiter.size]? == delimiter
-          parts << current.strip unless current.strip.empty?
-          current = ""
-          i += delimiter.size
-          next
-        end
-
-        current += ch.to_s
-        i += 1
-      end
-
-      parts << current.strip unless current.strip.empty?
-      parts.reject(&.empty?)
+      Noir::TopLevelSplit.split(input, delimiter, SPLIT_RULES)
     end
 
     private def normalize_path(path : String) : String

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -282,8 +282,18 @@ module Noir
     # ENTIRELY at depth 0 and outside quotes splits, so `":>"` does not fire on
     # a bare `":"` and `"||"` inside `f(a || b)` is invisible.
     #
-    # The delimiter itself must not contain a quote character or a backslash;
-    # every real separator (`":>"`, `":<|>"`, `"||"`, `"&&"`) is punctuation.
+    # PRECONDITION: no proper prefix of the delimiter may contain a character
+    # that is a quote under `rules`, a backslash, or an opener of an enabled
+    # `Nest` kind. Releasing a mismatched prefix character is what changes
+    # cursor state, and if that release opens a quote or raises depth the
+    # remaining buffered characters stop being top-level and are replayed
+    # after the characters that followed them in the source — `split("(((xy",
+    # "((x", nest: Paren)` yields `["(xy(("]`, not `["(", "y"]`.
+    #
+    # Every separator in the tree is punctuation outside all three sets
+    # (`","`, `":>"`, `":<|>"`, `"||"`, `"&&"`), so no caller is affected. The
+    # note in `Cursor#consume` about a quote-bearing delimiter is the same
+    # precondition seen from the other end.
     def split(text : String, delimiter : String, rules : Rules) : Array(String)
       chars = delimiter.chars
       return apply_empties([rules.strip? ? text.strip : text], rules) if chars.empty?


### PR DESCRIPTION
## Summary

Sixth step of the splitter consolidation (#2617 C++, #2618 Python, #2619 Java, #2620 JS/TS, #2621 long tail). **37 of 44 sites are now converted.**

`haskell/servant.cr` and `specification/traefik.cr` are the **first production users** of `TopLevelSplit.split(text, delimiter : String, rules)`. That overload had unit specs but no real caller until now, so proving it on real input is as much the point of this PR as the two conversions.

## The two sites

**servant** splits on `","`, `":>"` and `":<|>"` across **7 in-file call sites**. Its rules are `Rules::CPP` differing on exactly one axis — `DropAll` rather than `DropTrailing` (`parts.map(&.strip).reject(&.empty?)`) — which is why it carries a file-local constant instead of reusing the preset:

```
"a :> :> b"  ->  ["a", "b"]        under DropAll
             ->  ["a", "", "b"]    under DropTrailing
```

Its `'` is deliberately **not** a quote character: Haskell writes `Get '[JSON] X` and primed identifiers, so treating it as one would swallow the rest of every route. Now documented at the constant.

**traefik** splits on `"||"` and `"&&"` with quote handling **off**, which is load-bearing — router rules are written `` Host(`a.com`) && PathPrefix(`/x`) `` and enabling quotes would move every split.

## Two findings

**1. `input[i, delimiter.size]?` never returned nil in traefik's loop.** I had briefed that it "returns nil near the end of the string". Crystal's `String#[]?(start, count)` is nil only when `start > size`, and the loop guard is `i < input.size`, so the worst case is a *truncated* window that simply fails `== delimiter` — the same outcome as the shared implementation's end-of-input `flush_pending`. There was nothing to reconcile.

**2. Both old bodies test the delimiter in an `elsif` after their structural arms**, so neither could ever match a delimiter beginning with a nest or quote character; the shared implementation tests the delimiter first. Unobservable for all five separators in use, but it means the equivalence proof covers *these* separators rather than arbitrary ones.

## The multi-char machinery, on real input

No gap found in the paths that had no production caller until now:

| case | result |
|---|---|
| late-failing partial (`"a :<\| b"` on `":<\|>"`) | buffer released verbatim |
| overlapping retry (`"a :<\|:<\|> b"`) | `["a :<\|", "b"]` — one-char release finds the later match |
| trailing partial (`"a :> b :"`) | dangling prefix lands in the tail |
| prefix-sharing separators (`":>"` vs `":<\|>"`) | each call sees one separator; no competition |
| `<`/`>` inside `":<\|>"` | inert — servant's nest set excludes `Angle`, so a buffered `<` cannot touch depth |

## Latent bug in the shared module — found, documented, NOT fixed

If a **proper prefix of the delimiter contains a quote character or an opener of an enabled `Nest` kind**, releasing a mismatched character can change cursor state while the rest of the buffer is still held, replaying it out of order:

```crystal
TopLevelSplit.split("(((xy", "((x", nest: Paren)   # => ["(xy(("]   expected ["(", "y"]
TopLevelSplit.split("\"\"\"xy", "\"\"x", quotes: "\"")  # => ["\"xy\"\""]
```

The overload's doc comment previously stated only **half** of this precondition — quote characters and backslashes — so it was actively incomplete. It now states all three sets with the reproduction inline.

**No separator anywhere in the tree violates it** (`","`, `":>"`, `":<|>"`, `"||"`, `"&&"` are all punctuation outside every set), so no caller is affected. The fix belongs in its own change rather than riding along with a conversion whose whole claim is behavioral equivalence.

Also noted, pre-existing and untouched: traefik's final `parts.reject(&.empty?)` is dead — the push guard already made every element non-empty.

## Equivalence proof

Verbatim copies of both old bodies vs. their replacements, run **once per separator each site actually uses**, over **46,200 unique inputs = 231,000 comparisons**:

```
servant  sep=","    : 0 mismatches / 46200   (6223 inputs split into >1 part)
servant  sep=":>"   : 0 mismatches / 46200   (4880 inputs split into >1 part)
servant  sep=":<|>" : 0 mismatches / 46200   (1702 inputs split into >1 part)
traefik  sep="||"   : 0 mismatches / 46200   (3344 inputs split into >1 part)
traefik  sep="&&"   : 0 mismatches / 46200   (3391 inputs split into >1 part)
```

The split-count column is there deliberately, as a guard against a harness that passes because nothing ever split.

Corpus: fixture lines from `haskell/**` and `specification/**` plus their inner bracket slices; real Servant type-level APIs and Traefik rules including backticks inside matchers; partial-match edges (`:`, `:<`, `:<|`, `|`, `&`, adjacent and edge separators); unbalanced fragments with leading closers; interior/trailing/lone/empty cases; non-ASCII — plus 25,000 char-level **and** 25,000 token-biased seeded-random strings. The token-biased set was added after observing that char-level randomness produces `:<|>` only about four times in 900k positions.

## Test plan

- `crystal spec spec/unit_test` → **5063 examples, 0 failures** (5051 + 12 new)
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** — unchanged
- Real binary: `haskell` **42 → 42**, `specification` **291 → 291**, endpoint sets identical
- `crystal tool format --check src/ spec/` → clean
- `ameba` on the 3 touched files → `3 inspected, 0 failures`
- `typos .` → clean

## New coverage

12 examples in a `describe "multi-character delimiter, production rule sets"` block, using local copies of both derived rule sets: late-failing partial match, late-fail-then-retry overlap, trailing partial for all three separators, prefix-sharing `:>`/`:<|>` on a real Servant API, angles inert when `Angle` is off, nesting inside promoted lists, separator inside a double-quoted segment, backticks inert under `quotes: ""`, separators inside Traefik matcher args, regexp brackets uncounted, interior/edge empties, and multi-byte desync.

## Remaining

Seven sites, all in the offset-returning group — `express.cr`, `feathers.cr`, `hono.cr` and `js_http_route_extractor.cr` return `{part, offset}` tuples. They need `split_spans`, which needs a design pass first: the `String::Builder` core has no char offsets, and "start offset of the current part" is non-obvious once a multi-char delimiter buffers a pending prefix.

Two known defects are queued behind that: `express/router_mount_scanner.cr`'s `prev_char != '\\'` escape lookback (#2620), and `engines/cfml_engine.cr`'s `\`-escape where CFML doubles the quote (#2621). Both change detection, so each needs its own PR with fixture evidence.