### PR TITLE
feat(cli): report files an analyzer skipped, not just analyzers that died

### DIFF
--- a/docs/content/get_started/running/index.ko.md
+++ b/docs/content/get_started/running/index.ko.md
@@ -159,7 +159,7 @@ noir scan . --ai-context guards,sinks
 | `--concurrency <N>`   | 워커 수 (기본값: CPU 코어 수) |
 | `--cache-disable`     | 이번 실행에 한해 LLM 응답 캐시 비활성화 |
 | `--cache-clear`       | 실행 전에 LLM 응답 캐시 초기화 |
-| `--strict`            | 분석기가 하나라도 실패하면 종료 코드 2 반환 (결과 출력은 그대로) |
+| `--strict`            | 분석기가 실패했거나 건너뛴 파일이 있으면 종료 코드 2 반환 (결과 출력은 그대로) |
 | `--verbose`           | 상세 로깅 |
 | `--no-log`            | 모든 로그 억제 |
 | `--no-color`          | plain 출력의 ANSI 색상 비활성화 |

--- a/docs/content/get_started/running/index.md
+++ b/docs/content/get_started/running/index.md
@@ -156,7 +156,7 @@ See [Callee Coverage](@/usage/supported/callee_coverage/index.md) and [AI Contex
 | `--concurrency <N>`   | Worker count (default: CPU cores) |
 | `--cache-disable`     | Disable the LLM response cache for this run |
 | `--cache-clear`       | Clear the LLM response cache before running |
-| `--strict`            | Exit with code 2 if any analyzer failed (the scan still reports its results) |
+| `--strict`            | Exit with code 2 if any analyzer failed or skipped a file (the scan still reports its results) |
 | `--verbose`           | Detailed logging |
 | `--no-log`            | Suppress all logs |
 | `--no-color`          | Disable ANSI colors in plain output |

--- a/docs/content/usage/output_formats/json/index.ko.md
+++ b/docs/content/usage/output_formats/json/index.ko.md
@@ -53,19 +53,22 @@ noir scan . -f json --no-log
 
 ## 분석기 실패 기록
 
-분석기 하나가 예외로 죽어도 스캔은 나머지 기술을 계속 처리합니다. `errors`에는 그렇게 건너뛴 분석기가 남기 때문에, 결과가 비어 있는 이유가 "해당 프레임워크가 없어서"인지 "아예 분석하지 못해서"인지 구분할 수 있습니다.
+분석기 하나가 예외로 죽어도 스캔은 나머지 기술을 계속 처리합니다. 읽거나 파싱할 수 없는 파일 하나(예: 파싱 시간 상한을 넘긴 파일) 역시 그 파일만 건너뛰고 스캔은 이어집니다. `errors`에는 두 경우가 모두 남기 때문에, 결과가 비어 있는 이유가 "해당 프레임워크가 없어서"인지 "아예 분석하지 못해서"인지, 그리고 조용히 빠진 파일이 있었는지 구분할 수 있습니다.
 
 ```json
 {
   "endpoints": [],
   "passive_results": [],
   "errors": [
-    { "tech": "go_gin", "message": "Index out of bounds" }
+    { "tech": "go_gin", "message": "Index out of bounds" },
+    { "tech": "rust_axum", "message": "skipped 2 files: src/gen.rs, src/vendor.rs; first error: ts_parser_parse_string returned null (timed out after 10000ms, or out of memory)" }
   ]
 }
 ```
 
-이 키는 항상 출력됩니다. `"errors": []`는 선택된 분석기가 모두 끝까지 실행됐다는 뜻입니다.
+건너뛴 파일은 파일마다 한 줄이 아니라 기술별로 묶어서 개수와 예시 경로 최대 5개로 기록합니다. 깨진 체크아웃 하나가 리포트를 뒤덮지 않도록 하기 위해서입니다.
+
+이 키는 항상 출력됩니다. `"errors": []`는 선택된 분석기가 주어진 모든 파일을 끝까지 처리했다는 뜻입니다.
 
 `-f yaml`도 같은 키를 담고, `-f sarif`는 `runs[0].invocations[0].executionSuccessful`로 같은 사실을 알립니다. `--strict`를 붙이면 리포트를 출력한 뒤 종료 코드 2로 끝나므로 CI에서 바로 걸러낼 수 있습니다.
 

--- a/docs/content/usage/output_formats/json/index.md
+++ b/docs/content/usage/output_formats/json/index.md
@@ -65,19 +65,22 @@ The result is an object with an `endpoints` array. Each endpoint has the URL, HT
 
 ## Analyzer Failures
 
-A tech analyzer that raises is logged and skipped, and the scan continues with the rest. `errors` records which ones that happened to, so an empty result for a framework can be told apart from a framework that was never analyzed:
+A tech analyzer that raises is logged and skipped, and the scan continues with the rest. So is a single file the analyzer cannot read or parse — a file over the parse-time ceiling, for instance — which costs only itself rather than the run. `errors` records both, so an empty result for a framework can be told apart from a framework that was never analyzed, and a complete scan from one that quietly dropped files:
 
 ```json
 {
   "endpoints": [],
   "passive_results": [],
   "errors": [
-    { "tech": "go_gin", "message": "Index out of bounds" }
+    { "tech": "go_gin", "message": "Index out of bounds" },
+    { "tech": "rust_axum", "message": "skipped 2 files: src/gen.rs, src/vendor.rs; first error: ts_parser_parse_string returned null (timed out after 10000ms, or out of memory)" }
   ]
 }
 ```
 
-The key is always present. `"errors": []` is the positive statement that every selected analyzer ran to completion.
+Skipped files are tallied per tech rather than listed one entry each, with up to five example paths, so a broken checkout cannot flood the report.
+
+The key is always present. `"errors": []` is the positive statement that every selected analyzer ran to completion over every file it was given.
 
 `-f yaml` carries the same key, and `-f sarif` reports it as `runs[0].invocations[0].executionSuccessful`. Add `--strict` to make a degraded scan exit with code 2, after the report has been written:
 

--- a/spec/unit_test/models/analyzer_spec.cr
+++ b/spec/unit_test/models/analyzer_spec.cr
@@ -7,6 +7,20 @@ class AnalyzerBasePathHarness < Analyzer
   end
 end
 
+# Names itself the way a real analyzer does, so a skipped file can be
+# attributed to a tech.
+class AnalyzerSkipHarness < Analyzer
+  analyzer_for "spec_skip_harness"
+
+  def scan(files : Array(String), &block : String -> Nil)
+    scan_files(files, &block)
+  end
+
+  def scan_via_workers(files : Array(String), &block : String -> Nil)
+    parallel_analyze(files, &block)
+  end
+end
+
 describe "Initialize Analyzer" do
   options = create_test_options
   options["base"] = YAML::Any.new([YAML::Any.new("noir")])
@@ -94,5 +108,50 @@ describe "Initialize FileAnalyzer" do
   # documents invisible to `noir scan ./app`.
   it "reports that url-independent hooks exist" do
     FileAnalyzer.url_independent_hooks?.should be_true
+  end
+end
+
+# One unreadable or unparsable file costs only itself — that is what the
+# per-file rescues are for. But until they tallied it, the result of a scan
+# that dropped a file was byte-identical to one that read everything, so the
+# skip has to reach `Noir::SkippedFiles` and from there the `errors` array.
+describe "Analyzer per-file skips" do
+  before_each { Noir::SkippedFiles.clear }
+  after_each { Noir::SkippedFiles.clear }
+
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new("noir")])
+
+  it "records a file whose analysis raised, and attributes it to the tech" do
+    harness = AnalyzerSkipHarness.new(options)
+
+    harness.scan(["a.cr", "b.cr"]) do |path|
+      raise "boom on #{path}" if path == "a.cr"
+    end
+
+    Noir::SkippedFiles.count.should eq(1)
+    failure = Noir::SkippedFiles.failures.first
+    failure.tech.should eq("spec_skip_harness")
+    failure.message.should contain("a.cr")
+    failure.message.should contain("boom on a.cr")
+  end
+
+  it "records a skip from the bare worker loop too" do
+    harness = AnalyzerSkipHarness.new(options)
+
+    harness.scan_via_workers(["c.cr"]) { raise "worker boom" }
+
+    Noir::SkippedFiles.count.should eq(1)
+    Noir::SkippedFiles.failures.first.message.should contain("worker boom")
+  end
+
+  it "records nothing when every file is analyzed" do
+    harness = AnalyzerSkipHarness.new(options)
+
+    seen = [] of String
+    harness.scan(["a.cr", "b.cr"]) { |path| seen << path }
+
+    seen.sort.should eq(["a.cr", "b.cr"])
+    Noir::SkippedFiles.count.should eq(0)
   end
 end

