### PR TITLE
fix(analyzer): close Express destructuring strings with an escape flag, not a lookback

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_escaped_backslash_mount/app.js
+++ b/spec/functional_test/fixtures/javascript/express_escaped_backslash_mount/app.js
@@ -1,0 +1,17 @@
+const express = require('express');
+
+// The destructuring default is a Windows path whose trailing separator is an
+// escaped backslash. A quoted-run tracker that decides a string ended by
+// looking one character back reads the `\\'` at the end as an escaped quote,
+// so the literal never closes, the comma after it is never seen, and
+// `createUploadRouter` is never registered as an import — which drops the
+// mount and leaves the upload routes unprefixed.
+const { UPLOAD_ROOT = 'C:\\uploads\\', createUploadRouter } = require('./routes/uploads');
+
+const app = express();
+
+app.use('/uploads', createUploadRouter());
+
+app.get('/config', (req, res) => res.json({ root: UPLOAD_ROOT }));
+
+app.listen(3000);

--- a/spec/functional_test/fixtures/javascript/express_escaped_backslash_mount/routes/uploads.js
+++ b/spec/functional_test/fixtures/javascript/express_escaped_backslash_mount/routes/uploads.js
@@ -1,0 +1,16 @@
+const express = require('express');
+
+// Windows deployments keep uploads on a drive path, so the default root ends
+// with an escaped backslash.
+const UPLOAD_ROOT = 'C:\\uploads\\';
+
+function createUploadRouter() {
+  const router = express.Router();
+
+  router.get('/', (req, res) => res.json({ root: UPLOAD_ROOT }));
+  router.post('/', (req, res) => res.json({}));
+
+  return router;
+}
+
+module.exports = { UPLOAD_ROOT, createUploadRouter };

