### PR TITLE
refactor(analyzer): add split_spans and finish the splitter consolidation

### DIFF
--- a/spec/unit_test/utils/top_level_split_spec.cr
+++ b/spec/unit_test/utils/top_level_split_spec.cr
@@ -468,6 +468,116 @@ describe Noir::TopLevelSplit do
     end
   end
 
+  describe ".split_spans" do
+    it "reports the offset of each part" do
+      TLS.split_spans("a,b,c", ',', tls_rules(empties: TLSEmpties::Keep))
+        .should eq [{"a", 0}, {"b", 2}, {"c", 4}]
+    end
+
+    it "skips leading whitespace when reporting an offset" do
+      TLS.split_spans("  a ,   b  ", ',', tls_rules(empties: TLSEmpties::Keep))
+        .should eq [{"a", 2}, {"b", 8}]
+    end
+
+    it "reports offsets as char indices, not byte indices" do
+      # "한국" is six bytes but two chars, so a byte offset would report 8.
+      TLS.split_spans("한국, handler", ',', tls_rules(empties: TLSEmpties::Keep))
+        .should eq [{"한국", 0}, {"handler", 4}]
+    end
+
+    it "keeps offsets in char units with an emoji before the window" do
+      TLS.split_spans("🚀🚀 x, y", ',', tls_rules(empties: TLSEmpties::Keep))
+        .should eq [{"🚀🚀 x", 0}, {"y", 6}]
+    end
+
+    it "returns absolute offsets when a window is given" do
+      content = "app.get('/users', handler)"
+      TLS.split_spans(content, ',', TLSRules::JS_POSITIONAL_ARGS, 8, 25)
+        .should eq [{"'/users'", 8}, {"handler", 18}]
+    end
+
+    it "returns absolute offsets when non-ASCII precedes the window" do
+      content = "// 한국어 주석\napp.get('/유저', handler)"
+      open_paren = content.index!('(')
+      close_paren = content.rindex!(')')
+      TLS.split_spans(content, ',', TLSRules::JS_POSITIONAL_ARGS, open_paren + 1, close_paren)
+        .should eq [{"'/유저'", open_paren + 1}, {"handler", open_paren + 8}]
+    end
+
+    it "treats a negative end_pos as the end of the text" do
+      TLS.split_spans("a, b", ',', tls_rules(empties: TLSEmpties::Keep))
+        .should eq [{"a", 0}, {"b", 3}]
+    end
+
+    it "clamps a window that runs past the end of the text" do
+      TLS.split_spans("a,b", ',', tls_rules(empties: TLSEmpties::Keep), -5, 99)
+        .should eq [{"a", 0}, {"b", 2}]
+    end
+
+    it "emits one empty part for an empty window" do
+      TLS.split_spans("a,b", ',', tls_rules(empties: TLSEmpties::Keep), 1, 1)
+        .should eq [{"", 1}]
+    end
+
+    # An empty part still needs a position, and the position the replaced
+    # bodies reported is where their forward whitespace scan stopped: the
+    # delimiter that ended the part.
+    it "gives an interior empty part the offset of its delimiter" do
+      TLS.split_spans("a, ,b", ',', tls_rules(empties: TLSEmpties::Keep))
+        .should eq [{"a", 0}, {"", 3}, {"b", 4}]
+    end
+
+    it "gives consecutive empty parts each the offset of their own delimiter" do
+      TLS.split_spans(",,a", ',', tls_rules(empties: TLSEmpties::Keep))
+        .should eq [{"", 0}, {"", 1}, {"a", 2}]
+    end
+
+    # The scan for a whitespace-only part's offset is not bounded by the
+    # window, so it can land past `end_pos`. Callers index `text` with the
+    # offset, so it has to stay a real position in `text`.
+    it "lets a whitespace-only final part report an offset past the window" do
+      TLS.split_spans("a,  b", ',', tls_rules(empties: TLSEmpties::Keep), 0, 3)
+        .should eq [{"a", 0}, {"", 4}]
+    end
+
+    it "reports text.size when nothing but whitespace follows" do
+      TLS.split_spans("a,  ", ',', tls_rules(empties: TLSEmpties::Keep))
+        .should eq [{"a", 0}, {"", 4}]
+    end
+
+    it "honours Empties::DropAll while keeping the surviving offsets" do
+      TLS.split_spans("a, , b", ',', tls_rules(empties: TLSEmpties::DropAll))
+        .should eq [{"a", 0}, {"b", 5}]
+    end
+
+    it "honours Empties::DropTrailing while keeping the surviving offsets" do
+      TLS.split_spans("a, b,", ',', tls_rules(empties: TLSEmpties::DropTrailing))
+        .should eq [{"a", 0}, {"b", 3}]
+    end
+
+    it "does not split inside a template literal, and offsets the next part after it" do
+      input = "`/users/${a, b}`, handler"
+      TLS.split_spans(input, ',', TLSRules::JS_POSITIONAL_ARGS)
+        .should eq [{"`/users/${a, b}`", 0}, {"handler", 18}]
+    end
+  end
+
+  describe "Rules::JS_POSITIONAL_ARGS" do
+    # Unlike Rules::JS this shares one depth counter, so a `)` opened before
+    # the window cancels the `[`.
+    it "shares one depth counter across bracket kinds" do
+      TLS.split_spans("[a)b, c", ',', TLSRules::JS_POSITIONAL_ARGS)
+        .should eq [{"[a)b", 0}, {"c", 6}]
+    end
+
+    # Unlike Rules::JS an empty argument holds its slot, because every caller
+    # reads `args[2]` as the handler.
+    it "keeps empty arguments so later arguments hold their index" do
+      TLS.split_spans("'/x', , handler", ',', TLSRules::JS_POSITIONAL_ARGS)
+        .should eq [{"'/x'", 0}, {"", 6}, {"handler", 8}]
+    end
+  end
+
   describe "Rules::CPP" do
     it "keeps a whole nested handler call as one argument" do
       input = "app->Get(\"/users/{id}\", [](const Req &r, Res &s) { s.set(\"a,b\"); })"

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -2,6 +2,7 @@ require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
 require "../../../utils/url_path"
 require "../../../utils/js_literal_scanner"
