### PR TITLE
fix(analyzer): stop a column-0 comment from truncating a Python code block

### DIFF
--- a/spec/unit_test/analyzer/python_engine_spec.cr
+++ b/spec/unit_test/analyzer/python_engine_spec.cr
@@ -58,6 +58,38 @@ describe Analyzer::Python::PythonEngine do
     callees[0].line.should eq(2)
   end
 
+  it "keeps a function body running past a comment that starts at column 0" do
+    harness = PythonEngineSpecHarness.new(create_test_options)
+    source = <<-PY
+      def handler():
+          early = request.args.get("early")
+      # commented-out code, flush against the left margin
+          late = request.args.get("late")
+          return late
+      PY
+
+    block = harness.parse_code_block(source)
+
+    block.should_not be_nil
+    block.not_nil!.should contain("early")
+    block.not_nil!.should contain("late")
+  end
+
+  it "still ends a function body at the next column-0 statement" do
+    harness = PythonEngineSpecHarness.new(create_test_options)
+    source = <<-PY
+      def handler():
+          inside = request.args.get("inside")
+      outside = request.args.get("outside")
+      PY
+
+    block = harness.parse_code_block(source)
+
+    block.should_not be_nil
+    block.not_nil!.should contain("inside")
+    block.not_nil!.should_not contain("outside")
+  end
+
   it "skips multi-line route decorators when locating the decorated function" do
     harness = PythonEngineSpecHarness.new(create_test_options)
     lines = [

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -340,7 +340,15 @@ module Analyzer::Python
               elsif !double_quote_open && line[line_index] == '\'' && line[line_index - 1] != '\\'
                 single_quote_open = !single_quote_open
               elsif !single_quote_open && !double_quote_open && line[line_index] == '#' && line[line_index - 1] != '\\'
-                clear_line = line[..(line_index - 1)]
+                # Exclusive range, NOT `line[..(line_index - 1)]`: at
+                # `line_index == 0` that is `line[..-1]`, and a negative range
+                # end counts from the end of the string in Crystal, so a
+                # comment starting at column 0 kept the WHOLE line as its
+                # comment-stripped form. The indent test below then read `#`
+                # as code at column 0 and ended the block, truncating the rest
+                # of the function body — every param and callee after a
+                # column-0 comment was lost.
+                clear_line = line[...line_index]
                 break
               end
             end


### PR DESCRIPTION
`PythonEngine#parse_code_block` walks a `def`/`class` body line by line and
stops at the first line whose leading `indent_size` columns hold code. Before
that test it strips any trailing `#` comment:

    clear_line = line[..(line_index - 1)]

At `line_index == 0` that is `line[..-1]`, and a negative range end counts
from the END of the string in Crystal — so a comment starting at column 0 kept
the WHOLE line as its comment-stripped form. The indent test then read `#` as
code at column 0 and ended the block there.

Commented-out code flush against the left margin inside a handler is common,
and the block is what every Python analyzer feeds to param and callee
extraction, so everything after such a line was silently lost:

    @app.route("/d", methods=["POST"])
    def d():
        x = request.args.get("early")
    # commented-out code
        y = request.args.get("late")     # <- never seen

reported `POST /d` with `early` only. An indented comment was always fine;
only column 0 hit it. `line[...line_index]` is the exclusive range that was
meant, and at 0 it yields the empty string.

The engine is shared by 16 analyzers (Flask, FastAPI, Django, Sanic, …), so
this is a params/callees fix across all of them, not one framework.

Behaviour is otherwise unchanged: a real column-0 statement still ends the
block (second spec), and the full fixture corpus — 696 project directories,
endpoints compared as sorted JSON — is byte-identical before and after.