### PR TITLE
fix(analyzer): stop one line of source from erasing a file's routes

### DIFF
--- a/spec/functional_test/fixtures/clojure/compojure_char_literals/project.clj
+++ b/spec/functional_test/fixtures/clojure/compojure_char_literals/project.clj
@@ -1,0 +1,3 @@
+(defproject compojure-char-literals "0.1.0-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [compojure "1.7.1"]])

--- a/spec/functional_test/fixtures/clojure/compojure_char_literals/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure_char_literals/src/demo/core.clj
@@ -1,0 +1,19 @@
+(ns demo.core
+  (:require [compojure.core :refer [defroutes GET POST]]
+            [ring.util.response :as response]))
+
+;; Character literals sitting above the routes. `\(` is not an open paren,
+;; `\"` does not open a string, `\;` does not start a comment and `\\` is the
+;; backslash character itself rather than an escape — get any of them wrong
+;; and the reader loses track of depth, taking every route below with it.
+(defn render-row [row]
+  (let [open \( close \) quote-char \" semi \; back \\ nl \newline]
+    (formatter/render row open close quote-char semi back nl)))
+
+(defroutes app-routes
+  (GET "/rows" []
+    (response/ok (render-row (row.service/list))))
+
+  (POST "/rows" request
+    (let [sep \tab code \u00e9 oct \o101]
+      (response/created "/rows/1" (row.service/create! request sep code oct)))))

--- a/spec/functional_test/fixtures/csharp/lexer_repro/Controllers/ReproController.cs
+++ b/spec/functional_test/fixtures/csharp/lexer_repro/Controllers/ReproController.cs
@@ -26,5 +26,22 @@ namespace Demo.Controllers
         {
             return Ok(Compute(expr, limit));
         }
+
+        // BUG 3: a '{' char literal inside an interpolation hole must not desync method braces
+        [HttpGet("interp/{id}")]
+        public IActionResult Interp([FromRoute] int id)
+        {
+            var tag = $"{Chars['{']}";
+            SecretHelperCall(id);
+            AuditLog.Write("interp");
+            return Ok(SerializeOrder(tag));
+        }
+
+        [HttpPost("interp")]
+        public IActionResult InterpCreate([FromBody] string name)
+        {
+            var order = orderService.Create(name);
+            return Created("", SerializeOrder(order));
+        }
     }
 }

--- a/spec/functional_test/fixtures/javascript/express_regex_literal_state/app.js
+++ b/spec/functional_test/fixtures/javascript/express_regex_literal_state/app.js
@@ -1,0 +1,25 @@
+const express = require('express')
+const app = express()
+
+// A regex literal whose body contains a quote. The lexer used to read this
+// '/' as division, after which the quote opened a string token that ran to
+// end of file — every route in the file was lost.
+const hasQuote = (s) => /["']/.test(s)
+
+app.get('/users', (req, res) => res.json([hasQuote('a')]))
+
+app.post('/items', (req, res) => {
+  if (!/['"]/.test(req.body.name)) {
+    return res.status(400).json({})
+  }
+  return res.json({})
+})
+
+// No semicolons anywhere (StandardJS style). The chained-verb walk used to
+// stop only at a ';', so it ran on into the next statements and hung their
+// verbs on /profile as well.
+app.route('/profile')
+  .get((req, res) => res.json({}))
+
+app.post('/orders', (req, res) => res.json({}))
+app.delete('/carts', (req, res) => res.json({}))

--- a/spec/functional_test/fixtures/javascript/nestjs_regex_comment_state/users.controller.ts
+++ b/spec/functional_test/fixtures/javascript/nestjs_regex_comment_state/users.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Post } from '@nestjs/common';
+
+@Controller('users')
+export class UserController {
+  @Get()
+  findAll() {
+    return [];
+  }
+
+  // The regex body holds an unpaired quote. Without a regex state the
+  // comment stripper flipped into (and out of) string state for the rest of
+  // the file, which both un-blanked the commented-out decorator below and
+  // let the '/*' in a plain string open a block comment.
+  escape(str: string) { return str.replace(/'/g, '&#39;'); }
+
+  private readonly blockOpen = '/*';
+
+  // @Get('legacy-removed')
+  @Post('create')
+  create() { return {}; }
+}

--- a/spec/functional_test/fixtures/php/laravel_html_template/composer.json
+++ b/spec/functional_test/fixtures/php/laravel_html_template/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "laravel/laravel",
+    "type": "project",
+    "keywords": ["framework", "laravel"],
+    "require": {
+        "php": "^8.1",
+        "laravel/framework": "^10.10"
+    }
+}

--- a/spec/functional_test/fixtures/php/laravel_html_template/routes/web.php
+++ b/spec/functional_test/fixtures/php/laravel_html_template/routes/web.php
@@ -1,0 +1,37 @@
+<!doctype html>
+<h1>Today's report</h1>
+<p>That apostrophe used to open a PHP string literal that masked the rest of
+   the file, so every route declared below it disappeared.</p>
+<ul>
+  <li>It's a list</li>
+  <li>Don't stop</li>
+  <li>Can't hurt</li>
+</ul>
+<!-- A stray # and a // and a /* that never closes, plus a <<<EOT that is not
+     a heredoc opener: out here none of them are code. -->
+<div class="banner" data-note="unbalanced ' quote">
+  Route::get('/html-fake', 'FakeController@index');
+</div>
+<p>filler</p>
+<p>filler</p>
+<p>filler</p>
+<p>filler</p>
+<p>filler</p>
+<p>Here's the odd apostrophe that used to mask everything below.</p>
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/from-first-block', 'HomeController@index');
+
+?>
+<p>Between two PHP blocks, and it's still inert.</p>
+<?= route('/echo-tag-is-not-a-registration') ?>
+<p>Don't stop here either.</p>
+<?php
+
+Route::post('/after-html', 'ReportController@store');
+
+Route::group(['prefix' => 'admin'], function () {
+    Route::get('/widgets', 'WidgetController@index');
+});

--- a/spec/functional_test/testers/clojure/compojure_char_literals_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_char_literals_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Character literals (`\(`, `\"`, `\;`, `\\`, `\newline`, `\tab`, `\uXXXX`,
+# `\oNNN`) sit above and inside the routes. Reading them as raw characters
+# collapses the reader's depth accounting, which used to drop every route in
+# the file — so the whole point of this fixture is that both routes, with
+# their callees, still come out.
+rows_get = Endpoint.new("/rows", "GET")
+rows_get.push_callee(Callee.new("response/ok", line: 15))
+rows_get.push_callee(Callee.new("render-row", line: 15))
+rows_get.push_callee(Callee.new("row.service/list", line: 15))
+
+rows_post = Endpoint.new("/rows", "POST")
+rows_post.push_callee(Callee.new("response/created", line: 19))
+rows_post.push_callee(Callee.new("row.service/create!", line: 19))
+
+expected_endpoints = [
+  rows_get,
+  rows_post,
+]
+
+FunctionalTester.new("fixtures/clojure/compojure_char_literals/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/csharp/lexer_repro_spec.cr
+++ b/spec/functional_test/testers/csharp/lexer_repro_spec.cr
@@ -27,12 +27,29 @@ calc = Endpoint.new("/api/Repro/calc", "GET", [
 calc.push_callee(Callee.new("Ok", line: 27))
 calc.push_callee(Callee.new("Compute", line: 27))
 
+interp_get = Endpoint.new("/api/Repro/interp/{id}", "GET", [
+  Param.new("id", "", "path"),
+])
+interp_get.push_callee(Callee.new("SecretHelperCall", line: 35))
+interp_get.push_callee(Callee.new("AuditLog.Write", line: 36))
+interp_get.push_callee(Callee.new("Ok", line: 37))
+interp_get.push_callee(Callee.new("SerializeOrder", line: 37))
+
+interp_post = Endpoint.new("/api/Repro/interp", "POST", [
+  Param.new("name", "", "json"),
+])
+interp_post.push_callee(Callee.new("orderService.Create", line: 43))
+interp_post.push_callee(Callee.new("Created", line: 44))
+interp_post.push_callee(Callee.new("SerializeOrder", line: 44))
+
 FunctionalTester.new("fixtures/csharp/lexer_repro/", {
   :techs     => 1,
-  :endpoints => 2,
+  :endpoints => 4,
 }, [
   dirty,
   calc,
+  interp_get,
+  interp_post,
 ], {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/javascript/express_regex_literal_state_spec.cr
+++ b/spec/functional_test/testers/javascript/express_regex_literal_state_spec.cr
@@ -1,0 +1,32 @@
+require "../../func_spec.cr"
+
+# Two failures that both come from lexing JavaScript, in one semicolon-free
+# Express file:
+#
+#   * `(s) => /["']/.test(s)` and `if (!/['"]/.test(...))` — the lexer's
+#     regex-context check accepted only `( [ { , : ; =` and a keyword list,
+#     so the '/' after `=>` or `!` lexed as division. The quote inside the
+#     regex then opened a string token that ran to end of file and the scan
+#     reported zero endpoints for the whole file.
+#
+#   * `app.route('/profile').get(...)` written without semicolons — the
+#     chained-verb walk stopped only at a `;`, so it ran on through the
+#     following statements and reported POST /profile and DELETE /profile
+#     alongside the real POST /orders and DELETE /carts.
+#
+# The endpoint count is asserted so the two phantom /profile verbs cannot
+# come back unnoticed.
+expected_endpoints = [
+  Endpoint.new("/users", "GET"),
+  Endpoint.new("/items", "POST", [
+    Param.new("name", "", "json"),
+  ]),
+  Endpoint.new("/profile", "GET"),
+  Endpoint.new("/orders", "POST"),
+  Endpoint.new("/carts", "DELETE"),
+]
+
+FunctionalTester.new("fixtures/javascript/express_regex_literal_state/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/nestjs_regex_comment_state_spec.cr
+++ b/spec/functional_test/testers/javascript/nestjs_regex_comment_state_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+# `JSRouteExtractor.strip_js_comments` tracked `'`, `"` and backticks but had
+# no regex-literal state, so the unpaired quote in `str.replace(/'/g, ...)`
+# inverted the string state for the rest of the file. That cut both ways:
+#
+#   * real comments stopped being blanked, so the commented-out
+#     `// @Get('legacy-removed')` was reported as a live endpoint, and
+#   * real string bodies were scanned as code, so the `/*` in
+#     `blockOpen = '/*'` opened a block comment that blanked every route
+#     below it.
+#
+# Asserting the count pins the phantom route as much as the real ones.
+expected_endpoints = [
+  Endpoint.new("/users", "GET"),
+  Endpoint.new("/users/create", "POST"),
+]
+
+FunctionalTester.new("fixtures/javascript/nestjs_regex_comment_state/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/php/laravel_html_template_spec.cr
+++ b/spec/functional_test/testers/php/laravel_html_template_spec.cr
@@ -1,0 +1,36 @@
+require "../../func_spec.cr"
+
+# Laravel routes declared in a template-style `.php` file — HTML with islands
+# of code in it.
+#
+# Exercises the `<?php … ?>` mode machine in the shared `Noir::PhpLexer`:
+#   * The markup above the first open tag contains apostrophes ("Today's
+#     report"), a `#`, a `//`, an unclosed `/*` and a `<<<EOT`. Lexed as code,
+#     the first apostrophe opened a string literal that masked everything to
+#     EOF, so every route in the file was lost (false-negative recovery).
+#   * `?>` returns to HTML mode and `<?php` / `<?=` come back to code, so the
+#     routes in the second block are found too.
+#   * A route-shaped line sitting in the markup (`/html-fake`) is output text,
+#     not a registration, and must not surface (false-positive suppression).
+#     Neither must the `route(...)` URL helper inside the `<?=` echo tag.
+expected_endpoints = [
+  Endpoint.new("/from-first-block", "GET"),
+  Endpoint.new("/after-html", "POST"),
+  Endpoint.new("/admin/widgets", "GET"),
+]
+
+tester = FunctionalTester.new("fixtures/php/laravel_html_template/", {
+  :techs     => 2,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+tester.perform_tests
+
+# Blanking the HTML has to preserve its newlines: analyzers report `code_path`
+# lines from these offsets, so collapsing a 20-line header would slide every
+# reported line in the file.
+it "reports source lines below a 20-line HTML header unshifted" do
+  endpoints = tester.app.endpoints
+  endpoints.find! { |e| e.url == "/from-first-block" }.details.code_paths.first.line.should eq(25)
+  endpoints.find! { |e| e.url == "/after-html" }.details.code_paths.first.line.should eq(33)
+  endpoints.find! { |e| e.url == "/admin/widgets" }.details.code_paths.first.line.should eq(36)
+end

--- a/spec/unit_test/minilexer/js_lexer_spec.cr
+++ b/spec/unit_test/minilexer/js_lexer_spec.cr
@@ -151,5 +151,56 @@ describe Noir::JSLexer do
         tokens.map(&.type).should eq(expected_types)
       end
     end
+
+    it "identifies regex after operators the shared scanner accepts" do
+      # The lexer used to accept only `( [ { , : ; =` plus a keyword list,
+      # so `!`, the `>` of `=>`, `&&` and `||` all lexed the following `/`
+      # as division.
+      cases = {
+        "=> /abc/"    => [:assign, :unknown, :regex],
+        "! /abc/"     => [:unknown, :regex],
+        "&& /abc/"    => [:unknown, :unknown, :regex],
+        "|| /abc/"    => [:unknown, :unknown, :regex],
+        "? /abc/"     => [:unknown, :regex],
+        "return /a/g" => [:keyword, :regex],
+      }
+
+      cases.each do |code, expected_types|
+        lexer = Noir::JSLexer.new(code)
+        lexer.tokenize.map(&.type).should eq(expected_types)
+      end
+    end
+
+    it "keeps a quote-carrying regex out of the string state" do
+      # `(s) => /["']/.test(s)` — the unpaired quote inside the regex used
+      # to open a string token that ran to end of file, so every route
+      # below it disappeared.
+      code = <<-JS
+        const hasQuote = (s) => /["']/.test(s);
+        app.get('/users', h);
+        JS
+
+      tokens = Noir::JSLexer.new(code).tokenize
+      regex = tokens.find { |t| t.type == :regex }.should_not be_nil
+      # Regex value is the pattern, then \x00, then the flags.
+      regex.value.should eq("[\"']\x00")
+
+      # The route after it still lexes as its own statement.
+      tokens.select { |t| t.type == :string }.map(&.value).should eq(["/users"])
+    end
+
+    it "still treats a division that follows a value as an operator" do
+      {
+        "(a + b) / 2" => :rparen,
+        "arr[0] / 2"  => :rbracket,
+        "'a' / 2"     => :string,
+        "x.y / 2"     => :identifier,
+      }.each do |code, before_slash|
+        tokens = Noir::JSLexer.new(code).tokenize
+        slash_idx = tokens.index { |t| t.type == :operator && t.value == "/" }
+        slash_idx = slash_idx.should_not be_nil
+        tokens[slash_idx - 1].type.should eq(before_slash)
+      end
+    end
   end
 end

--- a/spec/unit_test/minilexer/scala_lexer_spec.cr
+++ b/spec/unit_test/minilexer/scala_lexer_spec.cr
@@ -111,17 +111,17 @@ describe Noir::ScalaLexer do
     # skewed the moment a paren falls on the wrong side of the split — so
     # these assert the lexer's own output rather than any endpoint count.
     it "keeps an interpolated string with a quoted hole as ONE string token" do
-      src = %q|val x = s"a ${cfg("k")} b"|
+      src = "val x = s\"a ${cfg(\"k\")} b\""
       lex = Noir::ScalaLexer.new(src)
 
       strings = lex.tokens.select { |t| t.kind == :string }
-      strings.map(&.value).should eq([%q|"a ${cfg("k")} b"|])
+      strings.map(&.value).should eq(["\"a ${cfg(\"k\")} b\""])
       # `k` used to leak out of the string and be lexed as an identifier.
       lex.tokens.select { |t| t.kind == :ident }.map(&.value).should eq(["val", "x", "s"])
     end
 
     it "keeps parenthesis depth balanced around an interpolated hole" do
-      src = %q|foo(s"${f("(")}")|
+      src = "foo(s\"${f(\"(\")}\")"
       lex = Noir::ScalaLexer.new(src)
 
       masked = lex.masked.join
@@ -132,7 +132,7 @@ describe Noir::ScalaLexer do
     end
 
     it "does not treat `${` inside a plain (non-interpolated) string as a hole" do
-      src = %q|val x = "${cfg("k")}"|
+      src = "val x = \"${cfg(\"k\")}\""
       lex = Noir::ScalaLexer.new(src)
 
       # No interpolator prefix, so `"${cfg("` really is the whole literal and
@@ -141,7 +141,7 @@ describe Noir::ScalaLexer do
     end
 
     it "treats `$$` as an escaped dollar rather than the start of a hole" do
-      src = %q|val x = s"$${literal} tail"|
+      src = "val x = s\"$${literal} tail\""
       lex = Noir::ScalaLexer.new(src)
 
       lex.tokens.count { |t| t.kind == :string }.should eq(1)
@@ -159,11 +159,11 @@ describe Noir::ScalaLexer do
     end
 
     it "leaves the short `$ident` form as plain string content" do
-      src = %q|val u = s"/api/$version/users"|
+      src = "val u = s\"/api/$version/users\""
       lex = Noir::ScalaLexer.new(src)
 
-      lex.code_lines[0].should eq(%q|val u = s"/api/$version/users"|)
-      lex.tokens.select { |t| t.kind == :string }.map(&.value).should eq([%q|"/api/$version/users"|])
+      lex.code_lines[0].should eq("val u = s\"/api/$version/users\"")
+      lex.tokens.select { |t| t.kind == :string }.map(&.value).should eq(["\"/api/$version/users\""])
     end
   end
 end

--- a/spec/unit_test/minilexer/scala_lexer_spec.cr
+++ b/spec/unit_test/minilexer/scala_lexer_spec.cr
@@ -101,4 +101,69 @@ describe Noir::ScalaLexer do
       tokens[-1].line.should eq(2)
     end
   end
+
+  describe "string interpolation holes" do
+    # There was no interpolation state at all: the first `"` inside `${…}`
+    # closed the literal, so the hole's expression was lexed as code and the
+    # next `"` re-opened a string. Nothing observable broke today (the Scala
+    # analyzers key on braces, and in the simple case both stray parens
+    # happened to land inside one of the two string spans), but the depth is
+    # skewed the moment a paren falls on the wrong side of the split — so
+    # these assert the lexer's own output rather than any endpoint count.
+    it "keeps an interpolated string with a quoted hole as ONE string token" do
+      src = %q|val x = s"a ${cfg("k")} b"|
+      lex = Noir::ScalaLexer.new(src)
+
+      strings = lex.tokens.select { |t| t.kind == :string }
+      strings.map(&.value).should eq([%q|"a ${cfg("k")} b"|])
+      # `k` used to leak out of the string and be lexed as an identifier.
+      lex.tokens.select { |t| t.kind == :ident }.map(&.value).should eq(["val", "x", "s"])
+    end
+
+    it "keeps parenthesis depth balanced around an interpolated hole" do
+      src = %q|foo(s"${f("(")}")|
+      lex = Noir::ScalaLexer.new(src)
+
+      masked = lex.masked.join
+      masked.count('(').should eq(1)
+      masked.count(')').should eq(1)
+      lex.tokens.map(&.kind).count(:lparen).should eq(1)
+      lex.tokens.map(&.kind).count(:rparen).should eq(1)
+    end
+
+    it "does not treat `${` inside a plain (non-interpolated) string as a hole" do
+      src = %q|val x = "${cfg("k")}"|
+      lex = Noir::ScalaLexer.new(src)
+
+      # No interpolator prefix, so `"${cfg("` really is the whole literal and
+      # `k` really is code — same as before, and as Scala reads it.
+      lex.tokens.select { |t| t.kind == :ident }.map(&.value).should eq(["val", "x", "k"])
+    end
+
+    it "treats `$$` as an escaped dollar rather than the start of a hole" do
+      src = %q|val x = s"$${literal} tail"|
+      lex = Noir::ScalaLexer.new(src)
+
+      lex.tokens.count { |t| t.kind == :string }.should eq(1)
+      lex.tokens.map(&.kind).should_not contain(:lbrace)
+    end
+
+    it "tracks holes in a triple-quoted interpolated string too" do
+      src = "val x = s\"\"\"a ${f(\"\"\"b\"\"\")} c\"\"\"\npath(\"real\")"
+      lex = Noir::ScalaLexer.new(src)
+
+      lex.code_lines[0].includes?("b").should be_false # inside the triple quote
+      lex.code_lines[1].should eq("path(\"real\")")
+      lex.masked.join.count('(').should eq(1) # only `path(`
+      lex.masked.join.count(')').should eq(1)
+    end
+
+    it "leaves the short `$ident` form as plain string content" do
+      src = %q|val u = s"/api/$version/users"|
+      lex = Noir::ScalaLexer.new(src)
+
+      lex.code_lines[0].should eq(%q|val u = s"/api/$version/users"|)
+      lex.tokens.select { |t| t.kind == :string }.map(&.value).should eq([%q|"/api/$version/users"|])
+    end
+  end
 end

--- a/spec/unit_test/miniparser/adonisjs_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/adonisjs_extractor_ts_spec.cr
@@ -101,4 +101,47 @@ describe Noir::TreeSitterAdonisJsExtractor do
     routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source, include_callees: true)
     routes.first.callees.map(&.[0]).should contain("UsersController.index")
   end
+
+  it "accepts a backtick template-literal route path" do
+    source = <<-TS
+      Route.get(`/users`, 'UsersController.show')
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/users"}])
+  end
+
+  # Regression: `string_argument_at` used to index among string nodes only,
+  # so a template literal at position 0 was invisible and the controller
+  # string slid onto index 0 — reporting `GET /UsersController.show`, a URL
+  # that exists nowhere in the app, while the real route vanished.
+  it "does not fabricate a URL from the controller argument of a template-literal route" do
+    source = <<-TS
+      Route.group(() => {
+          Route.get(`/users/${'x'}`, 'UsersController.show')
+      }).prefix('/api/v1')
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source, include_callees: true)
+    routes.map(&.path).should_not contain("/api/v1/UsersController.show")
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/api/v1/users/{'x'}"}])
+    routes.first.callees.map(&.[0]).should contain("UsersController.show")
+  end
+
+  it "keeps a template-literal substitution as a `{expr}` path placeholder" do
+    source = <<-TS
+      Route.get(`/users/${id}/posts`, 'PostsController.index')
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/users/{id}/posts"}])
+  end
+
+  it "does not promote a later string when the first argument is not a literal" do
+    source = <<-TS
+      Route.get(routePath, 'UsersController.show')
+      TS
+
+    Noir::TreeSitterAdonisJsExtractor.extract_routes(source).should be_empty
+  end
 end

--- a/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
@@ -124,4 +124,53 @@ describe Noir::ClojureCalleeExtractor do
     ])
     callees["ignored"].map(&.[0]).should eq(["safe/run!"])
   end
+
+  it "reads character literals instead of letting them open strings or forms" do
+    # Every reader-significant character literal: `\"` must not open a string
+    # that runs to the next quote in the file, `\(` must not count as an open
+    # paren, `\;` must not start a comment, and `\\` is the backslash character
+    # itself — it does not escape the `]` after it.
+    body = <<-CLJ
+      (let [q \\" open \\( semi \\; back \\\\]
+        (render/quote q open semi back))
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.callees_for_body(body, "core.clj", 5)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"render/quote", 6},
+    ])
+  end
+
+  it "reads named, unicode and octal character literals as whole tokens" do
+    # `\newline` must be consumed whole; leaving `ewline` behind would read it
+    # as a symbol and `(ewline ...)` style breakage follows.
+    body = <<-'CLJ'
+      (let [nl \newline sp \space tab \tab ff \formfeed
+            bs \backspace cr \return u \u00e9 o \o101]
+        (render/join nl sp tab ff bs cr u o))
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.callees_for_body(body, "core.clj", 1)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"render/join", 3},
+    ])
+  end
+
+  it "keeps collecting callees in a defn body that follows a character literal" do
+    source = <<-CLJ
+      (ns demo.core)
+
+      (defn alpha-handler [request]
+        (let [quote-char \\"]
+          (render-alpha request quote-char)))
+
+      (defn beta-handler [request]
+        (render-beta request))
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.function_callees(source, "core.clj")
+
+    callees["alpha-handler"].map(&.[0]).should eq(["render-alpha"])
+    callees["beta-handler"].map(&.[0]).should eq(["render-beta"])
+  end
 end

--- a/spec/unit_test/miniparser/clojure_scanner_spec.cr
+++ b/spec/unit_test/miniparser/clojure_scanner_spec.cr
@@ -1,0 +1,75 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/clojure_scanner"
+
+# `skip_char_literal` returns the offset of the literal's last byte, so the
+# whole token it consumed is `source[0..result]`.
+private def read_char_literal(source : String) : String
+  last = Noir::ClojureScanner.skip_char_literal(source, 0, source.bytesize)
+  source.byte_slice(0, last + 1)
+end
+
+describe Noir::ClojureScanner do
+  describe "skip_char_literal" do
+    it "reads a single-character literal, reader-significant characters included" do
+      read_char_literal("\\a rest").should eq("\\a")
+      read_char_literal("\\\" rest").should eq("\\\"")
+      read_char_literal("\\( rest").should eq("\\(")
+      read_char_literal("\\) rest").should eq("\\)")
+      read_char_literal("\\; rest").should eq("\\;")
+    end
+
+    it "ends a backslash literal at the backslash instead of escaping what follows" do
+      # In a character literal `\\` *is* the backslash character; unlike a
+      # string escape it does not swallow the character after it.
+      read_char_literal("\\\\ rest").should eq("\\\\")
+      read_char_literal("\\\\\"").should eq("\\\\")
+    end
+
+    it "reads the whole named literal, not just two characters" do
+      # `\newline` must not leave `ewline` behind to be read as a symbol.
+      read_char_literal("\\newline)").should eq("\\newline")
+      read_char_literal("\\space]").should eq("\\space")
+      read_char_literal("\\tab ").should eq("\\tab")
+      read_char_literal("\\formfeed ").should eq("\\formfeed")
+      read_char_literal("\\backspace ").should eq("\\backspace")
+      read_char_literal("\\return ").should eq("\\return")
+    end
+
+    it "reads unicode and octal literals whole" do
+      read_char_literal("\\u00e9 ").should eq("\\u00e9")
+      read_char_literal("\\o101)").should eq("\\o101")
+    end
+
+    it "stops at the range limit without running past it" do
+      Noir::ClojureScanner.skip_char_literal("\\", 0, 1).should eq(0)
+      # `\newline` clipped to `\new` by the caller's limit.
+      Noir::ClojureScanner.skip_char_literal("\\newline", 0, 4).should eq(3)
+    end
+  end
+
+  describe "find_matching_delimiter" do
+    it "does not count a `\\(` character literal as an open paren" do
+      source = "(let [open \\(] open)"
+      Noir::ClojureScanner.find_matching_delimiter(source, 0, '(', ')', source.bytesize)
+        .should eq(source.bytesize - 1)
+    end
+
+    it "does not let a quote character literal open a string" do
+      source = "(let [q \\\"] (str q \"x\"))"
+      Noir::ClojureScanner.find_matching_delimiter(source, 0, '(', ')', source.bytesize)
+        .should eq(source.bytesize - 1)
+    end
+
+    it "does not let a `\\;` character literal start a comment" do
+      source = "(let [semi \\;] semi)"
+      Noir::ClojureScanner.find_matching_delimiter(source, 0, '(', ')', source.bytesize)
+        .should eq(source.bytesize - 1)
+    end
+
+    it "still treats a real `;` comment and a real string as opaque" do
+      source = "(do ; )\n  \"( ; \")"
+      Noir::ClojureScanner.find_matching_delimiter(source, 0, '(', ')', source.bytesize)
+        .should eq(source.bytesize - 1)
+    end
+  end
+end

--- a/spec/unit_test/miniparser/cpp_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/cpp_callee_extractor_spec.cr
@@ -74,4 +74,162 @@ describe Noir::CppCalleeExtractor do
     block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, 0)
     block.should be_nil
   end
+
+  it "does not let a raw string literal close the enclosing block" do
+    source = <<-CPP
+      CROW_ROUTE(app, "/alpha")
+      ([](const crow::request& req) {
+          auto body = std::string(R"(it says " and })");
+          alphaHelper(body);
+          return crow::response(200);
+      });
+      CPP
+
+    block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, 0)
+    block.should_not be_nil
+    block.try do |found_block|
+      body, start_line = found_block
+      Noir::CppCalleeExtractor.callees_for_body(body, "app.cpp", start_line).map(&.[0]).should eq([
+        "std::string",
+        "alphaHelper",
+        "crow::response",
+      ])
+    end
+  end
+
+  it "terminates a delimited raw string only on its own )delim sequence" do
+    source = <<-CPP
+      CROW_ROUTE(app, "/xyz")
+      ([](const crow::request& req) {
+          auto body = R"xyz(nested )" still inside } here)xyz";
+          xyzHelper(body);
+          return crow::response(200);
+      });
+      CPP
+
+    block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, 0)
+    block.should_not be_nil
+    block.try do |found_block|
+      body, start_line = found_block
+      Noir::CppCalleeExtractor.callees_for_body(body, "app.cpp", start_line).map(&.[0]).should eq([
+        "xyzHelper",
+        "crow::response",
+      ])
+    end
+  end
+
+  it "handles a multi-line raw string body without emitting phantom callees" do
+    body = <<-CPP
+      auto doc = R"json({
+        "ghost": Ghost::call(),
+        "brace": "}"
+      })json";
+      realHelper(doc);
+      CPP
+
+    Noir::CppCalleeExtractor.callees_for_body(body, "app.cpp", 1).map(&.[0]).should eq([
+      "realHelper",
+    ])
+  end
+
+  it "keeps encoding-prefixed raw strings and plain strings apart" do
+    source = <<-CPP
+      handler([] {
+          auto wide = LR"(a } b)";
+          auto utf8 = u8R"(c } d)";
+          Kept::call();
+      });
+      CPP
+
+    block = Noir::CppCalleeExtractor.extract_block_after(source, 0)
+    block.should_not be_nil
+    block.try do |found_block|
+      body, start_line = found_block
+      Noir::CppCalleeExtractor.callees_for_body(body, "app.cpp", start_line).map(&.[0]).should eq([
+        "Kept::call",
+      ])
+    end
+  end
+
+  it "degrades an unterminated raw string to the end of the source" do
+    source = <<-CPP
+      handler([] {
+          auto broken = R"(never closed } "
+          Lost::call();
+      });
+      CPP
+
+    Noir::CppCalleeExtractor.extract_block_after(source, 0).should be_nil
+    Noir::CppCalleeExtractor.callees_for_body(source, "app.cpp", 1).map(&.[0]).should eq([
+      "handler",
+    ])
+  end
+
+  it "treats a C++14 decimal digit separator as part of the number" do
+    source = <<-CPP
+      CROW_ROUTE(app, "/beta")
+      ([](const crow::request& req) {
+          int limit = 1'000;
+          betaHelper(limit);
+          return crow::response(200);
+      });
+      CPP
+
+    block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, 0)
+    block.should_not be_nil
+    block.try do |found_block|
+      body, start_line = found_block
+      Noir::CppCalleeExtractor.callees_for_body(body, "app.cpp", start_line).map(&.[0]).should eq([
+        "betaHelper",
+        "crow::response",
+      ])
+    end
+  end
+
+  it "treats a hex digit separator as part of the number" do
+    source = <<-CPP
+      CROW_ROUTE(app, "/gamma")
+      ([](const crow::request& req) {
+          unsigned mask = 0x1'F;
+          gammaHelper(mask);
+          return crow::response(200);
+      });
+      CPP
+
+    block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, 0)
+    block.should_not be_nil
+    block.try do |found_block|
+      body, start_line = found_block
+      Noir::CppCalleeExtractor.callees_for_body(body, "app.cpp", start_line).map(&.[0]).should eq([
+        "gammaHelper",
+        "crow::response",
+      ])
+    end
+  end
+
+  it "still lexes char literals that follow an encoding prefix" do
+    body = <<-CPP
+      char sep = L'}';
+      char16_t u = u'}';
+      Real::call();
+      CPP
+
+    Noir::CppCalleeExtractor.callees_for_body(body, "app.cpp", 1).map(&.[0]).should eq([
+      "Real::call",
+    ])
+  end
+
+  it "strips comments without desynchronizing on raw strings or digit separators" do
+    source = <<-CPP
+      auto a = R"(// not a comment )";
+      int n = 1'000; // dropped
+      Kept::call();
+      CPP
+
+    stripped = Noir::CppCalleeExtractor.strip_comments(source)
+    stripped.bytesize.should eq(source.bytesize)
+    stripped.includes?("// not a comment").should be_true
+    stripped.includes?("dropped").should be_false
+    stripped.includes?("Kept::call").should be_true
+  end
 end

