### PR TITLE
fix(analyzer): CFML strings have no backslash escape

### DIFF
--- a/spec/functional_test/fixtures/cfml/fw1/Application.cfc
+++ b/spec/functional_test/fixtures/cfml/fw1/Application.cfc
@@ -15,7 +15,10 @@ component extends="framework.one" {
 
 			// `hint` labels the entry; only the second key is a route.
 			{ 'hint' = 'Standard Route', '$GET/old/path' = '/new/path' },
-			{ 'hint' = "Standard \" Route, with comma", '$GET/escaped/comma' = '/new/path' },
+			// A quote inside a CFML string is written by DOUBLING it — there is
+			// no backslash escape — and the comma after it is still inside the
+			// literal.
+			{ 'hint' = "Standard "" Route, with comma", '$GET/escaped/comma' = '/new/path' },
 
 			// Expands per the framework's resourceRouteTemplates.
 			{ 'hint' = 'Resource Routes', '$RESOURCES' = 'dogs' }

--- a/spec/functional_test/fixtures/cfml/pure/api/Files.cfc
+++ b/spec/functional_test/fixtures/cfml/pure/api/Files.cfc
@@ -1,0 +1,16 @@
+component {
+
+	// CFML has no backslash escape, so this default is the eleven-character
+	// string `C:\uploads\`: the literal ends at the quote before the comma,
+	// and `mask` is a second argument rather than part of the first.
+	remote array function listUploads( string folder = "C:\uploads\", string mask = "*.pdf" ) {
+		return directoryList( arguments.folder, false, "name", arguments.mask );
+	}
+
+	// A quote inside a CFML string is written by doubling it, and the comma
+	// inside that literal is not an argument separator.
+	remote string function describe( string label = "report ""Q1"", final", numeric page = 1 ) {
+		return arguments.label & arguments.page;
+	}
+
+}

--- a/spec/functional_test/testers/cfml/pure_spec.cr
+++ b/spec/functional_test/testers/cfml/pure_spec.cr
@@ -41,6 +41,28 @@ expected_endpoints = [
     Param.new("page", "", "form"),
   ]),
 