+require "../../../utils/top_level_split"
 require "./express_constants"
 require "./express/router_mount_scanner"
 
@@ -164,62 +165,7 @@ module Analyzer::Javascript
     end
 
     private def split_top_level_args(content : String, start_pos : Int32, end_pos : Int32) : Array(Tuple(String, Int32))
-      args = [] of Tuple(String, Int32)
-      arg_start = start_pos
-      depth = 0
-      quote : Char? = nil
-      escaped = false
-      i = start_pos
-
-      # `content[i]` re-decodes UTF-8 from byte 0 on every call once the
-      # string isn't single_byte_optimizable? (any non-ASCII char), making
-      # this O(n^2) on a large non-ASCII handler body. Index a
-      # pre-materialized Char array instead — same semantics, O(1) lookup.
-      chars = content.chars
-      while i < end_pos
-        char = chars[i]
-
-        if quote
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            quote = nil
-          end
-          i += 1
-          next
-        end
-
-        case char
-        when '\'', '"', '`'
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        when ','
-          if depth == 0
-            args << normalized_arg(content, arg_start, i)
-            arg_start = i + 1
-          end
-        end
-
-        i += 1
-      end
-
-      args << normalized_arg(content, arg_start, end_pos)
-      args
-    end
-
-    private def normalized_arg(content : String, start_pos : Int32, end_pos : Int32) : Tuple(String, Int32)
-      start_idx = skip_whitespace(content, start_pos)
-      stop_idx = end_pos
-      while stop_idx > start_idx && content[stop_idx - 1].whitespace?
-        stop_idx -= 1
-      end
-
-      {content[start_idx...stop_idx], start_idx}
+      Noir::TopLevelSplit.split_spans(content, ',', Noir::TopLevelSplit::Rules::JS_POSITIONAL_ARGS, start_pos, end_pos)
     end
 
     private def skip_whitespace(content : String, pos : Int32) : Int32