--- a/spec/unit_test/miniparser/csharp_lexer_spec.cr
+++ b/spec/unit_test/miniparser/csharp_lexer_spec.cr
@@ -50,11 +50,50 @@ describe Noir::CSharpLexer do
     it "blanks a char literal so a brace char is not counted" do
       Noir::CSharpLexer.new("c = '}'; d = '\\''; e();").masked_lines[0].count('}').should eq(0)
     end
+
+    it "handles char literals inside an interpolation hole" do
+      cases = [
+        "var s = $\"{Chars['{']}\"; after();",
+        "var s = $\"{Chars['}']}\"; after();",
+        "var s = $\"{Chars['\"']}\"; after();",
+        "var s = $\"{Chars['a']}\"; after();",
+        "var s = $\"{Chars['\\'']}\"; after();",
+        "var s = $\"{Chars['\\\\']}\"; after();",
+        "var s = $\"{Chars['\\n']}\"; after();",
+        "var s = $\"{Chars['\\0']}\"; after();",
+        "var s = $\"{Chars['\\x41']}\"; after();",
+        "var s = $\"{Chars['\\u0041']}\"; after();",
+        "var s = $@\"{Chars['{']}\"; after();",
+        "var s = @$\"{Chars['{']}\"; after();",
+      ]
+      cases.each do |src|
+        lex = Noir::CSharpLexer.new(src)
+        lex.in_code?(src.index!("after")).should be_true
+        lex.masked_lines[0].count('{').should eq(0)
+        lex.masked_lines[0].count('}').should eq(0)
+      end
+    end
+
+    it "handles comments inside an interpolation hole" do
+      src1 = "var s = $\"{\n// comment with { and } and \"\nfoo()\n}\"; after();"
+      lex1 = Noir::CSharpLexer.new(src1)
+      lex1.in_code?(src1.index!("after")).should be_true
+
+      src2 = "var s = $\"{ /* comment { \" } */ foo() }\"; after();"
+      lex2 = Noir::CSharpLexer.new(src2)
+      lex2.in_code?(src2.index!("after")).should be_true
+    end
   end
 
   describe "#matching_delimiter" do
     it "closes a method block past a `}` inside a string" do
       src = "{ var j = T(\"a } b\"); More(); }"
+      lex = Noir::CSharpLexer.new(src)
+      lex.matching_delimiter(src.index!('{')).should eq(src.size - 1)
+    end
+
+    it "closes a method block past a char literal inside an interpolated string" do
+      src = "{ var tag = $\"{ Chars['{'] }\"; More(); }"
       lex = Noir::CSharpLexer.new(src)
       lex.matching_delimiter(src.index!('{')).should eq(src.size - 1)
     end

--- a/spec/unit_test/miniparser/elysia_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/elysia_extractor_ts_spec.cr
@@ -111,4 +111,24 @@ describe Noir::TreeSitterElysiaExtractor do
     routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
     routes.first.query_params.should eq(["filter"])
   end
+
+  # Regression: the route/group path gates matched node type "string" only,
+  # so every backtick path was invisible and the route was dropped.
+  it "accepts backtick template-literal route and group paths" do
+    source = <<-TS
+      const app = new Elysia()
+          .group(`/api/v1`, (app) =>
+              app
+                  .get(`/health`, () => 'ok')
+                  .post(`/users/${id}`, ({ body }) => body)
+          )
+          .listen(3000)
+      TS
+
+    routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"GET", "/api/v1/health"},
+      {"POST", "/api/v1/users/{id}"},
+    ].sort)
+  end
 end

--- a/spec/unit_test/miniparser/hapi_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/hapi_extractor_ts_spec.cr
@@ -106,4 +106,32 @@ describe Noir::TreeSitterHapiExtractor do
     routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
     routes.should be_empty
   end
+
+  # Regression: the `path:` gate matched node type "string" only, so a route
+  # object written with a backtick path produced no endpoint at all.
+  it "accepts a backtick template-literal path value" do
+    source = <<-JS
+      server.route({
+          method: 'GET',
+          path: `/users`,
+          handler: (request, h) => []
+      });
+      JS
+
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/users"}])
+  end
+
+  it "keeps a template-literal substitution as a `{expr}` path placeholder" do
+    source = <<-JS
+      server.route({
+          method: 'POST',
+          path: `/users/${id}/roles`,
+          handler: (request, h) => {}
+      });
+      JS
+
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"POST", "/users/{id}/roles"}])
+  end
 end

--- a/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
@@ -132,4 +132,48 @@ describe Noir::HaskellCalleeExtractor do
       {"invalidArgs", 65},
     ])
   end
+
+  # Regression: a `'` glued to an identifier matched the <= 8 character
+  # char-literal heuristic, so `xs' <- go' 1` was masked from the first
+  # prime to the second — `go'` disappeared and the leftover `xs` was
+  # reported as a phantom callee.
+  it "treats a prime as part of the identifier, not the start of a char literal" do
+    body = <<-HASKELL
+      do
+        xs' <- go' 1
+        pure xs'
+      HASKELL
+
+    callees = Noir::HaskellCalleeExtractor.callees_for_body(body, "Handler/Home.hs", 10)
+    names = callees.map { |name, _, _| name }
+    names.should contain("go'")
+    names.should_not contain("xs")
+  end
+
+  it "handles a primed identifier sitting next to a real char literal" do
+    body = <<-HASKELL
+      do
+        xs' <- splitOn' ','
+        render' xs'
+      HASKELL
+
+    callees = Noir::HaskellCalleeExtractor.callees_for_body(body, "Handler/Home.hs", 20)
+    names = callees.map { |name, _, _| name }
+    # The primes belong to the identifiers; `','` is preceded by a space, so
+    # it is still a genuine char literal and stays masked.
+    names.should eq(["splitOn'", "render'"])
+  end
+
+  it "keeps the prime on a primed top-level function name" do
+    source = <<-HASKELL
+      module Handler.Home where
+
+      getHomeR' :: Handler Html
+      getHomeR' = do
+        pure ()
+      HASKELL
+
+    bodies = Noir::HaskellCalleeExtractor.function_bodies(source, "Handler/Home.hs")
+    bodies.map { |body| body[:name] }.should eq(["getHomeR'"])
+  end
 end

--- a/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
@@ -198,4 +198,40 @@ describe Noir::TreeSitterHttp4kExtractor do
       {"QUERY", "/items"},
     ])
   end
+
+  it "ignores a commented-out const val shadowing the live declaration" do
+    # `constants[name] ||= value` is first-wins, and the declaration regex used
+    # to run over the raw source: a dead constant left above the real one
+    # permanently shadowed it, so every route built from it reported a URL that
+    # does not exist while the real one was lost.
+    source = <<-KT
+      package com.example
+
+      import org.http4k.core.Method.GET
+      import org.http4k.core.Response
+      import org.http4k.core.Status.Companion.OK
+      import org.http4k.routing.bind
+      import org.http4k.routing.routes
+
+      object Paths {
+          // deprecated: const val API = "/old-api"
+          /* const val API = "/older-api" */
+          const val API = "/api"
+      }
+
+      val app = routes(
+          Paths.API bind routes(
+              "/users" bind GET to { req -> Response(OK) }
+          )
+      )
+      KT
+
+    constants = Noir::TreeSitterHttp4kExtractor.extract_string_constants(source)
+    constants["Paths.API"].should eq("/api")
+
+    routes = Noir::TreeSitterHttp4kExtractor.extract_routes(source, constants)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/users"},
+    ])
+  end
 end

--- a/spec/unit_test/miniparser/java_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/java_route_extractor_ts_spec.cr
@@ -525,4 +525,41 @@ describe Noir::TreeSitterJavaRouteExtractor do
     missing = expected.reject { |e| found.includes?(e) }
     missing.should be_empty
   end
+
+  it "reads implements/extends from the AST so a brace in a class annotation cannot truncate the header" do
+    # `@RequestMapping({"/api"})` and `@CrossOrigin(origins = {...})` put a
+    # `{` in the class node's text *before* `implements`. The header used to
+    # be cut at the first `{` on the assumption it opened the class body, so
+    # neither the interface nor the superclass was ever seen and every
+    # inherited route silently vanished.
+    source = <<-JAVA
+      package com.example;
+
+      @RequestMapping("/catalog")
+      public interface CatalogApi {
+          @GetMapping("/{id}")
+          Catalog getCatalog(@PathVariable("id") String id);
+      }
+
+      @RequestMapping("/base")
+      public abstract class BaseController {
+          @DeleteMapping("/purge")
+          void purge();
+      }
+
+      @RestController
+      @CrossOrigin(origins = {"https://a.example", "https://b.example"})
+      @RequestMapping({"/api"})
+      public class CatalogController extends BaseController implements CatalogApi {}
+      JAVA
+
+    implementations = [] of Noir::TreeSitterJavaRouteExtractor::ControllerInterfaceImplementation
+    Noir::TreeSitter.parse_java(source) do |root|
+      implementations = Noir::TreeSitterJavaRouteExtractor.extract_controller_interface_implementations_from(root, source)
+    end
+
+    implementations.map { |i| {i.class_name, i.interface_names, i.paths} }.should eq([
+      {"CatalogController", ["CatalogApi", "BaseController"], ["/api"]},
+    ])
+  end
 end

--- a/spec/unit_test/miniparser/jaxrs_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/jaxrs_extractor_ts_spec.cr
@@ -462,4 +462,73 @@ describe Noir::TreeSitterJaxRsExtractor do
       {"GET", "/search/status", [] of Param},
     ])
   end
+
+  it "reads implements/extends from the AST so a brace in a class annotation cannot truncate the header" do
+    # `@Produces({MediaType.APPLICATION_JSON})` is the canonical JAX-RS
+    # spelling and puts a `{` in the class node's text before `implements`.
+    # The header used to be cut at the first `{` on the assumption it opened
+    # the class body, so the interface was never seen and every inherited
+    # route silently vanished.
+    source = <<-JAVA
+      package com.example.api;
+
+      import jakarta.ws.rs.GET;
+      import jakarta.ws.rs.POST;
+      import jakarta.ws.rs.Path;
+      import jakarta.ws.rs.PathParam;
+      import jakarta.ws.rs.Produces;
+      import jakarta.ws.rs.core.MediaType;
+      import jakarta.ws.rs.core.Response;
+
+      @Path("/catalog")
+      public interface CatalogApi {
+          @GET
+          @Path("/{id}")
+          Response show(@PathParam("id") String id);
+      }
+
+      @Produces({MediaType.APPLICATION_JSON})
+      @Path("/api")
+      public class CatalogResource implements CatalogApi {
+          public Response show(String id) {
+              return Response.ok().build();
+          }
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJaxRsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/catalog/{id}"},
+    ])
+  end
+
+  it "reads the superclass from the AST even behind a brace-carrying annotation" do
+    source = <<-JAVA
+      package com.example.api;
+
+      import jakarta.ws.rs.GET;
+      import jakarta.ws.rs.Path;
+      import jakarta.ws.rs.Produces;
+      import jakarta.ws.rs.core.MediaType;
+      import jakarta.ws.rs.core.Response;
+
+      public abstract class BaseResource {
+          @GET
+          @Path("/ping")
+          public Response ping() {
+              return Response.ok().build();
+          }
+      }
+
+      @Produces({MediaType.APPLICATION_JSON})
+      @Path("/api")
+      public class PingResource extends BaseResource {
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJaxRsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/ping"},
+    ])
+  end
 end

--- a/spec/unit_test/miniparser/js_http_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_http_route_extractor_spec.cr
@@ -77,5 +77,26 @@ describe Noir::JSHttpRouteExtractor do
       ep.params.map(&.name).should eq(["filter"])
       ep.params.map(&.param_type).should eq(["json"])
     end
+
+    it "finds a named handler declared with a non-ASCII type annotation" do
+      # The handler offset was computed as `match.begin(0) + match[0].bytesize`,
+      # mixing a char index with a byte length. Any multi-byte character in
+      # the declaration pushed the offset past the handler body and the
+      # route disappeared entirely.
+      code = <<-TS
+        import { createServer } from 'node:http';
+
+        const handler: 요청핸들러 = function (req, res) {
+          if (req.url === '/api/status' && req.method === 'GET') {
+            res.end('ok');
+          }
+        };
+
+        createServer(handler).listen(3000);
+        TS
+
+      endpoints = Noir::JSHttpRouteExtractor.extract("server.ts", code)
+      endpoints.map { |e| {e.method, e.url} }.should eq([{"GET", "/api/status"}])
+    end
   end
 end

--- a/spec/unit_test/miniparser/js_parser_spec.cr
+++ b/spec/unit_test/miniparser/js_parser_spec.cr
@@ -208,6 +208,43 @@ describe Noir::JSParser do
     end
   end
 
+  describe "route builder chains" do
+    it "stops the .route() chain at the end of a semicolon-free statement" do
+      # StandardJS / Prettier `semi: false` style. The chain walk used to
+      # stop only at a `;`, so with none in the file it kept collecting
+      # verbs from the following statements and hung them on /profile.
+      code = <<-JS
+        const express = require('express')
+        const app = express()
+
+        app.route('/profile')
+          .get((req, res) => res.json({}))
+
+        app.post('/orders', (req, res) => res.json({}))
+        app.delete('/carts', (req, res) => res.json({}))
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      pairs = routes.map { |r| "#{r.method} #{r.path}" }.uniq!.sort!
+      pairs.should eq(["DELETE /carts", "GET /profile", "POST /orders"])
+    end
+
+    it "still collects every verb of a real chain" do
+      code = <<-JS
+        const express = require('express');
+        const app = express();
+        app.route('/profile')
+          .get((req, res) => res.json({}))
+          .put((req, res) => res.json({}))
+          .delete((req, res) => res.json({}));
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      methods = routes.select { |r| r.path == "/profile" }.map(&.method).uniq!.sort!
+      methods.should eq(["DELETE", "GET", "PUT"])
+    end
+  end
+
   describe "JSRoutePattern" do
     it "stores method and path" do
       pattern = Noir::JSRoutePattern.new("GET", "/users")

--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -735,4 +735,71 @@ describe Noir::JSRouteExtractor do
       ).should be_false
     end
   end