+  # A CFML string has no backslash escape, so a default value ending in one
+  # (a Windows path) closes at the next quote: the argument list still ends
+  # at the `)` on the same line, and `mask` is its own argument.
+  Endpoint.new("/api/Files.cfc?method=listUploads", "GET", [
+    Param.new("folder", "", "query"),
+    Param.new("mask", "", "query"),
+  ]),
+  Endpoint.new("/api/Files.cfc?method=listUploads", "POST", [
+    Param.new("folder", "", "form"),
+    Param.new("mask", "", "form"),
+  ]),
+  # A quote inside a string is written by doubling it, and the comma inside
+  # that literal does not separate arguments.
+  Endpoint.new("/api/Files.cfc?method=describe", "GET", [
+    Param.new("label", "", "query"),
+    Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/api/Files.cfc?method=describe", "POST", [
+    Param.new("label", "", "form"),
+    Param.new("page", "", "form"),
+  ]),
+
   # .cfm pages are file-path routed
   Endpoint.new("/index.cfm", "GET", [
     Param.new("view", "", "query"),

--- a/spec/unit_test/analyzer/cfml_string_literals_spec.cr
+++ b/spec/unit_test/analyzer/cfml_string_literals_spec.cr
@@ -1,0 +1,110 @@
+require "../../spec_helper"
+require "../../../src/analyzer/engines/cfml_engine"
+
+# CFML string literals have exactly one escape: the delimiter doubled
+# (`"say ""hi"""`, `'it''s'`). A backslash is an ORDINARY character, so
+# `"C:\uploads\"` is a complete eleven-character string — the shape that
+# used to break every scanner in this engine, because each of them treated
+# `\` as escaping the quote that closes the literal and so left the run open
+# for the rest of the file.
+class CfmlEngineSpecHarness < Analyzer::Cfml::CfmlEngine
+  def analyze
+    @result
+  end
+
+  def split(raw : String) : Array(String)
+    split_arguments(raw)
+  end
+
+  def arguments_of(raw : String) : Array(String)
+    script_arguments(raw)
+  end
+
+  def paren_close(content : String, open_paren : Int32) : Int32?
+    matching_paren(content, open_paren)
+  end
+
+  def strip_comments(content : String) : String
+    strip_script_comments(content)
+  end
+end
+
+describe Analyzer::Cfml::CfmlEngine do
+  harness = CfmlEngineSpecHarness.new(create_test_options)
+
+  describe "#split_arguments" do
+    it "keeps a comma that sits inside a doubled-quote literal" do
+      harness.split(%q(label = "report ""Q1"", final", page = 1))
+        .should eq [%q(label = "report ""Q1"", final"), "page = 1"]
+    end
+
+    it "keeps a comma inside a doubled-quote literal in single quotes" do
+      harness.split(%q(label = 'it''s, fine', page = 1))
+        .should eq [%q(label = 'it''s, fine'), "page = 1"]
+    end
+
+    it "treats a doubled quote at the start and at the end of a literal as literal" do
+      harness.split(%q(a = """quoted, value""", b = 2))
+        .should eq [%q(a = """quoted, value"""), "b = 2"]
+    end
+
+    # The regression this file is named after. `\` is not an escape, so the
+    # literal ends at the quote after it and the following comma is a real
+    # separator. While `\` was read as an escape the run stayed open and
+    # every later argument was swallowed by the first one.
+    it "ends a literal at the quote following a backslash" do
+      harness.split(%q(folder = "C:\uploads\", mask = "*.pdf"))
+        .should eq [%q(folder = "C:\uploads\"), %q(mask = "*.pdf")]
+    end
+
+    it "leaves an interior backslash as an ordinary character" do
+      harness.split(%q(pattern = "^\d{4}$", limit = 10))
+        .should eq [%q(pattern = "^\d{4}$"), "limit = 10"]
+    end
+
+    # An odd run of quotes: `"a"""` is `a"`, and the run is closed by the
+    # last quote, so the comma after it splits.
+    it "closes the run on the unpaired quote of an odd run" do
+      harness.split(%q(a = "x""", b = 2)).should eq [%q(a = "x"""), "b = 2"]
+    end
+  end
+
+  describe "#script_arguments" do
+    it "reports every argument of a signature holding a backslash default" do
+      harness.arguments_of(%q(string folder = "C:\uploads\", string mask = "*.pdf"))
+        .should eq ["folder", "mask"]
+    end
+
+    it "reports every argument of a signature holding a doubled-quote default" do
+      harness.arguments_of(%q(string label = "report ""Q1"", final", numeric page = 1))
+        .should eq ["label", "page"]
+    end
+  end
+
+  describe "#matching_paren" do
+    # `paren_content` feeds `script_arguments`, so a run that never closes
+    # does not merely mis-split the arguments — it loses the whole call, and
+    # with it the endpoint.
+    it "finds the closing paren of a call whose literal ends in a backslash" do
+      source = %q(remote function listUploads( string folder = "C:\uploads\", string mask = "*.pdf" ) {})
+      close = harness.paren_close(source, source.index!('('))
+      close.should eq source.index(") {")
+    end
+
+    it "ignores a paren inside a doubled-quote literal" do
+      # `%q` is unusable here: the `)` inside the literal is unbalanced.
+      source = "route( \"/a\"\") b\", \"main.index\" ) "
+      close = harness.paren_close(source, source.index!('('))
+      close.should eq source.rindex(')')
+    end
+  end
+
+  describe "#strip_script_comments" do
+    it "does not mistake the tail of a backslash-terminated literal for a comment" do
+      source = %Q(var root = "C:\\uploads\\";\n// gone\nroute( "/files" );\n)
+      stripped = harness.strip_comments(source)
+      stripped.should contain(%q(route( "/files" )))
+      stripped.should_not contain("gone")
+    end
+  end
+end

--- a/spec/unit_test/utils/top_level_split_spec.cr
+++ b/spec/unit_test/utils/top_level_split_spec.cr
@@ -189,6 +189,47 @@ describe Noir::TopLevelSplit do
     end
   end
 
+  # Languages that escape a quote by DOUBLING it rather than with a
+  # backslash — CFML (`analyzer/engines/cfml_engine.cr`), SQL, VB — need no
+  # `Rules` axis of their own, and these cases are why.
+  #
+  # Toggling on every quote and treating a doubled pair as a literal are
+  # indistinguishable to a top-level splitter: a pair is two ADJACENT quote
+  # characters, so the window in which the toggling model believes the run
+  # closed is zero characters wide. A run of L quotes flips the state iff L
+  # is odd under either reading, and the only characters processed in a
+  # differing state are the quote characters themselves, which neither nest
+  # nor split. Checked exhaustively when `cfml_engine.cr` moved to
+  # `Escape::None`: a doubling model agreed with this module on all
+  # 159,999,840 comparisons of 1,440 `Rules` combinations against every
+  # string up to length 5 over `" ' , a \ ( ) < ` {`.
+  describe "doubled-quote escapes (no dedicated mode)" do
+    doubling = tls_rules(escape: TLSEscape::None)
+
+    it "keeps a delimiter inside a literal holding a doubled quote" do
+      TLS.split(%q(a = "say ""hi"", loudly", b = 2), ',', doubling)
+        .should eq [%q(a = "say ""hi"", loudly"), "b = 2"]
+    end
+
+    it "keeps a delimiter inside a single-quoted literal holding a doubled quote" do
+      TLS.split(%q(a = 'it''s, fine', b = 2), ',', doubling)
+        .should eq [%q(a = 'it''s, fine'), "b = 2"]
+    end
+
+    it "handles a doubled quote at the very start and the very end of a literal" do
+      TLS.split(%q(a = """x, y""", b = 2), ',', doubling)
+        .should eq [%q(a = """x, y"""), "b = 2"]
+    end
+
+    it "closes the run on the unpaired quote of an odd run" do
+      TLS.split(%q(a = "x""", b = 2), ',', doubling).should eq [%q(a = "x"""), "b = 2"]
+    end
+
+    it "treats an empty literal followed by a delimiter as closed" do
+      TLS.split(%q(a = "", b = 2), ',', doubling).should eq [%q(a = ""), "b = 2"]
+    end
+  end
+
   describe "Escape::InQuotes" do
     it "does not close the run on an escaped quote" do
       TLS.split("\"a\\\"b\", c", ',', tls_rules(escape: TLSEscape::InQuotes))

--- a/src/analyzer/engines/cfml_engine.cr
+++ b/src/analyzer/engines/cfml_engine.cr
@@ -63,7 +63,6 @@ module Analyzer::Cfml
     private BYTE_CLOSE_BRACKET = ']'.ord.to_u8
     private BYTE_DQUOTE        = '"'.ord.to_u8
     private BYTE_SQUOTE        = '\''.ord.to_u8
-    private BYTE_BACKSLASH     = '\\'.ord.to_u8
 
     # Route registrations are statements. An identifier as generic as
     # `get` or `delete` also appears inside expressions
@@ -165,11 +164,31 @@ module Analyzer::Cfml
     # Observable on the unbalanced fragments the CFML regexes hand over, so
     # it is preserved rather than normalised.
     #
-    # Escaping is `\\`-based, which is what the old body did and is NOT how
-    # CFML escapes a quote — CFML doubles it (`"say ""hi"""`), the way
-    # `matching_delimiter` below already handles. Reproduced verbatim here;
-    # correcting it changes where arguments split and belongs in its own
-    # change.
+    # `Escape::None` because CFML has no backslash escape at all. `"C:\log\"`
+    # is the seven-character string `C:\log\`, and a quote is escaped by
+    # DOUBLING it (`"say ""hi"""`). Reading `\` as an escape — which the
+    # hand-rolled body this replaced did, and which the rest of this engine
+    # did too until the same change — swallowed the closing quote of any
+    # string ending in a backslash, i.e. any Windows path, leaving the run
+    # open so the remainder of the argument list merged into the current part
+    # and every argument after it was lost.
+    #
+    # There is deliberately no doubled-quote mode for the OTHER half of the
+    # rule, and that is not an oversight. For a top-level splitter "a
+    # repeated delimiter is a literal delimiter" and "quotes toggle" are
+    # indistinguishable: a doubled pair is two ADJACENT quote characters, so
+    # the toggling model's spurious closed-then-reopened window is zero
+    # characters wide. The state after any maximal run of quotes is the same
+    # under both models (a run of length L flips the state iff L is odd
+    # either way), and the only characters ever processed in a differing
+    # state are the quote characters themselves, which neither nest nor
+    # split. Checked by brute force rather than by argument: a doubling
+    # model run against `TopLevelSplit` over all 1,440 `Rules` combinations
+    # x 111,111 inputs (every string up to length 5 over `" ' , a \ ( ) < `
+    # backtick `{`) agreed on all 159,999,840 comparisons. `matching_delimiter`
+    # below implements doubling explicitly; that is equally correct and
+    # equally immaterial, and it is kept because a byte scanner reads more
+    # obviously with the rule written out.
     #
     # File-local because this is the only splitter pairing `clamp: false`
     # with `DropAll`.
@@ -177,7 +196,7 @@ module Analyzer::Cfml
       nest: Noir::TopLevelSplit::Nest::Paren | Noir::TopLevelSplit::Nest::Bracket |
             Noir::TopLevelSplit::Nest::Brace,
       quotes: "\"'",
-      escape: Noir::TopLevelSplit::Escape::InQuotes,
+      escape: Noir::TopLevelSplit::Escape::None,
       strip: true,
       empties: Noir::TopLevelSplit::Empties::DropAll,
       per_kind: false,
@@ -266,6 +285,13 @@ module Analyzer::Cfml
     # the same trap `PhpEngine#find_matching_php_close_brace` documents
     # after CJK-commented sources hung the PHP analyzer. Every delimiter
     # is ASCII, so it can never collide with a UTF-8 continuation byte.
+    #
+    # A quoted run ends at the first unpaired quote of the kind that opened
+    # it: CFML escapes a quote by doubling it and has NO backslash escape,
+    # so `"C:\log\"` is a complete string and the `)` after it closes the
+    # call. Treating `\` as an escape here consumed that closing quote and
+    # left the run open, and a run that never closes means no match — the
+    # whole call, and every route in it, silently disappeared.
     protected def matching_delimiter(content : String, open_index : Int32,
                                      open_byte : UInt8, close_byte : UInt8) : Int32?
       bytes = content.to_slice
@@ -276,17 +302,12 @@ module Analyzer::Cfml
       position = start
       size = bytes.size
       quote = 0_u8
-      escape = false
 
       while position < size
         byte = bytes[position]
 
         if quote != 0_u8
-          if escape
-            escape = false
-          elsif byte == BYTE_BACKSLASH
-            escape = true
-          elsif byte == quote
+          if byte == quote
             if position + 1 < size && bytes[position + 1] == quote
               position += 2
               next
@@ -359,8 +380,9 @@ module Analyzer::Cfml
     # mentions `mapper()` move the start of the chain, so unrelated calls
     # before the real chain were read as routes.
     #
-    # The scan is string-aware: CFML escapes a quote by doubling it, and
-    # `//` occurs inside ordinary string values (URLs).
+    # The scan is string-aware: CFML escapes a quote by doubling it and has
+    # no backslash escape (`"C:\wwwroot\"` is a whole string), and `//`
+    # occurs inside ordinary string values (URLs).
     protected def strip_script_comments(content : String) : String
       return content unless content.includes?("//") || content.includes?("/*")
 
@@ -369,17 +391,12 @@ module Analyzer::Cfml
       io = String::Builder.new(content.bytesize)
       index = 0
       quote = nil.as(Char?)
-      escape = false
 
       while index < size
         char = chars[index]
 
         if quote
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == quote
+          if char == quote
             if index + 1 < size && chars[index + 1] == quote
               io << char
               io << chars[index + 1]
@@ -452,7 +469,6 @@ module Analyzer::Cfml
     # the header mid-value and silently dropped every tokenised route.
     private def attributes_before_body(window : String) : String
       quote = nil.as(Char?)
-      escape = false
       chars = window.chars
       size = chars.size
       index = 0
@@ -461,11 +477,7 @@ module Analyzer::Cfml
         char = chars[index]
 
         if quote
-          if escape
-            escape = false
-          elsif char == '\\'
-            escape = true
-          elsif char == quote
+          if char == quote
             if index + 1 < size && chars[index + 1] == quote
               index += 2
               next


### PR DESCRIPTION
## The bug

CFML has **no backslash escape** in string literals. `"C:\log\"` is the seven-character string `C:\log\`, and a quote is escaped by **doubling** it.

Four scanners in `cfml_engine.cr` assumed otherwise — `split_arguments`, `matching_delimiter`, `strip_script_comments`, `attributes_before_body`. Reading `\` as an escape swallows the closing quote of any string ending in a backslash (any Windows path), leaving the run open: the rest of an argument list merges into the current part, or the enclosing call is never matched at all and **every route in it silently disappears**.

All four are fixed together because fixing one alone is unobservable — `matching_paren` fails to find the closing paren first, so the call is dropped before the splitter ever runs.

Last of the three defects the splitter-consolidation series (#2617–#2623) recorded rather than fixed; #2624 and #2625 were the others.

## No doubled-quote mode was added, and `top_level_split.cr` is untouched

The premise I started from — that `resources( except = "a""b,c" )` splits mid-literal — **does not reproduce, and cannot.**

For a top-level splitter, *"a repeated delimiter is a literal delimiter"* and *"quotes toggle"* are indistinguishable. A doubled pair is two **adjacent** quotes, so the toggling model's spurious closed-then-reopened window is **zero characters wide**. A maximal run of L quotes flips the state iff L is odd under either reading, and the only characters ever processed in a differing state are the quote characters themselves — which neither nest nor split.

Checked by brute force rather than argued: a faithful model of `split` carrying an extra doubling axis, diffed against the real module over **1,440 `Rules` combinations × 111,111 inputs** (every string up to length 5 over ``" ' , a \ ( ) < ` {``) — **159,999,840 comparisons, 0 mismatches**, with the doubling axis both off and on.

Adding the mode would have bought an enum member, a `Cursor` field, a branch in the hot loop and a spec suite for behavior that provably cannot differ. The proof now lives in the comment where the next person will look for the missing mode.

The engine's own comment claiming `matching_delimiter` "already handles" CFML escaping correctly was **half right**: it implements doubling explicitly, but it carried the same backslash bug. Its doubling is kept — equally correct, equally immaterial, and a byte scanner reads more obviously with the rule spelled out.

## What actually changes

Differential over **374 inputs** (every `(...)`, `[...]`, `{...}` body and every raw line under `fixtures/cfml/**`, plus 23 synthetic CFML string shapes): **6 differ, in exactly one shape** — a literal whose closing quote is preceded by an odd run of backslashes.

| case | old | new | |
|---|---|---|---|
| `except = "a""b,c", module = "api"` | 2 parts | 2 parts | same |
| `a = """quoted, value""", b = 2` | 2 | 2 | same |
| `label = 'it''s, fine', page = 1` | 2 | 2 | same |
| `a = "x""", b = 2` (odd run) | 2 | 2 | same |
| `pattern = "^\d{4}$", limit = 10` | 2 | 2 | same |
| `folder = "C:\uploads\", mask = "*.pdf"` | **1** | **2** | **changed** |
| `hint = "Standard \" Route, with comma", url = "/x"` | **2** | **3** | **changed** |

Every doubled-quote, single-quote-doubling, odd-quote-run and interior-backslash input is byte-identical.

## The one reviewer-facing judgement call

`spec/functional_test/fixtures/cfml/fw1/Application.cfc:18` contained:

```cfml
{ 'hint' = "Standard \" Route, with comma", '$GET/escaped/comma' = '/new/path' },
```

That is **not valid CFML** — it is this bug written into the corpus as an expectation. Parsed as CFML actually defines it, the `"` after the comma opens a run that never closes, `matching_bracket` never finds the `]`, and the entire fw1 routes array vanishes: **cfml 105 → 86**.

Rewritten with CFML's real escape, preserving the fixture's intent (a quote **and** a comma inside a label):

```cfml
{ 'hint' = "Standard "" Route, with comma", '$GET/escaped/comma' = '/new/path' },
```

With that correction, old and new binaries agree exactly on the existing corpus — **105 = 105, endpoint-for-endpoint including params**, and `/escaped/comma` is still detected. If you would rather keep the old spelling, the alternative is accepting 105 → 86.

## Existing fixtures hitting the doubled-quote case: zero

All seven `""` occurrences in the cfml fixtures are empty strings (`default=""`). Which is consistent with the equivalence proof above — there was nothing for a doubling mode to fix.

## New fixture

`spec/functional_test/fixtures/cfml/pure/api/Files.cfc`, covering both halves:

```cfml
listUploads( string folder = "C:\uploads\", string mask = "*.pdf" )   // the shape that moves
describe( string label = "report ""Q1"", final", numeric page = 1 )   // regression guard
```

Measured old vs new on that fixture: `listUploads` was **not mis-split** before — it was **absent**, because `matching_paren` never found its `)`. `describe` is identical under both, as the equivalence predicts.

Reached via the `pure` path after reading the callers (`split_arguments` is `protected`, reached from `fw1.cr:81`, `call_arguments` for coldbox/wheels, and `script_arguments` for taffy/pure).

## Endpoint impact

| set | before | after |
|---|---|---|
| cfml, **without** the new fixture | 105 | **105** (byte-identical endpoints + params) |
| cfml, **with** the new fixture | 105 | **109** (+4, all from `Files.cfc`) |
| javascript | 489 | **489** |
| python | 419 | **419** |
| java | 412 | **412** |

## Test plan

- `crystal spec spec/unit_test` → **5104 examples, 0 failures** (5088 + 16, from a new `cfml_string_literals_spec.cr` and a block in `top_level_split_spec.cr` pinning the no-mode design decision)
- `crystal spec spec/functional_test` → **23937 examples, 0 failures** (23913 + 24)
- `crystal tool format --check src/ spec/` → clean
- `ameba` on the 4 touched files → `4 inspected, 0 failures`
- `typos .` → clean

## Honest real-world impact

Small, and I would not sell it as more.

**Doubled quotes** in CFML route/argument declarations do occur — hint text, message defaults, `resources()` descriptions — but handling them "properly" is worth exactly **zero endpoints**, because toggling already produces the same splits. The value there is documentation and a regression guard, not detection.

**Backslash-terminated strings** — the shape that actually moves — are rare in route DSLs but plausible in method signatures and config values on Windows-hosted CFML apps. Zero occurrences across the fixture corpus. When it does hit, the failure is not subtle: a call loses every argument after the offending one, or the call (or an entire routes array) disappears. The fw1 fixture was a live example of the second kind, sitting in the repo asserting the wrong semantics.