### PR TITLE
perf(parser): remember a failed parse so N analyzers don't each pay the ceiling

### DIFF
--- a/spec/unit_test/ext/tree_sitter_parse_failure_memo_spec.cr
+++ b/spec/unit_test/ext/tree_sitter_parse_failure_memo_spec.cr
@@ -1,0 +1,82 @@
+require "spec"
+require "../../../src/ext/tree_sitter/tree_sitter"
+
+# `parse_timeout_micros` bounds one `ts_parser_parse_string` call, but the
+# same file is handed to every analyzer of its language — nine Rust analyzers
+# each parsed the same unparsable `.rs` file and each burned the full ceiling,
+# so a 10 s bound cost 90 s. The verdict is a pure function of (content,
+# grammar), so it is remembered.
+describe "Noir::TreeSitter parse-failure memo" do
+  # Big enough that even the first parse cannot finish inside a 1 µs ceiling,
+  # small enough that the suite does not notice it.
+  pathological = "x = " + ("(" * 20_000) + "1\n"
+
+  it "raises on the first parse and skips the parse entirely on the next" do
+    previous = Noir::TreeSitter.parse_timeout_micros
+    Noir::TreeSitter.parse_timeout_micros = 1_u64
+    begin
+      before = Noir::TreeSitter.parse_failure_count
+
+      expect_raises(Exception, /timed out/) do
+        Noir::TreeSitter.parse_python(pathological) { |root| root }
+      end
+      Noir::TreeSitter.parse_failure_count.should eq(before + 1)
+
+      # Second call never reaches tree-sitter: a different message, and no
+      # second entry for the same (content, grammar) pair.
+      expect_raises(Exception, /already failed to parse/) do
+        Noir::TreeSitter.parse_python(pathological) { |root| root }
+      end
+      Noir::TreeSitter.parse_failure_count.should eq(before + 1)
+    ensure
+      Noir::TreeSitter.parse_timeout_micros = previous
+    end
+  end
+
+  it "keys the memo on the grammar, so another language still tries" do
+    previous = Noir::TreeSitter.parse_timeout_micros
+    Noir::TreeSitter.parse_timeout_micros = 1_u64
+    begin
+      source = pathological + "# grammar-keyed\n"
+      before = Noir::TreeSitter.parse_failure_count
+
+      expect_raises(Exception, /timed out/) do
+        Noir::TreeSitter.parse_python(source) { |root| root }
+      end
+      # Same bytes, different grammar: not a hit, so it parses (and times
+      # out) on its own account.
+      expect_raises(Exception, /timed out/) do
+        Noir::TreeSitter.parse_go(source) { |root| root }
+      end
+
+      Noir::TreeSitter.parse_failure_count.should eq(before + 2)
+    ensure
+      Noir::TreeSitter.parse_timeout_micros = previous
+    end
+  end
+
+  it "does not remember a source that parses" do
+    before = Noir::TreeSitter.parse_failure_count
+
+    Noir::TreeSitter.parse_python("def f():\n    pass\n") { |root| root }
+
+    Noir::TreeSitter.parse_failure_count.should eq(before)
+  end
+
+  it "forgets everything when the scan-scoped memos are cleared" do
+    previous = Noir::TreeSitter.parse_timeout_micros
+    Noir::TreeSitter.parse_timeout_micros = 1_u64
+    begin
+      expect_raises(Exception) do
+        Noir::TreeSitter.parse_python(pathological + "# cleared\n") { |root| root }
+      end
+      Noir::TreeSitter.parse_failure_count.should be > 0
+
+      Noir::ExtractionResultCache.clear_all
+
+      Noir::TreeSitter.parse_failure_count.should eq(0)
+    ensure
+      Noir::TreeSitter.parse_timeout_micros = previous
+    end
+  end
+end

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -11,6 +11,8 @@
 # Upstream versions currently vendored:
 #   tree-sitter-python  v0.23.6
 
+require "../../miniparsers/extraction_result_cache"
+
 @[Link(ldflags: "`sh #{__DIR__}/build.sh`")]
 lib LibTreeSitter
   # ----- Opaque types -----
@@ -226,9 +228,57 @@ module Noir::TreeSitter
   # On expiry the parse returns null and `parse` raises, which the
   # per-file rescue in `parallel_analyze` / `scan_files` logs at debug —
   # one file dropped instead of the whole run.
-  PARSE_TIMEOUT_MICROS = begin
+  # Writable so a spec can force the expiry path deterministically — a
+  # sub-millisecond ceiling times out on any non-trivial source, where
+  # reproducing a real 10 s timeout would need a pathological fixture and
+  # ten seconds of suite time. Nothing in a scan writes it: the value is
+  # read once per parse and comes from `NOIR_PARSE_TIMEOUT_MS`.
+  class_property parse_timeout_micros : UInt64 = begin
     ms = ENV["NOIR_PARSE_TIMEOUT_MS"]?.try(&.strip.to_u64?)
     (ms && ms > 0 ? ms : 10_000_u64) * 1000_u64