--- a/src/analyzer/analyzers/javascript/feathers.cr
+++ b/src/analyzer/analyzers/javascript/feathers.cr
@@ -3,6 +3,7 @@ require "../../../miniparsers/js_route_extractor"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/import_graph"
 require "../../../utils/url_path"
+require "../../../utils/top_level_split"
 
 module Analyzer::Javascript
   # Feathers.js (https://feathersjs.com) is service-based rather than
@@ -672,65 +673,7 @@ module Analyzer::Javascript
     # depth aware), local to this analyzer.
     # ---------------------------------------------------------------
     private def split_top_level_args(content : String, start_pos : Int32, end_pos : Int32) : Array(Tuple(String, Int32))
-      args = [] of Tuple(String, Int32)
-      arg_start = start_pos
-      depth = 0
-      quote : Char? = nil
-      escaped = false
-      i = start_pos
-      chars = content.chars
-
-      while i < end_pos
-        char = chars[i]
-
-        if quote
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            quote = nil
-          end
-          i += 1
-          next
-        end
-
-        case char
-        when '\'', '"', '`'
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        when ','
-          if depth == 0
-            args << normalized_arg(content, arg_start, i)
-            arg_start = i + 1
-          end
-        end
-
-        i += 1
-      end
-
-      args << normalized_arg(content, arg_start, end_pos)
-      args
-    end
-
-    private def normalized_arg(content : String, start_pos : Int32, end_pos : Int32) : Tuple(String, Int32)
-      start_idx = skip_ws(content, start_pos)
-      stop_idx = end_pos
-      while stop_idx > start_idx && content[stop_idx - 1].whitespace?
-        stop_idx -= 1
-      end
-      {content[start_idx...stop_idx], start_idx}
-    end
-
-    private def skip_ws(content : String, pos : Int32) : Int32
-      i = pos
-      while i < content.size && content[i].whitespace?
-        i += 1
-      end
-      i
+      Noir::TopLevelSplit.split_spans(content, ',', Noir::TopLevelSplit::Rules::JS_POSITIONAL_ARGS, start_pos, end_pos)
     end
 
     private def quoted_literal(text : String) : String?

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -1,6 +1,7 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
+require "../../../utils/top_level_split"
 require "./express/router_mount_scanner"
 
 module Analyzer::Javascript
@@ -181,62 +182,7 @@ module Analyzer::Javascript
     end
 
     private def split_top_level_args(content : String, start_pos : Int32, end_pos : Int32) : Array(Tuple(String, Int32))
-      args = [] of Tuple(String, Int32)
-      arg_start = start_pos
-      depth = 0
-      quote : Char? = nil
-      escaped = false
-      i = start_pos
-
-      # `content[i]` re-decodes UTF-8 from byte 0 on every call once the
-      # string isn't single_byte_optimizable? (any non-ASCII char), making
-      # this O(n^2) on a large non-ASCII handler body. Index a
-      # pre-materialized Char array instead — same semantics, O(1) lookup.
-      chars = content.chars
-      while i < end_pos
-        char = chars[i]
-
-        if quote
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            quote = nil
-          end
-          i += 1
-          next
-        end
-
-        case char
-        when '\'', '"', '`'
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        when ','
-          if depth == 0
-            args << normalized_arg(content, arg_start, i)
-            arg_start = i + 1
-          end
-        end
-
-        i += 1
-      end
-
-      args << normalized_arg(content, arg_start, end_pos)
-      args
-    end
-
-    private def normalized_arg(content : String, start_pos : Int32, end_pos : Int32) : Tuple(String, Int32)
-      start_idx = skip_whitespace(content, start_pos)
-      stop_idx = end_pos
-      while stop_idx > start_idx && content[stop_idx - 1].whitespace?
-        stop_idx -= 1
-      end
-
-      {content[start_idx...stop_idx], start_idx}
+      Noir::TopLevelSplit.split_spans(content, ',', Noir::TopLevelSplit::Rules::JS_POSITIONAL_ARGS, start_pos, end_pos)
     end
 
     private def skip_whitespace(content : String, pos : Int32) : Int32