--- a/spec/functional_test/testers/javascript/express_escaped_backslash_mount_spec.cr
+++ b/spec/functional_test/testers/javascript/express_escaped_backslash_mount_spec.cr
@@ -1,0 +1,21 @@
+require "../../func_spec.cr"
+
+# A destructured `require` whose first binding has a Windows-path default
+# (`{ UPLOAD_ROOT = 'C:\\uploads\\', createUploadRouter }`).
+#
+# The destructuring splitter used to close a quoted run with a one-character
+# lookback (`ch == quote && prev_char != '\\'`), which cannot tell an escaped
+# quote from an escaped backslash followed by a quote. The `\\'` ending the
+# default was read as an escaped quote, the literal never closed, the comma
+# after it was never seen, and `createUploadRouter` was never registered as an
+# import — so `app.use('/uploads', createUploadRouter())` resolved to nothing
+# and both upload routes came out as `/` instead of `/uploads/`.
+expected_endpoints = [
+  Endpoint.new("/config", "GET"),
+  Endpoint.new("/uploads/", "GET"),
+  Endpoint.new("/uploads/", "POST"),
+]
+
+FunctionalTester.new("fixtures/javascript/express_escaped_backslash_mount/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -1,6 +1,7 @@
 require "../../../../models/code_locator"
 require "../../../../utils/js_literal_scanner"
 require "../../../../utils/path_scope"
+require "../../../../utils/top_level_split"
 require "../../../../utils/url_path"
 require "../express_constants"
 require "../../../../utils/text_file"
@@ -1028,6 +1029,29 @@ module Analyzer::Javascript
       extracted
     end
 
+    # `Rules::JS` on five of seven axes — same nest kinds, same three quote
+    # characters, same per-kind depth counters, same clamp, same
+    # `Escape::InQuotes`. It diverges on `strip` and `empties` only, and only
+    # because the hand-rolled body it replaces never stripped and kept its
+    # interior empties: `Rules::JS` strips and drops every empty part.
+    #
+    # Both divergences are invisible to the single caller — the loop in
+    # `parse_destructured_names` does `item.strip` and skips the result when it
+    # is empty — so this is faithfulness to the replaced body, not a behavior
+    # requirement. File-local because no other splitter in the tree wants this
+    # combination, and promoting a preset for one caller whose two distinctive
+    # axes are unobservable would be misleading.
+    SPLIT_COMMA_RULES = Noir::TopLevelSplit::Rules.new(
+      nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
+            Noir::TopLevelSplit::Nest::Brace,
+      quotes: "\"'`",
+      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      strip: false,
+      empties: Noir::TopLevelSplit::Empties::DropTrailing,
+      per_kind: true,
+      clamp: true,
+    )
+
     # Split a string at top-level commas, respecting nesting and string literals.
     #
     # This is a literal-aware tokenizer that splits on commas only when they are
@@ -1035,69 +1059,17 @@ module Analyzer::Javascript
     #
     # Example: "a, b = {x: 1, y: 2}, c" → ["a", " b = {x: 1, y: 2}", " c"]
     #
+    # The hand-rolled body this replaces closed a quoted run with a one-character
+    # lookback (`ch == in_string && prev_char != '\\'`) rather than an escape
+    # flag. A lookback cannot tell an escaped quote from an escaped backslash
+    # followed by a quote, so `'C:\\uploads\\'` was read as an unterminated
+    # string: the closing quote looked escaped, the run never ended, and every
+    # remaining top-level comma was swallowed, collapsing the whole argument list
+    # into one part. `Escape::InQuotes` consumes the backslash AND the character
+    # after it, so a doubled backslash consumes itself and the quote that follows
+    # closes the run — while a genuinely escaped quote (`'it\'s'`) still does not.
     private def split_at_top_level_commas(input : String) : Array(String)
-      items = [] of String
-      current = ""
-      depth_brace = 0         # Tracks {} nesting (objects, blocks)
-      depth_bracket = 0       # Tracks [] nesting (arrays)
-      depth_paren = 0         # Tracks () nesting (function calls, grouping)
-      in_string : Char? = nil # Tracks if we're inside a string and which quote char
-      prev_char : Char? = nil # For detecting escaped quotes
-
-      input.each_char do |ch|
-        # --- String literal handling ---
-        # When inside a string, accumulate characters until we hit the closing quote
-        if in_string
-          current += ch
-          # End of string: same quote char, not escaped by backslash
-          if ch == in_string && prev_char != '\\'
-            in_string = nil
-          end
-          prev_char = ch
-          next
-        end
-
-        # Start of a string literal
-        if ch == '"' || ch == '\'' || ch == '`'
-          in_string = ch
-          current += ch
-          prev_char = ch
-          next
-        end
-
-        # --- Nesting depth tracking ---
-        # Track depth so we only split on commas at the top level
-        case ch
-        when '{'
-          depth_brace += 1
-        when '}'
-          depth_brace -= 1 if depth_brace > 0
-        when '['
-          depth_bracket += 1
-        when ']'
-          depth_bracket -= 1 if depth_bracket > 0
-        when '('
-          depth_paren += 1
-        when ')'
-          depth_paren -= 1 if depth_paren > 0
-        when ','
-          # Only split at top-level commas (not inside any nested structure)
-          if depth_brace == 0 && depth_bracket == 0 && depth_paren == 0
-            items << current
-            current = ""
-            prev_char = ch
-            next
-          end
-        end
-
-        current += ch
-        prev_char = ch
-      end
-
-      # Don't forget the last item (no trailing comma)
-      items << current unless current.empty?
-
-      items
+      Noir::TopLevelSplit.split(input, ',', SPLIT_COMMA_RULES)
     end
 
     # Resolve a require path relative to the requiring file

--- a/src/utils/top_level_split.cr
+++ b/src/utils/top_level_split.cr
@@ -234,14 +234,16 @@ module Noir
       #   javascript/remix.cr `split_flat_segments`    -> Nest::Bracket only,
       #                                          no quotes, strip: false,
       #                                          Empties::Keep, delimiter `.`
+      #   javascript/express/router_mount_scanner.cr
+      #                       `split_at_top_level_commas` -> strip: false,
+      #                                          Empties::DropTrailing
       #
-      # NOT converted — javascript/express/router_mount_scanner.cr
-      # `split_at_top_level_commas` agrees with this preset on every axis
-      # except escaping, which it does with `prev_char != '\\'` instead of an
-      # escape flag. That misreads `"a\\"` as an unterminated string (the
-      # escaped backslash is taken as escaping the closing quote), so no
-      # `Escape` value reproduces it and converting would change where it
-      # splits.
+      # That last one was the only site converted with a DELIBERATE behavior
+      # change: its hand-rolled body closed a quoted run with a `prev_char !=
+      # '\\'` lookback, which reads `"a\\"` as unterminated because the escaped
+      # backslash is taken as escaping the closing quote. No `Escape` value
+      # reproduces that, and reproducing it was not worth doing — it is a bug,
+      # and `Escape::InQuotes` is what the lookback was reaching for.
       JS = new(
         nest: Nest::Paren | Nest::Bracket | Nest::Brace,
         quotes: "\"'`",


### PR DESCRIPTION
## The bug

`split_at_top_level_commas` in the Express router-mount scanner decided a quoted run had ended by looking one character back:

```crystal
if ch == in_string && prev_char != '\\'
```

A lookback cannot tell an *escaped quote* from an *escaped backslash followed by a quote*. So `'C:\\uploads\\'` read as an unterminated string: the closing quote looked escaped, the run never ended, and every remaining top-level comma was swallowed — collapsing the whole argument list into one part.

The method is reachable only from `parse_destructured_names`, so the damage lands on destructured `require`/`import` bindings: **every binding after the offending default is dropped** from `function_map`. When a router factory is among them, its mount prefix is lost and its entire subtree is reported at the wrong URL — a *wrong answer* rather than a missing one, which is worse to triage.

```js
const { UPLOAD_ROOT = 'C:\\uploads\\', createUploadRouter } = require('./routes/uploads');
app.use('/uploads', createUploadRouter());
```

| | GET | POST |
|---|---|---|
| before | `/` | `/` |
| after | `/uploads/` | `/uploads/` |

This is the last of three defects the splitter-consolidation series (#2617–#2623) recorded rather than fixed, and **the only one that changes detection output**. #2624 fixed the first.

## The fix

Replaced with `Noir::TopLevelSplit` and `Escape::InQuotes`, which consumes the backslash **and** the character after it. A doubled backslash consumes itself so the following quote closes the run — while a genuinely escaped quote still does not:

| input | old | new |
|---|---|---|
| `"a\\", b` | 1 part | **2 parts** |
| `'C:\\uploads\\', router` | 1 part | **2 parts** |
| `'it\'s', b` | 2 parts | 2 parts (unchanged) |
| `"say \"hi\"", b` | unchanged | unchanged |
| `` `it\`s`, b `` | unchanged | unchanged |

Both directions were checked deliberately: simply deleting the lookback would have fixed the first case and broken the third.

## Rules derived — three divergences, not one

The earlier survey reported this site as `Rules::JS` differing only on escaping. Reading the body, it also has `strip: false` and `Empties::DropTrailing` (interior empties pushed unconditionally; final pushed `unless current.empty?`).

Both are **unobservable** here — the only caller does `name = item.strip; next if name.empty?` — so `Rules::JS` would give identical downstream results. They are reproduced faithfully in a file-local constant anyway, so that **exactly one thing changes** in this commit. The comment says as much, and swapping in `Rules::JS` later is provably safe for this call site.

## What changes, measured

Differential over **8,802 inputs**: every non-empty line of every file under `fixtures/javascript/**` and `fixtures/typescript/**`, plus each line's outermost `{…}` and `(…)` interior, plus 44 synthetic cases.

```
TOTAL INPUTS: 8802
DIFFERING:    20
  from fixtures (8758 inputs): 0
  from synthetic (44 inputs):  20
DISTINCT SHAPES: 13
```

All 13 shapes are one family — **an even, non-zero backslash run immediately before a closing quote** — across all three quote kinds, inside template literals and `${}`, inside nested `()`/`{}`/`[]`, and with non-ASCII. Odd-length runs (`\`, `\\\`), which genuinely escape the quote, are unchanged and absent from the list.

## Does any existing fixture hit it?

**No.** A repo-wide search finds exactly one backslash pair in the JS fixtures — `sails/config/routes.js:46`, `'r|^/\\d+/(\\w+)/(\\w+)$|foo,bar'` — where the pairs are mid-string rather than before the closing quote. The 8,758-input fixture differential agreeing at zero confirms it independently.

Correctness restored, no current fixture affected — which is why the existing endpoint count below is unchanged.

## Endpoint impact

```
main baseline, js fixtures                    486
fix applied, js fixtures WITHOUT new fixture  486   <- the fix alone: no change
old code,    js fixtures WITH new fixture     488
fix applied, js fixtures WITH new fixture     489
typescript                                     79   (unchanged)
```

The two effects separate cleanly: the fix contributes **0** to existing fixtures; the new fixture contributes **+3**, of which **+1** is attributable to the fix (the `/uploads/` GET and POST become distinct instead of merging into the tree-wide `/` GET and `/` POST).

## New fixture

`spec/functional_test/fixtures/javascript/express_escaped_backslash_mount/` plus a tester, so the fix is regression-protected. Both carry a comment explaining the shape rather than just asserting the expectation.

A note on why it looks the way it does: `app.use('C:\\uploads\\', router)` would *not* reproduce the bug — `.use()` arguments go through `split_top_level_args` / `JS_POSITIONAL_ARGS`. `split_at_top_level_commas` is reachable only from destructured `require`/`import`, and the binding also has to be a **factory** export, because `resolve_and_store_router_prefix` stores a function-scoped key. Hence the `createUploadRouter()` shape, matching the existing `express_prefix_issues` fixture.

## Test plan

- `crystal spec spec/unit_test` → **5088 examples, 0 failures** — unchanged
- `crystal spec spec/functional_test` → **23913 examples, 0 failures** (23906 + 7 from the new tester)
- `crystal tool format --check src/ spec/` → clean
- `ameba` on the 3 touched files → `3 inspected, 0 failures`
- `typos .` → clean

## Honest assessment of real-world impact

**Rare but real, and narrower than it first looks.** Three conditions must coincide: a destructured `require`/`import` (very common); a binding carrying a *string-literal default* (uncommon in import destructuring — defaults are mostly a function-parameter idiom); and that string ending in an even backslash run before its closing quote (in practice, a hardcoded Windows path with a trailing separator).

I would not sell this as a common-case fix. Its value is that the failure mode is a wrong URL rather than a missing one, and that it retires the last hand-rolled splitter in the JS/TS analyzers — escape semantics now live in one place instead of being re-derived per file.

Incidentally removes an O(n²) `current += ch` accumulation from the old body.