+
+  describe "strip_js_comments" do
+    it "keeps blanking comments after a regex literal containing a quote" do
+      # `str.replace(/'/g, "&#39;")` used to leave the scanner inside a
+      # string for the rest of the file, so the commented-out decorator
+      # below survived and was reported as a live endpoint.
+      content = <<-TS
+        escape(str: string) { return str.replace(/'/g, "&#39;"); }
+
+        // @Get('legacy-removed')
+        @Post('create')
+        TS
+
+      stripped = Noir::JSRouteExtractor.strip_js_comments(content)
+      stripped.should_not contain("legacy-removed")
+      stripped.should contain("@Post('create')")
+    end
+
+    it "does not open a comment from a '/*' inside a string" do
+      # Mirror image of the case above: with the state inverted, the `/*`
+      # in a plain string literal started a block comment that blanked
+      # every route below it.
+      content = <<-TS
+        escape(str) { return str.replace(/'/g, '&#39;'); }
+        const blockOpen = '/*';
+        @Get('list')
+        @Post('create')
+        TS
+
+      stripped = Noir::JSRouteExtractor.strip_js_comments(content)
+      stripped.should contain("@Get('list')")
+      stripped.should contain("@Post('create')")
+    end
+
+    it "keeps a '//' inside a regex character class out of comment state" do
+      content = "const sep = /[//]/; app.get('/kept', h);"
+
+      stripped = Noir::JSRouteExtractor.strip_js_comments(content)
+      stripped.should contain("app.get('/kept', h);")
+    end
+
+    it "preserves length and newline positions" do
+      content = <<-JS
+        const re = /a'b/;
+        // gone
+        app.get('/x', h);
+        JS
+
+      stripped = Noir::JSRouteExtractor.strip_js_comments(content)
+      stripped.size.should eq(content.size)
+      stripped.count('\n').should eq(content.count('\n'))
+    end
+
+    it "resyncs at end of line when a '/' is misjudged as a regex" do
+      # `</p>` looks like a regex opening after '<'. Bounding the state to
+      # one line keeps that misjudgement from eating the rest of the file.
+      content = <<-JSX
+        const el = <p>a</p>;
+        // gone
+        app.get('/x', h);
+        JSX
+
+      stripped = Noir::JSRouteExtractor.strip_js_comments(content)
+      stripped.should contain("app.get('/x', h);")
+      stripped.should_not contain("gone")
+    end
+  end
 end

--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -802,4 +802,47 @@ describe Noir::JSRouteExtractor do
       stripped.should_not contain("gone")
     end
   end
+  describe "line_for_char_pos" do
+    it "resolves a char index on non-ASCII content" do
+      # `to_slice` is byte-indexed; feeding it a char index straight from
+      # the lexer under-counted newlines once the file held any multi-byte
+      # character, so routes reported a line from earlier in the file.
+      content = "// 주석 — 설명\nconst a = 1;\napp.get('/x', h);\n"
+      pos = content.index("app").should_not be_nil
+
+      Noir::JSRouteExtractor.line_for_char_pos(content, pos).should eq(3)
+      Noir::JSRouteExtractor.line_for_char_pos(content, 0).should eq(1)
+    end
+
+    it "resolves a char index on ASCII content" do
+      content = "a\nb\nc"
+      Noir::JSRouteExtractor.line_for_char_pos(content, 4).should eq(3)
+    end
+
+    it "reports the right route line below a non-ASCII literal" do
+      content = <<-JS
+        const express = require('express');
+        const app = express();
+
+        const 메시지 = '안녕하세요 여러분 반갑습니다 오늘도 좋은 하루 되세요';
+
+        app.get('/users', (req, res) => res.json({ m: 메시지 }));
+
+        app.listen(3000);
+
+        app.post('/items', (req, res) => res.json({}));
+        JS
+
+      file = File.tempfile("noir_js_route", ".js")
+      begin
+        File.write(file.path, content)
+        endpoints = Noir::JSRouteExtractor.extract_routes(file.path, content)
+        lines = endpoints.to_h { |e| {"#{e.method} #{e.url}", e.details.code_paths.first.line} }
+        lines["GET /users"].should eq(6)
+        lines["POST /items"].should eq(10)
+      ensure
+        file.delete
+      end
+    end
+  end
 end

--- a/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
@@ -563,4 +563,34 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
       ])
     end
   end
+
+  it "ignores a commented-out const val shadowing the live declaration" do
+    # `constants[name] ||= value` is first-wins, and the declaration regex used
+    # to run over the raw source: a dead constant left above the real one
+    # permanently shadowed it, so every route built from it reported a URL that
+    # does not exist while the real one was lost.
+    source = <<-KT
+      package com.example
+
+      object Paths {
+          // deprecated: const val API = "/old-api"
+          /* const val API = "/older-api" */
+          const val API = "/api"
+      }
+
+      routing {
+          route(Paths.API) {
+              get("/users") { }
+          }
+      }
+      KT
+
+    constants = Noir::TreeSitterKotlinKtorRouteExtractor.extract_string_constants(source)
+    constants["Paths.API"].should eq("/api")
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source, constants)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/users"},
+    ])
+  end
 end

--- a/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
@@ -539,4 +539,92 @@ describe Noir::TreeSitterKotlinRouteExtractor do
     prefixes = Noir::TreeSitterKotlinRouteExtractor.extract_stomp_application_prefixes(source)
     prefixes.should eq(["/app", "/topic"])
   end
+
+  it "ignores a commented-out const val shadowing the live declaration" do
+    # `constants[name] ||= value` means first-wins, and the declaration regex
+    # used to run over the raw source: a dead constant left above the real one
+    # permanently shadowed it, so every route built from it reported a URL
+    # that does not exist while the real one was lost.
+    source = <<-KT
+      package com.example
+
+      object GatewayPolicy {
+          // deprecated: const val MCP_ENDPOINT_PATH = "/old-mcp"
+          /* const val MCP_ENDPOINT_PATH = "/older-mcp" */
+          const val MCP_ENDPOINT_PATH = "/mcp"
+      }
+      KT
+
+    constants = Noir::TreeSitterKotlinRouteExtractor.extract_string_constants(source)
+    constants["MCP_ENDPOINT_PATH"].should eq("/mcp")
+    constants["GatewayPolicy.MCP_ENDPOINT_PATH"].should eq("/mcp")
+    constants["com.example.GatewayPolicy.MCP_ENDPOINT_PATH"].should eq("/mcp")
+  end
+
+  it "keeps a gateway PredicateSpec helper readable behind a non-ASCII comment" do
+    # The comment mask emitted one space per *byte*; `MatchData#end` is a char
+    # offset, so a multi-byte comment on the helper line shifted every offset
+    # after it and the expression tail was over-trimmed away.
+    source = <<-KT
+      package com.example
+
+      object GatewayPolicy {
+          const val MCP_ENDPOINT_PATH = "/mcp"
+      }
+
+      class GatewayRouteConfig {
+          fun customRouteLocator(builder: RouteLocatorBuilder): RouteLocator {
+              val routesBuilder = builder.routes()
+              routesBuilder.route("post") { predicateSpec ->
+                  predicateSpec.isPostRequestToMcpEndpoint().uri("no://op")
+              }
+              return routesBuilder.build()
+          }
+
+          /* MCP 엔드포인트 전용 조건 */ private fun PredicateSpec.isPostRequestToMcpEndpoint() = method(HttpMethod.POST).and().path(GatewayPolicy.MCP_ENDPOINT_PATH)
+      }
+      KT
+
+    constants = Noir::TreeSitterKotlinRouteExtractor.extract_string_constants(source)
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source, constants)
+
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"POST", "/mcp"},
+    ])
+  end
+
+  it "does not turn a commented-out STOMP addEndpoint into a real endpoint" do
+    source = <<-KT
+      package com.example
+
+      class WsConfig {
+          override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+              // registry.addEndpoint("/ws-legacy-removed").withSockJS()
+              registry.addEndpoint("/ws").withSockJS()
+          }
+      }
+      KT
+
+    routes = [] of Noir::TreeSitterKotlinRouteExtractor::Route
+    Noir::TreeSitter.parse_kotlin(source) do |root|
+      routes = Noir::TreeSitterKotlinRouteExtractor.extract_stomp_routes_from(root, source)
+    end
+
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/ws"},
+    ])
+  end
+
+  it "does not read a STOMP application prefix out of a comment" do
+    source = <<-KT
+      class WsConfig {
+          override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+              // registry.setApplicationDestinationPrefixes("/legacy")
+              registry.setApplicationDestinationPrefixes("/app")
+          }
+      }
+      KT
+
+    Noir::TreeSitterKotlinRouteExtractor.extract_stomp_application_prefixes(source).should eq(["/app"])
+  end
 end

--- a/spec/unit_test/miniparser/kotlin_source_mask_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_source_mask_spec.cr
@@ -1,0 +1,62 @@
+require "spec"
+require "../../../src/miniparsers/kotlin_source_mask"
+
+describe Noir::KotlinSourceMask do
+  it "preserves the character count of a non-ASCII comment" do
+    # One space per *character*, not per byte. `String#[]` and
+    # `MatchData#begin/#end` are char-indexed, so a byte-per-space mask
+    # shifted every offset after a multi-byte comment and callers slicing
+    # the raw line with an offset taken on the mask over-trimmed it.
+    source = %(/* 조건 */ fun handler() = path("/mcp"))
+    masked = Noir::KotlinSourceMask.visible(source)
+
+    masked.size.should eq(source.size)
+    # `/* 조건 */` is 8 characters, plus the space before `fun`.
+    masked.should eq("#{" " * 9}fun handler() = path(#{" " * 6})")
+  end
+
+  it "preserves the character count of a non-ASCII string literal" do
+    source = %(val label = "설정 화면" // 주석)
+    Noir::KotlinSourceMask.visible(source).size.should eq(source.size)
+    Noir::KotlinSourceMask.code_only(source).size.should eq(source.size)
+  end
+
+  it "keeps line offsets and count for every line" do
+    source = <<-KT
+      // 한국어 주석
+      const val PATH = "/mcp"
+      /* 여러 줄
+         주석 */
+      val other = "값"
+      KT
+
+    source.lines.zip(Noir::KotlinSourceMask.visible(source).lines) do |raw, masked|
+      masked.size.should eq(raw.size)
+    end
+    source.lines.zip(Noir::KotlinSourceMask.code_only(source).lines) do |raw, masked|
+      masked.size.should eq(raw.size)
+    end
+  end
+
+  it "blanks comments but keeps string literals in code_only" do
+    source = <<-KT
+      // const val PATH = "/old"
+      const val PATH = "/mcp" /* trailing */
+      KT
+
+    Noir::KotlinSourceMask.code_only(source).should eq(
+      %(#{" " * 26}\nconst val PATH = "/mcp"#{" " * 15})
+    )
+  end
+
+  it "blanks both comments and string contents in visible" do
+    source = %(val path = "/a{b}" // {c})
+    # `"/a{b}"` (7) + separator (1) + `// {c}` (6), all blanked.
+    Noir::KotlinSourceMask.visible(source).should eq("val path =#{" " * 15}")
+  end
+
+  it "leaves a raw string's delimiters and body intact in code_only" do
+    source = %(val q = """SELECT * FROM t WHERE a = "b"""" + x)
+    Noir::KotlinSourceMask.code_only(source).should eq(source)
+  end
+end

--- a/spec/unit_test/miniparser/micronaut_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/micronaut_extractor_ts_spec.cr
@@ -335,4 +335,35 @@ describe Noir::TreeSitterMicronautExtractor do
       ]},
     ])
   end
+
+  it "reads implements from the AST so a brace in a class annotation cannot truncate the header" do
+    # `@Produces({MediaType.APPLICATION_JSON})` puts a `{` in the class
+    # node's text before `implements`. The header used to be cut at the
+    # first `{` on the assumption it opened the class body, so the
+    # interface was never seen and every inherited route silently vanished.
+    source = <<-JAVA
+      package com.example.api;
+
+      import io.micronaut.http.annotation.Controller;
+      import io.micronaut.http.annotation.Get;
+      import io.micronaut.http.annotation.Produces;
+      import io.micronaut.http.MediaType;
+
+      public interface CatalogApi {
+          @Get("/catalog/{id}")
+          String show(String id);
+      }
+
+      @Produces({MediaType.APPLICATION_JSON})
+      @Controller("/api")
+      public class CatalogController implements CatalogApi {
+          public String show(String id) { return ""; }
+      }
+      JAVA
+
+    implementations = Noir::TreeSitterMicronautExtractor.extract_controller_interface_implementations(source)
+    implementations.map { |impl| {impl.class_name, impl.interface_names, impl.paths} }.should eq([
+      {"CatalogController", ["CatalogApi"], ["/api"]},
+    ])
+  end
 end

--- a/spec/unit_test/miniparser/perl_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/perl_callee_extractor_spec.cr
@@ -98,4 +98,127 @@ describe Noir::PerlCalleeExtractor do
     ])
     callees.has_key?("users#show").should be_false
   end
+
+  it "does not lex a heredoc body as code" do
+    source = <<-PERL
+      get '/hello' => sub ($c) {
+        my $html = <<'HTML';
+      <div class="x"> } don't stop
+      HTML
+        AlphaService::build();
+        $c->render(text => $html);
+      };
+      PERL
+
+    sub_start = source.index!("sub")
+    body = Noir::PerlCalleeExtractor.extract_sub_after(source, sub_start)
+    body.should_not be_nil
+
+    body.try do |body_text, start_line|
+      Noir::PerlCalleeExtractor.callees_for_body(body_text, "app.pl", start_line).map(&.[0]).should eq([
+        "AlphaService::build",
+        "c.render",
+      ])
+    end
+  end
+
+  it "masks interpolating and bare heredocs and keeps line numbers" do
+    source = <<-PERL
+      sub render ($c) {
+        my $a = <<"ONE";
+      value { $c->wrong('x')
+      ONE
+        my $b = <<TWO;
+      more } text
+      TWO
+        RealService::run();
+      }
+      PERL
+
+    bodies = Noir::PerlCalleeExtractor.named_sub_bodies(source, "App.pm")
+    bodies.keys.should eq(["render"])
+    render = bodies["render"]
+    Noir::PerlCalleeExtractor.callees_for_body(render[:body], render[:path], render[:start_line])
+      .map { |name, _, line| {name, line} }.should eq([{"RealService::run", 8}])
+  end
+
+  it "masks an indented <<~ heredoc whose terminator is indented" do
+    source = <<-PERL
+      sub greet ($c) {
+          my $text = <<~END;
+              hi } there don't stop
+              END
+          IndentService::run();
+      }
+      PERL
+
+    bodies = Noir::PerlCalleeExtractor.named_sub_bodies(source, "App.pm")
+    greet = bodies["greet"]
+    Noir::PerlCalleeExtractor.callees_for_body(greet[:body], greet[:path], greet[:start_line])
+      .map(&.[0]).should eq(["IndentService::run"])
+  end
+
+  it "does not treat a left shift as a heredoc" do
+    source = <<-PERL
+      sub bits ($c) {
+        my $mask = $x << 2;
+        my $wide = 1 << MAX;
+        ShiftService::run();
+      }
+      PERL
+
+    Noir::PerlCalleeExtractor.strip_non_code(source).should eq(source)
+
+    bodies = Noir::PerlCalleeExtractor.named_sub_bodies(source, "App.pm")
+    bits = bodies["bits"]
+    Noir::PerlCalleeExtractor.callees_for_body(bits[:body], bits[:path], bits[:start_line])
+      .map(&.[0]).should eq(["ShiftService::run"])
+  end
+
+  it "blanks an unterminated heredoc to EOF instead of looping" do
+    source = <<-PERL
+      sub broken ($c) {
+        my $html = <<'NEVER';
+      dangling } body '
+        LostService::run();
+      }
+      PERL
+
+    stripped = Noir::PerlCalleeExtractor.strip_non_code(source)
+    stripped.lines.size.should eq(source.lines.size)
+    stripped.includes?("LostService").should be_false
+    Noir::PerlCalleeExtractor.named_sub_bodies(source, "App.pm").should be_empty
+  end
+
+  it "treats $# as the last-index sigil, not a comment" do
+    source = <<-'PERL'
+      get '/last' => sub ($c) { my $n = $#{$c->stash('items')}; BetaService::run(); $c->render(text => $n); };
+      PERL
+
+    sub_start = source.index!("sub")
+    body = Noir::PerlCalleeExtractor.extract_sub_after(source, sub_start)
+    body.should_not be_nil
+
+    body.try do |body_text, start_line|
+      Noir::PerlCalleeExtractor.callees_for_body(body_text, "app.pl", start_line).map(&.[0]).should eq([
+        "c.stash",
+        "BetaService::run",
+        "c.render",
+      ])
+    end
+  end
+
+  it "still treats a real # as a comment" do
+    source = <<-PERL
+      sub notes ($c) {
+        my $last = $#items; # Ghost::call();
+        NoteService::run();
+      }
+      PERL
+
+    bodies = Noir::PerlCalleeExtractor.named_sub_bodies(source, "App.pm")
+    notes = bodies["notes"]
+    Noir::PerlCalleeExtractor.callees_for_body(notes[:body], notes[:path], notes[:start_line])
+      .map(&.[0]).should eq(["NoteService::run"])
+  end
 end

--- a/spec/unit_test/miniparser/php_lexer_spec.cr
+++ b/spec/unit_test/miniparser/php_lexer_spec.cr
@@ -4,14 +4,14 @@ require "../../../src/minilexers/php_lexer"
 describe Noir::PhpLexer do
   it "keeps the masked buffer aligned with the source length" do
     src = "Route::get('a'); /* x */ $y = <<<EOT\nhi\nEOT;\n"
-    lex = Noir::PhpLexer.new(src)
+    lex = Noir::PhpLexer.new(src, php_mode: true)
     lex.masked.size.should eq(src.size)
   end
 
   describe "#matching_delimiter" do
     it "matches a closing brace, ignoring braces inside strings and comments" do
       src = %(function () { $a = "}"; /* } */ $b = 1; })
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       open = src.index!('{')
       lex.matching_delimiter(open).should eq(src.rindex!('}'))
     end
@@ -25,14 +25,14 @@ describe Noir::PhpLexer do
           return 1;
         }
         PHP
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       open = src.index!('{')
       lex.matching_delimiter(open).should eq(src.rindex!('}'))
     end
 
     it "matches parentheses across nested calls" do
       src = %(group(function () { get("/x", fn($r) => 1); }))
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       open = src.index!('(')
       lex.matching_delimiter(open).should eq(src.size - 1)
     end
@@ -41,7 +41,7 @@ describe Noir::PhpLexer do
   describe "#statement_end" do
     it "ends at the top-level semicolon past nested parens and strings" do
       src = %(Route::get("/x;y", [A::class, "m;n"]); next();)
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       stop = lex.statement_end(0)
       src[stop - 1].should eq(';')
       src[0...stop].should eq(%(Route::get("/x;y", [A::class, "m;n"]);))
@@ -49,7 +49,7 @@ describe Noir::PhpLexer do
 
     it "treats the semicolon after a heredoc terminator as the statement end" do
       src = "$x = <<<EOT\n a; b; {}\nEOT;\nnext();"
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       stop = lex.statement_end(0)
       src[0...stop].should end_with("EOT;")
     end
@@ -63,7 +63,7 @@ describe Noir::PhpLexer do
         /* Route::get("/b") */
         Route::get("/real");
         PHP
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       lex.in_code?(src.index!("/s")).should be_false
       lex.in_code?(src.index!("/c")).should be_false
       lex.in_code?(src.index!("/b")).should be_false
@@ -73,14 +73,14 @@ describe Noir::PhpLexer do
 
     it "masks heredoc and nowdoc bodies" do
       src = "$h = <<<EOT\nRoute::get('/hd')\nEOT;\n$n = <<<'EON'\nRoute::get('/nd')\nEON;\n"
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       lex.in_code?(src.index!("/hd")).should be_false
       lex.in_code?(src.index!("/nd")).should be_false
     end
 
     it "treats a PHP 8 attribute as code, not a # comment" do
       src = "#[Route('/p', methods: ['GET'])]\nfunction h() {}\n# real comment\n"
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       # `methods` is a bareword inside the attribute -> code.
       lex.in_code?(src.index!("methods")).should be_true
       # a genuine `#` line comment is masked.
@@ -93,7 +93,7 @@ describe Noir::PhpLexer do
       # `/*/` is an OPEN comment, not a complete one — the route inside must
       # stay masked rather than leaking as code after a phantom close.
       src = "/*/ Route::get('/leak') */ ok();"
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       lex.in_code?(src.index!("Route")).should be_false
       lex.in_code?(src.index!("ok")).should be_true
     end
@@ -101,7 +101,7 @@ describe Noir::PhpLexer do
     it "masks heredoc bodies under LF, CRLF and bare-CR line endings" do
       {"\n", "\r\n", "\r"}.each do |nl|
         src = "$h = <<<EOT#{nl}Route::get('/x')#{nl}EOT;#{nl}done();"
-        lex = Noir::PhpLexer.new(src)
+        lex = Noir::PhpLexer.new(src, php_mode: true)
         lex.masked.size.should eq(src.size)
         lex.in_code?(src.index!("Route::get")).should be_false
         lex.in_code?(src.index!("done")).should be_true
@@ -110,7 +110,7 @@ describe Noir::PhpLexer do
 
     it "does not treat a digit-leading `<<<` label as a heredoc" do
       src = "$x = 1 <<<3;"
-      lex = Noir::PhpLexer.new(src)
+      lex = Noir::PhpLexer.new(src, php_mode: true)
       lex.skip_ranges.should eq([] of Range(Int32, Int32))
     end
   end
@@ -118,7 +118,7 @@ describe Noir::PhpLexer do
   describe "#tokens" do
     it "produces a structural stream with operators, idents and string spans" do
       src = %(Route::get('/x')->name('home');)