--- a/src/miniparsers/js_http_route_extractor.cr
+++ b/src/miniparsers/js_http_route_extractor.cr
@@ -1,5 +1,6 @@
 require "../models/endpoint"
 require "../miniparsers/js_route_extractor"
+require "../utils/top_level_split"
 
 module Noir
   # Extracts routes from direct Node.js core http/https createServer handlers.
@@ -763,63 +764,12 @@ module Noir
       split_top_level(content, start_pos, end_pos, ',')
     end
 
+    # `delimiter` must not be a quote character or a bracket: the body this
+    # replaced tested it in a `case` arm AFTER the quote and bracket arms, so
+    # those shadowed it, while `split_spans` tests the delimiter first. Both
+    # call sites pass `,`, where the two agree.
     private def self.split_top_level(content : String, start_pos : Int32, end_pos : Int32, delimiter : Char) : Array(Tuple(String, Int32))
-      args = [] of Tuple(String, Int32)
-      # Chars-array walk (see arrow_params) — this scans a whole argument
-      # span at absolute offsets into the file, so per-access String
-      # re-seeking made it O(span x file) on non-ASCII sources.
-      chars = content.chars
-      arg_start = start_pos
-      depth = 0
-      quote : Char? = nil
-      escaped = false
-      i = start_pos
-
-      while i < end_pos
-        char = chars[i]
-        if quote
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            quote = nil
-          end
-          i += 1
-          next
-        end
-
-        case char
-        when '\'', '"', '`'
-          quote = char
-        when '(', '[', '{'
-          depth += 1
-        when ')', ']', '}'
-          depth -= 1 if depth > 0
-        when delimiter
-          if depth == 0
-            args << normalized_arg(content, chars, arg_start, i)
-            arg_start = i + 1
-          end
-        end
-        i += 1
-      end
-
-      args << normalized_arg(content, chars, arg_start, end_pos)
-      args
-    end
-
-    private def self.normalized_arg(content : String, chars : Array(Char), start_pos : Int32, end_pos : Int32) : Tuple(String, Int32)
-      start_idx = start_pos
-      while start_idx < chars.size && chars[start_idx].whitespace?
-        start_idx += 1
-      end
-      stop_idx = end_pos
-      while stop_idx > start_idx && chars[stop_idx - 1].whitespace?
-        stop_idx -= 1
-      end
-
-      {content[start_idx...stop_idx], start_idx}
+      Noir::TopLevelSplit.split_spans(content, delimiter, Noir::TopLevelSplit::Rules::JS_POSITIONAL_ARGS, start_pos, end_pos)
     end
 
     private def self.skip_whitespace(content : String, pos : Int32) : Int32

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -241,9 +241,7 @@ module Noir
       # escape flag. That misreads `"a\\"` as an unterminated string (the
       # escaped backslash is taken as escaping the closing quote), so no
       # `Escape` value reproduces it and converting would change where it