--- a/spec/unit_test/models/skipped_files_spec.cr
+++ b/spec/unit_test/models/skipped_files_spec.cr
@@ -1,0 +1,54 @@
+require "../../spec_helper"
+require "../../../src/models/skipped_files"
+
+describe Noir::SkippedFiles do
+  before_each { Noir::SkippedFiles.clear }
+  after_each { Noir::SkippedFiles.clear }
+
+  it "reports nothing when no file was skipped" do
+    Noir::SkippedFiles.count.should eq(0)
+    Noir::SkippedFiles.failures.should be_empty
+  end
+
+  it "tallies one failure per tech, not per file" do
+    Noir::SkippedFiles.record("rust_axum", "src/a.rs", "timed out")
+    Noir::SkippedFiles.record("rust_axum", "src/b.rs", "no such file")
+    Noir::SkippedFiles.record("go_gin", "main.go", "boom")
+
+    Noir::SkippedFiles.count.should eq(3)
+
+    failures = Noir::SkippedFiles.failures
+    failures.size.should eq(2)
+
+    axum = failures.find! { |f| f.tech == "rust_axum" }
+    axum.message.should contain("skipped 2 files")
+    axum.message.should contain("src/a.rs, src/b.rs")
+    # The first reason is kept; later ones would just be noise in one line.
+    axum.message.should contain("first error: timed out")
+  end
+
+  it "uses the singular for one file" do
+    Noir::SkippedFiles.record("python_flask", "app.py", "boom")
+
+    Noir::SkippedFiles.failures.first.message.should contain("skipped 1 file:")
+  end
+
+  it "caps the example paths and counts the rest" do
+    (Noir::SkippedFiles::MAX_PATHS_PER_TECH + 3).times do |i|
+      Noir::SkippedFiles.record("java_spring", "Src#{i}.java", "boom")
+    end
+
+    message = Noir::SkippedFiles.failures.first.message
+    message.should contain("skipped #{Noir::SkippedFiles::MAX_PATHS_PER_TECH + 3} files")
+    message.should contain("(+3 more)")
+    message.should_not contain("Src#{Noir::SkippedFiles::MAX_PATHS_PER_TECH}.java")
+  end
+
+  it "forgets everything on clear, so a second pass starts clean" do
+    Noir::SkippedFiles.record("go_gin", "main.go", "boom")
+    Noir::SkippedFiles.clear
+
+    Noir::SkippedFiles.count.should eq(0)
+    Noir::SkippedFiles.failures.should be_empty
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -3,6 +3,7 @@ require "./analyzers/file_analyzers/*"
 require "../miniparsers/extraction_result_cache"
 require "../models/analyzer_failure"
 require "../models/locator_keys"
