### PR TITLE
fix(utils): keep characters in source order when a delimiter prefix changes state

### DIFF
--- a/spec/unit_test/utils/top_level_split_spec.cr
+++ b/spec/unit_test/utils/top_level_split_spec.cr
@@ -13,6 +13,13 @@ private def tls_rules(**opts)
   TLSRules.new(**opts)
 end
 
+# `strip: false` + `Empties::Keep` so nothing but the delimiter is ever removed
+# and the emitted characters can be compared against the input directly.
+private def tls_raw_rules(nest : TLSNest, quotes : String)
+  TLSRules.new(nest: nest, quotes: quotes, escape: TLSEscape::None,
+    strip: false, empties: TLSEmpties::Keep)
+end
+
 describe Noir::TopLevelSplit do
   describe "basic splitting" do
     it "splits a flat list" do
@@ -333,6 +340,57 @@ describe Noir::TopLevelSplit do
     it "returns the whole input for an empty separator" do
       TLS.split(" a,b ", "", tls_rules(strip: true)).should eq ["a,b"]
       TLS.split(" a,b ", "", tls_rules(strip: false, empties: TLSEmpties::Keep)).should eq [" a,b "]
+    end
+  end
+
+  # A delimiter whose proper prefix is itself a nest opener or a quote character
+  # cannot match at depth 0 once that prefix has been released — releasing it is
+  # what raises the depth / opens the run. That suppresses SPLITS, which is what
+  # the depth-0 contract requires; it must never reorder the characters, which
+  # is what the buffered prefix used to do (it was replayed by the end-of-scan
+  # flush, i.e. AFTER everything that followed it in the source).
+  describe "multi-character delimiter whose prefix changes cursor state" do
+    it "keeps characters in source order when a released prefix raises depth" do
+      # `"((x"` can only match at index 1, but index 0's `(` already took the
+      # depth to 1, so no split is allowed. Every character survives, in order.
+      TLS.split("(((xy", "((x", tls_raw_rules(TLSNest::Paren, ""))
+        .should eq ["(((xy"]
+    end
+
+    it "keeps characters in source order when a released prefix opens a quote" do
+      TLS.split("\"\"\"xy", "\"\"x", tls_raw_rules(TLSNest::None, "\""))
+        .should eq ["\"\"\"xy"]
+    end
+
+    it "keeps characters in source order for a single-quote delimiter prefix" do
+      # Same shape with a one-character prefix, so the whole tail of the buffer
+      # is released while the run it just opened is still open.
+      TLS.split("''ab", "'a", tls_raw_rules(TLSNest::None, "'"))
+        .should eq ["''ab"]
+    end
+
+    it "still splits on matches that precede the state change" do
+      TLS.split("a((x b (((x c", "((x", tls_raw_rules(TLSNest::Paren, ""))
+        .should eq ["a", " b (((x c"]
+    end
+
+    it "resumes splitting once the depth returns to zero" do
+      TLS.split("(((x))) ((x tail", "((x", tls_raw_rules(TLSNest::Paren, ""))
+        .should eq ["(((x))) ", " tail"]
+    end
+
+    it "leaves the prefix inert when the opener is not an enabled nest kind" do
+      # `<` only opens depth when Nest::Angle is enabled; without it the buffer
+      # is never stranded and `"<<x"` matches at index 1 as usual.
+      TLS.split("<<<xy", "<<x", tls_raw_rules(TLSNest::Paren, ""))
+        .should eq ["<", "y"]
+      TLS.split("<<<xy", "<<x", tls_raw_rules(TLSNest::Angle, ""))
+        .should eq ["<<<xy"]
+    end
+
+    it "leaves the prefix inert when the quote character is not enabled" do
+      TLS.split("\"\"\"xy", "\"\"x", tls_raw_rules(TLSNest::None, ""))
+        .should eq ["\"", "y"]
     end
   end
 

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -302,18 +302,29 @@ module Noir
     # ENTIRELY at depth 0 and outside quotes splits, so `":>"` does not fire on
     # a bare `":"` and `"||"` inside `f(a || b)` is invisible.
     #
-    # PRECONDITION: no proper prefix of the delimiter may contain a character
-    # that is a quote under `rules`, a backslash, or an opener of an enabled
-    # `Nest` kind. Releasing a mismatched prefix character is what changes
-    # cursor state, and if that release opens a quote or raises depth the
-    # remaining buffered characters stop being top-level and are replayed
-    # after the characters that followed them in the source — `split("(((xy",
-    # "((x", nest: Paren)` yields `["(xy(("]`, not `["(", "y"]`.
+    # LIMITATION — a delimiter with a state-changing proper prefix: matching a
+    # multi-character separator means buffering characters while they are still
+    # a prefix of it, and a mismatch releases only the first buffered character
+    # before retrying the rest. That release is what changes cursor state, so if
+    # a proper prefix of the delimiter contains a quote character or an opener
+    # of an enabled `Nest` kind, releasing it opens a quoted run or raises the
+    # depth — and from that point the separator can no longer match at depth 0.
+    # `split("(((xy", "((x", nest: Paren)` therefore yields `["(((xy"]`: the
+    # only place `"((x"` could match starts at index 1, and index 0's `(` has
+    # already taken the depth to 1, so the depth-0 rule forbids the split. Same
+    # for quotes: `split("\"\"\"xy", "\"\"x", quotes: "\"")` yields
+    # `["\"\"\"xy"]`, the first `"` having opened a run that swallows the rest.
     #