-      # splits. The three `split_top_level_args` copies in
-      # javascript/{express,feathers,hono}.cr are likewise left alone: they
-      # return `{part, offset}` tuples, and this module returns only strings.
+      # splits.
       JS = new(
         nest: Nest::Paren | Nest::Bracket | Nest::Brace,
         quotes: "\"'`",
@@ -251,6 +249,28 @@ module Noir
         strip: true,
         empties: Empties::DropAll,
         per_kind: true,
+        clamp: true,
+      )
+
+      # JavaScript/TypeScript call-argument lists split with `split_spans`,
+      # where the caller needs each argument's absolute position as well as
+      # its text.
+      # Serves the three byte-identical `split_top_level_args` copies in
+      # analyzer/analyzers/javascript/{express,feathers,hono}.cr and
+      # miniparsers/js_http_route_extractor.cr `split_top_level`.
+      #
+      # Differs from `JS` on two axes, both load-bearing:
+      #   * one SHARED depth counter, not per-kind
+      #   * `Empties::Keep`, because every caller indexes the result
+      #     positionally (`args[0]` is the route, `args[2]` the handler), so
+      #     an empty argument must hold its slot or the handler shifts left.
+      JS_POSITIONAL_ARGS = new(
+        nest: Nest::Paren | Nest::Bracket | Nest::Brace,
+        quotes: "\"'`",
+        escape: Escape::InQuotes,
+        strip: true,
+        empties: Empties::Keep,
+        per_kind: false,
         clamp: true,
       )
 
@@ -300,12 +320,86 @@ module Noir
       split_impl(text, chars, rules)
     end
 
+    # Splits like `split`, but also reports where each part starts.
+    #
+    # Returns `{part, offset}` tuples where `offset` is an ABSOLUTE CHAR index
+    # into `text` (not a byte index, and not relative to `start_pos`) pointing
+    # at the first non-whitespace character of that part. Callers use it to map
+    # an argument back onto the file it was sliced out of, so they need a
+    # position in the same coordinate system they passed the window in.
+    #
+    # `start_pos` and `end_pos` bound the scan, again as char indices;
+    # `end_pos < 0` means "to the end of `text`". Both are clamped into
+    # `0..text.size`, and an inverted window is treated as empty.
+    #
+    # The window is applied by testing the index while iterating, NOT by
+    # slicing `text` first: char-range slicing is O(n) on any string holding a
+    # multi-byte codepoint, which is the very cost this module exists to avoid.
+    #
+    # Offset of an empty or whitespace-only part: the first non-whitespace
+    # character at or after where the part began, looked for in the WHOLE of
+    # `text` and not just inside the part — so a part that is only whitespace
+    # reports the index of the delimiter that ended it, and a whitespace-only
+    # final part can report an index past `end_pos`. That is what the four
+    # hand-rolled copies this replaces did (their `skip_whitespace` helper was
+    # bounded by `content.size`, never by the part or the window), and callers
+    # feed the offset straight back into `text`, so the position must stay a
+    # valid index into `text` rather than being clamped to the part.
+    #
+    # Char delimiter only, deliberately: every caller that needs offsets splits
+    # on a single character, and the multi-character path buffers a pending
+    # prefix whose release re-orders characters (see the `String` overload's
+    # precondition) — which would make an offset ambiguous.
+    def split_spans(
+      text : String,
+      delimiter : Char,
+      rules : Rules,
+      start_pos : Int32 = 0,
+      end_pos : Int32 = -1,
+    ) : Array(Tuple(String, Int32))
+      size = text.size
+      from = start_pos.clamp(0, size)
+      to = end_pos < 0 ? size : end_pos.clamp(from, size)
+
+      cur = Cursor.new(rules, spans: true)
+      scan(text, [delimiter], rules, cur, from, to)
+      cur.resolve_pending_spans(first_non_whitespace_at(text, to)) if cur.pending_spans?
+      apply_empties_spans(cur.parts, cur.offsets, rules)
+    end
+
     private def split_impl(text : String, delim : Array(Char), rules : Rules) : Array(String)
       cur = Cursor.new(rules)