-      kinds = Noir::PhpLexer.new(src).tokens.map(&.kind)
+      kinds = Noir::PhpLexer.new(src, php_mode: true).tokens.map(&.kind)
       kinds.should eq([
         :ident, :double_colon, :ident, :lparen, :string, :rparen,
         :arrow, :ident, :lparen, :string, :rparen, :semicolon,
@@ -127,14 +127,14 @@ describe Noir::PhpLexer do
 
     it "records line numbers and string values" do
       src = "a();\nRoute::post('/y');"
-      str = Noir::PhpLexer.new(src).tokens.find! { |t| t.kind == :string }
+      str = Noir::PhpLexer.new(src, php_mode: true).tokens.find! { |t| t.kind == :string }
       str.value.should eq("'/y'")
       str.line.should eq(2)
     end
 
     it "tokenizes variables, => and array brackets in a closure" do
       src = %(fn($r) => [$r => 1];)
-      kinds = Noir::PhpLexer.new(src).tokens.map(&.kind)
+      kinds = Noir::PhpLexer.new(src, php_mode: true).tokens.map(&.kind)
       kinds.should eq([
         :ident, :lparen, :variable, :rparen, :double_arrow,
         :lbracket, :variable, :double_arrow, :rbracket, :semicolon,
@@ -143,7 +143,7 @@ describe Noir::PhpLexer do
 
     it "emits comment and heredoc span tokens with correct kinds" do
       src = "/* c */ $x = <<<EOT\nbody\nEOT;\n"
-      kinds = Noir::PhpLexer.new(src).tokens.map(&.kind)
+      kinds = Noir::PhpLexer.new(src, php_mode: true).tokens.map(&.kind)
       kinds.should contain(:comment)
       kinds.should contain(:heredoc)
       kinds.should contain(:variable)
@@ -151,15 +151,119 @@ describe Noir::PhpLexer do
 
     it "returns no tokens for empty source and skips a lone $" do
       Noir::PhpLexer.new("").tokens.should be_empty
-      Noir::PhpLexer.new("$ ").tokens.should be_empty
+      Noir::PhpLexer.new("$ ", php_mode: true).tokens.should be_empty
     end
 
     it "numbers token lines under bare-CR and CRLF endings" do
-      cr = Noir::PhpLexer.new("a();\rb();\rc();").tokens
+      cr = Noir::PhpLexer.new("a();\rb();\rc();", php_mode: true).tokens
       cr.find! { |t| t.value == "b" }.line.should eq(2)
       cr.find! { |t| t.value == "c" }.line.should eq(3)
-      crlf = Noir::PhpLexer.new("a();\r\nb();").tokens
+      crlf = Noir::PhpLexer.new("a();\r\nb();", php_mode: true).tokens
       crlf.find! { |t| t.value == "b" }.line.should eq(2)
+    end
+  end
+
+  # A `.php` file is HTML with islands of code in it. Everything outside
+  # `<?php … ?>` is literal output: lexing it as code let one apostrophe in
+  # prose open a string that masked the rest of the file, so every route
+  # declared below it disappeared.
+  describe "inline HTML mode" do
+    it "does not let an apostrophe in leading HTML mask the code below it" do
+      src = <<-PHP
+        <h1>Today's report</h1>
+        <?php
+        Route::get('/one', 'C@a');
+        Route::post('/two', 'C@b');
+        PHP
+      lex = Noir::PhpLexer.new(src)
+      lex.masked.size.should eq(src.size)
+      lex.in_code?(src.index!("Route::get")).should be_true
+      lex.in_code?(src.index!("Route::post")).should be_true
+      lex.tokens.map(&.value).should contain("Route")
+      # The prose itself is inert, and it produces no token of its own.
+      lex.in_code?(src.index!("Today")).should be_false
+      lex.tokens.map(&.value).should_not contain("Today")
+    end
+
+    it "returns to HTML mode at `?>` and back to code at the next open tag" do
+      src = <<-PHP
+        <?php Route::get('/before', 'C@a'); ?>
+        <p>Today's report</p>
+        <?php Route::get('/after', 'C@b');
+        PHP
+      lex = Noir::PhpLexer.new(src)
+      lex.in_code?(src.index!("/before")).should be_false # a string, still masked
+      lex.in_code?(src.index!("'/after'")).should be_false
+      lex.in_code?(src.index!("Route::get('/after'")).should be_true
+      lex.in_code?(src.index!("report")).should be_false
+      lex.tokens.count { |t| t.value == "Route" }.should eq(2)
+    end
+
+    it "opens code on the `<?=` short echo tag" do
+      src = "<h1>it's here</h1>\n<?= route('/x') ?>\n<p>and's here</p>\n"
+      lex = Noir::PhpLexer.new(src)
+      lex.in_code?(src.index!("route")).should be_true
+      lex.tokens.map(&.value).should contain("route")
+      lex.tokens.map(&.value).should_not contain("h1")
+    end
+
+    it "keeps PHP mode when `?>` is written inside a string or a block comment" do
+      src = <<-PHP
+        <?php
+        $close = '?>';
+        /* ?> */
+        Route::get('/still-code', 'C@a');
+        PHP
+      lex = Noir::PhpLexer.new(src)
+      lex.in_code?(src.index!("Route::get")).should be_true
+      lex.tokens.map(&.value).should contain("Route")
+    end
+
+    it "closes PHP mode when `?>` ends a one-line `//` or `#` comment" do
+      {"//", "#"}.each do |marker|
+        src = "<?php #{marker} note ?>\n<p>Today's report</p>\n<?php Route::get('/x', 'C@a');"
+        lex = Noir::PhpLexer.new(src)
+        lex.masked.size.should eq(src.size)
+        lex.in_code?(src.index!("report")).should be_false
+        lex.in_code?(src.index!("Route::get")).should be_true
+      end
+    end
+
+    it "yields no tokens for a file that never opens PHP" do
+      src = "<h1>Today's report</h1>\n<p>No code here; just { markup }.</p>\n"
+      lex = Noir::PhpLexer.new(src)
+      lex.masked.size.should eq(src.size)
+      lex.tokens.should be_empty
+      lex.in_code?(0).should be_false
+      lex.masked.should_not contain('{')
+    end
+
+    it "does not open PHP on an XML processing instruction" do
+      src = "<?xml version=\"1.0\"?>\n<note>it's inert</note>\n"
+      Noir::PhpLexer.new(src).tokens.should be_empty
+    end
+
+    it "lexes to EOF when the final PHP block is never closed" do
+      src = "<p>hi</p>\n<?php Route::get('/tail', 'C@a');"
+      lex = Noir::PhpLexer.new(src)
+      lex.masked.size.should eq(src.size)
+      lex.in_code?(src.rindex!(';')).should be_true
+    end
+
+    it "preserves line numbers across a large HTML header" do
+      header = Array.new(20) { |i| "<p>Line #{i + 1}: it's fine</p>" }.join("\n")
+      src = "#{header}\n<?php\nRoute::get('/x', 'C@a');\n"
+      lex = Noir::PhpLexer.new(src)
+      lex.masked.size.should eq(src.size)
+      # 20 header lines, `<?php` on 21, the route on 22.
+      lex.tokens.find! { |t| t.value == "Route" }.line.should eq(22)
+    end
+
+    it "does not start a heredoc or a comment from markup outside PHP" do
+      src = "<p>a << b <<<EOT and // and /* never closed</p>\n<?php Route::get('/y', 'C@a');\n"
+      lex = Noir::PhpLexer.new(src)
+      lex.masked.size.should eq(src.size)
+      lex.in_code?(src.index!("Route::get")).should be_true
     end
   end
 end

--- a/spec/unit_test/miniparser/postgres_ddl_parser_spec.cr
+++ b/spec/unit_test/miniparser/postgres_ddl_parser_spec.cr
@@ -214,43 +214,30 @@ describe "Noir::PostgresDdlParser" do
   # literal was then parsed as code and the next quote re-opened a string,
   # masking the columns that followed off the generated PostgREST surface.
   it "does not close an E'...' escape string on a backslash-escaped quote" do
-    state = parse_ddl <<-'SQL'
-      create table public.notes (
-        id bigserial primary key,
-        title text not null default E'it\'s fine',
-        label text,
-        body text
-      );
-      SQL
+    state = parse_ddl(
+      "create table public.notes (" \
+      "id bigserial primary key, " \
+      "title text not null default E'it\\'s fine', " \
+      "label text, " \
+      "body text);"
+    )
 
     columns_of(state, "public.notes").should eq(["id", "title", "label", "body"])
   end
 
   it "honours a backslash-escaped backslash inside an E'...' string" do
-    state = parse_ddl <<-'SQL'
-      create table public.paths (
-        id int,
-        sep text default E'\\',
-        label text
-      );
-      SQL
+    state = parse_ddl(
+      "create table public.paths (id int, sep text default E'\\\\', label text);"
+    )
 
     columns_of(state, "public.paths").should eq(["id", "sep", "label"])
   end
 
   it "keeps the doubled-quote rule for both plain and escape strings" do
-    state = parse_ddl <<-'SQL'
-      create table public.plain (
-        id int,
-        title text default 'it''s fine',
-        label text
-      );
-      create table public.escaped (
-        id int,
-        title text default E'it''s fine',
-        body text
-      );
-      SQL
+    state = parse_ddl(
+      "create table public.plain (id int, title text default 'it''s fine', label text);\n" \
+      "create table public.escaped (id int, title text default E'it''s fine', body text);"
+    )
 
     columns_of(state, "public.plain").should eq(["id", "title", "label"])
     columns_of(state, "public.escaped").should eq(["id", "title", "body"])
@@ -260,25 +247,17 @@ describe "Noir::PostgresDdlParser" do
   # literal really does end at the quote right after it — only the `E`
   # prefix changes that.
   it "leaves the backslash literal in a plain SQL string" do
-    state = parse_ddl <<-'SQL'
-      create table public.win (
-        id int,
-        sep text default 'C:\',
-        label text
-      );
-      SQL
+    state = parse_ddl(
+      "create table public.win (id int, sep text default 'C:\\', label text);"
+    )
 
     columns_of(state, "public.win").should eq(["id", "sep", "label"])
   end
 
   it "accepts the lowercase e'...' escape-string prefix" do
-    state = parse_ddl <<-'SQL'
-      create table public.codes (
-        id int,
-        code text default e'a\'b',
-        label text
-      );
-      SQL
+    state = parse_ddl(
+      "create table public.codes (id int, code text default e'a\\'b', label text);"
+    )
 
     columns_of(state, "public.codes").should eq(["id", "code", "label"])
   end

--- a/spec/unit_test/miniparser/postgres_ddl_parser_spec.cr
+++ b/spec/unit_test/miniparser/postgres_ddl_parser_spec.cr
@@ -207,4 +207,79 @@ describe "Noir::PostgresDdlParser" do
   it "returns nothing for a statement-free document" do
     parse_ddl("insert into public.a values (1);").tables.should be_empty
   end
+
+  # Regression: the masker applied the standard-SQL rule (`''` escapes a
+  # quote, backslash is literal) to `E'…'` escape strings too, so `E'it\'s'`
+  # was read as ending at the backslash-escaped quote. The remainder of the
+  # literal was then parsed as code and the next quote re-opened a string,
+  # masking the columns that followed off the generated PostgREST surface.
+  it "does not close an E'...' escape string on a backslash-escaped quote" do
+    state = parse_ddl <<-'SQL'
+      create table public.notes (
+        id bigserial primary key,
+        title text not null default E'it\'s fine',
+        label text,
+        body text
+      );
+      SQL
+
+    columns_of(state, "public.notes").should eq(["id", "title", "label", "body"])
+  end
+
+  it "honours a backslash-escaped backslash inside an E'...' string" do
+    state = parse_ddl <<-'SQL'
+      create table public.paths (
+        id int,
+        sep text default E'\\',
+        label text
+      );
+      SQL
+
+    columns_of(state, "public.paths").should eq(["id", "sep", "label"])
+  end
+
+  it "keeps the doubled-quote rule for both plain and escape strings" do
+    state = parse_ddl <<-'SQL'
+      create table public.plain (
+        id int,
+        title text default 'it''s fine',
+        label text
+      );
+      create table public.escaped (
+        id int,
+        title text default E'it''s fine',
+        body text
+      );
+      SQL
+
+    columns_of(state, "public.plain").should eq(["id", "title", "label"])
+    columns_of(state, "public.escaped").should eq(["id", "title", "body"])
+  end
+
+  # A backslash is a literal character in a standard SQL string, so the
+  # literal really does end at the quote right after it — only the `E`
+  # prefix changes that.
+  it "leaves the backslash literal in a plain SQL string" do
+    state = parse_ddl <<-'SQL'
+      create table public.win (
+        id int,
+        sep text default 'C:\',
+        label text
+      );
+      SQL
+
+    columns_of(state, "public.win").should eq(["id", "sep", "label"])
+  end
+
+  it "accepts the lowercase e'...' escape-string prefix" do
+    state = parse_ddl <<-'SQL'
+      create table public.codes (
+        id int,
+        code text default e'a\'b',
+        label text
+      );
+      SQL
+
+    columns_of(state, "public.codes").should eq(["id", "code", "label"])
+  end
 end

--- a/spec/unit_test/miniparser/python_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/python_route_extractor_spec.cr
@@ -130,5 +130,49 @@ describe Noir::PythonRouteExtractor do
       lines = ["@app.route('/x')", "x = 1"]
       Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(0)
     end
+
+    it "ignores trailing comments with opening parenthesis" do
+      lines = [
+        "@route(\"/report\", method=\"GET\")  # note (",
+        "def report():",
+      ]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(1)
+    end
+
+    it "ignores trailing comments with closing parenthesis" do
+      lines = [
+        "@route(\"/report\", method=\"GET\")  # note )",
+        "def report():",
+      ]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(1)
+    end
+
+    it "does not treat '#' inside string literals as comments" do
+      lines = [
+        "@app.route(\"/tag/#anchor\")  # this is a comment (",
+        "def tag_handler():",
+      ]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(1)
+    end
+
+    it "handles multi-line decorators with continuation lines carrying comments" do
+      lines = [
+        "@app.route(",
+        "    \"/endpoint/#part1\", # inline comment (",
+        "    methods=[\"GET\"] # another comment )",
+        ") # final comment (",
+        "def handler():",
+      ]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(4)
+    end
+
+    it "skips intervening comment lines containing unbalanced parentheses" do
+      lines = [
+        "@app.route('/x')",
+        "# TODO: add auth (legacy notes",
+        "def handler():",
+      ]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(2)
+    end
   end
 end

--- a/spec/unit_test/utils/js_literal_scanner_spec.cr
+++ b/spec/unit_test/utils/js_literal_scanner_spec.cr
@@ -258,4 +258,32 @@ describe Noir::JSLiteralScanner do
       idx.should eq(9)
     end
   end
+
+  describe "regex_context?" do
+    it "accepts operators that expect an expression" do
+      ['(', '[', '{', ',', ':', ';', '=', '!', '&', '|', '?', '>', '<'].each do |ch|
+        Noir::JSLiteralScanner.regex_context?(ch, "").should be_true
+      end
+    end
+
+    it "accepts keywords that expect an expression" do
+      Noir::JSLiteralScanner.regex_context?('n', "return").should be_true
+      Noir::JSLiteralScanner.regex_context?('f', "typeof").should be_true
+    end
+
+    it "rejects a value-producing tail" do
+      Noir::JSLiteralScanner.regex_context?(')', "").should be_false
+      Noir::JSLiteralScanner.regex_context?(']', "").should be_false
+      Noir::JSLiteralScanner.regex_context?('x', "x").should be_false
+      Noir::JSLiteralScanner.regex_context?('n', "login").should be_false
+      Noir::JSLiteralScanner.regex_context?(nil, "").should be_false
+    end
+
+    it "matches whole words, not keyword suffixes" do
+      # "login" ends with "in" — a suffix match would call `login / 2`
+      # a regex and swallow the rest of the expression.
+      Noir::JSLiteralScanner.regex_context?('n', "in").should be_true
+      Noir::JSLiteralScanner.regex_context?('n', "login").should be_false
+    end
+  end
 end

--- a/src/analyzer/analyzers/clojure/clojure_helper.cr
+++ b/src/analyzer/analyzers/clojure/clojure_helper.cr
@@ -1,75 +1,51 @@
+require "../../../miniparsers/clojure_scanner"
+
 module Analyzer::Clojure
   # Shared helpers for the Clojure framework analyzers (CLI, Compojure,
   # Pedestal, Reitit, Ring). Every one of them walks s-expressions the same
   # way, so the scanning primitives live here instead of being copied per
   # analyzer.
   #
-  # All four operate on byte offsets into the raw source (`byte_at`), never on
-  # character indices, so the offsets they return stay usable with
+  # The primitives themselves belong to the parser layer, so this is only a
+  # thin adapter over `Noir::ClojureScanner` (`src/miniparsers/`). Keeping a
+  # second copy here is what let a reader bug — `\(` counted as a real open
+  # paren — live on in the analyzers after it was fixed in the miniparser.
+  #
+  # All of them operate on byte offsets into the raw source (`byte_at`), never
+  # on character indices, so the offsets they return stay usable with
   # `String#byte_slice` on sources containing non-ASCII text.
   module Helper
     extend self
 
     # Advance past a `;` line comment, stopping on the newline that ends it.
     def skip_comment(source : String, index : Int32, limit : Int32) : Int32
-      i = index
-      while i < limit && source.byte_at(i).unsafe_chr != '\n'
-        i += 1
-      end
-      i
+      Noir::ClojureScanner.skip_comment(source, index, limit)
     end
 
     # Advance from the opening `"` of a string literal to its closing quote,
     # honouring `\` escapes. Returns the last in-range offset when the literal
     # is unterminated so callers still make progress.
     def skip_string(source : String, index : Int32, limit : Int32) : Int32
-      i = index + 1
-      escaping = false
+      Noir::ClojureScanner.skip_string(source, index, limit)
+    end
 
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        if escaping
-          escaping = false
-        elsif char == '\\'
-          escaping = true
-        elsif char == '"'
-          return i
-        end
-        i += 1
-      end
-
-      limit - 1
+    # Advance from the `\` opening a character literal (`\a`, `\"`, `\(`,
+    # `\newline`, `\uXXXX`, …) to the literal's last byte.
+    def skip_char_literal(source : String, index : Int32, limit : Int32) : Int32
+      Noir::ClojureScanner.skip_char_literal(source, index, limit)
     end
 
     # Find the offset of the delimiter closing the one at `index`, skipping
-    # over comments and string literals so a `)` inside `";)"` never closes a
-    # form. Returns `index` unchanged when no match is found.
+    # over comments, strings and character literals so a `)` inside `";)"` or a
+    # `\(` never closes a form. Returns `index` unchanged when no match is
+    # found.
     def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
-      depth = 0
-      i = index
-
-      while i < limit
-        char = source.byte_at(i).unsafe_chr
-        case char
-        when ';'
-          i = skip_comment(source, i, limit)
-        when '"'
-          i = skip_string(source, i, limit)
-        when open_char
-          depth += 1
-        when close_char
-          depth -= 1
-          return i if depth == 0
-        end
-        i += 1
-      end
-
-      index
+      Noir::ClojureScanner.find_matching_delimiter(source, index, open_char, close_char, limit)
     end
 
     # 1-based line number of a byte offset.
     def line_number_for(source : String, index : Int32) : Int32
-      source.byte_slice(0, index).count('\n') + 1
+      Noir::ClojureScanner.line_number_for(source, index)
     end
   end
 end

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -183,13 +183,16 @@ module Analyzer::Php
                                        file_path : String,
                                        include_callee : Bool,
                                        base_line : Int32 = 1,
-                                       imports : Hash(String, String) = EMPTY_IMPORTS) : Array(Endpoint)
+                                       imports : Hash(String, String) = EMPTY_IMPORTS,
+                                       php_mode : Bool = false) : Array(Endpoint)
       endpoints = [] of Endpoint
       # One structural pass over this file/body. `PhpLexer` masks strings,
       # comments and heredoc/nowdoc bodies a single time; every
       # balanced-delimiter, statement-end and skip-range query below reuses
-      # the same lexer instead of re-scanning the raw text per route.
-      lexer = Noir::PhpLexer.new(content)
+      # the same lexer instead of re-scanning the raw text per route. A whole
+      # file starts outside `<?php`; a group body handed back by the recursive
+      # pass below was already carved out of a PHP region.
+      lexer = Noir::PhpLexer.new(content, php_mode: php_mode)
       route_groups = extract_route_groups(content, lexer)
       resource_controller_cache = {} of String => ControllerActionMap?
       # Character ranges that are inside PHP comments (`//`, `#`, `/* */`),
@@ -280,7 +283,7 @@ module Analyzer::Php
       route_groups.each do |group|
         new_prefix = group.prefix.empty? ? prefix : build_full_path(prefix, group.prefix)
         group_base_line = base_line + newline_count_before(content, group.body_start)
-        endpoints.concat(analyze_routes_content(group.body, new_prefix, file_path, include_callee, group_base_line, imports))
+        endpoints.concat(analyze_routes_content(group.body, new_prefix, file_path, include_callee, group_base_line, imports, php_mode: true))
       end
 
       endpoints

--- a/src/minilexers/csharp_lexer.cr
+++ b/src/minilexers/csharp_lexer.cr
@@ -106,17 +106,17 @@ module Noir
       end
     end
 
-    private def mask_line_comment(start : Int32) : Int32
+    private def mask_line_comment(start : Int32, record_span : Bool = true) : Int32
       i = start
       while i < @size && @chars[i] != '\n'
         @masked[i] = ' '
         i += 1
       end
-      @spans << {:comment, start, i}
+      @spans << {:comment, start, i} if record_span
       i
     end
 
-    private def mask_block_comment(start : Int32) : Int32
+    private def mask_block_comment(start : Int32, record_span : Bool = true) : Int32
       # Blank the `/*` opener first, then scan for `*/` from after it so `/*/`
       # is not mis-read as self-closing.
       @masked[start] = ' '
@@ -132,13 +132,13 @@ module Noir
         @masked[i] = ' ' unless @chars[i] == '\n'
         i += 1
       end
-      @spans << {:comment, start, i}
+      @spans << {:comment, start, i} if record_span
       i
     end
 
     # `start` points at the opening `'`. Masks a char literal, honouring a
     # single backslash escape (`'\''`, `'\\'`, `'\}'`).
-    private def mask_char_literal(start : Int32) : Int32
+    private def mask_char_literal(start : Int32, record_span : Bool = true) : Int32
       @masked[start] = ' '
       i = start + 1
       escaped = false
@@ -155,7 +155,7 @@ module Noir
         end
         i += 1
       end
-      @spans << {:string, start, i}
+      @spans << {:string, start, i} if record_span
       i
     end
 
@@ -197,6 +197,22 @@ module Noir
         if interpolated && interp_depth > 0 && c == '"' && !escaped
           i = mask_nested_hole_string(i)
           next
+        end
+
+        if interpolated && interp_depth > 0 && c == '\''
+          i = mask_char_literal(i, record_span: false)
+          next
+        end
+
+        if interpolated && interp_depth > 0 && c == '/'
+          nxt = i + 1 < @size ? @chars[i + 1] : '\0'
+          if nxt == '/'
+            i = mask_line_comment(i, record_span: false)
+            next
+          elsif nxt == '*'
+            i = mask_block_comment(i, record_span: false)
+            next
+          end
         end
 
         @masked[i] = ' ' unless c == '\n'

--- a/src/minilexers/js_lexer.cr
+++ b/src/minilexers/js_lexer.cr
@@ -1,3 +1,5 @@
+require "../utils/js_literal_scanner"
+
 module Noir
   # MiniToken represents a simple token in JavaScript code
   class JSToken
@@ -247,37 +249,34 @@ module Noir
     end
 
     # Heuristic to determine if '/' starts a regex literal.
-    # In JavaScript, regex literals can appear after certain tokens that cannot
-    # be followed by a division operator. This covers the most common cases
-    # for route definitions but is not exhaustive for all JS contexts.
+    #
+    # The rule itself lives in `JSLiteralScanner.regex_context?` — this only
+    # maps the last token onto the (last significant char, trailing word)
+    # pair that rule takes. Keeping one copy matters: the lexer used to
+    # accept a much shorter list of preceding tokens than the scanner, so
+    # `(s) => /["']/.test(s)` lexed the '/' as division and the following
+    # quote opened a string token that ran to EOF, losing every route in
+    # the file.
     private def looks_like_regex? : Bool
       return false if @tokens.empty?
 
       last_token = @tokens.last
 
-      # Regex can follow opening brackets and parentheses
-      return true if last_token.type == :lparen
-      return true if last_token.type == :lbracket
-      return true if last_token.type == :lbrace
-
-      # Regex can follow punctuation that expects an expression
-      return true if last_token.type == :comma
-      return true if last_token.type == :colon
-      return true if last_token.type == :semicolon
-
-      # Regex can follow assignment and comparison operators
-      return true if last_token.type == :assign
-      return true if last_token.value == "="
-
-      # Regex can follow keywords that expect an expression
-      if last_token.type == :keyword
-        case last_token.value
-        when "return", "case", "throw", "in", "of", "typeof", "instanceof", "void", "delete", "new"
-          return true
-        end
+      case last_token.type
+      when :string, :template_literal, :regex
+        # Literal payloads: the token's value is data, not code, so its last
+        # character says nothing about what follows the closing delimiter.
+        # A '/' after a completed literal is always division.
+        false
+      when :keyword
+        JSLiteralScanner.regex_context?(last_token.value[-1]?, last_token.value)
+      else
+        # Punctuation, operators and `:unknown` (where '!' and the '>' of
+        # '=>' land) each carry a single character; identifiers, numbers and
+        # closing brackets end in a character the shared set rejects, so the
+        # same probe covers them without a per-type list.
+        JSLiteralScanner.regex_context?(last_token.value[-1]?, "")
       end
-
-      false
     end
 
     # Tokenize a regex literal

--- a/src/minilexers/php_lexer.cr
+++ b/src/minilexers/php_lexer.cr
@@ -24,6 +24,11 @@ module Noir
   # re-implements (balanced-brace matching, statement-end scanning, string/
   # comment skip ranges) with a single shared pass that is:
   #
+  #   * open/close-tag aware — a `.php` file is HTML with islands of code in
+  #     it, so everything outside `<?php … ?>` is inert output text. Lexing it
+  #     as code let a lone apostrophe in `<h1>Today's report</h1>` open a
+  #     string that masked the rest of the file, silently dropping every route
+  #     declared below it.
   #   * heredoc/nowdoc aware — `<<<EOT … EOT` / `<<<'EOT' … EOT` bodies are
   #     masked, so route-shaped text or stray `{};` inside a heredoc can no
   #     longer leak as a false endpoint or corrupt a brace/statement bound.
@@ -33,8 +38,8 @@ module Noir
   #     `Array(Char)` with O(1) indexing, so CJK-commented controllers stay
   #     O(n) instead of the O(n^2) that `String#[](Int)` caused.
   #
-  # The lexer masks every non-code region (strings, comments, heredoc/nowdoc
-  # bodies) into spaces in `@masked` while preserving newlines and overall
+  # The lexer masks every non-code region (inline HTML, strings, comments,
+  # heredoc/nowdoc bodies) into spaces in `@masked` while preserving newlines and overall
   # length, so the structural helpers in `Noir::MaskedLexer` are plain depth
   # counters over `@masked` with no string-state bookkeeping of their own.
   class PhpLexer
@@ -46,27 +51,39 @@ module Noir
     @chars : Array(Char)
     @tokens : Array(PhpToken)?
 
-    def initialize(source : String)
+    # `source` is a whole `.php` file by default, so lexing starts in HTML
+    # mode: nothing is code until the first `<?php` / `<?=`. Pass
+    # `php_mode: true` when `source` is a fragment already carved out of a PHP
+    # region (a closure body handed back for a recursive pass, say), which by
+    # construction has no opening tag of its own.
+    def initialize(source : String, *, php_mode : Bool = false)
       @chars = source.chars
       @size = @chars.size
       @masked = Array(Char).new(@size)
       @spans = [] of Tuple(Symbol, Int32, Int32)
       @tokens = nil
       @skip_ranges = nil
-      scan
+      scan(php_mode)
     end
 
     # Single masking pass. Walks the character array once, copying code
     # characters into `@masked` verbatim and blanking the interior of strings,
-    # comments and heredoc/nowdoc bodies (newlines kept). Each masked region is
-    # recorded in `@spans`.
-    private def scan
-      i = 0
+    # comments, heredoc/nowdoc bodies and inline-HTML regions (newlines kept).
+    # Each masked region is recorded in `@spans`.
+    private def scan(php_mode : Bool)
+      i = php_mode ? 0 : mask_inline_html(0)
       while i < @size
         c = @chars[i]
         nxt = i + 1 < @size ? @chars[i + 1] : '\0'
 
-        if c == '/' && nxt == '/'
+        # `?>` leaves PHP mode. This test sits alongside the string/comment/
+        # heredoc branches rather than ahead of them on purpose: those branches
+        # consume their whole region, so a `?>` written inside a literal or a
+        # block comment never reaches the top of this loop and cannot close
+        # the block.
+        if c == '?' && nxt == '>'
+          i = mask_inline_html(i)
+        elsif c == '/' && nxt == '/'
           i = mask_line_comment(i)
         elsif c == '#' && nxt != '['
           # `#` is a line comment, but `#[` opens a PHP 8 attribute (code).
@@ -90,11 +107,68 @@ module Noir
       end
     end
 
+    # `start` is the first character of an inert region: the top of a file that
+    # has not opened PHP yet, or the `?` of the `?>` that just closed it.
+    # Everything from there up to and including the next open tag is literal
+    # output, not code — masking it is what stops an apostrophe in prose, a
+    # `#`, a `//` or a `<<<` in markup from opening a string, a comment or a
+    # heredoc that runs to EOF and swallows the code below.
+    #
+    # The region is blanked into `@masked` with its line breaks kept (every
+    # analyzer reports `code_path` lines from these offsets, so the character
+    # count and the newline positions have to survive) and recorded as a single
+    # `:html` span. Returns the index just past the open tag, or `@size` when
+    # the file never opens PHP again — a file whose last PHP block runs to EOF
+    # without a closing `?>` is the recommended style, not an error.
+    private def mask_inline_html(start : Int32) : Int32
+      i = start
+      while i < @size
+        if len = open_tag_len(i)
+          len.times { @masked << ' ' }
+          i += len
+          @spans << {:html, start, i}
+          return i
+        end
+        c = @chars[i]
+        @masked << (c == '\n' || c == '\r' ? c : ' ')
+        i += 1
+      end
+      @spans << {:html, start, @size} if start < @size
+      @size
+    end
+
+    # Length of the PHP open tag at `i`, or nil when `i` isn't one. `<?=` is
+    # the short echo tag and opens code just like `<?php`, which is spelled
+    # case-insensitively and must be followed by whitespace or EOF (`<?phpinfo`
+    # is text). The bare `<?` short tag is accepted too — legacy files that use
+    # it would otherwise be read as one giant HTML blob and lose every route —
+    # except before `xml`, which would make an XML processing instruction open
+    # a PHP block in a template.
+    private def open_tag_len(i : Int32) : Int32?
+      return unless @chars[i] == '<' && i + 1 < @size && @chars[i + 1] == '?'
+      return 3 if @chars[i + 2]? == '='
+      if @chars[i + 2]?.try(&.downcase) == 'p' &&
+         @chars[i + 3]?.try(&.downcase) == 'h' &&
+         @chars[i + 4]?.try(&.downcase) == 'p'
+        after = @chars[i + 5]?
+        return 5 if after.nil? || after.ascii_whitespace?
+      end
+      return if @chars[i + 2]?.try(&.downcase) == 'x' &&
+                @chars[i + 3]?.try(&.downcase) == 'm' &&
+                @chars[i + 4]?.try(&.downcase) == 'l'
+      2
+    end
+
     # Blank from `start` (a `/` or `#`) to end of line; the newline itself is
     # left intact. Returns the index just past the comment body.
     private def mask_line_comment(start : Int32) : Int32
       i = start
       while i < @size && @chars[i] != '\n'
+        # A `//` or `#` comment also ends at `?>`: PHP leaves the tag outside
+        # the comment so that it still closes the block. Without this a
+        # one-line `<?php // note ?>` would keep the lexer in PHP mode over all
+        # the markup that follows.
+        break if @chars[i] == '?' && @chars[i + 1]? == '>'
         @masked << ' '
         i += 1
       end
@@ -321,9 +395,14 @@ module Noir
         # Emit any recorded span that starts here.
         if span_idx < spans.size && spans[span_idx][1] == i
           kind, s, e = spans[span_idx]
-          result << PhpToken.new(kind, @chars[s...e].join, s, e, line_for.call(s))
           span_idx += 1
           i = e
+          # Inert markup outside `<?php … ?>` is masked like a string literal
+          # so it can never be read as code, but unlike a literal it is not
+          # part of the program: a `.php` file with no open tag at all is pure
+          # HTML and has no tokens.
+          next if kind == :html
+          result << PhpToken.new(kind, @chars[s...e].join, s, e, line_for.call(s))
           next
         end
 

--- a/src/minilexers/scala_lexer.cr
+++ b/src/minilexers/scala_lexer.cr
@@ -132,6 +132,7 @@ module Noir
     # `start` points at the first of `"""`. Triple-quoted strings are raw and
     # may span lines; close on the next `"""`. Blanked in BOTH views.
     private def mask_triple_string(start : Int32) : Int32
+      interpolated = interpolated_string?(start)
       emit(start, ' ', ' ')
       emit(start + 1, ' ', ' ')
       emit(start + 2, ' ', ' ')
@@ -144,9 +145,17 @@ module Noir
           i += 3
           break
         end
-        ch = @chars[i] == '\n' ? '\n' : ' '
-        emit(i, ch, ch)
-        i += 1
+        if interpolated && escaped_dollar?(i)
+          emit(i, ' ', ' ')
+          emit(i + 1, ' ', ' ')
+          i += 2
+        elsif interpolated && interpolation_hole?(i)
+          i = skip_interpolation(i, false)
+        else
+          ch = @chars[i] == '\n' ? '\n' : ' '
+          emit(i, ch, ch)
+          i += 1
+        end
       end
       @spans << {:string, start, i}
       i
@@ -155,6 +164,7 @@ module Noir
     # Regular `"…"` string. Blanked in the structural view; PRESERVED (quotes
     # and content) in the code view so route literals stay readable.
     private def mask_string(start : Int32) : Int32
+      interpolated = interpolated_string?(start)
       emit(start, ' ', '"')
       i = start + 1
       escaped = false
@@ -165,19 +175,129 @@ module Noir
           i += 1
           break # unterminated single-line string
         end
-        emit(i, ' ', c)
+
+        if interpolated && !escaped && escaped_dollar?(i)
+          # `$$` is how an interpolated string writes a literal `$`; it does
+          # not open a hole.
+          emit(i, ' ', c)
+          emit(i + 1, ' ', '$')
+          i += 2
+        elsif interpolated && !escaped && interpolation_hole?(i)
+          i = skip_interpolation(i, true)
+        else
+          # The `$ident` short form needs nothing special — it carries no
+          # delimiters, so it is plain string content either way.
+          emit(i, ' ', c)
+          if escaped
+            escaped = false
+          elsif c == '\\'
+            escaped = true
+          elsif c == '"'
+            i += 1
+            break
+          end
+          i += 1
+        end
+      end
+      @spans << {:string, start, i}
+      i
+    end
+
+    # `s"…"` / `f"…"` / `raw"…"` and any custom interpolator glue the opening
+    # quote straight onto an identifier; a plain literal never does.
+    private def interpolated_string?(start : Int32) : Bool
+      return false if start == 0
+      ident_char?(@chars[start - 1])
+    end
+
+    private def escaped_dollar?(i : Int32) : Bool
+      @chars[i] == '$' && i + 1 < @size && @chars[i + 1] == '$'
+    end
+
+    private def interpolation_hole?(i : Int32) : Bool
+      @chars[i] == '$' && i + 1 < @size && @chars[i + 1] == '{'
+    end
+
+    # `${…}` inside an interpolated string is a nested CODE region, not string
+    # content. Without tracking it, the first `"` inside the hole closed the
+    # literal, the rest of the expression was lexed as code, and the next `"`
+    # re-opened a string — so `s"x ${cfg("k")} y"` produced two string spans
+    # with a stray `k` token between them, and any parenthesis that landed on
+    # the wrong side of that split skewed the structural depth permanently
+    # (`foo(s"${f("(")}")` left an unmatched `(` in the masked view).
+    #
+    # `start` points at the `$`; the return value is the index just past the
+    # matching `}`. Every character in between is emitted as string content,
+    # so the hole contributes no delimiter of its own to the structural view
+    # and brace matching sees exactly what it saw before this fix.
+    private def skip_interpolation(start : Int32, keep_code : Bool) : Int32
+      i = start
+      depth = 0
+      while i < @size
+        c = @chars[i]
+        if c == '"'
+          # A literal inside the hole: consume it whole so its quotes and
+          # braces cannot be mistaken for the hole's terminator.
+          i = skip_nested_literal(i, keep_code)
+        else
+          depth += 1 if c == '{'
+          depth -= 1 if c == '}'
+          emit_content(i, keep_code)
+          i += 1
+          break if depth == 0 && c == '}'
+        end
+      end
+      i
+    end
+
+    # A `"…"` / `"""…"""` literal nested inside an interpolation hole. Emitted
+    # as content, like the hole around it.
+    private def skip_nested_literal(start : Int32, keep_code : Bool) : Int32
+      i = start
+      if start + 2 < @size && @chars[start + 1] == '"' && @chars[start + 2] == '"'
+        3.times do
+          emit_content(i, keep_code)
+          i += 1
+        end
+        while i < @size
+          if @chars[i] == '"' && i + 2 < @size && @chars[i + 1] == '"' && @chars[i + 2] == '"'
+            3.times do
+              emit_content(i, keep_code)
+              i += 1
+            end
+            return i
+          end
+          emit_content(i, keep_code)
+          i += 1
+        end
+        return i
+      end
+
+      emit_content(i, keep_code)
+      i += 1
+      escaped = false
+      while i < @size
+        c = @chars[i]
+        emit_content(i, keep_code)
+        i += 1
         if escaped
           escaped = false
         elsif c == '\\'
           escaped = true
-        elsif c == '"'
-          i += 1
+        elsif c == '"' || c == '\n'
           break
         end
-        i += 1
       end
-      @spans << {:string, start, i}
       i
+    end
+
+    # Emit one character as string content: blanked structurally, and either
+    # preserved (regular string, whose code view keeps route literals) or
+    # blanked (triple-quoted string, blanked in both views).
+    private def emit_content(index : Int32, keep_code : Bool)
+      c = @chars[index]
+      blank = c == '\n' ? '\n' : ' '
+      emit(index, blank, keep_code ? c : blank)
     end
 
     # True when the `'` at `pos` opens a real char literal (`'x'` or `'\x'`)

--- a/src/miniparsers/adonisjs_extractor_ts.cr
+++ b/src/miniparsers/adonisjs_extractor_ts.cr
@@ -90,6 +90,12 @@ module Noir
     # `session.get('plan')`, a Lucid `Model.query()...delete('*')`, etc.
     ROUTER_RECEIVERS = Set{"router", "Route"}
 
+    # Route paths and controller references are written as either a quoted
+    # string or a backtick template literal — tree-sitter-javascript emits
+    # `template_string` for the latter. `decode_string` has always known how
+    # to unwrap both; only the call-site gates were rejecting backticks.
+    STRING_LITERAL_TYPES = Set{"string", "template_string"}
+
     struct Route
       getter verb : String
       getter path : String
@@ -347,13 +353,24 @@ module Noir
       string_argument_at(call, source, 0)
     end
 
+    # Index over EVERY argument, not only the string-shaped ones.
+    # Counting string nodes alone made the positions depend on which
+    # arguments happened to be strings, so a non-string first argument
+    # silently promoted the second one:
+    # `Route.get(`/users/${id}`, 'UsersController.show')` used to report
+    # `GET /UsersController.show` — a URL that exists nowhere in the app —
+    # because the template literal was invisible to this counter and the
+    # controller string landed on index 0.
     private def string_argument_at(call : LibTreeSitter::TSNode, source : String, target_index : Int32) : String?
       args = arguments_node(call)
       return unless args
       index = 0
       Noir::TreeSitter.each_named_child(args) do |arg|
-        next unless Noir::TreeSitter.node_type(arg) == "string"
-        return decode_string(arg, source) if index == target_index
+        type = Noir::TreeSitter.node_type(arg)
+        next if type == "comment"
+        if index == target_index
+          return STRING_LITERAL_TYPES.includes?(type) ? decode_string(arg, source) : nil
+        end
         index += 1
       end
       nil
@@ -406,8 +423,16 @@ module Noir
     private def decode_string(node : LibTreeSitter::TSNode, source : String) : String
       buf = String.build do |io|
         Noir::TreeSitter.each_named_child(node) do |child|
-          if Noir::TreeSitter.node_type(child) == "string_fragment"
+          case Noir::TreeSitter.node_type(child)
+          when "string_fragment"
             io << Noir::TreeSitter.node_text(child, source)
+          when "template_substitution"
+            # `` `/users/${id}` `` — keep the hole as a `{id}` placeholder
+            # rather than dropping it, which would collapse the path to
+            # `/users/` (or `/users//edit` for an interior hole). Same
+            # convention the Python f-string and Kotlin template decoders
+            # use, and the shape downstream path-param extraction expects.
+            io << Noir::TreeSitter.node_text(child, source).lchop('$')
           end
         end
       end

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -1,9 +1,14 @@
 require "../models/endpoint"
 require "./callee_extractor_base"
+require "./clojure_scanner"
 
 module Noir::ClojureCalleeExtractor
   extend self
   include Noir::CalleeExtractorBase
+  # `skip_comment`, `skip_string`, `skip_char_literal`, `find_matching_delimiter`
+  # and `line_number_for` come from the shared reader, which the Clojure
+  # analyzers use too — there is one implementation, not a copy per caller.
+  include Noir::ClojureScanner
 
   RESERVED = Set{
     "def", "defn", "defmacro", "fn", "let", "letfn", "if", "if-not",
@@ -50,6 +55,11 @@ module Noir::ClojureCalleeExtractor
         i = skip_comment(source, i, end_index)
       when '"'
         i = skip_string(source, i, end_index) + 1
+      when '\\'
+        # Character literal — consume it whole, before anything reads the
+        # character it carries: `\"` must not open a string and `\(` must not
+        # open a form.
+        i = skip_char_literal(source, i, end_index) + 1
       when '\'', '`'
         i = skip_quoted_form(source, i + 1, end_index)
       when '#'
@@ -159,6 +169,9 @@ module Noir::ClojureCalleeExtractor
         i = skip_comment(source, i, end_index)
       when '"'
         i = skip_string(source, i, end_index) + 1
+      when '\\'
+        # Character literal — see `scan_function_definitions`.
+        i = skip_char_literal(source, i, end_index) + 1
       when '`'
         # Syntax-quote of a bare symbol (`` `ns/handler ``) is the idiomatic
         # Pedestal tabular-route handler reference — capture it. Syntax-quoted
@@ -253,7 +266,7 @@ module Noir::ClojureCalleeExtractor
     return i if i >= limit
 
     case source.byte_at(i).unsafe_chr
-    when '(', '[', '{', '"', '~'
+    when '(', '[', '{', '"', '\\', '~'
       skip_quoted_form(source, index + 1, limit)
     else
       symbol, after = read_symbol(source, i, limit)
@@ -279,6 +292,8 @@ module Noir::ClojureCalleeExtractor
       find_matching_delimiter(source, i, '{', '}', limit) + 1
     when '"'
       skip_string(source, i, limit) + 1
+    when '\\'
+      skip_char_literal(source, i, limit) + 1
     else
       _, after_symbol = read_symbol(source, i, limit)
       after_symbol
@@ -312,60 +327,6 @@ module Noir::ClojureCalleeExtractor
       end
     end
     i
-  end
-
-  private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
-    i = index
-    while i < limit && source.byte_at(i).unsafe_chr != '\n'
-      i += 1
-    end
-    i
-  end
-
-  private def skip_string(source : String, index : Int32, limit : Int32) : Int32
-    i = index + 1
-    escaping = false
-
-    while i < limit
-      char = source.byte_at(i).unsafe_chr
-      if escaping
-        escaping = false
-      elsif char == '\\'
-        escaping = true
-      elsif char == '"'
-        return i
-      end
-      i += 1
-    end
-
-    limit - 1
-  end
-
-  private def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
-    depth = 0
-    i = index
-
-    while i < limit
-      char = source.byte_at(i).unsafe_chr
-      case char
-      when ';'
-        i = skip_comment(source, i, limit)
-      when '"'
-        i = skip_string(source, i, limit)
-      when open_char
-        depth += 1
-      when close_char
-        depth -= 1
-        return i if depth == 0
-      end
-      i += 1
-    end
-
-    index
-  end
-
-  private def line_number_for(source : String, index : Int32, start_line : Int32) : Int32
-    start_line + source.to_slice[0, index].count('\n'.ord.to_u8)
   end
 
   private def whitespace?(char : Char) : Bool

--- a/src/miniparsers/clojure_scanner.cr
+++ b/src/miniparsers/clojure_scanner.cr
@@ -1,0 +1,108 @@
+module Noir
+  # Low-level Clojure reader primitives, shared by the callee extractor in this
+  # directory and by the Clojure framework analyzers — `Analyzer::Clojure::Helper`
+  # is a thin delegation layer over this module, so the two never drift again.
+  #
+  # Every offset here is a *byte* offset into the raw source (`byte_at`), never a
+  # character index, so the values stay usable with `String#byte_slice` on sources
+  # containing non-ASCII text.
+  module ClojureScanner
+    extend self
+
+    # Advance past a `;` line comment, stopping on the newline that ends it.
+    def skip_comment(source : String, index : Int32, limit : Int32) : Int32
+      i = index
+      while i < limit && source.byte_at(i).unsafe_chr != '\n'
+        i += 1
+      end
+      i
+    end
+
+    # Advance from the opening `"` of a string literal to its closing quote,
+    # honouring `\` escapes. Returns the last in-range offset when the literal
+    # is unterminated so callers still make progress.
+    def skip_string(source : String, index : Int32, limit : Int32) : Int32
+      i = index + 1
+      escaping = false
+
+      while i < limit
+        char = source.byte_at(i).unsafe_chr
+        if escaping
+          escaping = false
+        elsif char == '\\'
+          escaping = true
+        elsif char == '"'
+          return i
+        end
+        i += 1
+      end
+
+      limit - 1
+    end
+
+    # Advance from the `\` that opens a character literal to the literal's last
+    # byte (the same "last byte consumed" contract as `skip_string`).
+    #
+    # Clojure character literals are `\a`, `\"`, `\(`, `\\`, `\;` (a single
+    # character, reader-significant ones included), the named forms `\newline`,
+    # `\space`, `\tab`, `\formfeed`, `\backspace` and `\return`, `\uXXXX` and
+    # `\oNNN`. Without this, `\"` opens a string that runs to the next quote in
+    # the file and `\(` counts as a real open paren, so depth accounting — and
+    # with it every route below the literal — collapses.
+    def skip_char_literal(source : String, index : Int32, limit : Int32) : Int32
+      # A trailing backslash at the very end of the range has nothing to consume.
+      return index if index + 1 >= limit
+
+      # The character right after the backslash always belongs to the literal,
+      # whatever it is: in `\\` the escaped-looking backslash *is* the character
+      # and the literal ends there, and `\;` is a semicolon, not a comment.
+      last = index + 1
+
+      # Named, unicode and octal literals run longer than one character. Take the
+      # whole token so `\newline` cannot leave `ewline` behind to be read as a
+      # symbol.
+      if source.byte_at(last).unsafe_chr.ascii_alphanumeric?
+        while last + 1 < limit && source.byte_at(last + 1).unsafe_chr.ascii_alphanumeric?
+          last += 1
+        end
+      end
+
+      last
+    end
+
+    # Find the offset of the delimiter closing the one at `index`, skipping over
+    # comments, string literals and character literals so a `)` inside `";)"` or
+    # a `\(` never moves the depth counter. Returns `index` unchanged when no
+    # match is found.
+    def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
+      depth = 0
+      i = index
+
+      while i < limit
+        char = source.byte_at(i).unsafe_chr
+        case char
+        when ';'
+          i = skip_comment(source, i, limit)
+        when '"'
+          i = skip_string(source, i, limit)
+        when '\\'
+          i = skip_char_literal(source, i, limit)
+        when open_char
+          depth += 1
+        when close_char
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+
+      index
+    end
+
+    # Line number of a byte offset, counted from `start_line` (1-based by
+    # default, matching a whole-file offset).
+    def line_number_for(source : String, index : Int32, start_line : Int32 = 1) : Int32
+      start_line + source.to_slice[0, index].count('\n'.ord.to_u8)
+    end
+  end
+end

--- a/src/miniparsers/cpp_callee_extractor.cr
+++ b/src/miniparsers/cpp_callee_extractor.cr
@@ -35,9 +35,10 @@ module Noir::CppCalleeExtractor
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     entries = [] of Entry
     in_block_comment = false
+    raw_terminator = nil.as(String?)
 
     body.each_line.with_index do |line, index|
-      stripped, in_block_comment = strip_non_code_with_state(line, in_block_comment)
+      stripped, in_block_comment, raw_terminator = strip_non_code_with_state(line, in_block_comment, raw_terminator)
       scan_line(stripped, file_path, start_line + index, entries)
     end
 
@@ -151,7 +152,13 @@ module Noir::CppCalleeExtractor
     while i < size
       char = ptr[i].unsafe_chr
 
-      if char == '"' || char == '\''
+      if char == '"' && (delimiter = raw_string_delimiter(source, i, size))
+        # Comments are only blanked at or before `i`, so reading ahead in the
+        # untouched `source` and in `bytes` is equivalent here.
+        i = skip_raw_string(source, i, size, delimiter) + 1
+      elsif char == '\'' && digit_separator?(source, i)
+        i += 1
+      elsif char == '"' || char == '\''
         quote = char
         i += 1
         while i < size
@@ -228,7 +235,9 @@ module Noir::CppCalleeExtractor
     RESERVED.includes?(last) || ROUTE_MACROS.includes?(last)
   end
 
-  private def strip_non_code_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+  private def strip_non_code_with_state(line : String,
+                                        in_block_comment : Bool,
+                                        raw_terminator : String?) : Tuple(String, Bool, String?)
     bytesize = line.bytesize
     ptr = line.to_unsafe
     in_string = false
@@ -236,6 +245,15 @@ module Noir::CppCalleeExtractor
     escaped = false
     index = 0
     stripped = String::Builder.new(bytesize)
+
+    # A raw string opened on an earlier line runs until its `)delim"`; nothing
+    # before that is code, however many quotes or braces it contains.
+    if pending = raw_terminator
+      closed = find_bytes(line, pending, 0, bytesize)
+      return {"", in_block_comment, pending} unless closed
+      index = closed + pending.bytesize
+      raw_terminator = nil
+    end
 
     while index < bytesize
       byte = ptr[index]
@@ -262,9 +280,18 @@ module Noir::CppCalleeExtractor
         elsif char == '\''
           in_char = false
         end
+      elsif char == '"' && (delimiter = raw_string_delimiter(line, index, bytesize))
+        terminator = ")#{delimiter}\""
+        body_start = index + delimiter.bytesize + 2
+        if closed = find_bytes(line, terminator, body_start, bytesize)
+          index = closed + terminator.bytesize
+          next
+        end
+        raw_terminator = terminator
+        break
       elsif char == '"'
         in_string = true
-      elsif char == '\''
+      elsif char == '\'' && !digit_separator?(line, index)
         in_char = true
       elsif char == '/' && index + 1 < bytesize && ptr[index + 1].unsafe_chr == '/'
         break
@@ -278,10 +305,26 @@ module Noir::CppCalleeExtractor
       index += 1
     end
 
-    {stripped.to_s, in_block_comment}
+    {stripped.to_s, in_block_comment, raw_terminator}
+  end
+
+  private def find_bytes(source : String, needle : String, start_index : Int32, limit : Int32) : Int32?
+    size = needle.bytesize
+    index = start_index
+
+    while index + size <= limit
+      return index if bytes_match?(source, index, needle)
+      index += 1
+    end
+
+    nil
   end
 
   private def skip_string(source : String, index : Int32, limit : Int32) : Int32
+    if delimiter = raw_string_delimiter(source, index, limit)
+      return skip_raw_string(source, index, limit, delimiter)
+    end
+
     i = index + 1
     escaping = false
 
@@ -300,7 +343,100 @@ module Noir::CppCalleeExtractor
     limit - 1
   end
 
+  # A raw string literal (`R"(...)"`, `R"tag(...)tag"`, optionally prefixed
+  # `u8`/`L`/`u`/`U`) ends only at its exact `)delim"` terminator. Its body may
+  # hold unbalanced quotes, braces and newlines — that is the point of the
+  # form — so the ordinary quote scanner desynchronizes on it. Returns the
+  # d-char delimiter (possibly empty) when `index` opens a raw string.
+  private def raw_string_delimiter(source : String, index : Int32, limit : Int32) : String?
+    return unless raw_string_prefix?(source, index)
+
+    i = index + 1
+    # At most 16 d-chars, then the mandatory `(`.
+    stop = Math.min(limit, index + 18)
+    delimiter = String::Builder.new
+
+    while i < stop
+      char = source.byte_at(i).unsafe_chr
+      return delimiter.to_s if char == '('
+      return if char == ')' || char == '\\' || char == '"' || char.ascii_whitespace?
+      delimiter << char
+      i += 1
+    end
+
+    nil
+  end
+
+  # Returns the index of the closing `"`, matching `skip_string`'s contract.
+  # An unterminated raw string degrades to the end of the scanned range.
+  private def skip_raw_string(source : String, index : Int32, limit : Int32, delimiter : String) : Int32
+    terminator = ")#{delimiter}\""
+    size = terminator.bytesize
+    i = index + delimiter.bytesize + 2
+
+    while i + size <= limit
+      return i + size - 1 if bytes_match?(source, i, terminator)
+      i += 1
+    end
+
+    limit - 1
+  end
+
+  private def raw_string_prefix?(source : String, index : Int32) : Bool
+    return false if index <= 0
+    return false unless source.byte_at(index - 1).unsafe_chr == 'R'
+
+    start = index - 1
+    if start >= 2 && source.byte_at(start - 2).unsafe_chr == 'u' && source.byte_at(start - 1).unsafe_chr == '8'
+      start -= 2
+    elsif start >= 1 && {'L', 'u', 'U'}.includes?(source.byte_at(start - 1).unsafe_chr)
+      start -= 1
+    end
+
+    return true if start == 0
+    !identifier_byte?(source.byte_at(start - 1).unsafe_chr)
+  end
+
+  private def bytes_match?(source : String, index : Int32, needle : String) : Bool
+    return false if index + needle.bytesize > source.bytesize
+
+    offset = index
+    needle.each_byte do |byte|
+      return false unless source.byte_at(offset) == byte
+      offset += 1
+    end
+    true
+  end
+
+  private def identifier_byte?(char : Char) : Bool
+    char.ascii_alphanumeric? || char == '_'
+  end
+
+  # C++14 digit separators (`1'000'000`, `0x1'F`) are not char literals. Every
+  # `'` opening one made the scanner run to EOF, so a handler containing one
+  # yielded zero callees — parity-dependent, so it failed silently.
+  private def digit_separator?(source : String, index : Int32) : Bool
+    return false if index <= 0
+    return false unless source.byte_at(index - 1).unsafe_chr.ascii_alphanumeric?
+    return false if index + 1 >= source.bytesize
+    return false unless source.byte_at(index + 1).unsafe_chr.ascii_alphanumeric?
+
+    # Walk back to the start of the token: a separator only ever appears inside
+    # a numeric literal, so the token must begin with a digit. This keeps the
+    # `L'a'` / `u8'x'` / `U'x'` encoding prefixes reading as char literals.
+    start = index - 1
+    while start > 0
+      char = source.byte_at(start - 1).unsafe_chr
+      break unless char.ascii_alphanumeric? || char == '_' || char == '\'' || char == '.'
+      start -= 1
+    end
+
+    source.byte_at(start).unsafe_chr.ascii_number?
+  end
+
   private def skip_char_literal(source : String, index : Int32, limit : Int32) : Int32
+    return index if digit_separator?(source, index)
+
     i = index + 1
     escaping = false
 

--- a/src/miniparsers/elysia_extractor_ts.cr
+++ b/src/miniparsers/elysia_extractor_ts.cr
@@ -69,6 +69,12 @@ module Noir
     GROUP_METHODS       = Set{"group"}
     TRANSPARENT_METHODS = Set{"guard", "use"}
 
+    # Route and group paths are written as either a quoted string or a
+    # backtick template literal — tree-sitter-javascript emits
+    # `template_string` for the latter, and every path gate below accepts
+    # both. `decode_string` has always known how to unwrap them; only the
+    # call-site gates rejected backticks.
+
     struct Route
       getter verb : String
       getter path : String
@@ -159,7 +165,7 @@ module Noir
       group_body : LibTreeSitter::TSNode? = nil
       Noir::TreeSitter.each_named_child(args) do |arg|
         case Noir::TreeSitter.node_type(arg)
-        when "string"
+        when "string", "template_string"
           group_path ||= decode_string(arg, source)
         when "arrow_function"
           group_body ||= arrow_body(arg)
@@ -190,7 +196,7 @@ module Noir
       handler : LibTreeSitter::TSNode? = nil
       Noir::TreeSitter.each_named_child(args) do |arg|
         case Noir::TreeSitter.node_type(arg)
-        when "string"
+        when "string", "template_string"
           path ||= decode_string(arg, source)
         when "arrow_function"
           handler ||= arg
@@ -397,8 +403,15 @@ module Noir
     private def decode_string(node : LibTreeSitter::TSNode, source : String) : String
       buf = String.build do |io|
         Noir::TreeSitter.each_named_child(node) do |child|
-          if Noir::TreeSitter.node_type(child) == "string_fragment"
+          case Noir::TreeSitter.node_type(child)
+          when "string_fragment"
             io << Noir::TreeSitter.node_text(child, source)
+          when "template_substitution"
+            # `` `/users/${id}` `` — keep the hole as a `{id}` placeholder
+            # rather than dropping it, which would collapse the path to
+            # `/users/`. Same convention as the Python f-string and Kotlin
+            # template decoders.
+            io << Noir::TreeSitter.node_text(child, source).lchop('$')
           end
         end
       end

--- a/src/miniparsers/hapi_extractor_ts.cr
+++ b/src/miniparsers/hapi_extractor_ts.cr
@@ -48,6 +48,12 @@ module Noir
       "HEAD", "OPTIONS",
     }
 
+    # `path:` is written as either a quoted string or a backtick template
+    # literal — tree-sitter-javascript emits `template_string` for the
+    # latter. `decode_string` has always known how to unwrap both; the
+    # gate below rejecting backticks dropped the whole route object.
+    STRING_LITERAL_TYPES = Set{"string", "template_string"}
+
     struct Route
       getter verb : String
       getter path : String
@@ -130,7 +136,7 @@ module Noir
         when "method"
           collect_method_values(value, source, methods)
         when "path"
-          path = decode_string(value, source) if Noir::TreeSitter.node_type(value) == "string"
+          path = decode_string(value, source) if STRING_LITERAL_TYPES.includes?(Noir::TreeSitter.node_type(value))
         when "handler"
           handler = value
         end
@@ -315,20 +321,27 @@ module Noir
     end
 
     # tree-sitter-javascript wraps string contents in
-    # `string_fragment` named children. Templates / escapes get
-    # additional siblings — we just join the fragments which keeps
-    # the simple-string case correct without choking on the rest.
+    # `string_fragment` named children — template literals included.
+    # Escapes get additional siblings we skip, which keeps the simple
+    # case correct without choking on the rest.
     private def decode_string(node : LibTreeSitter::TSNode, source : String) : String
       buf = String.build do |io|
         Noir::TreeSitter.each_named_child(node) do |child|
-          if Noir::TreeSitter.node_type(child) == "string_fragment"
+          case Noir::TreeSitter.node_type(child)
+          when "string_fragment"
             io << Noir::TreeSitter.node_text(child, source)
+          when "template_substitution"
+            # `` `/users/${id}` `` — keep the hole as a `{id}` placeholder
+            # rather than dropping it, which would collapse the path to
+            # `/users/`. Same convention as the Python f-string and Kotlin
+            # template decoders.
+            io << Noir::TreeSitter.node_text(child, source).lchop('$')
           end
         end
       end
       return buf unless buf.empty?
       raw = Noir::TreeSitter.node_text(node, source)
-      if raw.size >= 2 && (raw[0] == '\'' || raw[0] == '"') && raw[0] == raw[-1]
+      if raw.size >= 2 && (raw[0] == '\'' || raw[0] == '"' || raw[0] == '`') && raw[0] == raw[-1]
         raw[1..-2]
       else
         raw

--- a/src/miniparsers/haskell_callee_extractor.cr
+++ b/src/miniparsers/haskell_callee_extractor.cr
@@ -17,12 +17,19 @@ module Noir::HaskellCalleeExtractor
     "not", "and", "or", "maybe", "either", "fst", "snd",
   }
 
-  QUALIFIED_CALL_REGEX = /(?<![A-Za-z0-9_'.])((?:[A-Z][A-Za-z0-9_']*\.)+[a-z_][A-Za-z0-9_']*)\b/
-  STATEMENT_CALL_REGEX = /^\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
-  BIND_CALL_REGEX      = /(?:<-|=)\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
-  DOLLAR_CALL_REGEX    = /\$\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
-  PAREN_CALL_REGEX     = /[(,]\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
-  BRANCH_CALL_REGEX    = /(?:->|\bthen\b|\belse\b)\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
+  # No trailing `\b` on the captured name. `\b` after `[A-Za-z0-9_']*` is
+  # redundant whenever the name ends in a word character (the greedy class
+  # has already consumed every one of them), and it is *unsatisfiable* when
+  # the name ends in a prime: `\b` would demand a word character after the
+  # `'` while the lookahead demands whitespace / EOL / `(`. So the only
+  # thing it ever did was force `go'` to backtrack down to `go` — or, with
+  # the lookahead, fail to match at all.
+  QUALIFIED_CALL_REGEX = /(?<![A-Za-z0-9_'.])((?:[A-Z][A-Za-z0-9_']*\.)+[a-z_][A-Za-z0-9_']*)(?![A-Za-z0-9_'])/
+  STATEMENT_CALL_REGEX = /^\s*([a-z_][A-Za-z0-9_']*)(?=\s|$|\()/
+  BIND_CALL_REGEX      = /(?:<-|=)\s*([a-z_][A-Za-z0-9_']*)(?=\s|$|\()/
+  DOLLAR_CALL_REGEX    = /\$\s*([a-z_][A-Za-z0-9_']*)(?=\s|$|\()/
+  PAREN_CALL_REGEX     = /[(,]\s*([a-z_][A-Za-z0-9_']*)(?=\s|$|\()/
+  BRANCH_CALL_REGEX    = /(?:->|\bthen\b|\belse\b)\s*([a-z_][A-Za-z0-9_']*)(?=\s|$|\()/
 
   def function_bodies(content : String, file_path : String) : Array(FunctionBody)
     cleaned = strip_non_code(content)
@@ -32,7 +39,7 @@ module Noir::HaskellCalleeExtractor
 
     while index < lines.size
       line = lines[index]
-      match = line.match(/^([a-z_][A-Za-z0-9_']*)\b.*=/)
+      match = line.match(/^([a-z_][A-Za-z0-9_']*).*=/)
       unless match
         index += 1
         next
@@ -145,7 +152,9 @@ module Noir::HaskellCalleeExtractor
   end
 
   private def same_function_equation?(line : String, name : String) : Bool
-    !!line.match(/^#{Regex.escape(name)}\b.*=/)
+    # `(?![A-Za-z0-9_'])` rather than `\b`: `\b` treats the prime as a
+    # boundary, so `foo` would claim `foo' x = …` — a different function.
+    !!line.match(/^#{Regex.escape(name)}(?![A-Za-z0-9_']).*=/)
   end
 
   # Index of the binding `=`, skipping operators that merely contain `=`
@@ -230,9 +239,23 @@ module Noir::HaskellCalleeExtractor
     return false if start + 2 >= chars.size
     return false if chars[start + 1] == '['
 
+    # A `'` glued to the end of an identifier is a prime — part of the name
+    # (`go'`, `xs''`), never the opening of a char literal. Haskell char
+    # literals (`'a'`, `'\n'`, `'\''`, `'\1234'`) are always preceded by
+    # whitespace or a delimiter. Without this, `xs' <- go' 1` matched the
+    # <= 8 character heuristic and everything from the prime on `xs` to the
+    # prime on `go` was masked away: `go'` vanished and the leftover `xs`
+    # was reported as a phantom callee.
+    return false if start > 0 && identifier_char?(chars[start - 1])
+
     finish = skip_char(chars, start)
     return false if finish >= chars.size
     finish - start <= 8
+  end
+
+  # Characters that may appear *inside* a Haskell identifier, prime included.
+  private def identifier_char?(char : Char) : Bool
+    char.alphanumeric? || char == '_' || char == '\''
   end
 
   private def append_blanks_until_line_end(stripped : String::Builder, chars : Array(Char), start : Int32) : Int32

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -2,6 +2,7 @@ require "../utils/url_path"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./kotlin_callee_extractor"
+require "./kotlin_source_mask"
 
 module Noir
   # Tree-sitter-backed http4k extractor.
@@ -108,7 +109,12 @@ module Noir
       current_type = ""
       current_depth = 0
 
-      source.each_line do |line|
+      # Comment-free copy that still carries the literal values. Read the
+      # raw source instead and a commented-out `const val PATH = "/old"`
+      # above the live declaration wins the `||=` below and permanently
+      # shadows it, so every route built from that constant reports a URL
+      # that does not exist while the real one is lost.
+      Noir::KotlinSourceMask.code_only(source).each_line do |line|
         if package_name.empty?
           if match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)/)
             package_name = match[1]

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -1,5 +1,4 @@
 require "../utils/url_path"
-require "../utils/top_level_split"
 require "../ext/tree_sitter/tree_sitter"
 require "./extraction_result_cache"
 require "../models/endpoint"
@@ -405,28 +404,45 @@ module Noir
       name == "HttpExchange" || name.ends_with?("Exchange")
     end
 
+    # Simple names of the `implements` interfaces, read straight from the
+    # tree-sitter `interfaces` field (a `super_interfaces` node wrapping a
+    # `type_list`).
+    #
+    # Reading the field rather than slicing the class node's text at the
+    # first `{` matters: the node text starts at the `modifiers` child, so
+    # a class-level annotation whose arguments contain a brace —
+    # `@Produces({MediaType.APPLICATION_JSON})`, `@RequestMapping({"/api"})`,
+    # `@CrossOrigin(origins = {...})` — was mistaken for the class body and
+    # cut the header off before `implements` was ever reached, silently
+    # killing interface route inheritance. `superclass_name` below already
+    # reads its field; this is the same idea for the interface list.
     private def implemented_interface_names(class_decl : LibTreeSitter::TSNode, source : String) : Array(String)
-      header = Noir::TreeSitter.node_text(class_decl, source)
-      if body_start = header.index('{')
-        header = header[...body_start]
-      end
+      names = [] of String
+      return names unless interfaces = Noir::TreeSitter.field(class_decl, "interfaces")
 
-      match = header.match(/\bimplements\s+(.+)\z/m)
-      return [] of String unless match
-
-      names = split_top_level_commas(match[1]).compact_map do |raw|
-        type_name = raw.strip
-        next if type_name.empty?
-        type_name = strip_generic_arguments(type_name)
-        type_name = type_name.split(/\s+/).first? || type_name
-        if idx = type_name.rindex('.')
-          type_name[(idx + 1)..]
+      Noir::TreeSitter.each_named_child(interfaces) do |child|
+        if Noir::TreeSitter.node_type(child) == "type_list"
+          Noir::TreeSitter.each_named_child(child) do |type_node|
+            append_simple_type_name(type_node, source, names)
+          end
         else
-          type_name
+          append_simple_type_name(child, source, names)
         end
       end
-      names.uniq!
       names
+    end
+
+    # Appends the simple name of a type node — generics dropped, package
+    # qualifier dropped, any leading `@Annotation` on an `annotated_type`
+    # discarded — skipping empties and duplicates.
+    private def append_simple_type_name(type_node : LibTreeSitter::TSNode, source : String, names : Array(String))
+      name = strip_generic_arguments(Noir::TreeSitter.node_text(type_node, source))
+      name = name.split(/\s+/).last? || name
+      return if name.empty?
+      if idx = name.rindex('.')
+        name = name[(idx + 1)..]
+      end
+      names << name unless name.empty? || names.includes?(name)
     end
 
     # An `abstract class` is never instantiated as a controller, so its
@@ -456,15 +472,6 @@ module Noir
       else
         name
       end
-    end
-
-    # Delegates to the shared splitter. `Rules::GENERICS_ONLY` reproduces this
-    # file's previous hand-rolled loop exactly: only `<` and `>` contribute
-    # depth (clamped at 0), quotes and backslashes are ordinary characters, no
-    # part is stripped and every empty part is kept. The caller strips and
-    # skips empties itself.
-    private def split_top_level_commas(text : String) : Array(String)
-      Noir::TopLevelSplit.split(text, ',', Noir::TopLevelSplit::Rules::GENERICS_ONLY)
     end
 
     private def strip_generic_arguments(text : String) : String

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -1,5 +1,4 @@
 require "../utils/url_path"
-require "../utils/top_level_split"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./java_callee_extractor"
@@ -615,58 +614,58 @@ module Noir
       false
     end
 
+    # Simple names of the `implements` interfaces, read straight from the
+    # tree-sitter `interfaces` field (a `super_interfaces` node wrapping a
+    # `type_list`).
+    #
+    # Reading the field rather than slicing the class node's text at the
+    # first `{` matters: the node text starts at the `modifiers` child, so
+    # a class-level annotation whose arguments contain a brace —
+    # `@Produces({MediaType.APPLICATION_JSON})` is the canonical JAX-RS
+    # spelling — was mistaken for the class body and cut the header off
+    # before `implements` was ever reached, silently killing interface
+    # route inheritance.
     private def implemented_interface_names(class_decl : LibTreeSitter::TSNode, source : String) : Array(String)
-      header = Noir::TreeSitter.node_text(class_decl, source)
-      if body_start = header.index('{')
-        header = header[...body_start]
-      end
+      names = [] of String
+      return names unless interfaces = Noir::TreeSitter.field(class_decl, "interfaces")
 
-      match = header.match(/\bimplements\s+(.+)\z/m)
-      return [] of String unless match
-
-      names = split_top_level_commas(match[1]).compact_map do |raw|
-        type_name = strip_generic_arguments(raw.strip)
-        next if type_name.empty?
-        type_name = type_name.split(/\s+/).first? || type_name
-        if idx = type_name.rindex('.')
-          type_name[(idx + 1)..]
+      Noir::TreeSitter.each_named_child(interfaces) do |child|
+        if Noir::TreeSitter.node_type(child) == "type_list"
+          Noir::TreeSitter.each_named_child(child) do |type_node|
+            append_simple_type_name(type_node, source, names)
+          end
         else
-          type_name
+          append_simple_type_name(child, source, names)
         end
       end
-      names.uniq!
       names
     end
 
-    # Single superclass from `extends SuperClass` (or `extends SuperClass
-    # implements ...`). Returns the simple type name, or nil when the
-    # class does not extend anything.
+    # Single superclass from `extends SuperClass`, read from the
+    # tree-sitter `superclass` field for the same reason as above.
+    # Returns the simple type name, or nil when the class does not
+    # extend anything.
     private def extended_class_name(class_decl : LibTreeSitter::TSNode, source : String) : String?
-      header = Noir::TreeSitter.node_text(class_decl, source)
-      if body_start = header.index('{')
-        header = header[...body_start]
-      end
+      return unless superclass = Noir::TreeSitter.field(class_decl, "superclass")
 
-      match = header.match(/\bextends\s+([A-Za-z_][\w.$]*(?:\s*<[^;{]*>)?)/)
-      return unless match
-
-      type_name = strip_generic_arguments(match[1].strip)
-      return if type_name.empty?
-      type_name = type_name.split(/\s+/).first? || type_name
-      if idx = type_name.rindex('.')
-        type_name[(idx + 1)..]
-      else
-        type_name
+      names = [] of String
+      Noir::TreeSitter.each_named_child(superclass) do |type_node|
+        append_simple_type_name(type_node, source, names)
       end
+      names.first?
     end
 
-    # Delegates to the shared splitter. `Rules::GENERICS_ONLY` reproduces this
-    # file's previous hand-rolled loop exactly: only `<` and `>` contribute
-    # depth (clamped at 0), quotes and backslashes are ordinary characters, no
-    # part is stripped and every empty part is kept. The caller strips and
-    # skips empties itself.
-    private def split_top_level_commas(text : String) : Array(String)
-      Noir::TopLevelSplit.split(text, ',', Noir::TopLevelSplit::Rules::GENERICS_ONLY)
+    # Appends the simple name of a type node — generics dropped, package
+    # qualifier dropped, any leading `@Annotation` on an `annotated_type`
+    # discarded — skipping empties and duplicates.
+    private def append_simple_type_name(type_node : LibTreeSitter::TSNode, source : String, names : Array(String))
+      name = strip_generic_arguments(Noir::TreeSitter.node_text(type_node, source))
+      name = name.split(/\s+/).last? || name
+      return if name.empty?
+      if idx = name.rindex('.')
+        name = name[(idx + 1)..]
+      end
+      names << name unless name.empty? || names.includes?(name)
     end
 
     private def strip_generic_arguments(text : String) : String

--- a/src/miniparsers/js_http_route_extractor.cr
+++ b/src/miniparsers/js_http_route_extractor.cr
@@ -200,7 +200,11 @@ module Noir
 
       content.scan(/(?:const|let|var)\s+([A-Za-z_$]\w*)\s*(?::[^=;]+)?=\s*/) do |match|
         name = match[1]
-        start_pos = (match.begin(0) || 0) + match[0].bytesize
+        # `begin(0)` is a char index but `bytesize` is a byte length, so the
+        # sum landed short of the handler on any file with a non-ASCII
+        # character before it (a Korean type annotation was enough to lose
+        # the route). `end(0)` is the char index we actually want.
+        start_pos = match.end(0) || 0
         if handler = function_handler_at(content, start_pos)
           handlers[name] = handler
         elsif handler = arrow_handler_at(content, start_pos)

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -761,22 +761,28 @@ module Noir
           route_rparen = skip_matching_paren(idx + 3)
           if route_rparen
             each_prefixed_path(paths, router_var, router_prefixes) do |path_entry, prefixed_path|
-              # Scan ahead for chained HTTP method calls (bounded to avoid O(n^2))
+              # Walk the chained calls that follow `route(...)`. A member-call
+              # chain is contiguous: the only thing that may follow the
+              # closing paren and still belong to this statement is the '.'
+              # of the next call. Stopping at anything else — rather than
+              # only at a semicolon — is what makes this correct in
+              # semicolon-free (ASI) style, where the previous scan ran on
+              # into the next statement and hung its verbs on this path.
+              # Still bounded so a pathological chain can't go quadratic.
               j = route_rparen + 1
               steps = 0
               max_steps = 1000
               while j + 2 < limit && steps < max_steps
-                if @tokens[j].type == :dot && http_method?(@tokens[j + 1]) && @tokens[j + 2].type == :lparen
+                break unless @tokens[j].type == :dot && @tokens[j + 2].type == :lparen &&
+                             (@tokens[j + 1].type == :identifier || http_method?(@tokens[j + 1]))
+                method_rparen = skip_matching_paren(j + 2)
+                break unless method_rparen
+                # Non-verb links (`.all(...)`-style middleware) keep the
+                # chain alive without emitting a route.
+                if http_method?(@tokens[j + 1])
                   results << create_route_with_params(@tokens[j + 1].value, prefixed_path, path_entry.path, start_pos, path_entry.is_regex?)
-                  method_rparen = skip_matching_paren(j + 2)
-                  break unless method_rparen
-                  j = method_rparen + 1
-                  steps += 1
-                  next
-                elsif @tokens[j].type == :semicolon
-                  break
                 end
-                j += 1
+                j = method_rparen + 1
                 steps += 1
               end
             end
@@ -1024,36 +1030,45 @@ module Noir
           method_idx += 1
         end
 
-        # Now look for the next chained method
+        # Now look for the next chained method. `method_idx` sits on the
+        # token right after the previous call's closing paren, and a
+        # member-call chain is contiguous — only a '.' can follow and still
+        # belong to this statement. Scanning past anything else (the old
+        # loop only stopped at a semicolon) attributed the verbs of the
+        # following statements to this path whenever the file was written
+        # in semicolon-free style.
         while method_idx < @tokens.size - 2
-          if @tokens[method_idx].type == :dot &&
-             http_method?(@tokens[method_idx + 1]) &&
-             @tokens[method_idx + 2].type == :lparen
-            method = @tokens[method_idx + 1].value.upcase
+          break unless @tokens[method_idx].type == :dot &&
+                       @tokens[method_idx + 2].type == :lparen &&
+                       (@tokens[method_idx + 1].type == :identifier || http_method?(@tokens[method_idx + 1]))
 
-            # Create routes for all prefixed paths
-            paths = @current_route_paths || [@current_route_path.as(String)]
-            raw_path = @current_route_raw_path || paths.first
-            start_pos = @current_route_start_pos || @tokens[@current_route_start_idx.as(Int32)].position
-
-            paths.each do |path|
-              route = JSRoutePattern.new(method, path, raw_path, start_pos)
-              extract_path_params(path).each do |param|
-                route.push_param(param)
-              end
-              results << route
-            end
-
-            @position = method_idx + 2 # Move past the dot and method name
-            # Don't reset yet - there might be more methods chained
-            return results
-          elsif @tokens[method_idx].type == :semicolon ||
-                (@tokens[method_idx].value == "route" && method_idx > @position + 5)
-            # End of chain
-            break
+          unless http_method?(@tokens[method_idx + 1])
+            # A non-verb link (middleware, `.all(...)`-style helpers) keeps
+            # the chain alive without producing a route.
+            link_rparen = skip_matching_paren(method_idx + 2)
+            break unless link_rparen
+            method_idx = link_rparen + 1
+            next
           end
 
-          method_idx += 1
+          method = @tokens[method_idx + 1].value.upcase
+
+          # Create routes for all prefixed paths
+          paths = @current_route_paths || [@current_route_path.as(String)]
+          raw_path = @current_route_raw_path || paths.first
+          start_pos = @current_route_start_pos || @tokens[@current_route_start_idx.as(Int32)].position
+
+          paths.each do |path|
+            route = JSRoutePattern.new(method, path, raw_path, start_pos)
+            extract_path_params(path).each do |param|
+              route.push_param(param)
+            end
+            results << route
+          end
+
+          @position = method_idx + 2 # Move past the dot and method name
+          # Don't reset yet - there might be more methods chained
+          return results
         end
 
         # No more methods found in chain, reset
@@ -1098,36 +1113,41 @@ module Noir
 
         paths = prefixes_to_apply.map { |prefix| prefix.empty? ? base_path : URLPath.join(prefix, base_path) }
 
-        # Look for method chaining after .route('/path')
+        # Look for method chaining after .route('/path'). Same contiguity
+        # rule as the continuation scan above: only a '.' may follow the
+        # closing paren, otherwise the statement is over.
         method_idx = idx + 6 # Skip past string and closing paren
         while method_idx < @tokens.size - 2
-          if @tokens[method_idx].type == :dot &&
-             http_method?(@tokens[method_idx + 1]) &&
-             @tokens[method_idx + 2].type == :lparen
-            method = @tokens[method_idx + 1].value.upcase
+          break unless @tokens[method_idx].type == :dot &&
+                       @tokens[method_idx + 2].type == :lparen &&
+                       (@tokens[method_idx + 1].type == :identifier || http_method?(@tokens[method_idx + 1]))
 
-            # Create routes for all prefixed paths
-            paths.each do |path|
-              route = JSRoutePattern.new(method, path, raw_path, start_pos)
-              extract_path_params(path).each do |param|
-                route.push_param(param)
-              end
-              results << route
-            end
-
-            # Set up for chain continuation (store all paths)
-            @current_route_path = paths.first
-            @current_route_paths = paths
-            @current_route_start_idx = idx
-            @current_route_raw_path = raw_path
-            @current_route_start_pos = start_pos
-            @position = method_idx + 2 # Move past dot and method
-            return results
-          elsif @tokens[method_idx].type == :semicolon
-            # End of statement without finding a method
-            break
+          unless http_method?(@tokens[method_idx + 1])
+            link_rparen = skip_matching_paren(method_idx + 2)
+            break unless link_rparen
+            method_idx = link_rparen + 1
+            next
           end
-          method_idx += 1
+
+          method = @tokens[method_idx + 1].value.upcase
+
+          # Create routes for all prefixed paths
+          paths.each do |path|
+            route = JSRoutePattern.new(method, path, raw_path, start_pos)
+            extract_path_params(path).each do |param|
+              route.push_param(param)
+            end
+            results << route
+          end
+
+          # Set up for chain continuation (store all paths)
+          @current_route_path = paths.first
+          @current_route_paths = paths
+          @current_route_start_idx = idx
+          @current_route_raw_path = raw_path
+          @current_route_start_pos = start_pos
+          @position = method_idx + 2 # Move past dot and method
+          return results
         end
       end
 

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -1122,10 +1122,23 @@ module Noir
     # accurate. Comment bodies are blanked to spaces so a commented-
     # out decorator like `// @Get('/old')` never matches the route
     # regex.
+    #
+    # Regex literals get their own state because their bodies routinely
+    # contain quote characters (`str.replace(/'/g, "&#39;")`). Without it a
+    # single such line inverted the string state for the rest of the file,
+    # which cut both ways: real comments stopped being blanked, so
+    # commented-out routes were reported as live endpoints, and real string
+    # bodies were scanned as code, so a `//` or `/*` inside a string opened
+    # a comment that swallowed every route below it.
     def self.strip_js_comments(content : String) : String
       builder = String::Builder.new(content.bytesize)
       state = :code
       escaped = false
+      in_char_class = false
+      # Index of the last non-whitespace character emitted outside a comment.
+      # Only consulted when a '/' shows up in code, so the backward word walk
+      # it feeds costs nothing on the common path.
+      last_sig = -1
       chars = content.chars
       i = 0
       len = chars.size
@@ -1148,17 +1161,25 @@ module Noir
               next
             end
           end
-          case char
-          when '\''
-            state = :single
-          when '"'
-            state = :double
-          when '`'
-            state = :template
+          if char == '/' && regex_literal_start?(chars, last_sig)
+            state = :regex
+            escaped = false
+            in_char_class = false
+          else
+            case char
+            when '\''
+              state = :single
+            when '"'
+              state = :double
+            when '`'
+              state = :template
+            end
           end
           builder << char
+          last_sig = i unless char.whitespace?
         when :single, :double, :template
           builder << char
+          last_sig = i unless char.whitespace?
           if escaped
             escaped = false
           elsif char == '\\'
@@ -1166,6 +1187,25 @@ module Noir
           elsif (state == :single && char == '\'') ||
                 (state == :double && char == '"') ||
                 (state == :template && char == '`')
+            state = :code
+          end
+        when :regex
+          builder << char
+          last_sig = i unless char.whitespace?
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == '\n'
+            # A JavaScript regex literal cannot span lines. Resyncing here
+            # keeps a misjudged '/' (a JSX `</tag>`, say) from swallowing
+            # the rest of the file.
+            state = :code
+          elsif char == '[' && !in_char_class
+            in_char_class = true
+          elsif char == ']' && in_char_class
+            in_char_class = false
+          elsif char == '/' && !in_char_class
             state = :code
           end
         when :line_comment
@@ -1188,6 +1228,27 @@ module Noir
       end
 
       builder.to_s
+    end
+
+    # Does the '/' the stripper is looking at open a regex literal?
+    # `last_sig` is the index of the last non-whitespace character already
+    # emitted as code. The decision itself belongs to JSLiteralScanner so
+    # the stripper, the literal scanners and JSLexer cannot drift apart.
+    private def self.regex_literal_start?(chars : Array(Char), last_sig : Int32) : Bool
+      return false if last_sig < 0
+
+      prev_char = chars[last_sig]
+      prev_word = if prev_char.alphanumeric? || prev_char == '_' || prev_char == '$'
+                    start = last_sig
+                    while start > 0 && (chars[start - 1].alphanumeric? || chars[start - 1] == '_' || chars[start - 1] == '$')
+                      start -= 1
+                    end
+                    String.build { |io| (start..last_sig).each { |k| io << chars[k] } }
+                  else
+                    ""
+                  end
+
+      JSLiteralScanner.regex_context?(prev_char, prev_word)
     end
 
     def self.extract_body_params(handler_body : String, endpoint : Endpoint)

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -274,9 +274,12 @@ module Noir
           # Normalize HTTP method (e.g., DEL -> DELETE)
           normalized_method = normalize_http_method(pattern.method)
 
-          # Convert byte offset to line number
+          # `start_pos` is a JSLexer token position, i.e. an index into
+          # `Array(Char)`. `to_slice` is bytes, so it has to be converted
+          # first or every route below a non-ASCII literal reports a line
+          # from somewhere earlier in the file.
           line_number = if pattern.start_pos >= 0
-                          content.to_slice[0, pattern.start_pos].count('\n'.ord.to_u8) + 1
+                          line_for_char_pos(content, pattern.start_pos)
                         else
                           1
                         end
@@ -1228,6 +1231,17 @@ module Noir
       end
 
       builder.to_s
+    end
+
+    # 1-based line number for a CHAR index into `content`.
+    def self.line_for_char_pos(content : String, pos : Int32) : Int32
+      byte_pos = if content.bytesize == content.size
+                   pos
+                 else
+                   content.char_index_to_byte_index(pos) || content.bytesize
+                 end
+      byte_pos = content.bytesize if byte_pos > content.bytesize
+      content.to_slice[0, byte_pos].count('\n'.ord.to_u8) + 1
     end
 
     # Does the '/' the stripper is looking at open a regex literal?

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -1,6 +1,7 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./kotlin_callee_extractor"
+require "./kotlin_source_mask"
 
 module Noir
   # Tree-sitter-backed Ktor DSL route extractor.
@@ -134,7 +135,12 @@ module Noir
       current_type = ""
       current_depth = 0
 
-      source.each_line do |line|
+      # Comment-free copy that still carries the literal values. Read the
+      # raw source instead and a commented-out `const val PATH = "/old"`
+      # above the live declaration wins the `||=` below and permanently
+      # shadows it, so every route built from that constant reports a URL
+      # that does not exist while the real one is lost.
+      Noir::KotlinSourceMask.code_only(source).each_line do |line|
         if package_name.empty?
           if match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)/)
             package_name = match[1]

--- a/src/miniparsers/kotlin_route_extractor_ts/core.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts/core.cr
@@ -1,5 +1,6 @@
 require "../../utils/url_path"
 require "../../ext/tree_sitter/tree_sitter"
+require "../kotlin_source_mask"
 
 module Noir
   # Tree-sitter-backed Kotlin route extractor.
@@ -75,8 +76,15 @@ module Noir
       # Scrubbed copy (strings/comments blanked, newlines preserved) for brace
       # counting, so a `}` inside a const string value can't close the type early.
       scrubbed_lines = visible_kotlin_code(source).lines
+      # Comment-free copy that still carries the literal values, so the
+      # declaration regexes below read real code only. Running them on the
+      # raw source let a commented-out `const val PATH = "/old"` above the
+      # live one win the `||=` and permanently shadow it — every route built
+      # from that constant then reported a URL that does not exist while the
+      # real one was lost.
+      code_lines = Noir::KotlinSourceMask.code_only(source).lines
 
-      source.each_line.with_index do |line, idx|
+      code_lines.each_with_index do |line, idx|
         if package_name.empty?
           if match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)/)
             package_name = match[1]

--- a/src/miniparsers/kotlin_route_extractor_ts/helpers.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts/helpers.cr
@@ -1,104 +1,10 @@
 # Part of Noir::TreeSitterKotlinRouteExtractor: shared annotation/string/expression decoding helpers.
 module Noir
   module TreeSitterKotlinRouteExtractor
+    # Comments and string contents blanked, character offsets preserved.
+    # See `Noir::KotlinSourceMask`.
     private def visible_kotlin_code(source : String) : String
-      slash = '/'.ord.to_u8
-      star = '*'.ord.to_u8
-      double_quote = '"'.ord.to_u8
-      single_quote = '\''.ord.to_u8
-      backslash = '\\'.ord.to_u8
-      newline = '\n'.ord.to_u8
-      space = ' '.ord.to_u8
-
-      bytes = source.to_slice
-      mode = :code
-      quote = 0_u8
-      raw_string = false
-      escaped = false
-      i = 0
-
-      String.build(source.bytesize) do |io|
-        while i < bytes.size
-          byte = bytes[i]
-
-          case mode
-          when :line_comment
-            if byte == newline
-              io.write_byte(byte)
-              mode = :code
-            else
-              io.write_byte(space)
-            end
-            i += 1
-          when :block_comment
-            if byte == newline
-              io.write_byte(byte)
-              i += 1
-            elsif i + 1 < bytes.size && byte == star && bytes[i + 1] == slash
-              io.write_byte(space)
-              io.write_byte(space)
-              i += 2
-              mode = :code
-            else
-              io.write_byte(space)
-              i += 1
-            end
-          when :string
-            if raw_string && i + 2 < bytes.size && byte == double_quote && bytes[i + 1] == double_quote && bytes[i + 2] == double_quote
-              io.write_byte(space)
-              io.write_byte(space)
-              io.write_byte(space)
-              i += 3
-              mode = :code
-              raw_string = false
-            elsif !raw_string && byte == quote && !escaped
-              io.write_byte(space)
-              i += 1
-              mode = :code
-            else
-              io.write_byte(byte == newline ? byte : space)
-              if raw_string
-                i += 1
-              elsif escaped
-                escaped = false
-                i += 1
-              else
-                escaped = byte == backslash
-                i += 1
-              end
-            end
-          else
-            if i + 1 < bytes.size && byte == slash && bytes[i + 1] == slash
-              io.write_byte(space)
-              io.write_byte(space)
-              i += 2
-              mode = :line_comment
-            elsif i + 1 < bytes.size && byte == slash && bytes[i + 1] == star
-              io.write_byte(space)
-              io.write_byte(space)
-              i += 2
-              mode = :block_comment
-            elsif i + 2 < bytes.size && byte == double_quote && bytes[i + 1] == double_quote && bytes[i + 2] == double_quote
-              io.write_byte(space)
-              io.write_byte(space)
-              io.write_byte(space)
-              i += 3
-              mode = :string
-              raw_string = true
-            elsif byte == double_quote || byte == single_quote
-              io.write_byte(space)
-              quote = byte
-              raw_string = false
-              escaped = false
-              i += 1
-              mode = :string
-            else
-              io.write_byte(byte)
-              i += 1
-            end
-          end
-        end
-      end
+      Noir::KotlinSourceMask.visible(source)
     end
 
     private def function_name(func : LibTreeSitter::TSNode, source : String) : String
@@ -347,21 +253,28 @@ module Noir
       methods
     end
 
+    # Call sites are located on the visible copy — a commented-out
+    # `registry.addEndpoint("/ws-legacy-removed")`, or the same call
+    # quoted inside a string, is not a call — but the argument text is
+    # sliced out of the raw source, because that is where the literal
+    # values the caller wants still exist. `KotlinSourceMask` preserves
+    # character offsets, so the two indexes refer to the same place.
     private def each_method_call_arguments(source : String, method_name : String, &)
+      visible = visible_kotlin_code(source)
       offset = 0
       name_size = method_name.size
 
-      while marker = source.index(method_name, offset)
+      while marker = visible.index(method_name, offset)
         offset = marker + name_size
-        next unless method_call_name?(source, marker, name_size)
+        next unless method_call_name?(visible, marker, name_size)
 
-        open_idx = source.index('(', marker)
+        open_idx = visible.index('(', marker)
         next unless open_idx
-        close_idx = find_matching_paren(source, open_idx)
+        close_idx = find_matching_paren(visible, open_idx)
         next unless close_idx
 
         args = source[(open_idx + 1)...close_idx]
-        line = source[0...marker].count('\n') + 1
+        line = visible[0...marker].count('\n') + 1
         yield args, line
       end
     end

--- a/src/miniparsers/kotlin_source_mask.cr
+++ b/src/miniparsers/kotlin_source_mask.cr
@@ -1,0 +1,146 @@
+module Noir
+  # Character-preserving masks over Kotlin source text.
+  #
+  # Both masks replace every masked-out character with a single space and
+  # keep every newline, so the result lines up with the original *by
+  # character*: `masked[i]` describes `source[i]`, `masked.lines[n]` is
+  # exactly as long as `source.lines[n]`, and a `Regex::MatchData#end`
+  # taken on the masked copy can be used to slice the raw text. Callers
+  # depend on that to gate a line scan on the masked copy while reading
+  # the real value out of the raw source.
+  #
+  # One space per *character*, not per byte: Crystal's `String#[]` and
+  # `MatchData#begin/#end` are char-indexed while the scanner walks bytes,
+  # so emitting one space per byte made every offset after a non-ASCII
+  # comment (a CJK line above a route, an accented author name) drift by
+  # the number of continuation bytes and over-trimmed the raw line.
+  module KotlinSourceMask
+    extend self
+
+    # Comments blanked, string literals kept verbatim. Use this to run a
+    # line regex that has to read a literal value — `const val PATH =
+    # "/mcp"` — without also harvesting a commented-out declaration.
+    def code_only(source : String) : String
+      mask(source, mask_strings: false)
+    end
+
+    # Comments *and* string-literal contents blanked. Use this for
+    # structural work — brace counting, delimiter matching, deciding
+    # whether a call site is real code — where a `{` or a `(` inside a
+    # string or a comment must not count.
+    def visible(source : String) : String
+      mask(source, mask_strings: true)
+    end
+
+    SLASH        = '/'.ord.to_u8
+    STAR         = '*'.ord.to_u8
+    DOUBLE_QUOTE = '"'.ord.to_u8
+    SINGLE_QUOTE = '\''.ord.to_u8
+    BACKSLASH    = '\\'.ord.to_u8
+    NEWLINE      = '\n'.ord.to_u8
+    SPACE        = ' '.ord.to_u8
+
+    # UTF-8 continuation bytes (`10xxxxxx`) carry no character of their
+    # own, so they contribute no space to the mask.
+    private def continuation?(byte : UInt8) : Bool
+      (byte & 0xC0) == 0x80
+    end
+
+    private def blank(io : IO, byte : UInt8)
+      return if continuation?(byte)
+      io.write_byte(byte == NEWLINE ? NEWLINE : SPACE)
+    end
+
+    private def mask(source : String, mask_strings : Bool) : String
+      bytes = source.to_slice
+      mode = :code
+      quote = 0_u8
+      raw_string = false
+      escaped = false
+      i = 0
+
+      String.build(source.bytesize) do |io|
+        while i < bytes.size
+          byte = bytes[i]
+
+          case mode
+          when :line_comment
+            if byte == NEWLINE
+              io.write_byte(byte)
+              mode = :code
+            else
+              blank(io, byte)
+            end
+            i += 1
+          when :block_comment
+            if byte == NEWLINE
+              io.write_byte(byte)
+              i += 1
+            elsif i + 1 < bytes.size && byte == STAR && bytes[i + 1] == SLASH
+              io.write_byte(SPACE)
+              io.write_byte(SPACE)
+              i += 2
+              mode = :code
+            else
+              blank(io, byte)
+              i += 1
+            end
+          when :string
+            if raw_string && i + 2 < bytes.size && byte == DOUBLE_QUOTE && bytes[i + 1] == DOUBLE_QUOTE && bytes[i + 2] == DOUBLE_QUOTE
+              3.times { io.write_byte(mask_strings ? SPACE : DOUBLE_QUOTE) }
+              i += 3
+              mode = :code
+              raw_string = false
+            elsif !raw_string && byte == quote && !escaped
+              io.write_byte(mask_strings ? SPACE : byte)
+              i += 1
+              mode = :code
+            else
+              if mask_strings
+                blank(io, byte)
+              else
+                io.write_byte(byte)
+              end
+              if raw_string
+                i += 1
+              elsif escaped
+                escaped = false
+                i += 1
+              else
+                escaped = byte == BACKSLASH
+                i += 1
+              end
+            end
+          else
+            if i + 1 < bytes.size && byte == SLASH && bytes[i + 1] == SLASH
+              io.write_byte(SPACE)
+              io.write_byte(SPACE)
+              i += 2
+              mode = :line_comment
+            elsif i + 1 < bytes.size && byte == SLASH && bytes[i + 1] == STAR
+              io.write_byte(SPACE)
+              io.write_byte(SPACE)
+              i += 2
+              mode = :block_comment
+            elsif i + 2 < bytes.size && byte == DOUBLE_QUOTE && bytes[i + 1] == DOUBLE_QUOTE && bytes[i + 2] == DOUBLE_QUOTE
+              3.times { io.write_byte(mask_strings ? SPACE : DOUBLE_QUOTE) }
+              i += 3
+              mode = :string
+              raw_string = true
+            elsif byte == DOUBLE_QUOTE || byte == SINGLE_QUOTE
+              io.write_byte(mask_strings ? SPACE : byte)
+              quote = byte
+              raw_string = false
+              escaped = false
+              i += 1
+              mode = :string
+            else
+              io.write_byte(byte)
+              i += 1
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -1,5 +1,4 @@
 require "../utils/url_path"
-require "../utils/top_level_split"
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
 require "./java_callee_extractor"
@@ -482,37 +481,44 @@ module Noir
       found ? [""] : paths
     end
 
+    # Simple names of the `implements` interfaces, read straight from the
+    # tree-sitter `interfaces` field (a `super_interfaces` node wrapping a
+    # `type_list`).
+    #
+    # Reading the field rather than slicing the class node's text at the
+    # first `{` matters: the node text starts at the `modifiers` child, so
+    # a class-level annotation whose arguments contain a brace —
+    # `@Produces({MediaType.APPLICATION_JSON})`, `@Controller` with a
+    # `consumes = {...}` argument — was mistaken for the class body and
+    # cut the header off before `implements` was ever reached, silently
+    # killing interface route inheritance.
     private def implemented_interface_names(class_decl : LibTreeSitter::TSNode, source : String) : Array(String)
-      header = Noir::TreeSitter.node_text(class_decl, source)
-      if body_start = header.index('{')
-        header = header[...body_start]
-      end
+      names = [] of String
+      return names unless interfaces = Noir::TreeSitter.field(class_decl, "interfaces")
 
-      match = header.match(/\bimplements\s+(.+)\z/m)
-      return [] of String unless match
-
-      names = split_top_level_commas(match[1]).compact_map do |raw|
-        type_name = raw.strip
-        next if type_name.empty?
-        type_name = strip_generic_arguments(type_name)
-        type_name = type_name.split(/\s+/).first? || type_name
-        if idx = type_name.rindex('.')
-          type_name[(idx + 1)..]
+      Noir::TreeSitter.each_named_child(interfaces) do |child|
+        if Noir::TreeSitter.node_type(child) == "type_list"
+          Noir::TreeSitter.each_named_child(child) do |type_node|
+            append_simple_type_name(type_node, source, names)
+          end
         else
-          type_name
+          append_simple_type_name(child, source, names)
         end
       end
-      names.uniq!
       names
     end
 
-    # Delegates to the shared splitter. `Rules::GENERICS_ONLY` reproduces this
-    # file's previous hand-rolled loop exactly: only `<` and `>` contribute
-    # depth (clamped at 0), quotes and backslashes are ordinary characters, no
-    # part is stripped and every empty part is kept. The caller strips and
-    # skips empties itself.
-    private def split_top_level_commas(text : String) : Array(String)
-      Noir::TopLevelSplit.split(text, ',', Noir::TopLevelSplit::Rules::GENERICS_ONLY)
+    # Appends the simple name of a type node — generics dropped, package
+    # qualifier dropped, any leading `@Annotation` on an `annotated_type`
+    # discarded — skipping empties and duplicates.
+    private def append_simple_type_name(type_node : LibTreeSitter::TSNode, source : String, names : Array(String))
+      name = strip_generic_arguments(Noir::TreeSitter.node_text(type_node, source))
+      name = name.split(/\s+/).last? || name
+      return if name.empty?
+      if idx = name.rindex('.')
+        name = name[(idx + 1)..]
+      end
+      names << name unless name.empty? || names.includes?(name)
     end
 
     private def strip_generic_arguments(text : String) : String

--- a/src/miniparsers/perl_callee_extractor.cr
+++ b/src/miniparsers/perl_callee_extractor.cr
@@ -70,7 +70,7 @@ module Noir::PerlCalleeExtractor
 
   def named_sub_bodies(source : String, file_path : String) : Hash(String, SubBody)
     bodies = {} of String => SubBody
-    chars = source.chars
+    chars = code_chars(source)
     stripped = strip_non_code(chars)
 
     stripped.scan(/\bsub\s+([A-Za-z_][A-Za-z0-9_]*)\b/) do |match|
@@ -89,7 +89,7 @@ module Noir::PerlCalleeExtractor
                         start_index : Int32,
                         search_limit : Int32 = source.size,
                         body_limit : Int32 = source.size) : Tuple(String, Int32)?
-    chars = source.chars
+    chars = code_chars(source)
     sub_index = find_keyword(chars, "sub", start_index, search_limit)
     return unless sub_index
 
@@ -100,7 +100,7 @@ module Noir::PerlCalleeExtractor
   def extract_sub_at(source : String,
                      sub_index : Int32,
                      limit : Int32 = source.size) : Tuple(String, Int32)?
-    extract_sub_at(source.chars, sub_index, limit)
+    extract_sub_at(code_chars(source), sub_index, limit)
   end
 
   def extract_sub_at(chars : Array(Char),
@@ -119,7 +119,7 @@ module Noir::PerlCalleeExtractor
   # Public String overload kept for callers outside this module.
   def find_matching_delimiter(source : String, open_index : Int32, open_char : Char, close_char : Char,
                               limit : Int32 = source.size) : Int32?
-    find_matching_delimiter(source.chars, open_index, open_char, close_char, limit)
+    find_matching_delimiter(code_chars(source), open_index, open_char, close_char, limit)
   end
 
   def find_matching_delimiter(chars : Array(Char), open_index : Int32, open_char : Char, close_char : Char,
@@ -154,11 +154,191 @@ module Noir::PerlCalleeExtractor
   # Public String overload kept for callers outside this module.
   def strip_non_code(source : String) : String
     # Fast path: nothing to blank when the source has no comment, short
-    # string, or quote-like (`q`/`qq`/`qw`/`qr`/`qx`) markers. Preserves
-    # byte-identical output for the common "already plain code" case used
-    # by brace-depth walks.
-    return source unless strip_non_code_needed?(source)
-    strip_non_code(source.chars)
+    # string, quote-like (`q`/`qq`/`qw`/`qr`/`qx`), or heredoc markers.
+    # Preserves byte-identical output for the common "already plain code"
+    # case used by brace-depth walks.
+    heredocs = source.includes?("<<")
+    needed = strip_non_code_needed?(source)
+    return source unless heredocs || needed
+
+    chars = source.chars
+    masked = heredocs ? mask_heredocs(chars) : chars
+    # `mask_heredocs` returns the input untouched when the `<<` was a shift,
+    # which keeps the byte-identical fast path for plain code.
+    return source if !needed && masked.same?(chars)
+
+    strip_non_code(masked)
+  end
+
+  # Heredoc bodies are data, not code: their braces would close the enclosing
+  # `sub` early and a stray apostrophe would open a "string" that blanks the
+  # statements after it. Mask them (and the `<<TAG` token itself) with spaces
+  # before any other lexing runs, keeping newlines so every character offset
+  # and line number stays identical.
+  private def code_chars(source : String) : Array(Char)
+    chars = source.chars
+    source.includes?("<<") ? mask_heredocs(chars) : chars
+  end
+
+  private def mask_heredocs(chars : Array(Char)) : Array(Char)
+    # `<<` is far more often a left shift than a heredoc, so the copy is only
+    # allocated once a real marker is seen.
+    masked = nil.as(Array(Char)?)
+    pending = [] of Tuple(String, Bool)
+    index = 0
+    size = chars.size
+
+    while index < size
+      if pending.empty?
+        if comment_start?(chars, index)
+          index = skip_comment(chars, index, size)
+          next
+        elsif quote_like_start?(chars, index)
+          index = skip_quote_like(chars, index, size)
+          next
+        elsif chars[index] == '"' || chars[index] == '\''
+          index = skip_short_string(chars, index, size)
+          next
+        end
+      elsif chars[index] == '\n'
+        # Bodies start on the line after the marker; several heredocs may be
+        # opened on one line (`print <<A, <<B;`) and stack in order.
+        buffer = masked || chars.dup
+        masked = buffer
+        cursor = index + 1
+        pending.each do |tag, indented|
+          cursor = blank_heredoc_body(chars, buffer, cursor, tag, indented)
+        end
+        pending.clear
+        index = cursor
+        next
+      end
+
+      if marker = heredoc_marker_at(chars, index)
+        tag, indented, token_end = marker
+        buffer = masked || chars.dup
+        masked = buffer
+        blank_range(buffer, index, token_end)
+        pending << {tag, indented}
+        index = token_end
+        next
+      end
+
+      index += 1
+    end
+
+    masked || chars
+  end
+
+  # `<<TAG` / `<<'TAG'` / `<<"TAG"` / `<<~TAG`. Perl only reads a bare
+  # (unquoted) terminator when it follows `<<` with no space, which is what
+  # keeps `$x << 2` and `$x << $bits` reading as a left shift. For the bare
+  # form we additionally require that a matching terminator line exists, so a
+  # shift by a named constant (`1<<MAX`) is not swallowed as a heredoc.
+  private def heredoc_marker_at(chars : Array(Char), index : Int32) : Tuple(String, Bool, Int32)?
+    return unless chars[index] == '<' && chars[index + 1]? == '<'
+
+    cursor = index + 2
+    indented = false
+    if chars[cursor]? == '~'
+      indented = true
+      cursor += 1
+    end
+
+    quote = chars[cursor]?
+    if quote == '\'' || quote == '"'
+      cursor += 1
+      tag_start = cursor
+      while (char = chars[cursor]?) && identifier_part?(char)
+        cursor += 1
+      end
+      return if cursor == tag_start
+      return unless chars[cursor]? == quote
+      return {chars[tag_start...cursor].join, indented, cursor + 1}
+    end
+
+    tag_start = cursor
+    first = chars[cursor]?
+    return unless first && identifier_start?(first)
+    while (char = chars[cursor]?) && identifier_part?(char)
+      cursor += 1
+    end
+
+    tag = chars[tag_start...cursor].join
+    return unless indented || heredoc_terminator_ahead?(chars, cursor, tag, indented)
+    {tag, indented, cursor}
+  end
+
+  private def heredoc_terminator_ahead?(chars : Array(Char), index : Int32, tag : String, indented : Bool) : Bool
+    cursor = index
+    while cursor < chars.size && chars[cursor] != '\n'
+      cursor += 1
+    end
+    cursor += 1
+
+    while cursor < chars.size
+      line_end = cursor
+      while line_end < chars.size && chars[line_end] != '\n'
+        line_end += 1
+      end
+      return true if heredoc_terminator?(chars, cursor, line_end, tag, indented)
+      cursor = line_end + 1
+    end
+
+    false
+  end
+
+  # Blanks every line of the body plus the terminator line. An unterminated
+  # heredoc blanks to EOF and returns — it never loops.
+  private def blank_heredoc_body(chars : Array(Char), masked : Array(Char),
+                                 index : Int32, tag : String, indented : Bool) : Int32
+    cursor = index
+
+    while cursor < chars.size
+      line_end = cursor
+      while line_end < chars.size && chars[line_end] != '\n'
+        line_end += 1
+      end
+
+      terminator = heredoc_terminator?(chars, cursor, line_end, tag, indented)
+      blank_range(masked, cursor, line_end)
+      cursor = line_end < chars.size ? line_end + 1 : line_end
+      return cursor if terminator
+    end
+
+    cursor
+  end
+
+  private def heredoc_terminator?(chars : Array(Char), line_start : Int32, line_end : Int32,
+                                  tag : String, indented : Bool) : Bool
+    start_index = line_start
+    if indented
+      while start_index < line_end && chars[start_index].whitespace?
+        start_index += 1
+      end
+    end
+
+    finish = line_end
+    while finish > start_index && chars[finish - 1].whitespace?
+      finish -= 1
+    end
+
+    return false unless finish - start_index == tag.size
+
+    offset = start_index
+    tag.each_char do |char|
+      return false unless chars[offset] == char
+      offset += 1
+    end
+    true
+  end
+
+  private def blank_range(masked : Array(Char), start_index : Int32, finish_index : Int32)
+    index = start_index
+    while index < finish_index && index < masked.size
+      masked[index] = ' ' unless masked[index] == '\n'
+      index += 1
+    end
   end
 
   def strip_non_code(chars : Array(Char)) : String
@@ -406,7 +586,11 @@ module Noir::PerlCalleeExtractor
   end
 
   private def comment_start?(chars : Array(Char), index : Int32) : Bool
-    chars[index] == '#'
+    return false unless chars[index] == '#'
+    # `$#array`, `$#{$ref}` and `$#$ref` are the last-index sigil, not a
+    # comment. Treating them as one blanked the rest of the line — including
+    # the closing brace of a one-line `sub` — and dropped every callee on it.
+    !(index > 0 && chars[index - 1] == '$')
   end
 
   private def skip_comment(chars : Array(Char), index : Int32, limit : Int32) : Int32

--- a/src/miniparsers/postgres_ddl_parser.cr
+++ b/src/miniparsers/postgres_ddl_parser.cr
@@ -180,11 +180,25 @@ module Noir
             end
           end
         when c == '\''
+          # In a standard SQL string a backslash is an ordinary character and
+          # `''` is the only way to write a quote. In an `E'…'` escape string
+          # `\'` is *also* an escaped quote (and `\\` an escaped backslash).
+          # Treating `E'it\'s fine'` as ending at the backslash-escaped quote
+          # left the rest of the literal parsed as code and re-opened a string
+          # on the next quote, which masked the columns that followed — the
+          # `label` / `body` params vanished from the PostgREST surface.
+          escape_string = escape_string_prefix?(chars, i)
           i += 1
           while i < size
             if chars[i] == '\'' && i + 1 < size && chars[i + 1] == '\''
               chars[i] = ' '
               chars[i + 1] = ' '
+              i += 2
+              next
+            end
+            if escape_string && chars[i] == '\\' && i + 1 < size
+              chars[i] = ' '
+              chars[i + 1] = ' ' unless chars[i + 1] == '\n'
               i += 2
               next
             end
@@ -212,6 +226,18 @@ module Noir
       end
 
       String.build(size) { |io| chars.each { |ch| io << ch } }
+    end
+
+    # True when the quote at `start` opens a Postgres escape string — a
+    # standalone `E` / `e` immediately before it (`E'…'`). The prefix has to
+    # be a token of its own: `codeE'x'` is not an escape string.
+    private def escape_string_prefix?(chars : Array(Char), start : Int32) : Bool
+      return false if start == 0
+      prev = chars[start - 1]
+      return false unless prev == 'E' || prev == 'e'
+      return true if start < 2
+      before = chars[start - 2]
+      !(before.alphanumeric? || before == '_' || before == '$')
     end
 
     # `$$` or `$name$` at `start`, else nil.

--- a/src/miniparsers/python_route_extractor.cr
+++ b/src/miniparsers/python_route_extractor.cr
@@ -166,9 +166,10 @@ module Noir
     end
 
     # Net `(` − `)` count for a single line, ignoring parens inside
-    # single- or double-quoted strings on the same line. Used by
-    # `find_def_line` to walk through multi-line decorator headers
-    # without breaking the loop on continuation tokens.
+    # single- or double-quoted strings on the same line and comments
+    # starting with `#`. Used by `find_def_line` to walk through
+    # multi-line decorator headers without breaking the loop on
+    # continuation tokens.
     private def line_paren_delta(line : String) : Int32
       depth = 0
       in_quote = nil
@@ -187,6 +188,8 @@ module Noir
         case ch
         when '\'', '"'
           in_quote = ch
+        when '#'
+          break
         when '('
           depth += 1
         when ')'

--- a/src/utils/js_literal_scanner.cr
+++ b/src/utils/js_literal_scanner.cr
@@ -274,27 +274,48 @@ module Noir
       end
     end
 
-    # Determine if '/' at current position likely starts a regex literal.
-    # `window` is the rstrip'd tail of the scanned output — enough for both
-    # the last-char probe and the keyword `ends_with?` probe.
-    private def self.looks_like_regex?(window : Array(Char)) : Bool
-      last_char = window.last?
-      return true if last_char && REGEX_PRECEDING_CHARS.includes?(last_char)
-
-      REGEX_PRECEDING_KEYWORDS.each do |keyword|
-        return true if window_ends_with?(window, keyword)
-      end
-
-      false
+    # The single rule for "can a '/' here start a regex literal?".
+    #
+    # `last_char` is the last non-whitespace character of the code scanned
+    # so far (nil when nothing has been scanned yet) and `last_word` is the
+    # identifier that ends at `last_char`, or "" when `last_char` is
+    # punctuation. Every JavaScript scanner in the tree asks this question —
+    # the literal scanners below, `JSRouteExtractor.strip_js_comments` and
+    # `JSLexer#looks_like_regex?` — and they must agree: a '/' misread as
+    # division lets the regex body's quotes and `//` open a string or a
+    # comment that runs to EOF, which silently drops every route in the file.
+    def self.regex_context?(last_char : Char?, last_word : String) : Bool
+      return false unless last_char
+      return true if REGEX_PRECEDING_CHARS.includes?(last_char)
+      return false if last_word.empty?
+      REGEX_PRECEDING_KEYWORDS.includes?(last_word)
     end
 
-    private def self.window_ends_with?(window : Array(Char), keyword : String) : Bool
-      return false if window.size < keyword.size
-      offset = window.size - keyword.size
-      keyword.each_char_with_index do |ch, i|
-        return false unless window[offset + i] == ch
+    # Determine if '/' at current position likely starts a regex literal.
+    # `window` is the rstrip'd tail of the scanned output — enough for both
+    # the last-char probe and the trailing-word keyword probe.
+    private def self.looks_like_regex?(window : Array(Char)) : Bool
+      last_char = window.last?
+      return false unless last_char
+      return true if REGEX_PRECEDING_CHARS.includes?(last_char)
+      return false unless word_char?(last_char)
+
+      regex_context?(last_char, window_tail_word(window))
+    end
+
+    private def self.word_char?(char : Char) : Bool
+      char.alphanumeric? || char == '_' || char == '$'
+    end
+
+    # The identifier ending at the window's last character. The window holds
+    # 12 chars and the longest keyword ("instanceof") is 10, so any word that
+    # fills the window is already longer than every keyword.
+    private def self.window_tail_word(window : Array(Char)) : String
+      start = window.size
+      while start > 0 && word_char?(window[start - 1])
+        start -= 1
       end
-      true
+      window[start..].join
     end
 
     private def self.find_matching_impl(src, open_idx : Int32, open_char : Char, close_char : Char) : Int32?
@@ -383,22 +404,19 @@ module Noir
         end
         prev_char = prev_idx >= 0 ? chr(src, prev_idx) : '('
 
-        # Check for punctuation or extract previous word for keyword check
-        is_regex = REGEX_PRECEDING_CHARS.includes?(prev_char)
+        # Extract the identifier ending at prev_char so the shared rule can
+        # do the keyword probe; punctuation carries no word.
+        prev_word = if word_char?(prev_char)
+                      word_start = prev_idx
+                      while word_start > 0 && word_char?(chr(src, word_start - 1))
+                        word_start -= 1
+                      end
+                      word_string(src, word_start, prev_idx + 1)
+                    else
+                      ""
+                    end
 
-        unless is_regex
-          word_end = prev_idx + 1
-          word_start = prev_idx
-          while word_start > 0 && (chr(src, word_start - 1).alphanumeric? || chr(src, word_start - 1) == '_')
-            word_start -= 1
-          end
-          if word_start < word_end
-            prev_word = word_string(src, word_start, word_end)
-            is_regex = REGEX_PRECEDING_KEYWORDS.includes?(prev_word)
-          end
-        end
-
-        if is_regex
+        if regex_context?(prev_char, prev_word)
           pos += 1
           in_char_class = false
           while pos < size


### PR DESCRIPTION
One ordinary line of source could make every route in a file disappear. Each fix
below is a literal form the lexer did not know about, so its contents were scanned
as code: a stray quote opened a string that ran to EOF, or a stray brace closed the
enclosing block early.

All of these were found by feeding hostile-but-completely-normal source through the
existing analyzers and diffing against what the file actually declares.

## Total loss of a file's routes

| Language | Trigger | Before | After |
|---|---|---|---|
| JavaScript | `const hasQuote = (s) => /["']/.test(s);` | 0 endpoints | all 5 |
| PHP | `<h1>Today's report</h1>` above `<?php` | 1 of 4 | 4 of 4 |
| Clojure | `(let [quote-char \"] …)` | 0 endpoints | all 3 |
| Python | `@route("/report")  # note (` | route dropped | route found |
| Perl | `<<'HTML'` heredoc containing `}` and an apostrophe | phantom callee `div` | the 2 real callees |
| C++ | `std::string(R"(it says " and })")` | 1 callee | all 3 |

The JavaScript one is the widest: `looks_like_regex?` in `js_lexer.cr` accepted a
shorter set of preceding tokens than `JSLiteralScanner` did, so a `/` after `=>` or
`!` was lexed as division. Every framework driven by `JSParser` was affected. The
three scanners now share one `JSLiteralScanner.regex_context?` rule instead of
keeping three copies that could drift again.

## Routes invented that do not exist

- **NestJS / Next.js** — `strip_js_comments` had no regex-literal state, so an
  unpaired quote inside a regex inverted it for the rest of the file and
  commented-out routes were reported as real: `// @Get('legacy-removed')` became
  `GET /users/legacy-removed`.
- **Express** — the chained `.route()` walk stopped only at a semicolon, so in
  semicolon-free style the verbs of *following* statements were attributed to the
  chain: `app.route('/profile').get(…)` followed by `app.post('/orders', …)` yielded
  a phantom `POST /profile` and `DELETE /profile`.
- **Kotlin** — `const val` constants were harvested from the raw source rather than
  the comment-masked copy, and stored first-wins. A commented-out
  `// const val MCP_ENDPOINT_PATH = "/old-mcp"` above the live declaration reported
  `/old-mcp` and lost the real `/mcp`.
- **AdonisJS / Elysia / Hapi** — route-path gates accepted only tree-sitter node type
  `string`, never `template_string`, even though each file's own `decode_string`
  already special-cased a backtick. In AdonisJS the argument index then shifted onto
  the controller name and reported `GET /api/v1/UsersController.show`. Hapi lost all
  12 of its endpoints; Elysia 4 of 12.
- **Java / JAX-RS / Micronaut** — `implemented_interface_names` cut the class header
  at the first `{`, which is the annotation's brace, not the class body's. A plain
  `@Produces({MediaType.APPLICATION_JSON})` silently killed interface route
  inheritance (15 → 13 endpoints on the JAX-RS fixture). These now read the
  `interfaces` / `superclass` fields from the AST, the way `superclass_name` next
  door already did.

## Smaller lexer gaps in the same class

C# char literals inside an interpolation hole (`$"{ Chars['{'] }"`) desynchronized
the mask and mis-attributed callees across handlers; Haskell primed identifiers
(`go'`) were read as char literals; Postgres `E'it\'s'` closed on the escaped quote;
the Scala lexer had no interpolation-hole state (latent — no analyzer keys on parens
today, fixed so the next one does not inherit it).

## Repro

Every fix ships a spec with the hostile input verbatim, plus fixtures for the four
end-to-end cases (`javascript/express_regex_literal_state`,
`javascript/nestjs_regex_comment_state`, `php/laravel_html_template`,
`clojure/compojure_char_literals`).

## Verification

- `crystal spec`: 29,544 examples, 0 failures
- `crystal tool format --check`, `ameba`: clean
- Every fixture directory scanned individually before and after: no endpoint lost
  anywhere. Counts that changed are named in the commit messages, in both
  directions — a count going *down* here means a phantom endpoint stopped being
  reported.