-    # Every separator in the tree is punctuation outside all three sets
-    # (`","`, `":>"`, `":<|>"`, `"||"`, `"&&"`), so no caller is affected. The
-    # note in `Cursor#consume` about a quote-bearing delimiter is the same
-    # precondition seen from the other end.
+    # This suppresses SPLITS only. The characters themselves are never lost or
+    # reordered: the moment a release ends the top-level/unquoted state, the
+    # rest of the buffer is flushed immediately, so every part holds the input
+    # characters of its window in source order.
+    #
+    # Every separator actually used in the tree is punctuation outside both sets
+    # (`","` and `":>"` / `":<|>"` in haskell/servant.cr, `"||"` in
+    # specification/traefik.cr), so no caller sees the limitation at all. The
+    # note in `Cursor#consume` about a quote-bearing delimiter is this same
+    # situation seen from the other end.
     def split(text : String, delimiter : String, rules : Rules) : Array(String)
       chars = delimiter.chars
       return apply_empties([rules.strip? ? text.strip : text], rules) if chars.empty?
@@ -348,8 +359,10 @@ module Noir
     #
     # Char delimiter only, deliberately: every caller that needs offsets splits
     # on a single character, and the multi-character path buffers a pending
-    # prefix whose release re-orders characters (see the `String` overload's
-    # precondition) — which would make an offset ambiguous.
+    # prefix that is only committed to a part once the match fails (see the
+    # `String` overload's limitation note) — so a part could begin with
+    # characters read well before the scan decided they belonged to it, which
+    # would make its offset ambiguous.
     def split_spans(
       text : String,
       delimiter : Char,
@@ -445,6 +458,20 @@ module Noir
                 break
               end
               cur.consume(pending.shift)
+
+              # Releasing a character is the only thing that moves the cursor,
+              # and it can raise depth or open a quoted run. Either one means
+              # the still-buffered characters can never complete a top-level
+              # match, so they must be released NOW: holding them would send
+              # every following character down the `cur.consume(ch)` path below
+              # while they waited for `flush_pending` at end of scan, which
+              # appends them AFTER characters that follow them in the source.
+              # This also keeps the invariant the rest of the loop relies on —
+              # a non-empty buffer implies depth 0 with no quote open.
+              if cur.quote || !cur.top_level?
+                cur.flush_pending
+                break
+              end
             end
             next
           elsif ch == first
@@ -600,9 +627,12 @@ module Noir
       end
 
       def consume(ch : Char) : Nil
-        # Only reachable with a quote open when a delimiter containing a quote
-        # character stranded a partial match (documented as unsupported); the
-        # char still lands verbatim in the part so nothing is lost.
+        # Reachable with a quote already open only from `flush_pending`, when a
+        # released delimiter-prefix character opened the run and the rest of the
+        # buffer is being drained behind it (see the `String` overload's
+        # limitation note). Inside a run nothing may change state, so the char
+        # lands verbatim in the part: order is preserved and nothing is lost,
+        # the run simply stays open.
         if @quote
           @current << ch
           return


### PR DESCRIPTION
## The bug

`TopLevelSplit`'s multi-character-delimiter path could emit characters **out of source order**.

Matching a multi-char separator means buffering characters while they are still a prefix of it; on a mismatch the first buffered character is released and the rest retried. That release is the only thing that moves the cursor, and it can raise depth or open a quoted run — after which the inner loop could still `break` with characters left in the buffer. Every subsequent character then took the `cur.consume(ch)` path (the `top_level?` guard now failing) while the buffered ones waited for the end-of-scan `flush_pending`, which appended them **after** characters that followed them in the source.

```crystal
split("(((xy",    "((x",   nest: Paren)     # => ["(xy(("]
split("\"\"\"xy", "\"\"x", quotes: "\"")    # => ["\"xy\"\""]
```

Found while converting the first production users of the `String` overload (#2622), and documented there as a precondition rather than fixed, so the conversion PR could keep its "behavior is identical" claim clean.

## The fix

Releasing now flushes the rest of the buffer as soon as it ends the top-level-and-unquoted state:

```crystal
cur.consume(pending.shift)
if cur.quote || !cur.top_level?
  cur.flush_pending
  break
end
```

The guard tests **`cur.quote || !cur.top_level?`**, not `top_level?` alone. `Cursor#top_level?` only inspects `@depths`, so the quote reproduction would have gone unfixed — `consume` can change exactly two things, and the guard has to test both.

## What "fixed" means here

The fix suppresses no splits that were happening and enables none that were not. Both reproductions now return the whole window as **one part**, which is what the depth-0 contract requires:

- `"((x"` can only align at index 1 of `"(((xy"`, and index 0's `(` has already taken the depth to 1.
- `"\"\"x"` likewise aligns only at index 1, and index 0's `"` has already opened a run.

An earlier note in this series claimed the first case "should" return `["(", "y"]`. That would have violated the documented rule that a separator run must sit **entirely** at depth 0, so implementing it would have been a different — and wrong — change.

## No caller is affected, and it is measured

Only two wrappers take a `String` delimiter: `haskell/servant.cr:833` (`","`, `":>"`, `":<|>"`) and `specification/traefik.cr:219` (`"||"`). None of those prefixes contains a quote character or an enabled nest opener — servant has `Angle` off, so `<` in `":<|>"` is inert; traefik has quotes disabled and only `Paren` enabled.

Empirically, in the differential below, mismatches occurred for **exactly three synthetic delimiters** — `"((x"` (2592), `"\"\"x"` (2160), `"<<x"` (432) — and **zero** for `","`, `":>"`, `":<|>"`, `"||"`, every `Char` delimiter, and every `split_spans` call.

## Differential vs `origin/main`

Old module loaded side by side as `NoirOld`. 1,440 rule combinations (5 nest × 4 quote × 3 escape × 2 strip × 3 empties × 2 per_kind × 2 clamp) × 83 inputs (43 hand-built + 40 seeded random, including Hangul and emoji) × 17 string delimiters, plus 7 char delimiters and 4 `split_spans` windows.

| | |
|---|---|
| comparisons | **6,215,040** |
| non-trivial | 2,459,544 |
| mismatches | 5,184 |
| …of which the OLD output was out of source order | **5,184** |
| …order-preserving outputs that changed | **0** |

Every mismatch is the bug. Nothing that was already correct moved.

### Order-preservation property sweep

Property: `parts.join` must be a subsequence of the input, since splitting only ever *removes* characters (delimiters, stripped whitespace, dropped empties) — so any reordering breaks it.

3,986,823 cases: **OLD 165 failures, NEW 0.** Across both sweeps OLD fails 5,349 cases and NEW fails none.

## Documentation corrected

The `String` overload's doc called this a **PRECONDITION callers must satisfy**. It is now a **LIMITATION** note describing what actually happens: a state-changing prefix suppresses splits, but characters are never lost or reordered.

It also listed `"&&"` as a live separator. traefik has exactly one `split_top_level` call site, on `"||"` — `"&&"` appears nowhere in the tree. The list now names only the separators that exist.

`Cursor#consume`'s note about a quote-open state being "documented as unsupported" is reworded too: that path is now reachable supported behavior, entered from `flush_pending`.

## No defensive flush was added

The invariant **"a non-empty buffer implies depth 0 with no quote open"** is airtight — the buffer is only filled inside the multi branch, which is guarded by `top_level?` and reached only after the quote branch has `next`ed, and every exit of the inner loop preserves it. So:

- a flush before the bottom `cur.consume(ch)` would be dead code (contrapositive of the invariant);
- the quoted-run branch needs `cur.quote` non-nil, which the invariant excludes while buffered;
- the `escaped?` branch needs `@escaped`, set only by the quoted-run branch or by `Escape::Always` — and the latter already flushes *before* setting it, which is the right order.

## Test plan

- `crystal spec spec/unit_test` → **5088 examples, 0 failures** (5081 + 7 new)
- `crystal spec spec/functional_test` → **23906 examples, 0 failures** — unchanged
- Real binary A/B against a baseline built from `origin/main`'s version of the file (swapped in, built, restored; `git diff --stat` verified clean afterwards). Endpoint sets compared as sorted normalized JSON, not counts: **haskell 42, specification 291, javascript 486, python 419 — all identical**
- `crystal tool format --check src/ spec/` → clean
- `ameba` on both touched files → `2 inspected, 0 failures`
- `typos .` → clean

New spec block `"multi-character delimiter whose prefix changes cursor state"` pins 7 examples: both reproductions; a single-character quote prefix (`"''ab"` + `"'a"` → `["''ab"]`, old gave `["'ab'"]`); a split that still fires *before* the state change; splitting resuming once depth returns to 0; and two controls showing the prefix is inert when the opener or quote is not enabled by the rules (`"<<<xy"` + `"<<x"` → `["<", "y"]` without `Angle`, `["<<<xy"]` with it).