+  end
+
+  # Sources that already failed to parse, keyed by content fingerprint and
+  # grammar.
+  #
+  # `parse_timeout_micros` bounds ONE `ts_parser_parse_string` call, but a
+  # file is offered to every analyzer of its language, and each one parses it
+  # independently — nine Rust analyzers each burn the full ceiling on the same
+  # unparsable `.rs` file, so a 10 s bound costs 90 s. The verdict is a pure
+  # function of (content, grammar), so remembering it turns that back into one
+  # ceiling per file. A timeout is wall-clock and so not strictly
+  # deterministic; that is the point — re-running a parse we already know
+  # takes longer than the ceiling cannot succeed in less time on the second
+  # try, it can only cost the ceiling again.
+  #
+  # Keyed on content rather than path because `parse` never sees a path, and
+  # content is the better key anyway: the `CodeLocator` cache hands the same
+  # string to sibling analyzers, and two paths holding identical bytes parse
+  # identically.
+  PARSE_FAILURE_MAX_ENTRIES = 4096
+
+  @@parse_failures = Hash(UInt64, Bool).new
+  @@parse_failure_order = [] of UInt64
+  @@parse_failure_mutex = Mutex.new
+
+  # A second scan in the same process (diff mode, library use) gets a clean
+  # slate, like every other content-keyed memo in the tree.
+  Noir::ExtractionResultCache.register_clearer do
+    @@parse_failure_mutex.synchronize do
+      @@parse_failures.clear
+      @@parse_failure_order.clear
+    end
+  end
+
+  private def self.parse_failure_key(source : String, language : LibTreeSitter::TSLanguage) : UInt64
+    Noir::ExtractionResultCache.source_fingerprint(source) &+
+      language.address &* 0xd6e8feb86659fd93_u64
+  end
+
+  # Number of remembered parse failures. Exposed for specs; not part of the
+  # public API contract.
+  def self.parse_failure_count : Int32
+    @@parse_failure_mutex.synchronize { @@parse_failures.size }
   end
 
   # Parses `source` with the given `language` and yields the root
@@ -236,9 +286,17 @@ module Noir::TreeSitter
   # pool and returned when the block exits; the tree is freed in the
   # same `ensure`.
   def self.parse(source : String, language : LibTreeSitter::TSLanguage, &)
+    failure_key = parse_failure_key(source, language)
+    # Checked before `checkout_parser` so a known-bad file does not even
+    # occupy a pool slot the other analyzers are waiting on.
+    if @@parse_failure_mutex.synchronize { @@parse_failures.has_key?(failure_key) }
+      raise "tree-sitter parse skipped: this source already failed to parse with this grammar"
+    end
+
     parser = checkout_parser(language)
     begin
-      LibTreeSitter.ts_parser_set_timeout_micros(parser, PARSE_TIMEOUT_MICROS)
+      timeout = parse_timeout_micros
+      LibTreeSitter.ts_parser_set_timeout_micros(parser, timeout)
       tree = LibTreeSitter.ts_parser_parse_string(parser, Pointer(Void).null.as(LibTreeSitter::TSTree), source.to_unsafe, source.bytesize.to_u32)
       if tree.null?
         # A halted parser holds the partial parse so the next call can
@@ -246,7 +304,12 @@ module Noir::TreeSitter
         # the shared pool — so reset it, or the next unrelated file
         # inherits this one's state.
         LibTreeSitter.ts_parser_reset(parser)
-        raise "ts_parser_parse_string returned null (timed out after #{PARSE_TIMEOUT_MICROS // 1000}ms, or out of memory)"
+        @@parse_failure_mutex.synchronize do
+          Noir::ExtractionResultCache.store_capped(
+            @@parse_failures, @@parse_failure_order, failure_key, true, PARSE_FAILURE_MAX_ENTRIES
+          )
+        end
+        raise "ts_parser_parse_string returned null (timed out after #{timeout // 1000}ms, or out of memory)"
       end
       begin
         yield LibTreeSitter.ts_tree_root_node(tree)


### PR DESCRIPTION
`PARSE_TIMEOUT_MICROS` (#2612) bounds ONE `ts_parser_parse_string` call, which
is what stopped a badly-malformed file from stalling the scan forever. But a
file is offered to every analyzer of its language, and each parses it
independently — so the bound is per parse, not per file, and the real cost is
`analyzers x ceiling`.

Measured on one 200 KB single-line `.rs` file of `a,a,a,…`, debug build:

    rust_actix_web 10.1s   rust_gotham 10.1s   rust_poem 10.1s
    rust_axum      10.1s   rust_rocket 10.1s   rust_rwf  10.1s
    rust_salvo     10.1s   rust_tide   10.1s   rust_warp 10.1s
    all nine together: 90s  ->  10.9s

Whether a parse expires is a pure function of (content, grammar), so `parse`
now remembers the failure and raises immediately on the next call with the
same pair, before it even checks a parser out of the pool. A timeout is
wall-clock and so not strictly deterministic — that is the argument FOR
memoizing, not against: a parse already known to take longer than the ceiling
cannot finish faster on the second try, it can only cost the ceiling again.

Keyed on content, not path: `parse` never sees a path, the `CodeLocator`
content cache hands sibling analyzers the same string, and two paths holding
identical bytes parse identically. Reuses `ExtractionResultCache`'s
fingerprint and its capped store, and registers a clearer so a second scan in
the same process (`--diff`, library use) starts clean — the same discipline
every other content-keyed memo in the tree follows.

`PARSE_TIMEOUT_MICROS` becomes `parse_timeout_micros`, a class property with
the same `NOIR_PARSE_TIMEOUT_MS` default. Nothing in a scan writes it; the
specs do, because forcing the expiry path with a sub-millisecond ceiling costs
a millisecond where reproducing a real 10 s timeout costs ten seconds of suite
time.

No detection change: the full fixture corpus (696 project directories,
endpoints compared as sorted JSON) is byte-identical, and an adversarial
corpus of 205 pathological files scanned with all 253 techs forced returns the
same 17 endpoints in 22s instead of 102s.