+      scan(text, delim, rules, cur, 0, Int32::MAX)
+      apply_empties(cur.parts, rules)
+    end
+
+    # The one state machine, shared by `split` and `split_spans`. `start_pos`
+    # and `end_pos` are already clamped; `split` passes the whole string, so
+    # its two window tests are constant-false and constant-true.
+    private def scan(
+      text : String,
+      delim : Array(Char),
+      rules : Rules,
+      cur : Cursor,
+      start_pos : Int32,
+      end_pos : Int32,
+    ) : Nil
       multi = delim.size > 1
       first = delim[0]
+      spans = cur.spans?
 
-      text.each_char do |ch|
+      text.each_char_with_index do |ch, index|
+        next if index < start_pos
+        break if index >= end_pos
+
+        # Every character inside the window is offered to the span tracker
+        # before anything else looks at it, delimiters included, because the
+        # replaced bodies computed offsets purely positionally: quoting and
+        # depth do not affect which character is "the first non-whitespace
+        # one", and a delimiter is the character that resolves the offset of
+        # a whitespace-only part.
+        cur.note_span(index, ch) if spans
+
         # Inside a quoted run nothing else can happen: no depth change, no
         # split, no new quote. This branch is first because it is also the
         # cheapest, and quoted route strings are where the delimiter character
@@ -364,7 +458,19 @@ module Noir
 
       cur.flush_pending
       cur.emit
-      apply_empties(cur.parts, rules)
+    end
+
+    # First non-whitespace char index at or after `from`, or `text.size` if
+    # there is none. Walks forward instead of indexing for the usual reason:
+    # `text[i]` is O(i) once the string is not single-byte. Only called when a
+    # part ended without ever seeing a non-whitespace character.
+    private def first_non_whitespace_at(text : String, from : Int32) : Int32
+      index = 0
+      text.each_char do |ch|
+        return index if index >= from && !ch.whitespace?
+        index += 1
+      end
+      index
     end
 
     private def prefix_of?(buffer : Array(Char), delim : Array(Char)) : Bool
@@ -387,6 +493,33 @@ module Noir
       end
     end
 
+    # `apply_empties` over parallel part/offset arrays. Written out rather than
+    # zipping first and filtering after so `Empties::Keep` — what every current
+    # span caller uses — pays for one allocation instead of two.
+    private def apply_empties_spans(
+      parts : Array(String),
+      offsets : Array(Int32),
+      rules : Rules,
+    ) : Array(Tuple(String, Int32))
+      last = parts.size
+      case rules.empties
+      in Empties::Keep
+        # nothing to drop
+      in Empties::DropTrailing
+        last -= 1 if last > 0 && parts[last - 1].empty?
+      in Empties::DropAll
+        spans = Array(Tuple(String, Int32)).new(parts.size)
+        parts.each_with_index do |part, i|
+          spans << {part, offsets[i]} unless part.empty?
+        end
+        return spans
+      end
+
+      spans = Array(Tuple(String, Int32)).new(last)
+      last.times { |i| spans << {parts[i], offsets[i]} }
+      spans
+    end
+
     # Mutable scan state. A class rather than a bundle of locals so the
     # delimiter-mismatch path can hand a buffered char back to the same
     # ordinary-consumption code the main loop uses, instead of duplicating the
@@ -400,9 +533,46 @@ module Noir
       property quote : Char? = nil
       property? escaped = false
 
-      @depths = StaticArray(Int32, 4).new(0)
+      # Parallel to `parts`, and only filled when `spans?`. `UNRESOLVED` marks
+      # a part that had no non-whitespace character of its own; it is patched
+      # by the next non-whitespace character seen anywhere after it.
+      UNRESOLVED = -1
 
