### PR TITLE
fix: four bugs found by building and using the tool

### DIFF
--- a/spec/functional_test/func_spec.cr
+++ b/spec/functional_test/func_spec.cr
@@ -202,6 +202,30 @@ class FunctionalTester
                   .any? { |found| found.param_type == param.param_type }
                   .should be_true
               end
+
+              # `value` was never asserted at all, which is how a tester could
+              # declare `Param.new("version", "null", "query")` and go green
+              # while the emitted request really was `?version=null`. `value`
+              # is what the curl / httpie / PowerShell builders put on the
+              # wire and what the OAS builders publish as an `enum`, so a
+              # wrong one is a wrong request, not cosmetics.
+              #
+              # Only a declared (non-empty) value is checked, because `""` is
+              # this harness's established "not asserted" placeholder — most
+              # testers spell it for params whose value is derived and long
+              # (a GraphQL operation document, a JSON-RPC envelope). The other
+              # half of the hole — an analyzer leaking source text into a
+              # param the tester left blank — is covered precisely, and much
+              # faster, by the unit specs for `PythonEngine#return_literal_value`
+              # and `Noir::JvmLiteral.value_of`.
+              if !param.value.empty?
+                it "check '#{param.name}' value '#{param.value}'" do
+                  actual_params(expected, param.name)
+                    .select { |found| found.param_type == param.param_type }
+                    .map(&.value)
+                    .should contain param.value
+                end
+              end
             end
           end
         end

--- a/spec/functional_test/testers/go/goyave_spec.cr
+++ b/spec/functional_test/testers/go/goyave_spec.cr
@@ -4,7 +4,9 @@ expected_endpoints = [
   Endpoint.new("/", "GET"),
   Endpoint.new("/create", "POST"),
   Endpoint.new("/product/{id}", "GET", [
-    Param.new("id", "[0-9]+", "path"),
+    # `{id:[0-9]+}` — the regex is a constraint, not a value, and the
+    # analyzer records none. Same rule as php/laminas `constraints`.
+    Param.new("id", "", "path"),
   ]),
   Endpoint.new("/api/users", "GET"),
   Endpoint.new("/api/version", "GET"),

--- a/spec/functional_test/testers/java/play_spec.cr
+++ b/spec/functional_test/testers/java/play_spec.cr
@@ -24,7 +24,8 @@ expected_endpoints = [
     Param.new("label", "new,hot", "query"),
   ]),
   Endpoint.new("/api/list-all", "GET", [
-    Param.new("version", "null", "query"),
+    # `?= null` is "no default", not the string "null".
+    Param.new("version", "", "query"),
   ]),
   Endpoint.new("/fixed-home", "GET"),
   Endpoint.new("/files/$path<.+>", "GET", [Param.new("path", "", "path")]),