+require "../models/skipped_files"
 require "../techs/techs"
 
 def initialize_analyzers(logger : NoirLogger)
@@ -119,6 +120,11 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   # / repeated library use) so fingerprints cannot serve stale tables.
   Noir::ExtractionResultCache.clear_all
 
+  # Same reasoning: a per-file skip tallied by the previous pass would be
+  # reported against this one, and under `--strict` would fail every
+  # subsequent build.
+  Noir::SkippedFiles.clear
+
   # Same reasoning, for the locator slots written and read inside one
   # analysis pass (the Express router prefixes). Detector-written keys are
   # deliberately NOT cleared here — this pass is what drains them.
@@ -182,6 +188,13 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
         end
       end
     end
+  end
+
+  # A file an analyzer opened and could not finish is coverage lost just as
+  # surely as an analyzer that never ran, so it joins the same list. Added
+  # after the tech-level failures so a dead analyzer still reads first.
+  if collected = failures
+    Noir::SkippedFiles.failures.each { |failure| collected << failure }
   end
 
   # `hooks_count` reports only the hooks that can produce something for

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -262,17 +262,19 @@ module Noir::CLI::ScanCommand
     !options["ai_model"].to_s.empty? || provider.downcase.starts_with?("acp:")
   end
 
-  # Names the analyzers that raised, so a scan whose coverage was cut short
-  # says so instead of reporting the surviving endpoints as the whole story.
-  # Laid out like the detected-techs list above it (`├──` / `└──`), because
-  # it answers the same question — which techs were actually processed.
+  # Names the analyzers whose coverage was cut short — the analyzer itself
+  # raised, or it skipped files it could not read or parse — so a degraded
+  # scan says so instead of reporting the surviving endpoints as the whole
+  # story. Laid out like the detected-techs list above it (`├──` / `└──`),
+  # because it answers the same question: which techs actually processed
+  # what.
   private def self.report_analyzer_failures(logger : NoirLogger,
                                             failures : Array(AnalyzerFailure),
                                             scope : String)
     return if failures.empty?
 
     plural = failures.size == 1 ? "analyzer" : "analyzers"