-      def initialize(@rules : Rules)
+      getter offsets = [] of Int32
+      getter? spans : Bool
+
+      @depths = StaticArray(Int32, 4).new(0)
+      @offset = UNRESOLVED
+      @pending_spans = 0
+
+      def initialize(@rules : Rules, @spans : Bool = false)
+      end
+
+      def pending_spans? : Bool
+        @pending_spans > 0
+      end
+
+      # Offered every character in the window, in order, before the split
+      # machinery looks at it.
+      def note_span(index : Int32, ch : Char) : Nil
+        return if ch.whitespace?
+
+        if @pending_spans > 0
+          # Parts emitted without an offset all resolve to the same character
+          # — the first non-whitespace one after them — because that is where
+          # each of their forward scans would have stopped.
+          stop = @offsets.size
+          (stop - @pending_spans).upto(stop - 1) { |i| @offsets[i] = index }
+          @pending_spans = 0
+        end
+
+        @offset = index if @offset == UNRESOLVED
+      end
+
+      def resolve_pending_spans(index : Int32) : Nil
+        stop = @offsets.size
+        (stop - @pending_spans).upto(stop - 1) { |i| @offsets[i] = index }
+        @pending_spans = 0
       end
 
       # In shared-depth mode only slot 0 is ever touched, so the same all-zero
@@ -416,6 +586,11 @@ module Noir
         part = part.strip if @rules.strip?
         @parts << part
         @current = String::Builder.new
+
+        return unless @spans
+        @offsets << @offset
+        @pending_spans += 1 if @offset == UNRESOLVED
+        @offset = UNRESOLVED
       end
 
       def flush_pending : Nil


### PR DESCRIPTION
## Summary

