### PR TITLE
fix(analyzer): close Python strings with an escape flag, not a lookback

### DIFF
--- a/spec/unit_test/analyzer/analyzer_tornado_docstring_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_tornado_docstring_spec.cr
@@ -1,0 +1,53 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/python/tornado"
+
+class TornadoDocstringHarness < Analyzer::Python::Tornado
+  def docstring_flags(lines : Array(String)) : Array(Bool)
+    compute_docstring_line_flags(lines)
+  end
+end
+
+# The flags decide which lines sit inside a module docstring and are therefore
+# not code. Getting one wrong does not drop a line — it flips every line after
+# it, because the triple-quote state is carried forward across the whole file.
+describe "Tornado docstring line flags" do
+  harness = TornadoDocstringHarness.new(create_test_options)
+
+  it "closes a single-line string that ends in an escaped backslash" do
+    # A Windows path, then a docstring opened later on the SAME line. The
+    # one-character lookback this replaces read the closing quote of `"C:\\"`
+    # as escaped, so the scan ran off the end of the line and never saw the
+    # `"""` — leaving the docstring unopened, and the closing `"""` on the next
+    # line free to open one instead. Every following line then counted as
+    # docstring, and its routes disappeared.
+    lines = <<-PY.split("\n")
+      PATH = "C:\\\\"; DOC = """start
+      of a docstring"""
+      app.add_handlers(".*", [(r"/late", LateHandler)])
+      PY
+
+    harness.docstring_flags(lines).should eq([false, true, false])
+  end
+
+  it "still treats an escaped quote as part of the string" do
+    # Odd number of backslashes: the quote really is escaped, the string runs
+    # on, and the `"""` inside it is not a docstring opener.
+    lines = <<-PY.split("\n")
+      MSG = "he said \\"\\"\\" and left"
+      app.add_handlers(".*", [(r"/after", AfterHandler)])
+      PY
+
+    harness.docstring_flags(lines).should eq([false, false])
+  end
+
+  it "tracks a plain module docstring across lines" do
+    lines = <<-PY.split("\n")
+      """Module docs.
+      Second line.
+      """
+      app.add_handlers(".*", [(r"/x", XHandler)])
+      PY
+
+    harness.docstring_flags(lines).should eq([false, true, true, false])
+  end
+end

--- a/spec/unit_test/analyzer/python_engine_spec.cr
+++ b/spec/unit_test/analyzer/python_engine_spec.cr
@@ -90,6 +90,40 @@ describe Analyzer::Python::PythonEngine do
     block.not_nil!.should_not contain("outside")
   end
 