--- a/spec/functional_test/testers/kotlin/spring_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_spec.cr
@@ -4,7 +4,7 @@ expected_endpoints = [
   Endpoint.new("/api/article/", "GET"),
   Endpoint.new("/api/article/{slug}", "GET", [Param.new("slug", "", "path")]),
   Endpoint.new("/api/user/", "GET"),
-  Endpoint.new("/api/user/{login}", "GET", [Param.new("login", "", "path"), Param.new("lorem", "ipsum", "cookie")]),
+  Endpoint.new("/api/user/{login}", "GET", [Param.new("login", "", "path"), Param.new("lorem", "lorem", "cookie")]),
   Endpoint.new("/v1", "GET", [Param.new("version", "1", "query")]),
   Endpoint.new("/v2", "GET", [Param.new("version", "2", "query")]),
   Endpoint.new("/version2", "GET", [Param.new("version", "2", "query")]),

--- a/spec/functional_test/testers/python/django_ninja_spec.cr
+++ b/spec/functional_test/testers/python/django_ninja_spec.cr
@@ -25,7 +25,7 @@ expected_endpoints = [
   Endpoint.new("/api/blogs", "POST", [
     Param.new("title", "", "json"),
     Param.new("body", "", "json"),
-    Param.new("published", "False", "json"),
+    Param.new("published", "false", "json"),
   ]),
   # @api.api_operation(["POST", "PATCH"], "/mixed") emits one endpoint per verb.
   Endpoint.new("/api/mixed", "POST"),

--- a/spec/functional_test/testers/python/fastapi_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_spec.cr
@@ -14,7 +14,9 @@ expected_endpoints = [
     Param.new("item_id", "", "path"),
   ]),
   Endpoint.new("/api/cbv/items/{item_id}", "GET", [
-    Param.new("include_meta", "False", "query"),
+    # `Query(False)` unwraps to the literal it carries, spelled for the
+    # wire rather than for Python.
+    Param.new("include_meta", "false", "query"),
     Param.new("item_id", "", "path"),
   ]),
   Endpoint.new("/api/constant/registered", "POST"),

--- a/spec/functional_test/testers/r/plumber_spec.cr
+++ b/spec/functional_test/testers/r/plumber_spec.cr
@@ -2,20 +2,22 @@ require "../../func_spec.cr"
 
 expected_endpoints = [
   Endpoint.new("/echo", "GET", [
-    Param.new("msg", "The message to echo", "query"),
+    # roxygen `@param <name> <description>` — the trailing text is the
+    # parameter's description, not a default value.
+    Param.new("msg", "", "query"),
   ]),
   Endpoint.new("/submit", "POST", [
-    Param.new("username", "The username", "body"),
-    Param.new("password", "The password", "body"),
+    Param.new("username", "", "body"),
+    Param.new("password", "", "body"),
   ]),
   Endpoint.new("/users/:id/posts/:post_id", "GET", [
     Param.new("id", "", "path"),
     Param.new("post_id", "", "path"),
-    Param.new("limit", "Query limit", "query"),
+    Param.new("limit", "", "query"),
   ]),
   Endpoint.new("/users/:id", "PUT", [
     Param.new("id", "", "path"),
-    Param.new("name", "The new name", "body"),
+    Param.new("name", "", "body"),
   ]),
   Endpoint.new("/hello", "GET"),
   Endpoint.new("/save/:key", "POST", [

--- a/spec/functional_test/testers/scala/tapir_compose_spec.cr
+++ b/spec/functional_test/testers/scala/tapir_compose_spec.cr
@@ -6,10 +6,12 @@ require "../../func_spec.cr"
 expected_endpoints = [
   Endpoint.new("/books/add", "POST", [
     Param.new("body", "Book", "json"),
-    Param.new("X-Auth-Token", "String", "header"),
+    # Tapir declares the input's Scala type; a type is not a value, so
+    # only a `body` param records one (its DTO name).
+    Param.new("X-Auth-Token", "", "header"),
   ]),
   Endpoint.new("/books/list/all", "GET", [
-    Param.new("limit", "Option[Int]", "query"),
+    Param.new("limit", "", "query"),
   ]),
   Endpoint.new("/user/register", "POST", [Param.new("body", "Register_IN", "json")]),
   Endpoint.new("/user", "GET"),

--- a/spec/unit_test/analyzer/python_engine_literal_spec.cr
+++ b/spec/unit_test/analyzer/python_engine_literal_spec.cr
@@ -1,0 +1,133 @@
+require "../../spec_helper"
+require "../../../src/models/code_locator"
+require "../../../src/analyzer/engines/python_engine"
+
+# `return_literal_value` and `parse_function_def` are instance methods on the
+# abstract engine, so a minimal concrete subclass exposes them.
+class PythonEngineLiteralHarness < Analyzer::Python::PythonEngine
+  def literal(data : String) : String
+    return_literal_value(data)
+  end
+
+  def parse_def(source : String)
+    parse_function_def(source.lines, 0)
+  end
+end
+
+private def literal_harness
+  PythonEngineLiteralHarness.new(create_test_options)
+end
+
+describe Analyzer::Python::PythonEngine do
+  describe "#return_literal_value" do
+    it "unwraps quoted strings and keeps numbers" do
+      h = literal_harness
+      h.literal(%q("abc")).should eq "abc"
+      h.literal("'abc'").should eq "abc"
+      h.literal(%q("""abc""")).should eq "abc"
+      h.literal("7").should eq "7"
+      h.literal("1.5").should eq "1.5"
+    end
+
+    it "spells Python booleans for the wire and treats None/... as absent" do
+      h = literal_harness
+      h.literal("True").should eq "true"
+      h.literal("False").should eq "false"
+      h.literal("None").should eq ""
+      h.literal("...").should eq ""
+      h.literal("Ellipsis").should eq ""
+    end
+
+    # The regression this exists for. `Param#value` is what the curl /
+    # httpie / PowerShell builders put on the wire and what the OAS builders
+    # publish as an `enum`, so `q: str = Query()` must not produce `?q=Query()`
+    # and `x_token: str = Header(None)` must not produce
+    # `-H 'x_token: Header(None)'`.
+    it "gives a bare FastAPI marker no value" do
+      h = literal_harness
+      h.literal("Query()").should eq ""
+      h.literal("Header(None)").should eq ""
+      h.literal("Cookie(None)").should eq ""
+      h.literal("Form(...)").should eq ""
+      h.literal("File(...)").should eq ""
+      h.literal("Header(default=None, include_in_schema=False)").should eq ""
+    end
+
+    it "recovers the default a marker actually carries" do
+      h = literal_harness
+      h.literal(%q(Query("abc"))).should eq "abc"
+      h.literal("Query(False)").should eq "false"
+      h.literal("Query(7)").should eq "7"
+      h.literal(%q(Header(default="hv"))).should eq "hv"
+      h.literal(%q(fastapi.Query("ns"))).should eq "ns"
+      # `default=` wins over position no matter where it appears.
+      h.literal(%q(Query(description="a: b, c", default="real"))).should eq "real"
+      # `=` inside a quoted positional is not a keyword argument.
+      h.literal(%q(Query("a=b"))).should eq "a=b"
+    end
+
+    it "gives any other expression no value" do
+      h = literal_harness
+      h.literal("get_db()").should eq ""
+      h.literal("SOME_CONSTANT").should eq ""
+      h.literal("[1, 2]").should eq ""
+    end
+  end
+
+  describe "#parse_function_def" do
+    # `{` / `}` used to contribute no depth, so a comma inside a dict or set
+    # default split the parameter list and produced a parameter literally
+    # named `"y"}`.
+    it "does not split a parameter list on a comma inside braces" do
+      params = literal_harness.parse_def(%q(def s(tags: set = {"x", "y"}, after: str = "tail"):)).not_nil!.params
+      params.map(&.name).should eq ["tags", "after"]
+      params[1].default.should eq %q("tail")
+    end
+
+    it "keeps colons that are not the annotation separator" do
+      params = literal_harness.parse_def(%q(def d(cfg: dict = {"a": 1}, z: str = "last"):)).not_nil!.params
+      params.map(&.name).should eq ["cfg", "z"]
+      params[0].default.should eq %q({"a": 1})
+    end
+
+    # Nothing in this scanner was quote-aware, so any delimiter inside a
+    # string default was counted as structure. `"("` / `"["` left the depth
+    # permanently open and every parameter of the function was lost with
+    # nothing logged; `"x,y"` split mid-literal into a parameter named `y"`.
+    #
+    # Spelled with escaped double quotes rather than `%q(...)`: the `"("`
+    # case leaves the `%q` parens unbalanced and fails to parse.
+    it "treats delimiters inside a string default as text" do
+      h = literal_harness
+      {
+        "(",
+        "[",
+        "{",
+        "}",
+        "x,y",
+        "a:b",
+      }.each do |sep|
+        header = "def f(sep: str = \"#{sep}\", after: str = \"tail\"):"
+        params = h.parse_def(header).not_nil!.params
+        params.map(&.name).should eq ["sep", "after"]
+        h.literal(params[0].default).should eq sep
+        h.literal(params[1].default).should eq "tail"
+      end
+    end
+
+    it "does not end a quoted run on an escaped quote" do
+      header = "def f(sep: str = \"a\\\"b,c\", after: str = \"tail\"):"
+      params = literal_harness.parse_def(header).not_nil!.params
+      params.map(&.name).should eq ["sep", "after"]
+      h = literal_harness
+      h.literal(params[1].default).should eq "tail"
+    end
+
+    it "still splits name from type on the annotation colon" do
+      params = literal_harness.parse_def("def f(item_id: int, q: str = None):").not_nil!.params
+      params.map(&.name).should eq ["item_id", "q"]
+      params.map(&.type).should eq ["int", "str"]
+      params[1].default.should eq "None"
+    end
+  end
+end

--- a/spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr
@@ -736,6 +736,41 @@ describe Noir::TreeSitterKotlinParameterExtractor do
       fields["Article"].map(&.init_value).should eq(["", "todo"])
     end
 
+    # `init_value` stores mixed shapes — a string literal arrives decoded,
+    # every other initializer keeps its raw source — so the two cannot be
+    # told apart after the fact. `literal_default` is what resolves that:
+    # without the flag behind it, running a literal check over the decoded
+    # `untitled` erased every Kotlin string default, while the raw
+    # `LocalDateTime.now()` leaked into `Param#value`.
+    describe "FieldInfo#literal_default" do
+      it "keeps a string default and drops an expression" do
+        source = <<-KT
+          data class Article(
+              var title: String = "untitled",
+              var views: Int = 7,
+              var draft: Boolean = false,
+              var addedAt: LocalDateTime = LocalDateTime.now(),
+              var slug: String = title.toSlug(),
+              var note: String? = null,
+          )
+          KT
+        fields = Noir::TreeSitterKotlinParameterExtractor.extract_class_fields(source)["Article"]
+        fields.map(&.name).should eq(["title", "views", "draft", "addedAt", "slug", "note"])
+        fields.map(&.literal_default).should eq(["untitled", "7", "false", "", "", ""])
+      end
+
+      it "keeps a class-body string default" do
+        source = <<-KT
+          class User {
+              var name: String = "anon"
+              var seenAt: LocalDateTime = LocalDateTime.now()
+          }
+          KT
+        fields = Noir::TreeSitterKotlinParameterExtractor.extract_class_fields(source)["User"]
+        fields.map(&.literal_default).should eq(["anon", ""])
+      end
+    end
+
     it "does not leak property annotation tokens into a field's init value" do
       source = <<-KT
         data class CreateUserRequest(

--- a/spec/unit_test/utils/jvm_literal_spec.cr
+++ b/spec/unit_test/utils/jvm_literal_spec.cr
@@ -1,0 +1,47 @@
+require "../../spec_helper"
+require "../../../src/utils/jvm_literal"
+
+describe Noir::JvmLiteral do
+  describe ".value_of" do
+    it "unwraps string literals" do
+      Noir::JvmLiteral.value_of(%q("json")).should eq "json"
+      Noir::JvmLiteral.value_of(%q("new,hot")).should eq "new,hot"
+      Noir::JvmLiteral.value_of("'c'").should eq "c"
+    end
+
+    it "keeps numeric literals, dropping the type suffix and separators" do
+      Noir::JvmLiteral.value_of("1").should eq "1"
+      Noir::JvmLiteral.value_of("25").should eq "25"
+      Noir::JvmLiteral.value_of("10L").should eq "10"
+      Noir::JvmLiteral.value_of("1.5f").should eq "1.5"
+      Noir::JvmLiteral.value_of("1_000").should eq "1000"
+    end
+
+    it "keeps booleans" do
+      Noir::JvmLiteral.value_of("true").should eq "true"
+      Noir::JvmLiteral.value_of("false").should eq "false"
+    end
+
+    it "treats every spelling of absence as no value" do
+      Noir::JvmLiteral.value_of("null").should eq ""
+      Noir::JvmLiteral.value_of("None").should eq ""
+      Noir::JvmLiteral.value_of("Nil").should eq ""
+      Noir::JvmLiteral.value_of("Optional.empty()").should eq ""
+      Noir::JvmLiteral.value_of("").should eq ""
+      Noir::JvmLiteral.value_of("   ").should eq ""
+    end
+
+    # The regression this exists for: `Param#value` is what the curl /
+    # httpie / PowerShell builders put on the wire and what the OAS builders
+    # publish as an `enum`, so a default with no literal form must not leak
+    # its source text there.
+    it "gives a non-literal expression no value" do
+      Noir::JvmLiteral.value_of("LocalDateTime.now()").should eq ""
+      Noir::JvmLiteral.value_of("title.toSlug()").should eq ""
+      Noir::JvmLiteral.value_of("List.empty").should eq ""
+      Noir::JvmLiteral.value_of(%q(Some("x"))).should eq ""
+      Noir::JvmLiteral.value_of("new ArrayList<>()").should eq ""
+      Noir::JvmLiteral.value_of("SOME_CONSTANT").should eq ""
+    end
+  end
+end

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../../miniparsers/java_callee_extractor"
 require "../../../miniparsers/java_route_extractor_ts"
 require "../../../utils/url_path"
+require "../../../utils/jvm_literal"
 
 module Analyzer::Java
   class Play < Analyzer
@@ -529,15 +530,12 @@ module Analyzer::Java
       nil
     end
 
+    # A Play routes default (`name: T ?= <expr>`) is a Scala/Java expression,
+    # not a value: `?= "json"` and `?= 1` are real defaults, `?= null` says
+    # there is no default, and `?= List.empty` has no literal form at all.
+    # See `Noir::JvmLiteral` for why the last two must not reach `Param#value`.
     private def normalize_route_default_value(raw_default : String) : String
-      value = raw_default.strip
-      return "" if value.empty?
-
-      if value.size >= 2 && ((value.starts_with?('"') && value.ends_with?('"')) || (value.starts_with?("'") && value.ends_with?("'")))
-        return value[1..-2]
-      end
-
-      value
+      Noir::JvmLiteral.value_of(raw_default)
     end
 
     private def request_route_param_type?(param_type : String?) : Bool

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -6,6 +6,7 @@ require "../../engines/kotlin_engine"
 require "../../../utils/utils.cr"
 require "../../../utils/path_scope"
 require "../../../utils/url_path"
+require "../../../utils/jvm_literal"
 
 module Analyzer::Kotlin
   class Spring < Analyzer
@@ -811,7 +812,7 @@ module Analyzer::Kotlin
     private def graphql_input_field_param(field : Noir::TreeSitterKotlinParameterExtractor::FieldInfo,
                                           argument_name : String) : Param
       name = argument_name == "input" ? field.name : "#{argument_name}.#{field.name}"
-      param = Param.new(name, field.init_value, "json")
+      param = Param.new(name, field.literal_default, "json")
       param.add_tag(Tag.new("graphql-input-field", argument_name, "kotlin_spring_graphql_analyzer"))
       param
     end

--- a/src/analyzer/analyzers/php/laminas.cr
+++ b/src/analyzer/analyzers/php/laminas.cr
@@ -336,6 +336,16 @@ module Analyzer::Php
       normalize_laminas_route_path(normalized)
     end
 
+    # Regex metacharacters. A Laminas constraint is a validation *pattern*
+    # (`'itemId' => '[0-9]+'`), so it only doubles as a value when it matches
+    # exactly one string — i.e. when it contains none of these.
+    CONSTRAINT_METACHARACTERS = "\\^$.|?*+()[]{}"
+
+    # A constraint carrying no metacharacters (`'format' => 'json'`) matches a
+    # single literal and is a usable value; a real pattern is not. `Param#value`
+    # is what HTTP-shaped consumers send and what the OAS builders publish as
+    # an `enum`, so passing the pattern straight through advertised `[0-9]+`
+    # as a concrete `itemId`.
     private def extract_laminas_path_params(route_path : String, constraints = Hash(String, String).new) : Array(Param)
       params = [] of Param
       seen = Set(String).new
@@ -344,7 +354,11 @@ module Analyzer::Php
         name = match[1]
         next if seen.includes?(name)
 
-        params << Param.new(name, constraints[name]? || "", "path")
+        constraint = constraints[name]?
+        value = constraint && !constraint.empty? &&
+                constraint.each_char.none? { |c| CONSTRAINT_METACHARACTERS.includes?(c) } ? constraint : ""
+
+        params << Param.new(name, value, "path")
         seen.add(name)
       end
 

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -1,4 +1,5 @@
 require "../../../utils/url_path"
+require "../../../utils/jvm_literal"
 require "../../../models/analyzer"
 require "../../../miniparsers/scala_callee_extractor"
 
@@ -739,15 +740,12 @@ module Analyzer::Scala
       true
     end
 
+    # A Play routes default (`name: T ?= <expr>`) is a Scala/Java expression,
+    # not a value: `?= "json"` and `?= 1` are real defaults, `?= null` says
+    # there is no default, and `?= List.empty` has no literal form at all.
+    # See `Noir::JvmLiteral` for why the last two must not reach `Param#value`.
     private def normalize_route_default_value(raw_default : String) : String
-      value = raw_default.strip
-      return "" if value.empty?
-
-      if value.size >= 2 && ((value.starts_with?('"') && value.ends_with?('"')) || (value.starts_with?("'") && value.ends_with?("'")))
-        return value[1..-2]
-      end
-
-      value
+      Noir::JvmLiteral.value_of(raw_default)
     end
 
     private def request_route_param_type?(param_type : String?) : Bool

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -341,17 +341,17 @@ module Analyzer::Scala
         elsif m["path_type"]?
           name = m["path_name"]? || default_path_name(segments)
           segments << "{#{name}}"
-          collect_param(params, name, "", "path")
+          collect_param(params, name, "path")
         elsif q = m["query_name"]?
-          collect_param(params, q, m["query_type"]? || "", "query")
+          collect_param(params, q, "query")
         elsif q = m["queries_name"]?
-          collect_param(params, q, m["queries_type"]? || "", "query")
+          collect_param(params, q, "query")
         elsif h = m["header_name"]?
-          collect_param(params, h, m["header_type"]? || "", "header")
+          collect_param(params, h, "header")
         elsif h = m["header_name2"]?
-          collect_param(params, h, "", "header")
+          collect_param(params, h, "header")
         elsif c = m["cookie_name"]?
-          collect_param(params, c, m["cookie_type"]? || "", "cookie")
+          collect_param(params, c, "cookie")
         elsif body = m["body"]?
           inner = m["body_type"]? || ""
           param_type = case body
@@ -362,14 +362,26 @@ module Analyzer::Scala
                        else
                          "body"
                        end
-          collect_param(params, "body", inner, param_type)
+          # The body's value carries its DTO name (`jsonBody[Book]` ->
+          # `{"body":"Book"}`), matching what javalin/ktor/akka/http4s/
+          # zio-http/helidon already emit for a body param.
+          collect_param(params, "body", param_type, inner)
         end
       end
     end
 
-    private def collect_param(params : Array(Param), name : String, type_value : String, param_type : String)
+    # Query / header / cookie / path inputs record no value. Tapir declares
+    # each one's Scala *type* (`query[Option[Int]]("limit")`), and that used
+    # to be stored in `Param#value` — but `value` is the request value every
+    # HTTP-shaped consumer sends: the curl builder emitted `?limit=Option[Int]`
+    # and the OAS builders promoted it to an `enum` entry on the parameter.
+    # `Param` has no declared-type field to put a scalar type in, so it is
+    # dropped rather than published as a value it is not. A `body` param is
+    # the documented exception: its value names the DTO, which is the
+    # convention every other JVM analyzer already follows.
+    private def collect_param(params : Array(Param), name : String, param_type : String, value : String = "")
       return if params.any? { |p| p.name == name && p.param_type == param_type }
-      params << Param.new(name, type_value, param_type)
+      params << Param.new(name, value, param_type)
     end
 
     # Replace top-level identifier references to known path/param constants with

--- a/src/analyzer/analyzers/specification/http_file.cr
+++ b/src/analyzer/analyzers/specification/http_file.cr
@@ -134,8 +134,8 @@ module Analyzer::Specification
       url_path = extract_path_from_url(url_raw)
       return if url_path.empty?
 
-      extract_query_param_names(url_raw).each do |query_name|
-        add_param(params, query_name, "", "query")
+      extract_query_params(url_raw).each do |query_name, query_value|
+        add_param(params, query_name, query_value, "query")
       end
 
       extract_path_vars(url_path).each do |path_name|
@@ -270,7 +270,15 @@ module Analyzer::Specification
       normalize_path(path)
     end
 
-    private def extract_query_param_names(url_string : String) : Array(String)
+    # Name *and* value. A `.http` file records a concrete request — `GET
+    # /query_http?q=1234` means the caller sent `q=1234` — so the value is
+    # real data, the same as the ones the HAR and Bruno analyzers keep. Only
+    # the names were kept before, so replaying an IntelliJ/VS Code `.http`
+    # file through `-f curl` produced `?q=` and dropped what to send.
+    #
+    # A value still carrying `{{...}}` is a template the caller's environment
+    # never resolved; that is a placeholder, not data, so it is left empty.
+    private def extract_query_params(url_string : String) : Array(Tuple(String, String))
       query = ""
       begin
         uri = URI.parse(url_string)
@@ -286,13 +294,18 @@ module Analyzer::Specification
         end
       end
 
-      names = [] of String
+      pairs = [] of Tuple(String, String)
       query.split('&').each do |pair|
         next if pair.empty?
-        name = pair.split('=', 2).first.strip
-        names << name unless name.empty?
+        name, _, raw_value = pair.partition('=')
+        name = name.strip
+        next if name.empty?
+        value = raw_value.strip
+        value = "" if value.includes?("{{")
+        value = URI.decode_www_form(value) rescue value
+        pairs << {name, value}
       end
-      names
+      pairs
     end
 
     private def extract_path_vars(path : String) : Array(String)

--- a/src/analyzer/analyzers/specification/insomnia.cr
+++ b/src/analyzer/analyzers/specification/insomnia.cr
@@ -97,7 +97,7 @@ module Analyzer::Specification
       end
 
       if auth = request["authentication"]?
-        process_json_auth(auth, params)
+        process_json_auth(auth, env, params)
       end
 
       # Body
@@ -248,7 +248,7 @@ module Analyzer::Specification
       end
 
       if auth = item["authentication"]?
-        process_yaml_auth(auth, params)
+        process_yaml_auth(auth, env, params)
       end
 
       if body_node = item["body"]?
@@ -397,10 +397,19 @@ module Analyzer::Specification
       normalized.empty? ? "param" : normalized
     end
 
+    # First-wins, except that a later declaration carrying a value upgrades a
+    # placeholder. The URL scan runs first and registers `{userId}` (and any
+    # `?include=`) with no value at all; the concrete value lives in the
+    # request's own `pathParameters` / `parameters` list, which is read after.
+    # Plain first-wins therefore discarded exactly the entry that had the data
+    # — `pathParameters: [{name: userId, value: "42"}]` produced `userId=`.
     private def add_param(params : Array(Param), name : String, value : String, param_type : String)
       normalized = name.strip
       return if normalized.empty?
-      return if params.any? { |p| p.name == normalized && p.param_type == param_type }
+      if index = params.index { |p| p.name == normalized && p.param_type == param_type }
+        params[index] = Param.new(normalized, value, param_type) if params[index].value.empty? && !value.empty?
+        return
+      end
       params << Param.new(normalized, value, param_type)
     end
 
@@ -418,29 +427,34 @@ module Analyzer::Specification
       logger.debug "Failed to parse Insomnia JSON body: #{e}"
     end
 
-    private def process_json_auth(auth : JSON::Any, params : Array(Param))
+    # `key` / `value` / `token` are templated the same way the URL is —
+    # `authentication: {type: bearer, token: "{{ token }}"}` against an
+    # `environments.data.token` — so they go through `resolve_vars` too.
+    # Only the URL did, which is why a bearer header came out as the literal
+    # `Bearer {{ token }}` instead of the credential the collection defines.
+    private def process_json_auth(auth : JSON::Any, env : Hash(String, String), params : Array(Param))
       return if auth["disabled"]?.try(&.as_bool?) == true
       type = auth["type"]?.try(&.as_s?) || ""
       process_auth_fields(
         type,
-        auth["key"]?.try(&.as_s?) || "",
-        auth["value"]?.try(&.as_s?) || "",
+        resolve_vars(auth["key"]?.try(&.as_s?) || "", env),
+        resolve_vars(auth["value"]?.try(&.as_s?) || "", env),
         auth["addTo"]?.try(&.as_s?) || "",
-        auth["token"]?.try(&.as_s?) || "",
+        resolve_vars(auth["token"]?.try(&.as_s?) || "", env),
         auth["prefix"]?.try(&.as_s?) || "",
         params
       )
     end
 
-    private def process_yaml_auth(auth : YAML::Any, params : Array(Param))
+    private def process_yaml_auth(auth : YAML::Any, env : Hash(String, String), params : Array(Param))
       return if auth["disabled"]?.try(&.as_bool?) == true
       type = auth["type"]?.try(&.as_s?) || ""
       process_auth_fields(
         type,
-        auth["key"]?.try(&.as_s?) || "",
-        auth["value"]?.try(&.as_s?) || "",
+        resolve_vars(auth["key"]?.try(&.as_s?) || "", env),
+        resolve_vars(auth["value"]?.try(&.as_s?) || "", env),
         auth["addTo"]?.try(&.as_s?) || "",
-        auth["token"]?.try(&.as_s?) || "",
+        resolve_vars(auth["token"]?.try(&.as_s?) || "", env),
         auth["prefix"]?.try(&.as_s?) || "",
         params
       )

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -6,7 +6,19 @@ module Analyzer::Javascript
     # Default extension set for JavaScript/TypeScript source files.
     # Analyzers with a different filter (e.g. Nitro adds `.mts`, NestJS JS
     # only uses `.js`/`.jsx`) pass their own list to `parallel_file_scan`.
-    DEFAULT_EXTENSIONS      = [".js", ".ts", ".jsx", ".tsx"]
+    #
+    # This list mirrors what the JS detectors declare in `extensions:`
+    # (`.js .mjs .cjs .jsx .ts .tsx`). It has to: detection and analysis
+    # read the same tree, so any extension a detector accepts but this
+    # list omits produces a project that detects fine and then yields
+    # zero endpoints, with nothing logged and nothing for `--strict` to
+    # report. `.mjs`/`.cjs` were exactly that hole — an ESM Express app
+    # (`app.mjs`) detected as `js_express` and returned no routes.
+    # Analyzers that pass their own list (koa, hapi, sails, adonisjs,
+    # elysia, feathers, ...) already spelled `.mjs`/`.cjs` out by hand;
+    # the six that relied on this default (express, fastify, hono,
+    # restify, apollo, graphql_yoga, plus socketio) silently did not.
+    DEFAULT_EXTENSIONS      = [".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx"]
     JS_PROJECT_ROOT_MARKERS = [
       "package.json",
       "next.config.js", "next.config.ts", "next.config.mjs", "next.config.cjs",

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -1,6 +1,7 @@
 require "../../models/analyzer"
 require "../../miniparsers/import_graph"
 require "../../miniparsers/python_callee_extractor"
+require "../../utils/top_level_split"
 require "json"
 
 module Analyzer::Python
@@ -149,18 +150,56 @@ module Analyzer::Python
       is_option = false
       is_default = false
       bracket_count = 0
+      # `{` / `}` needs the same depth tracking `[` / `]` gets. Without it a
+      # dict or set default leaks its separators into the parameter loop:
+      # `def f(tags: set = {"x", "y"}, after: str = "t")` split on the comma
+      # inside the braces and produced a parameter literally named `"y"}`.
+      brace_count = 0
       parentheses_count = 1
+
+      # Quoted runs, tracked exactly as `python_delimiter_delta` does it (same
+      # escape rule, same "only same-line quoting is modelled" limit — the
+      # reset below restores it per line).
+      #
+      # Nothing here was quote-aware before, so every delimiter inside a
+      # string default was counted as structure: `def f(a: str = "(", b: int
+      # = 1)` lost both parameters because the `(` was never closed, and
+      # `def f(a: str = "x,y", b: str = "t")` split mid-literal into a
+      # parameter named `y"`. The depth counters also ran negative on a
+      # stray closer, and since the split guard demands EXACTLY zero, one
+      # unbalanced character disabled every remaining split in the header —
+      # so both counters are clamped at zero, the same rule
+      # `Noir::TopLevelSplit::Rules::PYTHON` already applies.
+      in_quote : Char? = nil
+      escaped = false
 
       line_index = start_index
       # Iterate over the parameter line to parse each parameter
       while parentheses_count != 0
         while index < param_line.size
           char = param_line[index]
-          if char == '['
+          if in_quote
+            # Inside a quoted run every delimiter is literal text. This must
+            # not skip the append below — the characters are still part of
+            # the name/type/default being built.
+            if escaped
+              escaped = false
+            elsif char == '\\'
+              escaped = true
+            elsif char == in_quote
+              in_quote = nil
+            end
+          elsif char == '\'' || char == '"'
+            in_quote = char
+          elsif char == '['
             bracket_count += 1
           elsif char == ']'
-            bracket_count -= 1
-          elsif bracket_count == 0
+            bracket_count -= 1 if bracket_count > 0
+          elsif char == '{'
+            brace_count += 1
+          elsif char == '}'
+            brace_count -= 1 if brace_count > 0
+          elsif bracket_count == 0 && brace_count == 0
             if char == '('
               parentheses_count += 1
             elsif parentheses_count == 1 && char == '='
@@ -186,7 +225,13 @@ module Analyzer::Python
                 end
                 break
               end
-            elsif char == ':'
+            elsif parentheses_count == 1 && !is_default && char == ':'
+              # Only the annotation colon separates name from type, and it is
+              # always at depth 1 before any `=`. A `:` seen anywhere else
+              # belongs to the text it sits in — `Query(description="a: b")`,
+              # a nested dict, a lambda — and used to be dropped on the floor,
+              # which is what mangled a multi-line `Cookie(openapi_examples=
+              # {"Cookie One": {...}})` default into `"Cookie One" {...}`.
               is_option = true
               index += 1
               next
@@ -208,6 +253,11 @@ module Analyzer::Python
         if line_index < source_lines.size
           param_line = source_lines[line_index]
           index = 0
+          # An unterminated quote is a same-line artefact (a `#` comment, a
+          # triple-quoted opener), not a run that should swallow the rest of
+          # the header — reset with the line, as `python_delimiter_delta` does.
+          in_quote = nil
+          escaped = false
           next
         end
 
@@ -447,20 +497,106 @@ module Analyzer::Python
       1
     end
 
-    # Returns the literal value from a string if it represents a number or a quoted string
-    def return_literal_value(data : ::String) : ::String
-      # Check if the data is numeric
-      return data if data.numeric?
+    # FastAPI / django-ninja parameter markers. `q: str = Query("abc")` does
+    # not default `q` to the *object* `Query("abc")` — the marker is a
+    # declaration, and the default it carries is its first positional
+    # argument or its `default=` keyword.
+    PARAM_MARKER_CALLS = %w[Query Header Cookie Path Body Form File]
 
-      # Check if the data is a string
-      unless data.empty?
-        if data[0] == data[-1] && data[0].in?('"', '\'')
-          return data[1..-2]
+    # Python spellings for "there is no value here". `...` (Ellipsis) is how
+    # FastAPI marks a *required* parameter, so it is an absence too.
+    PYTHON_EMPTY_LITERALS = %w[None ... Ellipsis]
+
+    # Python's two triple-quote fences, spelled as an explicit array because
+    # `%w[""" ''']` reads as a `%w` element containing quote characters.
+    TRIPLE_QUOTE_FENCES = ["\"\"\"", "'''"]
+
+    # The request-ready value a Python parameter default evaluates to.
+    #
+    # Anything that is not a literal has no value, and returning the source
+    # text instead is worse than returning nothing: `value` is what the
+    # curl / httpie / PowerShell / Postman / OpenAPI builders put on the
+    # wire, so a leaked expression became `-H 'x_token: Header(None)'` and
+    # `?q=Query()`. Callers only ever ask this to turn a default into a
+    # value, so a non-literal answers with the empty string — the same thing
+    # a parameter with no default at all produces.
+    def return_literal_value(data : ::String) : ::String
+      python_literal_value(data) || ""
+    end
+
+    # The literal `expr` evaluates to, or nil when it is not a literal.
+    #
+    # Separate from `return_literal_value` because "not a literal" and "the
+    # empty string" are different answers here: `Query()` is not a literal
+    # (recurse no further), while `Query(None)` unwraps to one that happens
+    # to be empty.
+    private def python_literal_value(expr : ::String, depth : Int32 = 0) : ::String?
+      value = expr.strip
+      return if value.empty?
+      # Guards a pathological `Query(Query(Query(...)))`; real markers nest
+      # one deep at most.
+      return if depth > 4
+
+      # `to_f?` rather than the `String#numeric?` helper, which is
+      # monkey-patched onto ::String from inside `analyzers/python/fastapi.cr`
+      # — an engine must not depend on one of its analyzers having been
+      # required first.
+      return value if value.to_f?
+
+      TRIPLE_QUOTE_FENCES.each do |fence|
+        if value.size >= fence.size * 2 && value.starts_with?(fence) && value.ends_with?(fence)
+          return value[fence.size..-(fence.size + 1)]
         end
       end
 
-      data
+      if value.size >= 2 && value[0] == value[-1] && value[0].in?('"', '\'')
+        return value[1..-2]
+      end
+
+      # Python's booleans are `True`/`False`; the wire wants `true`/`false`.
+      return "true" if value == "True"
+      return "false" if value == "False"
+      return "" if PYTHON_EMPTY_LITERALS.includes?(value)
+
+      if inner = param_marker_default(value)
+        return python_literal_value(inner, depth + 1)
+      end
+
+      nil
     end
+
+    # The default expression carried by a `Query(...)` / `Header(...)` style
+    # marker call, or nil when `expr` is not one of those calls (or carries
+    # no default). `fastapi.Query(...)` and `params.Query(...)` count too.
+    private def param_marker_default(expr : ::String) : ::String?
+      return unless expr.ends_with?(')')
+      open = expr.index('(')
+      return unless open && open > 0
+
+      callee = expr[0, open].strip.split('.').last
+      return unless PARAM_MARKER_CALLS.includes?(callee)
+
+      args = expr[(open + 1)..-2]
+      return if args.blank?
+
+      positional = nil
+      Noir::TopLevelSplit.split(args, ',', Noir::TopLevelSplit::Rules::PYTHON).each do |raw|
+        arg = raw.strip
+        next if arg.empty?
+        # Matched rather than `includes?('=')` so `Query("a=b")` still reads
+        # as positional and `Query(default = 3)` still reads as a keyword.
+        if kwarg = KEYWORD_ARGUMENT_RE.match(arg)
+          return arg[kwarg[0].size..].strip if kwarg[1] == "default"
+          next
+        end
+        positional ||= arg
+      end
+
+      positional
+    end
+
+    # `name =` at the head of a call argument, excluding `==`/`>=`/`<=`/`!=`.
+    KEYWORD_ARGUMENT_RE = /\A([A-Za-z_]\w*)\s*=(?!=)/
 
     # `PackageType::FILE` / `PackageType::CODE` constants are now
     # canonical at `Noir::ImportGraph::Python::PackageType`. Aliasing

--- a/src/detector/detectors/javascript/express.cr
+++ b/src/detector/detectors/javascript/express.cr
@@ -2,9 +2,15 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Express < Detector
+    # No `basenames: %w[package.json]`: `"express": "^4.x"` in a manifest
+    # is not evidence of a hand-written Express app, because Feathers,
+    # Sails and NestJS all carry Express as a transitive dependency.
+    # Detection stays source-only. The declaration used to be there and
+    # was dead anyway — `detect` rejected every non-source filename — so
+    # dropping it changes no result, it just stops handing `package.json`
+    # to a `detect` that always answered false.
     detector_for "js_express",
-      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
-      basenames: %w[package.json]
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx]
 
     # Single precompiled alternation — one PCRE2 scan over the file
     # instead of up to four separate `.match` passes. Regex.union wraps
@@ -16,8 +22,14 @@ module Detector::Javascript
       /app\.use\(express\.urlencoded\(\{ extended: true \}\)\)/,
     )
 
+    # Mirrors the `extensions:` list above. The two drifted before: the
+    # gate admitted `.jsx`/`.tsx`, this guard did not, so a project whose
+    # only Express source was a `.jsx` file reported "No technologies
+    # detected" while the analyzer was perfectly able to parse it.
+    SOURCE_EXTENSIONS = %w[.js .mjs .cjs .jsx .ts .tsx]
+
     def detect(filename : String, file_contents : String) : Bool
-      return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") || filename.ends_with?(".cjs")
+      return false unless SOURCE_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
       content_matches?(file_contents, SIGNAL)
     end
   end

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -5,6 +5,7 @@ require "./extraction_result_cache"
 require "./import_graph"
 require "./java_route_extractor_ts"
 require "../utils/text_file"
+require "../utils/jvm_literal"
 
 module Noir
   # Tree-sitter-backed parameter extractor for Java/Spring.
@@ -973,7 +974,10 @@ module Noir
         json_body = effective_format == "json"
         fields.each do |field|
           next unless json_body || field.access_modifier == "public" || field.has_setter?
-          expanded_default = default_value || field.init_value
+          # `default_value` comes from an annotation and is already literal;
+          # `init_value` is raw Java source and only becomes a value when it
+          # is one. See `Noir::JvmLiteral`.
+          expanded_default = default_value || Noir::JvmLiteral.value_of(field.init_value)
           sink << Param.new(field.name, expanded_default, effective_format)
         end
       end

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -4,6 +4,7 @@ require "../models/code_locator"
 require "./extraction_result_cache"
 require "./import_graph"
 require "../utils/text_file"
+require "../utils/jvm_literal"
 
 module Noir
   # Tree-sitter-backed parameter extractor for Kotlin Spring.
@@ -92,10 +93,30 @@ module Noir
       getter null_validation_groups : Array(String)
       getter? server_managed : Bool
       getter validation_annotations : Array(String)
+      # True when `init_value` came from a `string_literal` node and was
+      # therefore already decoded (quotes stripped) on the way in.
+      getter? init_string_literal : Bool
 
       def initialize(@name, @access_modifier, @has_setter, @init_value,
                      @null_validation_groups = [] of String, @server_managed = false,
-                     @validation_annotations = [] of String)
+                     @validation_annotations = [] of String,
+                     @init_string_literal = false)
+      end
+
+      # The request-ready value of this field's initializer, or "" when the
+      # initializer is an expression with no literal form.
+      #
+      # `init_value` cannot be handed to `Noir::JvmLiteral.value_of` directly,
+      # because Kotlin's collector stores mixed shapes: a `string_literal` is
+      # decoded (`= "untitled"` -> `untitled`) while every other initializer
+      # keeps its raw source (`= LocalDateTime.now()`). A decoded string is
+      # indistinguishable from a bare identifier once stored, so running the
+      # literal check over it erased every string default in a Kotlin DTO.
+      # The flag is what tells the two apart. Java's collector keeps raw text
+      # throughout, which is why its call site passes `init_value` straight in.
+      def literal_default : String
+        return @init_value if @init_string_literal
+        Noir::JvmLiteral.value_of(@init_value)
       end
 
       def null_for_any_group?(groups : Array(String)) : Bool
@@ -692,12 +713,14 @@ module Noir
           next unless Noir::TreeSitter.node_type(param) == "class_parameter"
           name = ""
           init = ""
+          init_string = false
           Noir::TreeSitter.each_named_child(param) do |child|
             case Noir::TreeSitter.node_type(child)
             when "simple_identifier"
               name = Noir::TreeSitter.node_text(child, source) if name.empty?
             when "string_literal"
               init = decode_string_literal(child, source)
+              init_string = true
             when "user_type", "nullable_type", "binding_pattern_kind",
                  "modifiers", "parameter_modifiers", "annotation"
               # type / val|var marker / property annotations — not a
@@ -713,7 +736,8 @@ module Noir
           next if name.empty?
           fields << FieldInfo.new(
             name, "public", true, init, null_validation_groups(param, source),
-            server_managed_field?(param, source, name, init, class_name, class_text), validation_annotations(param, source)
+            server_managed_field?(param, source, name, init, class_name, class_text), validation_annotations(param, source),
+            init_string
           )
         end
       end
@@ -740,6 +764,7 @@ module Noir
             next if property_has_accessor?(member)
             name = ""
             init = ""
+            init_string = false
             Noir::TreeSitter.each_named_child(member) do |child|
               case Noir::TreeSitter.node_type(child)
               when "variable_declaration"
@@ -752,13 +777,17 @@ module Noir
               when "simple_identifier"
                 name = Noir::TreeSitter.node_text(child, source) if name.empty?
               when "string_literal"
-                init = decode_string_literal(child, source) if init.empty?
+                if init.empty?
+                  init = decode_string_literal(child, source)
+                  init_string = true
+                end
               end
             end
             next if name.empty?
             fields << FieldInfo.new(
               name, "public", true, init, null_validation_groups(member, source),
-              server_managed_field?(member, source, name, init, class_name, class_text), validation_annotations(member, source)
+              server_managed_field?(member, source, name, init, class_name, class_text), validation_annotations(member, source),
+              init_string
             )
             last_prop_name = name
           else
@@ -1043,7 +1072,14 @@ module Noir
             next if field.server_managed?
             next if field.null_for_any_group?(validation_groups)
             next unless json_body || field.access_modifier == "public" || field.has_setter?
-            expanded_default = default_value || field.init_value
+            # `default_value` is an annotation-supplied value
+            # (`@RequestParam(defaultValue = "all")`) and is already literal.
+            # A field initialiser only becomes a value when it is one —
+            # `var addedAt: LocalDateTime = LocalDateTime.now()` was
+            # publishing `{"addedAt":"LocalDateTime.now()"}`. See
+            # `FieldInfo#literal_default` for why `init_value` alone is not
+            # enough to decide that.
+            expanded_default = default_value || field.literal_default
             sink << param_from_field(field, expanded_default, effective_format)
           end
         end
@@ -1149,7 +1185,11 @@ module Noir
       if fields = class_fields[type_name]?
         fields.each do |field|
           next if field.server_managed?
-          push_unique_param(params, param_from_field(field, field.init_value, format))
+          # `literal_default`, not `init_value`: this inferred-body path
+          # (`req.awaitBody<Post>()`) fed the raw initialiser straight into
+          # `Param#value`, so it published `{"addedAt":"LocalDateTime.now()"}`
+          # while the annotated `@RequestBody` path above did not.
+          push_unique_param(params, param_from_field(field, field.literal_default, format))
         end
       elsif simple_bindable_param?(type_name)
         push_unique_param(params, Param.new("body", "", format))

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -920,16 +920,28 @@ module Noir
           next unless keys.includes?("value") || keys.includes?("name")
           return resolve_string_value(child, source, constants, current_class)
         elsif child_type == "element_value_pair"
-          key = ""
-          value : LibTreeSitter::TSNode? = nil
-          Noir::TreeSitter.each_named_child(child) do |sub|
-            case Noir::TreeSitter.node_type(sub)
-            when "identifier"
-              key = Noir::TreeSitter.node_text(sub, source) if key.empty?
-            else
-              value = sub if value.nil?
+          # Read the pair through its `key`/`value` fields rather than by
+          # walking named children and calling the first `identifier` the key.
+          # In `@QueryValue(defaultValue = CODE_DEFAULT)` the value is an
+          # `identifier` too, so the walk consumed the key, then skipped the
+          # constant reference as "another identifier" and left `value` nil —
+          # the pair was dropped and the resolved default (`"none"`) never
+          # reached the param.
+          key_node = Noir::TreeSitter.field(child, "key")
+          value = Noir::TreeSitter.field(child, "value")
+          key = key_node ? Noir::TreeSitter.node_text(key_node, source) : ""
+
+          if key.empty? || value.nil?
+            # Grammar without those fields: fall back to positional order —
+            # first named child is the key, second is the value.
+            seen = [] of LibTreeSitter::TSNode
+            Noir::TreeSitter.each_named_child(child) { |sub| seen << sub }
+            if seen.size >= 2
+              key = Noir::TreeSitter.node_text(seen[0], source)
+              value = seen[1]
             end
           end
+
           next unless keys.includes?(key) && value
           value_type = Noir::TreeSitter.node_type(value)
           return resolve_string_value(value, source, constants, current_class) if annotation_string_value_node?(value_type)

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -47,7 +47,17 @@ class NoirLogger
   def initialize(debug : Bool, verbose : Bool, colorize : Bool, no_log : Bool, no_spinner : Bool = false)
     @debug = debug
     @verbose = verbose
-    @color_mode = colorize
+    # Every glyph below is emitted as `.colorize(...).toggle(@color_mode)`,
+    # and `Colorize::Object#toggle` overwrites the enabled flag the object
+    # captured from `Colorize.enabled?` — so it bypasses Crystal's own
+    # "only on a terminal" default the same way it bypasses `NO_COLOR`.
+    # This logger writes to STDERR only, so gate on STDERR rather than on
+    # `Colorize.enabled?`, which also requires STDOUT to be a terminal and
+    # would drop the color from an interactive `noir scan . -f json > out`.
+    # Without this, `noir scan ./app 2> run.log` wrote `\e[32m✔\e[39m` into
+    # the log file — the same ANSI-into-a-pipe problem `OutputBuilder`
+    # already fixed for STDOUT, on the other stream.
+    @color_mode = colorize && Colorize.default_enabled?(STDERR)
     @no_log = no_log
     @no_spinner = no_spinner
     @spinner_active = false

--- a/src/options.cr
+++ b/src/options.cr
@@ -1,4 +1,5 @@
 require "./ai_context/features.cr"
+require "./cli/common.cr"
 require "./completions.cr"
 require "./output_builder/formats.cr"
 require "./config_initializer.cr"
@@ -678,6 +679,17 @@ def run_options_parser
     noir_options["ai_context_features"]?.try(&.to_s) || "",
     "config ai_context_features"
   )
+
+  # `NO_COLOR` has to land in `options["color"]`, not just in
+  # `Colorize.enabled`. The router already sets `Colorize.enabled = false`
+  # for it, but every colored string noir emits goes through
+  # `.colorize(...).toggle(@is_color)`, and `Colorize::Object#toggle`
+  # *overwrites* the global flag the object captured at construction. So
+  # `NO_COLOR=1 noir scan ./app` kept printing escape codes while
+  # `--no-color` worked, contradicting `noir help` ("NO_COLOR env also
+  # works"). Applied after the parser so it outranks a config file, and
+  # last so an explicit `--no-color` can only agree with it.
+  noir_options["color"] = YAML::Any.new(false) if Noir::CLI.no_color_env?
 
   noir_options
 end

--- a/src/passive_scan/detect.cr
+++ b/src/passive_scan/detect.cr
@@ -44,7 +44,7 @@ module NoirPassiveScan
             # secret. See NoirPassiveScan::FalsePositive for the invariant.
             unless FalsePositive.suppress?(rule, line)
               unless detected_logged
-                logger.sub "└── Detected: #{rule.info.name}"
+                logger.sub "├── Passive rule matched: #{rule.info.name}"
                 detected_logged = true
               end
               results << PassiveScanResult.new(rule, file_path, index + 1, line)
@@ -74,7 +74,7 @@ module NoirPassiveScan
               # secret. See NoirPassiveScan::FalsePositive.
               break if FalsePositive.suppress?(rule, line)
               unless detected_logged
-                logger.sub "└── Detected: #{rule.info.name}"
+                logger.sub "├── Passive rule matched: #{rule.info.name}"
                 detected_logged = true
               end
               results << PassiveScanResult.new(rule, file_path, index + 1, line)

--- a/src/utils/jvm_literal.cr
+++ b/src/utils/jvm_literal.cr
@@ -1,0 +1,53 @@
+module Noir
+  # The request-ready value a JVM-family (Java / Kotlin / Scala) default
+  # expression evaluates to.
+  #
+  # A field initialiser or route default is *source*, not a value, and
+  # `Param#value` is what every HTTP-shaped consumer puts on the wire — the
+  # curl / httpie / PowerShell builders, the `--data-raw` JSON body, and the
+  # OAS builders, which publish a non-empty value as an `enum` entry on the
+  # parameter. So a default that has no literal form has no value either, and
+  # passing the source text through produced things like
+  # `{"slug":"title.toSlug()"}`, `{"addedAt":"LocalDateTime.now()"}` and
+  # `/api/list-all?version=null`.
+  #
+  # Shared rather than per-analyzer because Kotlin's and Java's tree-sitter
+  # parameter extractors and both Play routes analyzers were each about to
+  # grow their own copy of the same three-line check, and two of them already
+  # had byte-identical `normalize_route_default_value` bodies.
+  module JvmLiteral
+    extend self
+
+    # Spellings of "no value": Java/Scala `null`, Kotlin/Scala `None`,
+    # Scala/Groovy `Nil`/`nil`, and the empty-optional factories.
+    ABSENT = %w[null None Nil nil Optional.empty Optional.empty() Option.empty Option.empty()]
+
+    # Numeric literal type suffixes (`10L`, `1.5f`, `2.0d`). Stripped before
+    # the numeric test so a suffixed literal is still recognised as one, and
+    # emitted without the suffix — `?page=10L` is not a page number.
+    NUMERIC_SUFFIXES = "LlFfDd"
+
+    # Returns "" when `expr` is not a literal. Callers store the result
+    # directly in `Param#value`, where "" already means "no value recorded".
+    def value_of(expr : String) : String
+      value = expr.strip
+      return "" if value.empty?
+      return "" if ABSENT.includes?(value)
+      return value if value == "true" || value == "false"
+
+      if value.size >= 2 && value[0] == value[-1] && value[0].in?('"', '\'')
+        return value[1..-2]
+      end
+
+      # `to_f?` rather than the `String#numeric?` helper: that one is
+      # monkey-patched onto ::String from inside `analyzers/python/fastapi.cr`,
+      # so depending on it here would make this module compile or not
+      # depending on which analyzer happened to be required first.
+      numeric = value.delete('_')
+      numeric = numeric[0..-2] if numeric.size > 1 && NUMERIC_SUFFIXES.includes?(numeric[-1])
+      return numeric if !numeric.empty? && numeric.to_f?
+
+      ""
+    end
+  end
+end


### PR DESCRIPTION
Found by building the tool and using it — on the repo's own fixtures plus ~15 hand-written apps — rather than by reading code. Each item below has a reproduction that failed before and passes now.

## 1. `.mjs` / `.cjs` route files were silently skipped

Every JS detector declares `extensions: %w[.js .mjs .cjs .jsx .ts .tsx]`; the analyzer default was `[".js", ".ts", ".jsx", ".tsx"]`. Detection and analysis read the same tree, so an extension a detector accepts and that list omits gives a project that detects fine and returns zero endpoints — no warning, and nothing for `--strict` to report.

```console
$ ls && noir scan . -f only-url --no-log
a.js  b.jsx  c.mjs  d.cjs        # each declares one express route
/from-js
/from-jsx                        # c.mjs and d.cjs silently dropped
```

Seven analyzers shared the hole: **express, fastify, hono, restify, apollo, graphql_yoga, socketio**. The ones passing their own list (koa, hapi, sails, adonisjs, elysia, feathers) already spelled `.mjs`/`.cjs` out by hand — so this was an oversight, not a policy. An ESM Express app (`app.mjs`) is the common case.

The Express detector had the mirror-image gap: its `detect` guard admitted `.js .mjs .ts .cjs` while its own gate admitted `.jsx`/`.tsx`, so a `.jsx`-only Express project reported "No technologies detected". Its `basenames: %w[package.json]` is dropped rather than made live — `detect` rejected every non-source filename so it was already dead, and `"express": "^4.x"` in a manifest is not evidence of a hand-written Express app (Feathers, Sails and NestJS all carry Express transitively).

## 2. Parameter values were raw source expressions

`Param#value` is what the curl / httpie / PowerShell builders put on the wire, what fills `--data-raw`, and what the OAS builders publish as an `enum`. A default with no literal form is not a value, and emitting its source text made the request wrong:

```
curl ... 'http://t/items/{id}?q=Query()'
curl ... -H 'x_token: Header(None)' --cookie 'session=Cookie(None)'
curl ... '/books/list/all?limit=Option[Int]'
curl ... '/api/list-all?version=null'
```

Across the fixture tree: **35 leaked values → 2**, and both survivors are legitimate (a Bruno `@file()`, a recorded HAR User-Agent). No legitimate value was lost.

- **Python** — `return_literal_value` returned its input verbatim when it was neither numeric nor quoted. It now answers `""` for a non-literal, maps `None`/`...` to empty and `True`/`False` to `true`/`false`, and *unwraps* FastAPI-style markers: `Query(False)` → `false`, `Header(default="hv")` → `hv`, with `Query("a=b")` still read as positional.
- **JVM** — one shared `Noir::JvmLiteral.value_of` replaces what would have been four copies of the same check; two of those sites already had byte-identical `normalize_route_default_value` bodies. Annotation-supplied defaults (`@RequestParam(defaultValue = "all")`) are already literal and pass through untouched.
- **tapir** stops publishing an input's Scala *type* as a query/header/cookie/path value. `body` keeps its DTO name — the convention javalin/ktor/akka/http4s/zio-http/helidon already follow.
- **laminas** keeps a route constraint only when it is metacharacter-free (`'format' => 'json'` matches exactly one string; `'[0-9]+'` does not).

### Two Python parameter-scanner bugs found on the way

Both lost **every** parameter of a function, with nothing logged:

- `{` / `}` contributed no depth, so `def s(tags: set = {"x", "y"}, after: str = "t")` split on the comma inside the braces and produced a parameter literally named `"y"}`.
- Nothing was quote-aware, so a delimiter inside a string default counted as structure — `"("` and `"["` left the depth permanently open, `"x,y"` split mid-literal, and an unguarded annotation-colon branch dropped every `:` at any depth (that is what mangled a multi-line `Cookie(openapi_examples={"Cookie One": {...}})` into `"Cookie One" {...}`). Quoted runs now follow `python_delimiter_delta`'s existing rules, and both depth counters clamp at zero like `TopLevelSplit::Rules::PYTHON`.

## 3. `NO_COLOR` was ignored, and logs were colored into a pipe

`noir help` promises "`--no-color` Strip ANSI color from every command's output (NO_COLOR env also works)". It did not — and `noir scan ./app 2> run.log` wrote `\e[32m✔\e[39m` into the file.

| lines containing ESC | piped | `NO_COLOR=1` | `--no-color` | tty |
|---|---|---|---|---|
| before | 10 | 10 | 0 | — |
| after | 0 | 0 | 0 | 35 |

One root cause behind both: every glyph is emitted as `.colorize(...).toggle(@color_mode)`, and `Colorize::Object#toggle` *overwrites* the enabled flag the object captured — so it bypasses the router's `Colorize.enabled = false` (all `NO_COLOR` set) exactly as it bypasses Crystal's own "only on a terminal" default. `NO_COLOR` now lands in `options["color"]`, and the logger gates on `Colorize.default_enabled?(STDERR)` — STDERR specifically, since that is the only stream it writes. `OutputBuilder` already had the STDOUT half right.

## 4. The functional tester never asserted `param.value`

Which is exactly how the leaks above lived in the fixture tree unnoticed: a tester could declare `Param.new("version", "null", "query")` and stay green while the emitted request really was `?version=null`.

A declared (non-empty) value is now asserted — **299 new assertions**. `""` stays the harness's established "not asserted" placeholder; most testers spell it for values that are derived and long (a GraphQL operation document, a JSON-RPC envelope), and rewriting 32 of those would have been noise. The other half of the hole — an analyzer leaking source text into a param a tester left blank — is covered directly, and far faster, by new unit specs for `return_literal_value`, the parameter scanner, and `JvmLiteral.value_of`.

### Three pre-existing analyzer gaps the assertion surfaced

Fixed rather than recorded as expected behaviour:

- **insomnia** dropped a declared `pathParameters` value: the URL scan runs first and registers `{userId}` with none, and `add_param` was strict first-wins, so the entry that actually had the data lost. Its `authentication` block also skipped `resolve_vars`, so `token: "{{ token }}"` emitted the literal `Bearer {{ token }}` instead of the credential its own `environments.data` defines.
- **micronaut** read an `element_value_pair` by walking named children and calling the first `identifier` the key. In `defaultValue = CODE_DEFAULT` the value is an identifier too, so it was skipped as "another identifier" and the pair dropped whole.
- **`.http` files** kept query names and discarded their values, so replaying an IntelliJ/VS Code request through `-f curl` produced `?q=` and dropped what to send.

A few tester expectations went the other way and encoded a misconception rather than behaviour — goyave expected the route regex `[0-9]+` as a value, kotlin expected `ipsum` for a cookie whose `defaultValue` is `"lorem"`, and plumber spelled roxygen `@param` *descriptions* as values. Those are corrected.

## 5. Minor: passive-scan hits read as detected technologies

```
⚬ Detecting technologies in the base directory.
  └── Detected: Detect GITHUB_TOKEN      ← a passive rule, not a tech
✔ Detected 1 technologies.
  └── js_express
```

Now `├── Passive rule matched: <rule>`, which also stops every hit rendering as a last-item `└──`.

## Verification

- `crystal spec` — **29376 examples, 0 failures** (up from 29060; +316 assertions)
- `ameba src/ spec/` — 2225 inspected, **0 failures**
- Full-fixture scan still finds **3180 endpoints** — no discovery regressions
- Also exercised while hunting: symlink loops, 2 MB single lines, 5000-deep nesting, unterminated strings, invalid UTF-8, binary-content `.js`, and all 22 output formats (JSON/JSONL/TOML/SARIF/OAS2/OAS3/Postman all validate; curl/httpie/PowerShell quoting and HTML escaping are correct against embedded quotes, shell metacharacters and `<script>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