Final step of the series (#2617 C++, #2618 Python, #2619 Java, #2620 JS/TS, #2621 long tail, #2622 multi-char).

The four sites returning `{part, offset}` tuples — `express.cr`, `feathers.cr`, `hono.cr` and `js_http_route_extractor.cr` — were held back because the module returned strings only. `split_spans` gives them offsets.

**With these converted, the only hand-rolled splitters left in `src/` are the four documented exceptions:**

| File | Why it stays |
|---|---|
| `python/flask.cr`, `python/quart.cr` | counter grouping — `(` on its own counter, `[ ] { }` sharing a second — is neither `per_kind: true` nor `false` |
| `specification/apache_httpd.cr` | different algorithm: a whitespace tokenizer that *deletes* quote characters from its output |
| `express/router_mount_scanner.cr` | `prev_char != '\\'` escape lookback (#2620) — a real defect; converting it would be a fix, not a refactor |

41 files now call the shared module.

## The new preset

All four converged on identical rules, so they share `Rules::JS_POSITIONAL_ARGS` rather than four file-local constants. It is **not** `Rules::JS` — it differs on two axes:

- one **shared** depth counter, not per-kind
- **`Empties::Keep`**, not `DropAll` — load-bearing, because every caller indexes the result positionally (`args[0]` is the route, `args[2]` the handler), so an empty argument must hold its slot or the handler shifts left

## Design

`split_spans` takes a **`Char` delimiter only**. The multi-character path buffers a pending prefix whose release can re-order characters (see the `String` overload's precondition, documented in #2622), which would make an offset ambiguous. No caller that needs offsets splits on more than one character.

The window is applied by **testing the index while iterating**, not by slicing `text` first: char-range slicing is O(n) on any string holding a multi-byte codepoint, which is the cost this whole module exists to avoid. The bodies being replaced materialized `content.chars` on every call, so this allocates strictly less.

Both entry points drive one private `scan`; `split_impl` was **not** forked.

## Three findings that changed the implementation

**1. "Byte-identical" held for express and hono, but not feathers** — it lacks express's `.chars` perf comment and names its helper `skip_ws` rather than `skip_whitespace`. Semantically the same, textually not, so there were **two** distinct bodies to prove equivalent rather than one.

**2. The offset rule I briefed was wrong for empty parts, and this was the load-bearing detail.** I said "the first non-whitespace character of that part". The old `skip_whitespace` helper is bounded by **`content.size`** — not by the part, and not by `end_pos`:

```
"a, ,b"  window [0,5)  ->  [{"a",0}, {"",3}, {"b",4}]     # offset 3 is the comma
"a,  b"  window [0,3)  ->  [{"a",0}, {"",4}]              # offset 4 is OUTSIDE the window
```

Matched verbatim rather than clamped: callers feed the offset straight back into `content` (e.g. `handler_start + arrow_idx`), so it has to stay a valid index into the text. Clamping it into the part would produce a position where the caller's text is not.

**3. The old bodies index `chars[i]` unguarded**, so an out-of-range or inverted window raises `IndexError` (verified: `"a,b"` with `[0,99)` and `[-5,3)` both raise). `split_spans` clamps instead. No caller is affected — all pass `paren_open + 1, paren_close` or `0, params.size`.

Also confirmed: none of the four uses the `prev_char` lookback, which is why `Escape::InQuotes` reproduces them; and Crystal's `String#strip` uses the same `whitespace?` predicate as the hand-rolled trim loops, so there is no non-ASCII-whitespace divergence.

## Equivalence proof

**Comparing parts AND offsets as tuples** — an off-by-one offset is exactly what this PR risks, and comparing only strings would hide it.

```
harvested paren windows: 4001 from 305 fixture files
corpus size: 37816 cases
express/hono/feathers body:    total=37816  nontrivial=9558  mismatches=0
js_http_route_extractor body:  total=37816  nontrivial=9558  mismatches=0
```

Corpus: every `(`…matching-`)` region in every `.js/.ts/.jsx/.tsx/.mjs/.cjs` fixture file — the exact `(paren_open+1, paren_close)` window shape callers pass — plus mid-token variants; 45 hand-written texts expanded over **all** `(a,b)` sub-windows, each re-run with `"안"`, `"🎉"`, `"가나다"` and `" "` prefixed so the window starts after non-ASCII; template literals with `${}` holding commas and nested braces, nested backticks, arrow functions, object/array literals, edge and lone delimiters, empty and `start == end` windows, unbalanced fragments, unterminated quotes of all three kinds; and 20,000 seeded-random strings with randomized bounds.

### Non-span `split` verified unchanged

It has 37 callers and five merged PRs of evidence behind it, so it got its own differential against `git show origin/main:src/utils/top_level_split.cr` loaded side by side:

```
rule sets: 1440
split (non-span) differential: total=80216  nontrivial=11183  mismatches=0
```

1,440 rule combinations (5 nest sets × 4 quote sets × 3 escapes × strip × 3 empties × per_kind × clamp) across both overloads, plus all six pre-existing presets.

## Test plan

- `crystal spec spec/unit_test` → **5081 examples, 0 failures** (5063 + 18 new)
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** — unchanged
- Real binary: `javascript` **486 → 486**, `typescript` **79 → 79**, compared as sorted key-sorted JSON of every endpoint object, not by count
- `crystal tool format --check src/ spec/` → clean
- `ameba` on the 6 touched files → `6 inspected, 0 failures`
- `typos .` → clean

18 new unit examples: offsets after leading whitespace; char-vs-byte offsets (`"한국, handler"` → 4, not 8); windowed calls with absolute offsets; a window preceded by non-ASCII; `end_pos = -1`; out-of-range clamping; empty window; interior empty; consecutive empties; the past-the-window offset; `text.size`; `DropAll`/`DropTrailing` with offsets surviving; template literals; and the two axes separating `JS_POSITIONAL_ARGS` from `JS`.

## Known defects left for their own PRs

Three, all documented in the code where they live rather than only here:

1. **`TopLevelSplit`'s multi-char path** re-orders characters when a proper prefix of the delimiter contains a quote or an enabled nest opener (#2622). Unreachable — no separator in the tree violates the precondition.
2. **`express/router_mount_scanner.cr`'s `prev_char != '\\'` lookback** misreads `"a\\"` as unterminated (#2620).
3. **`engines/cfml_engine.cr`'s `\`-escape** where CFML escapes a quote by doubling it, which `matching_delimiter` in the same file already handles correctly (#2621).

2 and 3 change detection output, so each needs its own PR with fixture evidence.