+  it "closes a string that ends in an escaped backslash" do
+    harness = PythonEngineSpecHarness.new(create_test_options)
+    source = <<-PY
+      def handler():
+          root = "C:\\\\"
+          inside = request.args.get("inside")
+      outside = request.args.get("outside")
+      PY
+
+    block = harness.parse_code_block(source)
+
+    block.should_not be_nil
+    block.not_nil!.should contain("inside")
+    # The escaped backslash used to leave the string open for the rest of the
+    # file, so every following line was kept "because a quote is still open".
+    block.not_nil!.should_not contain("outside")
+  end
+
+  it "still treats a genuinely escaped quote as part of the string" do
+    harness = PythonEngineSpecHarness.new(create_test_options)
+    source = <<-PY
+      def handler():
+          msg = 'it\\'s # not a comment'
+          inside = request.args.get("inside")
+      outside = request.args.get("outside")
+      PY
+
+    block = harness.parse_code_block(source)
+
+    block.should_not be_nil
+    block.not_nil!.should contain("inside")
+    block.not_nil!.should_not contain("outside")
+  end
+
   it "skips multi-line route decorators when locating the decorated function" do
     harness = PythonEngineSpecHarness.new(create_test_options)
     lines = [

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -142,11 +142,17 @@ module Analyzer::Python
       lines.each_with_index do |line, idx|
         flags[idx] = in_triple
         i = 0
-        size = line.size
+        # `chars`, not `line[i]`: `String#[](Int)` walks from the start of the
+        # string on every call once the content is not single-byte, so
+        # indexing inside this loop was O(n^2) per line on any file with a
+        # non-ASCII comment or string literal. `join_multiline_call` below
+        # already carried this fix; this scan did not.
+        chars = line.chars
+        size = chars.size
         while i < size
-          c = line[i]
+          c = chars[i]
           if in_triple
-            if c == triple_char && i + 2 < size && line[i + 1] == triple_char && line[i + 2] == triple_char
+            if c == triple_char && i + 2 < size && chars[i + 1] == triple_char && chars[i + 2] == triple_char
               in_triple = false
               i += 3
               next
@@ -155,16 +161,29 @@ module Analyzer::Python
           elsif c == '#'
             break # comment runs to end of line
           elsif c == '"' || c == '\''
-            if i + 2 < size && line[i + 1] == c && line[i + 2] == c
+            if i + 2 < size && chars[i + 1] == c && chars[i + 2] == c
               in_triple = true
               triple_char = c
               i += 3
               next
             end
-            # Single-line string: skip to its (unescaped) closing quote.
+            # Single-line string: skip to its closing quote, consuming a
+            # backslash and whatever follows it.
+            #
+            # An escape FLAG, not the one-character lookback this replaces
+            # (`line[i] == c && line[i - 1] != '\\'`): a lookback cannot tell
+            # an escaped quote from an escaped BACKSLASH followed by a quote,
+            # so `"C:\\"` read as unterminated and the scan ran off the end of
+            # the line — taking any `"""` later on that line with it, which is
+            # what decides whether the FOLLOWING lines count as docstring.
+            # Same defect as #2625 fixed in the Express router-mount scanner.
             i += 1
             while i < size
-              break if line[i] == c && line[i - 1] != '\\'
+              if chars[i] == '\\'
+                i += 2
+                next
+              end
+              break if chars[i] == c
               i += 1
             end
             i += 1

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -319,14 +319,46 @@ module Analyzer::Python
         lines[1..].each_with_index do |line, body_idx|
           line_index = 0
           clear_line = line
-          while line_index < line.size
-            if line_index < line.size - 2
+          # `String#[](Int)` walks from the start of the string on every call
+          # once the content is not single-byte, so indexing `line` inside this
+          # loop was O(n^2) per line on any file with a non-ASCII comment or
+          # string literal — and `line[i..i + 2]` allocated a three-character
+          # String for every character besides. `join_multiline_call` in
+          # `python/tornado.cr` already carried the same `chars` fix with the
+          # same reasoning.
+          chars = line.chars
+          size = chars.size
+          # A backslash inside a quoted run consumes the next character,
+          # whatever it is. This used to be a one-character lookback
+          # (`line[line_index - 1] != '\\'`), which cannot tell an escaped
+          # quote from an escaped BACKSLASH followed by a quote: `"C:\\"` read
+          # as unterminated, so the run stayed open and the rest of the line —
+          # `#` comments included — was swallowed. Same defect as #2625 fixed
+          # in the Express router-mount scanner. The lookback also indexed
+          # `line[-1]` at column 0, and a negative index counts from the END of
+          # the string in Crystal, so a quote in column 0 was read as escaped
+          # whenever the line happened to end in a backslash.
+          #
+          # Reset per line, like the quote flags are not: a backslash at
+          # end-of-line continues a string, but the continuation is a fresh
+          # line and the first character of it is not escaped.
+          escaped = false
+          while line_index < size
+            ch = chars[line_index]
+
+            if escaped
+              escaped = false
+              line_index += 1
+              next
+            end
+
+            if line_index < size - 2
               if !single_quote_open && !double_quote_open
-                if !double_comment_open && line[line_index..line_index + 2] == "'''"
+                if !double_comment_open && ch == '\'' && chars[line_index + 1] == '\'' && chars[line_index + 2] == '\''
                   single_comment_open = !single_comment_open
                   line_index += 3
                   next
-                elsif !single_comment_open && line[line_index..line_index + 2] == "\"\"\""
+                elsif !single_comment_open && ch == '"' && chars[line_index + 1] == '"' && chars[line_index + 2] == '"'
                   double_comment_open = !double_comment_open
                   line_index += 3
                   next
@@ -335,11 +367,13 @@ module Analyzer::Python
             end
 
             if !single_comment_open && !double_comment_open
-              if !single_quote_open && line[line_index] == '"' && line[line_index - 1] != '\\'
+              if ch == '\\' && (single_quote_open || double_quote_open)
+                escaped = true
+              elsif !single_quote_open && ch == '"'
                 double_quote_open = !double_quote_open
-              elsif !double_quote_open && line[line_index] == '\'' && line[line_index - 1] != '\\'
+              elsif !double_quote_open && ch == '\''
                 single_quote_open = !single_quote_open
-              elsif !single_quote_open && !double_quote_open && line[line_index] == '#' && line[line_index - 1] != '\\'
+              elsif !single_quote_open && !double_quote_open && ch == '#'
                 # Exclusive range, NOT `line[..(line_index - 1)]`: at
                 # `line_index == 0` that is `line[..-1]`, and a negative range
                 # end counts from the end of the string in Crystal, so a


### PR DESCRIPTION
Two Python scanners decided a quoted run had ended by looking one character
back:

    line[line_index] == '"' && line[line_index - 1] != '\\'

A lookback cannot tell an escaped quote from an escaped BACKSLASH followed by
a quote, so `"C:\\"` — any Windows path — read as unterminated. Same defect
#2625 fixed in the Express router-mount scanner; these are the last two
instances in the tree.

`PythonEngine#parse_code_block` walks a handler body and stops at the first
line whose leading columns hold code, unless a quote is still open. An
unterminated string means the quote never closes, so `open_status` stays true
for the rest of the file and the block never ends:

    def handler():
        root = "C:\\"
        inside = request.args.get("inside")
    outside = request.args.get("outside")   # <- swallowed into the body

The engine is shared by 16 analyzers, and the body is what feeds param and
callee extraction, so a handler with a Windows path pulled in whatever
followed it — a wrong answer rather than a missing one.

`Tornado#compute_docstring_line_flags` decides which lines sit inside a module
docstring. There the scan ran off the end of the line and never saw a `"""`
later on it, so the docstring was not opened — and the CLOSING `"""` on the
next line opened one instead. The flags invert from that point on and every
route in the rest of the file is discarded as docstring text. The spec shows
it: `[false, true, false]` became `[false, false, true]`.

Both now carry an explicit escape flag that consumes the backslash and the
character after it, so a doubled backslash consumes itself and the following
quote closes the run, while a genuinely escaped quote (`'it\'s'`) still does
not — both cases are specced, since deleting the lookback outright would have
fixed the first and broken the second.

Two more defects fall out of the same rewrite:

* The lookback indexed `line[line_index - 1]`, which at column 0 is
  `line[-1]` — Crystal counts a negative index from the END of the string. A
  quote in column 0 was read as escaped whenever the line happened to end in a
  backslash.
* Both loops indexed `line[i]` (and `parse_code_block` sliced
  `line[i..i + 2]`, allocating a three-character String per character).
  `String#[](Int)` walks from the start of the string once the content is not
  single-byte, so both were O(n^2) per line on any file with a non-ASCII
  comment or string literal. `join_multiline_call`, twenty lines below the
  Tornado scan, already carried the `chars` fix with exactly this reasoning.

No detection change on the fixture corpus: 696 project directories,
endpoints compared as sorted JSON, byte-identical.

---

Stacked on #2627, which touches the adjacent lines of the same loop. Base retargets to `main` once that merges.