-    logger.warning "#{failures.size} #{plural} failed#{scope}; results may be incomplete."
+    logger.warning "#{failures.size} #{plural} reported incomplete coverage#{scope}; some endpoints may be missing."
     failures.each_with_index do |failure, index|
       prefix = index < failures.size - 1 ? "├──" : "└──"
       logger.sub "#{prefix} #{failure.tech}: #{failure.message}"

--- a/src/cli/scan_flags.cr
+++ b/src/cli/scan_flags.cr
@@ -86,7 +86,7 @@ module Noir::CLI::ScanFlags
     Flag.new("--no-color", "Disable color output"),
     Flag.new("--no-spinner", "Disable loading spinner animations"),
     Flag.new("--no-log", "Show only results"),
-    Flag.new("--strict", "Exit with code 2 if any analyzer failed"),
+    Flag.new("--strict", "Exit with code 2 if any analyzer failed or skipped a file"),
     Flag.new("--passive-scan", "Enable passive security scan", shorts: %w[-P]),
     Flag.new("--passive-scan-path", "Custom passive rules path", Arg::File, hint: "path"),
     Flag.new("--passive-scan-severity", "Min severity", Arg::Choice,

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -2,6 +2,7 @@ require "./logger"
 require "./endpoint"
 require "./file_helper"
 require "./code_locator"
+require "./skipped_files"
 require "wait_group"
 require "../utils/media_filter"
 require "../utils/path_scope"
@@ -84,6 +85,22 @@ class Analyzer
     def self.tech_name : String
       {{ tech }}
     end
+
+    # Instance-side view of the same declaration. The per-file rescues live on
+    # this base class, which has no way to name the analyzer that is running
+    # inside them, so a skipped file could not be attributed to a tech.
+    # Deriving it from `analyzer_for` keeps the name written exactly once.
+    def tech : String
+      {{ tech }}
+    end
+  end
+
+  # Overridden by `analyzer_for` in every registered analyzer. The base value
+  # exists so shared code can call it unconditionally; it is deliberately NOT
+  # a `self.tech_name` fallback, which would turn "forgot `analyzer_for`" from
+  # a compile error into an analyzer that silently never runs.
+  def tech : String
+    ""
   end
 
   # Prefer the detector-populated cache over a fresh disk read. On
@@ -238,10 +255,15 @@ class Analyzer
               block.call(path)
             rescue File::NotFoundError
               @logger.debug "File not found: #{path}"
+              Noir::SkippedFiles.record(tech, path, "file not found") if path
             rescue e : Exception
               if path
                 @logger.debug "Error processing file #{path}: #{e.message}"
+                Noir::SkippedFiles.record(tech, path, e.message.presence || e.class.name)
               else
+                # No path means the worker itself failed, not a file — there is
+                # nothing to tally, and the tech-level rescue in
+                # `analysis_endpoints` is what reports a dead analyzer.
                 @logger.debug "Error in worker: #{e.message}"
               end
             end
@@ -263,6 +285,7 @@ class Analyzer
         block.call(path)
       rescue e
         logger.debug "Error analyzing #{path}: #{e}"
+        Noir::SkippedFiles.record(tech, path, e.message.presence || e.class.name)
       end
     end
   rescue e

--- a/src/models/analyzer_failure.cr
+++ b/src/models/analyzer_failure.cr
@@ -1,8 +1,13 @@
 require "json"
 require "yaml"
 
-# One tech analyzer that raised and was skipped, named so the scan can say
-# which part of the code base it never actually looked at.
+# Coverage a tech analyzer did not deliver, named so the scan can say which
+# part of the code base it never actually looked at. Two shapes reach this,
+# both of them "endpoints may be missing here":
+#
+#   * the analyzer raised and was skipped entirely
+#   * the analyzer completed but skipped individual files it could not read
+#     or parse — one entry per tech, tallied by `Noir::SkippedFiles`
 #
 # `analysis_endpoints` has always caught per-tech exceptions and kept going,
 # which is the right call — one broken analyzer must not cost the user the

--- a/src/models/skipped_files.cr
+++ b/src/models/skipped_files.cr
@@ -1,0 +1,82 @@
+require "./analyzer_failure"
+
+# Files an analyzer opened and could not finish, tallied per tech.
+#
+# `AnalyzerFailure` covers the case where a whole analyzer raised: coverage
+# lost by the tech. The other half of the same problem is a single file
+# raising inside an analyzer that otherwise completed — the per-file rescues in
+# `Analyzer#parallel_analyze` and `Analyzer#scan_files` exist precisely so one
+# unreadable or unparsable file costs only itself. That is the right
+# behaviour, but until now the only trace was a `--debug` line, so the result
+# of a scan that silently dropped a file was byte-identical to one that read
+# everything.
+#
+# #2612 made that gap wider by adding a ceiling on parse time: a
+# pathologically malformed file now raises and is skipped where it used to
+# take the process down. Loud-and-fatal became quiet-and-partial, which is the
+# better failure mode only if the "partial" part is visible somewhere.
+#
+# Tallied rather than listed one entry per file: a repository that trips this
+# usually trips it in bulk (a vendored minified bundle, a generated tree), and
+# `errors` is part of the JSON/YAML/TOML output — one entry per tech with a
+# count and a few example paths says the same thing without letting a broken
+# checkout print thousands of lines.
+module Noir::SkippedFiles
+  extend self
+
+  # Example paths kept per tech. Beyond this only the count grows.
+  MAX_PATHS_PER_TECH = 5
+
+  private class Tally
+    property count = 0
+    property reason = ""
+    getter paths = [] of String
+  end
+
+  @@tallies = {} of String => Tally
+  @@mutex = Mutex.new
+
+  # `tech` may be empty — `Analyzer`'s own `tech` returns `""` and only
+  # `analyzer_for` fills it in, so a base-class caller is still recorded,
+  # just unattributed.
+  def record(tech : String, path : String, reason : String) : Nil
+    @@mutex.synchronize do
+      tally = @@tallies[tech] ||= Tally.new
+      tally.count += 1
+      tally.reason = reason if tally.reason.empty?
+      tally.paths << path if tally.paths.size < MAX_PATHS_PER_TECH
+    end
+  end
+
+  # Cleared at the start of every analysis pass: diff mode runs two, and an
+  # embedder can call `analyze` twice on one runner. A tally carried over
+  # would report the previous codebase's skips — and, under `--strict`, fail
+  # the build for them forever after.
+  def clear : Nil
+    @@mutex.synchronize { @@tallies.clear }
+  end
+
+  # Total files skipped since the last `clear`, across every tech.
+  def count : Int32
+    @@mutex.synchronize { @@tallies.values.sum(&.count) }
+  end
+
+  # One `AnalyzerFailure` per tech that skipped at least one file, so a
+  # dropped file lands in the same `errors` array — and the same `--strict`
+  # exit code — as a dropped analyzer.
+  def failures : Array(AnalyzerFailure)
+    @@mutex.synchronize do
+      @@tallies.map do |tech, tally|
+        AnalyzerFailure.new(tech, message_for(tally))
+      end
+    end
+  end
+
+  private def message_for(tally : Tally) : String
+    noun = tally.count == 1 ? "file" : "files"
+    examples = tally.paths.join(", ")
+    hidden = tally.count - tally.paths.size
+    examples += " (+#{hidden} more)" if hidden > 0
+    "skipped #{tally.count} #{noun}: #{examples}; first error: #{tally.reason}"
+  end
+end

--- a/src/options.cr
+++ b/src/options.cr
@@ -429,7 +429,7 @@ def run_options_parser
     parser.on "--no-log", "Show only results" do
       noir_options["nolog"] = YAML::Any.new(true)
     end
-    parser.on "--strict", "Exit with code 2 if any analyzer failed" do
+    parser.on "--strict", "Exit with code 2 if any analyzer failed or skipped a file" do
       noir_options["strict"] = YAML::Any.new(true)
     end
 


### PR DESCRIPTION
`--strict` and the `errors` key (#2616) exist because "this project has no Go
endpoints" and "the Go analyzer crashed before it could look" produced the
same empty list and the same exit 0. They cover the analyzer-level half of
that. The file-level half was still silent: the per-file rescues in
`parallel_analyze` and `scan_files` drop one unreadable or unparsable file and
keep going — the right call — but the only trace was a `--debug` line, so a
scan that quietly skipped files was byte-identical to one that read
everything.

#2612 widened that gap. A pathologically malformed file used to take the
process down with a stack overflow or hang for minutes; now it raises against
the parse-time ceiling and is skipped. Loud-and-fatal became quiet-and-partial,
which is the better failure mode only if "partial" is visible somewhere.

    NOIR_PARSE_TIMEOUT_MS=1 noir scan ./app -t rust_axum -f json --strict
    before: "errors": []          exit 0
    after:  "errors": [{ "tech": "rust_axum",
              "message": "skipped 1 file: src/gen.rs; first error: …" }]
            exit 2

Tallied per tech, not one entry per file, with up to five example paths and a
count: a repository that trips this trips it in bulk (a vendored bundle, a
generated tree), and `errors` is part of the JSON/YAML/TOML output — a broken
checkout must not be able to print thousands of lines into it.

Attribution comes from `analyzer_for`, which now also defines an instance-side
`tech`. The rescues live on the `Analyzer` base, which had no way to name the
analyzer running inside them; deriving it from the existing declaration keeps
the tech name written exactly once. The base returns `""` and is deliberately
not a `self.tech_name` fallback — that would turn "forgot `analyzer_for`" from
a compile error into an analyzer that silently never runs.

The warning line becomes "N analyzers reported incomplete coverage" rather
than "N analyzers failed", which is now the accurate summary of both shapes.

No new noise on healthy input: scanning the whole fixture corpus with all 253
techs forced produces zero per-file rescues today, and every fixture still
reports `"errors": []` with endpoints byte-identical across 696 project
directories.

Known limit, stated rather than chased: this covers the two shared per-file
rescues. An analyzer that catches its own per-file exception locally still
reports nothing.