### PR TITLE
fix(detector): revive dead gate branches and stop ancestor-directory false positives

### DIFF
--- a/spec/unit_test/detector/csharp/aspnet_mvc_spec.cr
+++ b/spec/unit_test/detector/csharp/aspnet_mvc_spec.cr
@@ -5,7 +5,111 @@ describe "Detect C# ASP.Net MVC" do
   options = create_test_options
   instance = Detector::CSharp::AspNetMvc.new options
 
-  it "packages" do
-    instance.detect("packages.config", "Microsoft.AspNet.Mvc").should be_true
+  it "packages.config" do
+    instance.detect("packages.config", "<package id=\"Microsoft.AspNet.Mvc\" version=\"5.2.9\" />").should be_true
+  end
+
+  it "csproj PackageReference" do
+    instance.detect("Web.csproj", "<PackageReference Include=\"Microsoft.AspNet.Mvc\" Version=\"5.2.9\" />").should be_true
+  end
+
+  it "csproj Reference" do
+    instance.detect("Web.csproj", "<Reference Include=\"System.Web.Mvc, Version=5.2.9.0, Culture=neutral\" />").should be_true
+  end
+
+  it "cs controller class" do
+    source = <<-CS
+      using System.Web.Mvc;
+
+      namespace MyApp.Controllers
+      {
+          public class HomeController : Controller
+          {
+              public ActionResult Index()
+              {
+                  return View();
+              }
+          }
+      }
+      CS
+    instance.detect("Controllers/HomeController.cs", source).should be_true
+  end
+
+  it "cs RouteConfig with MapRoute" do
+    source = <<-CS
+      using System.Web.Mvc;
+      using System.Web.Routing;
+
+      public class RouteConfig
+      {
+          public static void RegisterRoutes(RouteCollection routes)
+          {
+              routes.MapRoute("Default", "{controller}/{action}/{id}");
+          }
+      }
+      CS
+    instance.detect("App_Start/RouteConfig.cs", source).should be_true
+  end
+
+  it "does not match file with using System.Web.Mvc and ControllerBase" do
+    source = <<-CS
+      using System.Web.Mvc;
+
+      namespace MyApp.Controllers
+      {
+          public class UsersController : ControllerBase
+          {
+              public ActionResult GetAll()
+              {
+                  return Ok();
+              }
+          }
+      }
+      CS
+    instance.detect("Controllers/UsersController.cs", source).should be_false
+  end
+
+  it "does not match ASP.NET Core csproj" do
+    source = <<-XML
+      <Project Sdk="Microsoft.NET.Sdk.Web">
+        <ItemGroup>
+          <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+        </ItemGroup>
+      </Project>
+      XML
+    instance.detect("MyApp.csproj", source).should be_false
+  end
+
+  it "does not match ASP.NET Core controller" do
+    source = <<-CS
+      using Microsoft.AspNetCore.Mvc;
+
+      namespace MyApp.Controllers
+      {
+          [ApiController]
+          [Route("api/[controller]")]
+          public class UsersController : ControllerBase
+          {
+              [HttpGet]
+              public ActionResult GetAll()
+              {
+                  return Ok();
+              }
+          }
+      }
+      CS
+    instance.detect("Controllers/UsersController.cs", source).should be_false
+  end
+
+  it "does not match unrelated cs file" do
+    source = <<-CS
+      using System;
+
+      public class Utils
+      {
+          public static void DoWork() {}
+      }
+      CS
+    instance.detect("Utils.cs", source).should be_false
   end
 end

--- a/spec/unit_test/detector/groovy/grails_spec.cr
+++ b/spec/unit_test/detector/groovy/grails_spec.cr
@@ -98,4 +98,23 @@ describe "Detect Groovy Grails" do
   it "non_groovy_file_outside_grails_app" do
     instance.detect("project/src/main/groovy/Foo.groovy", "println 'hi'").should be_false
   end
+
+  # The `grails-app/` branch carries no content check, so it has to run on
+  # the scan-base-relative path. On the raw path a checkout that merely
+  # *sat under* an unrelated directory named `grails-app` made every file
+  # in the project — a one-line Python script included — report as Grails.
+  it "scopes the grails-app layout to the scan base" do
+    locator = CodeLocator.instance
+    previous_bases = locator.scan_base_paths
+
+    begin
+      locator.scan_base_paths = ["/srv/myproj"]
+      instance.detect("/srv/myproj/grails-app/controllers/BookController.groovy", "class BookController {}").should be_true
+
+      locator.scan_base_paths = ["/srv/grails-app/myproj"]
+      instance.detect("/srv/grails-app/myproj/src/a.py", "print(1)").should be_false
+    ensure
+      locator.scan_base_paths = previous_bases
+    end
+  end
 end

--- a/spec/unit_test/detector/haskell/scotty_spec.cr
+++ b/spec/unit_test/detector/haskell/scotty_spec.cr
@@ -24,4 +24,14 @@ describe "Detect Haskell Scotty" do
   it "haskell/unrelated" do
     instance.detect("src/Main.hs", "main = putStrLn \"hello\"").should be_false
   end
+
+  it "literate_haskell/applicable" do
+    instance.applicable?("src/Main.lhs").should be_true
+    instance.applicable?("src/Main.hs").should be_true
+    instance.applicable?("src/Main.rs").should be_false
+  end
+
+  it "literate_haskell/import_scotty" do
+    instance.detect("src/Main.lhs", "import Web.Scotty\nmain = pure ()").should be_true
+  end
 end

--- a/spec/unit_test/detector/haskell/servant_spec.cr
+++ b/spec/unit_test/detector/haskell/servant_spec.cr
@@ -32,4 +32,14 @@ describe "Detect Haskell Servant" do
   it "haskell/unrelated" do
     instance.detect("src/Main.hs", "main = putStrLn \"hello\"").should be_false
   end
+
+  it "literate_haskell/applicable" do
+    instance.applicable?("src/Api.lhs").should be_true
+    instance.applicable?("src/Api.hs").should be_true
+    instance.applicable?("src/Api.rs").should be_false
+  end
+
+  it "literate_haskell/import_servant" do
+    instance.detect("src/Api.lhs", "import Servant\nmain = pure ()").should be_true
+  end
 end

--- a/spec/unit_test/detector/haskell/yesod_spec.cr
+++ b/spec/unit_test/detector/haskell/yesod_spec.cr
@@ -24,4 +24,14 @@ describe "Detect Haskell Yesod" do
   it "haskell/unrelated" do
     instance.detect("src/Main.hs", "main = putStrLn \"hello\"").should be_false
   end
+
+  it "literate_haskell/applicable" do
+    instance.applicable?("src/Foundation.lhs").should be_true
+    instance.applicable?("src/Foundation.hs").should be_true
+    instance.applicable?("src/Foundation.rs").should be_false
+  end
+
+  it "literate_haskell/import_yesod" do
+    instance.detect("src/Foundation.lhs", "import Yesod\nmain = pure ()").should be_true
+  end
 end

--- a/spec/unit_test/detector/javascript/adonisjs_spec.cr
+++ b/spec/unit_test/detector/javascript/adonisjs_spec.cr
@@ -5,18 +5,46 @@ describe "Detect JS AdonisJS" do
   options = create_test_options
   instance = Detector::Javascript::Adonisjs.new options
 
-  it "detects ace bootstrap file" do
+  it "detects ace bootstrap file with AdonisJS markers" do
+    adonis_v5_ace = <<-ACE
+      #!/usr/bin/env node
+      const { Ignitor } = require('@adonisjs/core/build/standalone')
+      new Ignitor(__dirname).ace().handle(process.argv.slice(2))
+      ACE
+
+    adonis_v6_ace = <<-ACE
+      import 'reflect-metadata'
+      import { Ignitor, prettyPrintError } from '@adonisjs/core'
+      const APP_ROOT = new URL('./', import.meta.url)
+      new Ignitor(APP_ROOT).ace().handle(process.argv.splice(2))
+      ACE
+
     instance.applicable?("ace").should be_true
-    instance.detect("ace", "#!/usr/bin/env node").should be_true
+    instance.detect("ace", adonis_v5_ace).should be_true
 
     instance.applicable?("./ace").should be_true
-    instance.detect("./ace", "#!/usr/bin/env node").should be_true
+    instance.detect("./ace", adonis_v5_ace).should be_true
 
     instance.applicable?("bin/ace").should be_true
-    instance.detect("bin/ace", "#!/usr/bin/env node").should be_true
+    instance.detect("bin/ace", adonis_v5_ace).should be_true
 
     instance.applicable?("ace.js").should be_true
-    instance.detect("ace.js", "import './bin/console.js'").should be_true
+    instance.detect("ace.js", adonis_v6_ace).should be_true
+  end
+
+  it "does not detect vendored ace editor ace.js" do
+    vendored_ace_editor = <<-ACE
+      define("ace/ace", ["require", "exports", "module"], function(require, exports, module) {
+        "use strict";
+        var ace = exports;
+        ace.edit = function(el) { return new Editor(el); };
+      });
+      ACE
+
+    instance.applicable?("ace.js").should be_true
+    instance.detect("ace.js", vendored_ace_editor).should be_false
+    instance.detect("public/js/ace.js", vendored_ace_editor).should be_false
+    instance.detect("vendor/ace/ace.js", "/** Ace Editor v1.4.12 */ window.ace = {};").should be_false
   end
 
   it "detects package.json with AdonisJS dependency" do

--- a/spec/unit_test/detector/javascript/adonisjs_spec.cr
+++ b/spec/unit_test/detector/javascript/adonisjs_spec.cr
@@ -27,13 +27,13 @@ describe "Detect JS AdonisJS" do
 
   it "detects source files with AdonisJS markers" do
     instance.applicable?("start/routes.ts").should be_true
-    instance.detect("start/routes.ts", %{import router from '@adonisjs/core/services/router';}).should be_true
+    instance.detect("start/routes.ts", %(import router from '@adonisjs/core/services/router';)).should be_true
 
     instance.applicable?("start/routes.js").should be_true
-    instance.detect("start/routes.js", %{const Route = use('@ioc:Adonis/Core/Route');}).should be_true
+    instance.detect("start/routes.js", %(const Route = use('@ioc:Adonis/Core/Route');)).should be_true
 
     instance.applicable?("start/routes.mjs").should be_true
-    instance.detect("start/routes.mjs", %{import router from '@adonisjs/core/services/router';}).should be_true
+    instance.detect("start/routes.mjs", %(import router from '@adonisjs/core/services/router';)).should be_true
   end
 
   it "does not detect package.json without AdonisJS" do

--- a/spec/unit_test/detector/javascript/adonisjs_spec.cr
+++ b/spec/unit_test/detector/javascript/adonisjs_spec.cr
@@ -1,0 +1,47 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/javascript/adonisjs"
+
+describe "Detect JS AdonisJS" do
+  options = create_test_options
+  instance = Detector::Javascript::Adonisjs.new options
+
+  it "detects ace bootstrap file" do
+    instance.applicable?("ace").should be_true
+    instance.detect("ace", "#!/usr/bin/env node").should be_true
+
+    instance.applicable?("./ace").should be_true
+    instance.detect("./ace", "#!/usr/bin/env node").should be_true
+
+    instance.applicable?("bin/ace").should be_true
+    instance.detect("bin/ace", "#!/usr/bin/env node").should be_true
+
+    instance.applicable?("ace.js").should be_true
+    instance.detect("ace.js", "import './bin/console.js'").should be_true
+  end
+
+  it "detects package.json with AdonisJS dependency" do
+    instance.applicable?("package.json").should be_true
+    instance.detect("package.json", %({"dependencies": {"@adonisjs/core": "^6.0.0"}})).should be_true
+    instance.detect("package.json", %({"dependencies": {"adonis-auth": "^3.0.0"}})).should be_true
+  end
+
+  it "detects source files with AdonisJS markers" do
+    instance.applicable?("start/routes.ts").should be_true
+    instance.detect("start/routes.ts", %{import router from '@adonisjs/core/services/router';}).should be_true
+
+    instance.applicable?("start/routes.js").should be_true
+    instance.detect("start/routes.js", %{const Route = use('@ioc:Adonis/Core/Route');}).should be_true
+
+    instance.applicable?("start/routes.mjs").should be_true
+    instance.detect("start/routes.mjs", %{import router from '@adonisjs/core/services/router';}).should be_true
+  end
+
+  it "does not detect package.json without AdonisJS" do
+    instance.detect("package.json", %({"dependencies": {"express": "^4.0.0"}})).should be_false
+  end
+
+  it "does not detect unrelated source files" do
+    instance.detect("app.js", "console.log('hello');").should be_false
+    instance.applicable?("app.py").should be_false
+  end
+end

--- a/spec/unit_test/detector/javascript/astro_spec.cr
+++ b/spec/unit_test/detector/javascript/astro_spec.cr
@@ -1,0 +1,43 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/javascript/astro"
+
+describe "Detect JS Astro" do
+  options = create_test_options
+  instance = Detector::Javascript::Astro.new options
+
+  it "detects .astro files" do
+    instance.applicable?("src/pages/index.astro").should be_true
+    instance.detect("src/pages/index.astro", "---
+const title = 'Home';
+---
+<html><body>{title}</body></html>").should be_true
+  end
+
+  it "detects astro config files" do
+    instance.applicable?("astro.config.mjs").should be_true
+    instance.detect("astro.config.mjs", "export default defineConfig({});").should be_true
+
+    instance.applicable?("astro.config.ts").should be_true
+    instance.detect("astro.config.ts", "export default defineConfig({});").should be_true
+
+    instance.applicable?("astro.config.js").should be_true
+    instance.detect("astro.config.js", "module.exports = {};").should be_true
+
+    instance.applicable?("astro.config.cjs").should be_true
+    instance.detect("astro.config.cjs", "module.exports = {};").should be_true
+  end
+
+  it "detects package.json with astro dependency" do
+    instance.applicable?("package.json").should be_true
+    instance.detect("package.json", %({"dependencies": {"astro": "^4.0.0"}})).should be_true
+  end
+
+  it "does not detect package.json without astro" do
+    instance.detect("package.json", %({"dependencies": {"express": "^4.0.0"}})).should be_false
+  end
+
+  it "does not detect unrelated files" do
+    instance.detect("app.js", "console.log('hello')").should be_false
+    instance.applicable?("app.py").should be_false
+  end
+end

--- a/spec/unit_test/detector/javascript/astro_spec.cr
+++ b/spec/unit_test/detector/javascript/astro_spec.cr
@@ -7,10 +7,13 @@ describe "Detect JS Astro" do
 
   it "detects .astro files" do
     instance.applicable?("src/pages/index.astro").should be_true
-    instance.detect("src/pages/index.astro", "---
-const title = 'Home';
----
-<html><body>{title}</body></html>").should be_true
+    content = <<-ASTRO
+      ---
+      const title = 'Home';
+      ---
+      <html><body>{title}</body></html>
+      ASTRO
+    instance.detect("src/pages/index.astro", content).should be_true
   end
 
   it "detects astro config files" do

--- a/spec/unit_test/detector/javascript/fresh_spec.cr
+++ b/spec/unit_test/detector/javascript/fresh_spec.cr
@@ -27,21 +27,21 @@ describe "Detect JS Fresh" do
 
   it "detects main.ts with $fresh/ marker" do
     instance.applicable?("main.ts").should be_true
-    instance.detect("main.ts", %{import { start } from "$fresh/server.ts";}).should be_true
+    instance.detect("main.ts", %(import { start } from "$fresh/server.ts";)).should be_true
   end
 
   it "detects source files with $fresh/ marker" do
     instance.applicable?("routes/index.tsx").should be_true
-    instance.detect("routes/index.tsx", %{import { Handlers } from "$fresh/server.ts";}).should be_true
+    instance.detect("routes/index.tsx", %(import { Handlers } from "$fresh/server.ts";)).should be_true
 
     instance.applicable?("routes/api/users.ts").should be_true
-    instance.detect("routes/api/users.ts", %{import { FreshContext } from "$fresh/server.ts";}).should be_true
+    instance.detect("routes/api/users.ts", %(import { FreshContext } from "$fresh/server.ts";)).should be_true
 
     instance.applicable?("routes/index.js").should be_true
-    instance.detect("routes/index.js", %{import { Handlers } from "$fresh/server.ts";}).should be_true
+    instance.detect("routes/index.js", %(import { Handlers } from "$fresh/server.ts";)).should be_true
 
     instance.applicable?("routes/index.jsx").should be_true
-    instance.detect("routes/index.jsx", %{import { Handlers } from "$fresh/server.ts";}).should be_true
+    instance.detect("routes/index.jsx", %(import { Handlers } from "$fresh/server.ts";)).should be_true
   end
 
   it "does not detect deno.json without fresh marker" do

--- a/spec/unit_test/detector/javascript/fresh_spec.cr
+++ b/spec/unit_test/detector/javascript/fresh_spec.cr
@@ -1,0 +1,59 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/javascript/fresh"
+
+describe "Detect JS Fresh" do
+  options = create_test_options
+  instance = Detector::Javascript::Fresh.new options
+
+  it "detects deno.json with $fresh/ marker" do
+    instance.applicable?("deno.json").should be_true
+    content = %({"imports": {"$fresh/": "https://deno.land/x/fresh@1.6.8/"}})
+    instance.detect("deno.json", content).should be_true
+  end
+
+  it "detects deno.jsonc with $fresh/ marker" do
+    instance.applicable?("deno.jsonc").should be_true
+    content = %({"imports": {"$fresh/": "https://deno.land/x/fresh@1.6.8/"}})
+    instance.detect("deno.jsonc", content).should be_true
+  end
+
+  it "detects fresh.config files" do
+    instance.applicable?("fresh.config.ts").should be_true
+    instance.detect("fresh.config.ts", "import { defineConfig } from '$fresh/server.ts';").should be_true
+
+    instance.applicable?("fresh.config.js").should be_true
+    instance.detect("fresh.config.js", "export default {};").should be_true
+  end
+
+  it "detects main.ts with $fresh/ marker" do
+    instance.applicable?("main.ts").should be_true
+    instance.detect("main.ts", %{import { start } from "$fresh/server.ts";}).should be_true
+  end
+
+  it "detects source files with $fresh/ marker" do
+    instance.applicable?("routes/index.tsx").should be_true
+    instance.detect("routes/index.tsx", %{import { Handlers } from "$fresh/server.ts";}).should be_true
+
+    instance.applicable?("routes/api/users.ts").should be_true
+    instance.detect("routes/api/users.ts", %{import { FreshContext } from "$fresh/server.ts";}).should be_true
+
+    instance.applicable?("routes/index.js").should be_true
+    instance.detect("routes/index.js", %{import { Handlers } from "$fresh/server.ts";}).should be_true
+
+    instance.applicable?("routes/index.jsx").should be_true
+    instance.detect("routes/index.jsx", %{import { Handlers } from "$fresh/server.ts";}).should be_true
+  end
+
+  it "does not detect deno.json without fresh marker" do
+    instance.detect("deno.json", %({"tasks": {"start": "deno run main.ts"}})).should be_false
+  end
+
+  it "does not detect main.ts without fresh marker" do
+    instance.detect("main.ts", "console.log('hello');").should be_false
+  end
+
+  it "does not detect unrelated files" do
+    instance.detect("app.js", "console.log('hello')").should be_false
+    instance.applicable?("main.py").should be_false
+  end
+end

--- a/spec/unit_test/detector/javascript/nestjs_spec.cr
+++ b/spec/unit_test/detector/javascript/nestjs_spec.cr
@@ -57,12 +57,27 @@ describe "Detect JS NestJS" do
     instance.detect("component.jsx", "@Controller('api')").should be_true
   end
 
-  it "should_not_detect_typescript_file" do
-    instance.detect("component.ts", "@Controller('api')").should be_false
+  it "mjs_and_cjs_files" do
+    instance.applicable?("app.mjs").should be_true
+    instance.detect("app.mjs", "import { NestFactory } from '@nestjs/core'").should be_true
+
+    instance.applicable?("app.cjs").should be_true
+    instance.detect("app.cjs", "require('@nestjs/core')").should be_true
   end
 
-  it "should_not_detect_tsx_file" do
+  it "should_not_gate_in_typescript_or_manifest_files" do
+    instance.applicable?("component.ts").should be_false
+    instance.applicable?("component.tsx").should be_false
+    instance.applicable?("component.mts").should be_false
+    instance.applicable?("component.cts").should be_false
+    instance.applicable?("package.json").should be_false
+  end
+
+  it "should_not_detect_typescript_file" do
+    instance.detect("component.ts", "@Controller('api')").should be_false
     instance.detect("component.tsx", "@Controller('api')").should be_false
+    instance.detect("component.mts", "@Controller('api')").should be_false
+    instance.detect("component.cts", "@Controller('api')").should be_false
   end
 
   it "should_not_detect_non_nestjs" do

--- a/spec/unit_test/detector/javascript/nextjs_spec.cr
+++ b/spec/unit_test/detector/javascript/nextjs_spec.cr
@@ -61,6 +61,41 @@ describe "Detect JS Next.js" do
     instance.detect("project/app/api/products/[id]/route.ts", "export async function GET() {}").should be_true
   end
 
+  it "app_route_with_next_types_only" do
+    # No verb export in this file (the handlers are re-exported elsewhere),
+    # but it speaks to the Next.js request/response types.
+    instance.detect("project/app/api/products/route.ts", %(import { NextResponse } from "next/server")).should be_true
+  end
+
+  it "app_route_destructured_handler_export" do
+    instance.detect("project/app/api/workflows/route.ts", "export const { POST } = serve(async () => {});").should be_true
+  end
+
+  it "app_route_without_next_signal" do
+    # `route.ts` under an `app/` directory, but nothing in the file says
+    # Next.js — no verb export and no `Next*` type. The App Router branch
+    # used to accept this on the path alone.
+    instance.detect("project/src/app/admin/route.ts", "export const route = { path: \"/admin\" };").should be_false
+  end
+
+  # `app` is an ordinary directory name — the project's own documented
+  # Docker command mounts the repo at `-w /app` — so the App Router branch
+  # has to match the scan-base-relative path, not the raw one.
+  it "scopes the app router directory to the scan base" do
+    locator = CodeLocator.instance
+    previous_bases = locator.scan_base_paths
+
+    begin
+      locator.scan_base_paths = ["/srv/myproj"]
+      instance.detect("/srv/myproj/app/api/products/route.ts", "export async function GET() {}").should be_true
+
+      locator.scan_base_paths = ["/app/myproj"]
+      instance.detect("/app/myproj/server/route.ts", "export async function GET() {}").should be_false
+    ensure
+      locator.scan_base_paths = previous_bases
+    end
+  end
+
   it "import_from_next" do
     instance.detect("index.ts", "import Link from 'next/link'").should be_true
   end

--- a/spec/unit_test/detector/javascript/nuxtjs_spec.cr
+++ b/spec/unit_test/detector/javascript/nuxtjs_spec.cr
@@ -1,0 +1,51 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/javascript/nuxtjs"
+
+describe "Detect JS Nuxtjs" do
+  options = create_test_options
+  instance = Detector::Javascript::Nuxtjs.new options
+
+  it "detects nuxt config files" do
+    instance.applicable?("nuxt.config.js").should be_true
+    instance.detect("nuxt.config.js", "export default defineNuxtConfig({})").should be_true
+
+    instance.applicable?("nuxt.config.ts").should be_true
+    instance.detect("nuxt.config.ts", "export default defineNuxtConfig({})").should be_true
+  end
+
+  it "detects nuxt imports in source files" do
+    instance.applicable?("app.ts").should be_true
+    instance.detect("app.ts", "import { defineNuxtConfig } from 'nuxt';").should be_true
+    instance.detect("app.ts", "import { useAppConfig } from '#app';").should be_true
+    instance.detect("app.ts", "import { defineNuxtModule } from '@nuxt/kit';").should be_true
+
+    instance.applicable?("app.mjs").should be_true
+    instance.detect("app.mjs", "import { defineNuxtConfig } from 'nuxt';").should be_true
+
+    instance.applicable?("app.js").should be_true
+    instance.detect("app.js", "const nuxt = require('nuxt');").should be_true
+  end
+
+  it "detects server routes with defineEventHandler including .mts" do
+    instance.applicable?("/server/api/users.mts").should be_true
+    instance.detect("/server/api/users.mts", "export default defineEventHandler((event) => { return []; });").should be_true
+
+    instance.applicable?("/server/api/users.ts").should be_true
+    instance.detect("/server/api/users.ts", "export default defineEventHandler((event) => { return []; });").should be_true
+
+    instance.applicable?("/server/routes/test.mjs").should be_true
+    instance.detect("/server/routes/test.mjs", "export default defineEventHandler((event) => { return []; });").should be_true
+
+    instance.applicable?("/server/routes/test.js").should be_true
+    instance.detect("/server/routes/test.js", "export default defineEventHandler((event) => { return []; });").should be_true
+  end
+
+  it "does not detect server route directory without defineEventHandler" do
+    instance.detect("/server/api/users.mts", "export const router = express.Router();").should be_false
+  end
+
+  it "does not detect unrelated files" do
+    instance.detect("app.js", "console.log('hello');").should be_false
+    instance.applicable?("app.py").should be_false
+  end
+end

--- a/spec/unit_test/detector/php/cakephp_spec.cr
+++ b/spec/unit_test/detector/php/cakephp_spec.cr
@@ -29,10 +29,11 @@ describe "Detect CakePHP" do
   end
 
   it "detects CakePHP from cake script" do
-    cake_content = <<-PHP
+    cake_content = <<-'PHP'
       #!/usr/bin/php
       <?php
-      // This is a dummy cake executable
+      use Cake\Console\CommandRunner;
+      exit((new CommandRunner())->run($argv));
       PHP
     instance.detect("cake", cake_content).should be_true
   end
@@ -48,8 +49,9 @@ describe "Detect CakePHP" do
     instance.detect("config/routes.php", routes_content).should be_true
   end
 
-  it "does not detect CakePHP from unrelated cake file without Cake marker" do
+  it "does not detect CakePHP from unrelated cake file without Cake console marker" do
     instance.detect("cake", "#!/bin/bash\necho hello").should be_false
+    instance.detect("bin/cake", "#!/usr/bin/php\n<?php\n// dummy script without CommandRunner").should be_false
   end
 
   it "does not detect CakePHP from non-CakePHP files" do

--- a/spec/unit_test/detector/php/cakephp_spec.cr
+++ b/spec/unit_test/detector/php/cakephp_spec.cr
@@ -1,0 +1,69 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/php/*"
+
+describe "Detect CakePHP" do
+  options = create_test_options
+  instance = Detector::Php::CakePHP.new options
+
+  it "detects CakePHP from composer.json" do
+    composer_content = <<-JSON
+      {
+        "require": {
+          "php": ">=8.1",
+          "cakephp/cakephp": "^5.0"
+        }
+      }
+      JSON
+    instance.detect("composer.json", composer_content).should be_true
+  end
+
+  it "detects CakePHP from bin/cake console script" do
+    cake_content = <<-'PHP'
+      #!/usr/bin/php -q
+      <?php
+      require dirname(__DIR__) . '/vendor/autoload.php';
+      require dirname(__DIR__) . '/config/bootstrap.php';
+      exit((new Cake\Console\CommandRunner(new App\Application(dirname(__DIR__) . '/config')))->run($argv));
+      PHP
+    instance.detect("bin/cake", cake_content).should be_true
+  end
+
+  it "detects CakePHP from cake script" do
+    cake_content = <<-PHP
+      #!/usr/bin/php
+      <?php
+      // This is a dummy cake executable
+      PHP
+    instance.detect("cake", cake_content).should be_true
+  end
+
+  it "detects CakePHP from config/routes.php" do
+    routes_content = <<-'PHP'
+      <?php
+      use Cake\Routing\RouteBuilder;
+      $routes->scope('/', function (RouteBuilder $builder): void {
+          $builder->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
+      });
+      PHP
+    instance.detect("config/routes.php", routes_content).should be_true
+  end
+
+  it "does not detect CakePHP from unrelated cake file without Cake marker" do
+    instance.detect("cake", "#!/bin/bash\necho hello").should be_false
+  end
+
+  it "does not detect CakePHP from non-CakePHP files" do
+    instance.detect("index.php", "<?php echo 'Hello World';").should be_false
+    instance.detect("composer.json", %({"name": "app", "require": {"php": "^8.0"}})).should be_false
+  end
+
+  it "applicable? admits cake, composer.json, and PHP files" do
+    instance.applicable?("cake").should be_true
+    instance.applicable?("bin/cake").should be_true
+    instance.applicable?("bin/cake.php").should be_true
+    instance.applicable?("composer.json").should be_true
+    instance.applicable?("config/routes.php").should be_true
+    instance.applicable?("cake.py").should be_false
+    instance.applicable?("app.rb").should be_false
+  end
+end

--- a/spec/unit_test/detector/php/codeigniter_spec.cr
+++ b/spec/unit_test/detector/php/codeigniter_spec.cr
@@ -59,4 +59,13 @@ describe "Detect CodeIgniter" do
     instance.detect("index.php", "<?php echo 'Hello World';").should_not be_true
     instance.detect("composer.json", %({"name": "app", "require": {"php": "^8.0"}})).should_not be_true
   end
+
+  it "applicable? admits spark, composer.json, and PHP files" do
+    instance.applicable?("spark").should be_true
+    instance.applicable?("./spark").should be_true
+    instance.applicable?("t5/spark").should be_true
+    instance.applicable?("composer.json").should be_true
+    instance.applicable?("app/Config/Routes.php").should be_true
+    instance.applicable?("spark.py").should be_false
+  end
 end

--- a/spec/unit_test/detector/php/laravel_spec.cr
+++ b/spec/unit_test/detector/php/laravel_spec.cr
@@ -21,11 +21,18 @@ describe "Detect Laravel" do
   end
 
   it "detects Laravel from routes/web.php" do
-    instance.detect("routes/web.php", "<?php Route::get('/', function() {});").should be_true
+    instance.detect("project/routes/web.php", "<?php Route::get('/', function() {});").should be_true
   end
 
   it "detects Laravel from routes/api.php" do
-    instance.detect("routes/api.php", "<?php Route::get('/api/users', [UserController::class, 'index']);").should be_true
+    instance.detect("project/routes/api.php", "<?php Route::get('/api/users', [UserController::class, 'index']);").should be_true
+  end
+
+  # `routes/web.php` and `routes/api.php` are conventions Slim, plain PHP
+  # and hand-rolled routers share. The filename used to be enough on its
+  # own, which ran the whole Laravel analyzer over unrelated projects.
+  it "does not detect Laravel from a route file with no Laravel symbol" do
+    instance.detect("project/routes/web.php", %(<?php $app->get("/x", fn() => 1);)).should be_false
   end
 
   it "detects Laravel from bootstrap/app.php" do
@@ -48,6 +55,25 @@ describe "Detect Laravel" do
     instance.detect("artisan", artisan_content).should be_true
   end
 
+  # `artisan` reaches `detect` as a path, never as a bare basename, so the
+  # old `filename == "artisan"` was unreachable — and `artisan` was not in
+  # the `basenames:` gate either, so `detect` was not even dispatched on it.
+  it "detects Laravel from artisan reached by path" do
+    artisan_content = <<-PHP
+      #!/usr/bin/env php
+      <?php
+      define('LARAVEL_START', microtime(true));
+      require __DIR__.'/vendor/autoload.php';
+      $status = (require_once __DIR__.'/bootstrap/app.php')->handleCommand($input);
+      PHP
+    instance.applicable?("project/artisan").should be_true
+    instance.detect("project/artisan", artisan_content).should be_true
+  end
+
+  it "does not detect Laravel from an unrelated file named artisan" do
+    instance.detect("project/artisan", "#!/bin/sh\necho artisan\n").should be_false
+  end
+
   it "detects Laravel from Illuminate namespace usage" do
     controller_content = <<-'PHP'
       <?php
@@ -57,7 +83,7 @@ describe "Detect Laravel" do
 
       class UserController extends Controller {}
       PHP
-    instance.detect("app/Http/Controllers/UserController.php", controller_content).should be_true
+    instance.detect("project/app/Http/Controllers/UserController.php", controller_content).should be_true
   end
 
   it "detects Laravel from controller in app/Http/Controllers/" do
@@ -69,7 +95,7 @@ describe "Detect Laravel" do
         public function index() {}
       }
       PHP
-    instance.detect("app/Http/Controllers/ProductController.php", controller_content).should be_true
+    instance.detect("project/app/Http/Controllers/ProductController.php", controller_content).should be_true
   end
 
   it "detects Laravel from config/app.php" do
@@ -81,6 +107,25 @@ describe "Detect Laravel" do
       ];
       PHP
     instance.detect("config/app.php", config_content).should be_true
+  end
+
+  # Both layout branches match the scan-base-relative path: a checkout that
+  # merely sits under an `app/Http/Controllers/` directory must not make
+  # every PHP file in it look like a Laravel controller.
+  it "scopes the layout branches to the scan base" do
+    locator = CodeLocator.instance
+    previous_bases = locator.scan_base_paths
+
+    begin
+      locator.scan_base_paths = ["/srv/myproj"]
+      instance.detect("/srv/myproj/routes/web.php", "<?php Route::get('/', fn() => 1);").should be_true
+      instance.detect("/srv/myproj/app/Http/Controllers/ThingController.php", "<?php class ThingController { }").should be_true
+
+      locator.scan_base_paths = ["/srv/app/Http/Controllers/myproj"]
+      instance.detect("/srv/app/Http/Controllers/myproj/ThingController.php", "<?php class ThingController { }").should be_false
+    ensure
+      locator.scan_base_paths = previous_bases
+    end
   end
 
   it "does not detect Laravel from non-Laravel files" do

--- a/spec/unit_test/detector/scala/play_spec.cr
+++ b/spec/unit_test/detector/scala/play_spec.cr
@@ -9,8 +9,8 @@ describe "Detect Scala Play" do
     instance.detect("routes", "GET /users controllers.Users.list(page: Option[Int])").should be_true
   end
 
-  it "routes.conf file with Scala-style route definitions (optional param)" do
-    instance.detect("routes.conf", "POST /users/:id controllers.Users.update(id: Long, name: String ?= \"default\")").should be_true
+  it "routes.conf file with Scala-style route definitions (Option type)" do
+    instance.detect("routes.conf", "POST /users/:id controllers.Users.update(id: Long, name: Option[String] ?= None)").should be_true
   end
 
   it "scala file with play.api.mvc import" do
@@ -51,7 +51,7 @@ describe "Detect Scala Play" do
     instance.applicable?("app/controllers/HomeController.java").should be_false
   end
 
-  it "routes file with Java-specific Integer type is not detected as Scala" do
-    instance.detect("conf/routes", "GET /items controllers.Items.list(category: String, page: Integer ?= 1)").should be_false
+  it "routes file with only ?= default parameter without Option is not detected as Scala" do
+    instance.detect("conf/routes", "GET /clients controllers.Clients.list(page: Int ?= 1, label: String ?= \"new,hot\")").should be_false
   end
 end

--- a/spec/unit_test/detector/scala/play_spec.cr
+++ b/spec/unit_test/detector/scala/play_spec.cr
@@ -40,4 +40,18 @@ describe "Detect Scala Play" do
   it "routes file without route definitions" do
     instance.detect("routes", "# Just comments").should be_false
   end
+
+  it "applicable? admits routes and routes.conf" do
+    instance.applicable?("conf/routes").should be_true
+    instance.applicable?("conf/admin.routes").should be_true
+    instance.applicable?("conf/routes.conf").should be_true
+    instance.applicable?("routes").should be_true
+    instance.applicable?("build.sbt").should be_true
+    instance.applicable?("app/controllers/HomeController.scala").should be_true
+    instance.applicable?("app/controllers/HomeController.java").should be_false
+  end
+
+  it "routes file with Java-specific Integer type is not detected as Scala" do
+    instance.detect("conf/routes", "GET /items controllers.Items.list(category: String, page: Integer ?= 1)").should be_false
+  end
 end

--- a/spec/unit_test/detector/typescript/nestjs_spec.cr
+++ b/spec/unit_test/detector/typescript/nestjs_spec.cr
@@ -53,12 +53,32 @@ describe "Detect TypeScript NestJS" do
     instance.detect("component.tsx", "@Controller('api')").should be_true
   end
 
+  it "mts_and_cts_files" do
+    instance.applicable?("app.mts").should be_true
+    instance.detect("app.mts", "import { NestFactory } from '@nestjs/core'").should be_true
+
+    instance.applicable?("app.cts").should be_true
+    instance.detect("app.cts", "require('@nestjs/core')").should be_true
+  end
+
+  it "should_not_gate_in_javascript_or_manifest_files" do
+    instance.applicable?("app.js").should be_false
+    instance.applicable?("app.jsx").should be_false
+    instance.applicable?("app.mjs").should be_false
+    instance.applicable?("app.cjs").should be_false
+    instance.applicable?("package.json").should be_false
+    instance.applicable?("tsconfig.json").should be_false
+  end
+
   it "should_not_detect_non_nestjs" do
     instance.detect("app.ts", "import express from 'express'").should be_false
   end
 
   it "should_not_detect_javascript_file" do
     instance.detect("app.js", "import { NestFactory } from '@nestjs/core'").should be_false
+    instance.detect("app.jsx", "@Controller('api')").should be_false
+    instance.detect("app.mjs", "@Controller('api')").should be_false
+    instance.detect("app.cjs", "@Controller('api')").should be_false
   end
 
   it "should_not_detect_wrong_file_extension" do

--- a/spec/unit_test/techs/alias_resolution_spec.cr
+++ b/spec/unit_test/techs/alias_resolution_spec.cr
@@ -116,4 +116,14 @@ describe "tech alias resolution" do
     claims.size.should be > 500
     claims.count { |_, techs| techs.size > 1 }.should be > 10
   end
+
+  it "pins ambiguous aliases to their home ecosystem where known" do
+    # When multiple technologies claim a popular tool/library name, the pin
+    # must resolve to the tool's native home ecosystem rather than an arbitrary
+    # claimant reached first in catalog order.
+    NoirTechs.similar_to_tech("clap").should eq("rust_cli")
+    NoirTechs.similar_to_tech("argparse").should eq("python_cli")
+    NoirTechs.similar_to_tech("optionparser").should eq("ruby_cli")
+    NoirTechs.similar_to_tech("picocli").should eq("java_cli")
+  end
 end

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -75,7 +75,6 @@ UNTESTED_DETECTORS = [
   "java/micronaut",
   "java/quarkus",
   "java/spark",
-  "javascript/adonisjs",
   "javascript/cli",
   "javascript/hapi",
   "javascript/nuxtjs",

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -76,7 +76,6 @@ UNTESTED_DETECTORS = [
   "java/quarkus",
   "java/spark",
   "javascript/adonisjs",
-  "javascript/astro",
   "javascript/cli",
   "javascript/fresh",
   "javascript/hapi",

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -85,7 +85,6 @@ UNTESTED_DETECTORS = [
   "mobile/android",
   "mobile/well_known",
   "perl/cli",
-  "php/cakephp",
   "php/cli",
   "php/thinkphp",
   "python/bottle",

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -77,7 +77,6 @@ UNTESTED_DETECTORS = [
   "java/spark",
   "javascript/adonisjs",
   "javascript/cli",
-  "javascript/fresh",
   "javascript/hapi",
   "javascript/nuxtjs",
   "javascript/remix",

--- a/spec/unit_test/techs/detector_coverage_spec.cr
+++ b/spec/unit_test/techs/detector_coverage_spec.cr
@@ -77,7 +77,6 @@ UNTESTED_DETECTORS = [
   "java/spark",
   "javascript/cli",
   "javascript/hapi",
-  "javascript/nuxtjs",
   "javascript/remix",
   "javascript/sveltekit",
   "kotlin/cli",

--- a/src/detector/detectors/csharp/aspnet_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_mvc.cr
@@ -1,4 +1,5 @@
 require "../../../models/detector"
+require "../../../models/locator_keys"
 
 module Detector::CSharp
   class AspNetMvc < Detector
@@ -7,14 +8,36 @@ module Detector::CSharp
     # this detector after its first match would lose the
     # registration on subsequent files.
     detector_for "cs_aspnet_mvc",
-      extensions: %w[.cs .csproj .vbproj .sln .config],
+      extensions: %w[.cs .csproj .config],
       idempotent: false
+
+    CONTROLLER_INHERITANCE      = /:\s*Controller\b/
+    CONTROLLER_BASE_INHERITANCE = /:\s*ControllerBase\b/
 
     def detect(filename : String, file_contents : String) : Bool
       check_routeconfig filename, file_contents
 
-      return false unless filename.includes?("packages.config")
-      file_contents.includes?("Microsoft.AspNet.Mvc")
+      if filename.includes?("packages.config")
+        return true if file_contents.includes?("Microsoft.AspNet.Mvc")
+      end
+
+      if filename.ends_with?(".csproj")
+        return true if file_contents.includes?("Microsoft.AspNet.Mvc") ||
+                       file_contents.includes?("<Reference Include=\"System.Web.Mvc")
+      end
+
+      if filename.ends_with?(".cs")
+        return false if content_matches?(file_contents, CONTROLLER_BASE_INHERITANCE)
+
+        has_namespace = file_contents.includes?("using System.Web.Mvc;")
+        has_controller_signal = content_matches?(file_contents, CONTROLLER_INHERITANCE) ||
+                                file_contents.includes?("ActionResult") ||
+                                file_contents.includes?("routes.MapRoute") ||
+                                file_contents.includes?(".MapRoute")
+        return true if has_namespace && has_controller_signal
+      end
+
+      false
     end
 
     def check_routeconfig(filename : String, file_contents : String)

--- a/src/detector/detectors/groovy/grails.cr
+++ b/src/detector/detectors/groovy/grails.cr
@@ -4,6 +4,12 @@ module Detector::Groovy
   class Grails < Detector
     # Memo safety: `applicable?` consults the path
     # (/grails-app/ gate), not just the basename.
+    #
+    # The gate matches that segment on the RAW path while `detect` matches
+    # it on `base_relative_path`, so the gate is deliberately the wider of
+    # the two. It only decides whether `detect` is dispatched — `detect`
+    # is what answers — and keeping it a pure string test keeps the
+    # per-file lookup off the base resolution.
     detector_for "groovy_grails",
       extensions: %w[.groovy .gsp .gradle .gradle.kts .java .yml .yaml .xml],
       path_segments: %w[/grails-app/]
@@ -32,7 +38,12 @@ module Detector::Groovy
 
       # Any file under the conventional `grails-app/` layout — controllers,
       # services, domain classes, taglibs, views, conf, etc.
-      return true if filename.includes?("/grails-app/")
+      #
+      # Base-relative, not the raw path: this branch has no content check,
+      # so on the absolute path a checkout that merely *sat* under some
+      # unrelated `grails-app/` directory made every file in the project —
+      # `.py` included — report as Grails.
+      return true if base_relative_path(filename).includes?("/grails-app/")
 
       # GSP (Groovy Server Pages) files only exist in Grails projects.
       return true if filename.ends_with?(".gsp")

--- a/src/detector/detectors/haskell/scotty.cr
+++ b/src/detector/detectors/haskell/scotty.cr
@@ -3,7 +3,7 @@ require "../../../models/detector"
 module Detector::Haskell
   class Scotty < Detector
     detector_for "haskell_scotty",
-      extensions: %w[.hs .cabal .dhall],
+      extensions: %w[.hs .lhs .cabal .dhall],
       basenames: %w[stack.yaml package.yaml]
 
     def detect(filename : String, file_contents : String) : Bool

--- a/src/detector/detectors/haskell/servant.cr
+++ b/src/detector/detectors/haskell/servant.cr
@@ -3,7 +3,7 @@ require "../../../models/detector"
 module Detector::Haskell
   class Servant < Detector
     detector_for "haskell_servant",
-      extensions: %w[.hs .cabal .dhall],
+      extensions: %w[.hs .lhs .cabal .dhall],
       basenames: %w[stack.yaml package.yaml]
 
     def detect(filename : String, file_contents : String) : Bool

--- a/src/detector/detectors/haskell/yesod.cr
+++ b/src/detector/detectors/haskell/yesod.cr
@@ -3,7 +3,7 @@ require "../../../models/detector"
 module Detector::Haskell
   class Yesod < Detector
     detector_for "haskell_yesod",
-      extensions: %w[.hs .cabal .dhall],
+      extensions: %w[.hs .lhs .cabal .dhall],
       basenames: %w[stack.yaml package.yaml]
 
     def detect(filename : String, file_contents : String) : Bool

--- a/src/detector/detectors/javascript/adonisjs.cr
+++ b/src/detector/detectors/javascript/adonisjs.cr
@@ -4,7 +4,7 @@ module Detector::Javascript
   class Adonisjs < Detector
     detector_for "js_adonisjs",
       extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
-      basenames: %w[package.json]
+      basenames: %w[package.json ace]
 
     PACKAGE_MARKERS = Regex.union("@adonisjs/core", "\"adonis-") # legacy adonis-* packages
     SOURCE_MARKERS  = Regex.union("@adonisjs/core", "@ioc:Adonis")

--- a/src/detector/detectors/javascript/adonisjs.cr
+++ b/src/detector/detectors/javascript/adonisjs.cr
@@ -17,9 +17,12 @@ module Detector::Javascript
         return true
       end
 
-      # `ace.js` is the AdonisJS CLI bootstrap — present in every
-      # project root.
-      return true if base == "ace.js" || base == "ace"
+      # `ace.js` / `ace` is the AdonisJS CLI bootstrap. Must contain
+      # AdonisJS markers to avoid false-positive matches on vendored
+      # Ace code editor files (`ace.js`).
+      if (base == "ace.js" || base == "ace") && content_matches?(file_contents, SOURCE_MARKERS)
+        return true
+      end
 
       # Source-side markers — handlers / route files import the v6
       # service-locator router or the v5 IoC alias.

--- a/src/detector/detectors/javascript/astro.cr
+++ b/src/detector/detectors/javascript/astro.cr
@@ -3,7 +3,7 @@ require "../../../models/detector"
 module Detector::Javascript
   class Astro < Detector
     detector_for "js_astro",
-      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx .astro],
       basenames: %w[package.json]
 
     def detect(filename : String, file_contents : String) : Bool

--- a/src/detector/detectors/javascript/fresh.cr
+++ b/src/detector/detectors/javascript/fresh.cr
@@ -4,7 +4,7 @@ module Detector::Javascript
   class Fresh < Detector
     detector_for "js_fresh",
       extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
-      basenames: %w[package.json]
+      basenames: %w[package.json deno.json deno.jsonc]
 
     FRESH_MARKER = /\$fresh\//
 

--- a/src/detector/detectors/javascript/nestjs.cr
+++ b/src/detector/detectors/javascript/nestjs.cr
@@ -3,8 +3,7 @@ require "../../../models/detector"
 module Detector::Javascript
   class Nestjs < Detector
     detector_for "js_nestjs",
-      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
-      basenames: %w[package.json]
+      extensions: %w[.js .mjs .cjs .jsx]
 
     # Single precompiled alternation — one PCRE2 scan instead of seven.
     SIGNAL = Regex.union(
@@ -17,8 +16,10 @@ module Detector::Javascript
       /NestFactory\.create\s*\(/,
     )
 
+    SOURCE_EXTENSIONS = %w[.js .mjs .cjs .jsx]
+
     def detect(filename : String, file_contents : String) : Bool
-      return false unless filename.ends_with?(".js") || filename.ends_with?(".jsx")
+      return false unless SOURCE_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
       content_matches?(file_contents, SIGNAL)
     end
   end

--- a/src/detector/detectors/javascript/nestjs.cr
+++ b/src/detector/detectors/javascript/nestjs.cr
@@ -16,10 +16,9 @@ module Detector::Javascript
       /NestFactory\.create\s*\(/,
     )
 
-    SOURCE_EXTENSIONS = %w[.js .mjs .cjs .jsx]
-
     def detect(filename : String, file_contents : String) : Bool
-      return false unless SOURCE_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
+      return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") ||
+                          filename.ends_with?(".cjs") || filename.ends_with?(".jsx")
       content_matches?(file_contents, SIGNAL)
     end
   end

--- a/src/detector/detectors/javascript/nextjs.cr
+++ b/src/detector/detectors/javascript/nextjs.cr
@@ -11,6 +11,12 @@ module Detector::Javascript
     # four separate whole-file scans per JS/TS source.
     NEXT_IMPORT = /require\(['"]next(?:\/[^'"]+)?['"]\)|from\s+['"]next(?:\/[^'"]+)?['"]/
 
+    # The named HTTP-verb export an App Router `route.{js,ts}` must declare
+    # to serve anything, in the forms Next.js accepts: `export async
+    # function GET`, `export const POST = ...`, and the destructured
+    # `export const { POST } = serve(...)` a handler factory returns.
+    ROUTE_HANDLER_EXPORT = /\bexport\s+(?:async\s+)?(?:function|const|let|var)?\s*\{?\s*(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b/
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for Next.js config files
       if filename.ends_with?("next.config.js") ||
@@ -42,10 +48,20 @@ module Detector::Javascript
       end
 
       # App Router route handlers: /app/**/route.{js,ts}
-      if filename.includes?("/app/") &&
+      #
+      # `app` is an ordinary directory name — the project's own documented
+      # Docker command mounts the repo at `-w /app` — so this matches the
+      # base-relative path, and demands a content signal the same way the
+      # Pages Router branch above does. A bare `route.ts` under some
+      # `app/` directory is not on its own a Next.js marker; a route
+      # handler additionally exports a named HTTP verb or speaks to the
+      # `Next*` request/response types.
+      if base_relative_path(filename).includes?("/app/") &&
          (filename.ends_with?("/route.js") || filename.ends_with?("/route.ts") ||
          filename.ends_with?("/route.jsx") || filename.ends_with?("/route.tsx") ||
-         filename.ends_with?("/route.mjs"))
+         filename.ends_with?("/route.mjs")) &&
+         (next_js_content_signal?(file_contents) ||
+         content_matches?(file_contents, ROUTE_HANDLER_EXPORT))
         return true
       end
 

--- a/src/detector/detectors/javascript/nuxtjs.cr
+++ b/src/detector/detectors/javascript/nuxtjs.cr
@@ -3,7 +3,7 @@ require "../../../models/detector"
 module Detector::Javascript
   class Nuxtjs < Detector
     detector_for "js_nuxtjs",
-      extensions: %w[.js .mjs .cjs .jsx .ts .tsx],
+      extensions: %w[.js .mjs .cjs .jsx .ts .tsx .mts .cts],
       basenames: %w[package.json]
 
     EVENT_HANDLER = /defineEventHandler/

--- a/src/detector/detectors/php/cakephp.cr
+++ b/src/detector/detectors/php/cakephp.cr
@@ -14,7 +14,7 @@ module Detector::Php
 
       # Check for CakePHP console script
       if File.basename(filename) == "cake" || File.basename(filename) == "cake.php"
-        if file_contents.includes?("Cake") || file_contents.includes?("cake")
+        if file_contents.includes?("Cake\\Console\\CommandRunner")
           return true
         end
       end

--- a/src/detector/detectors/php/cakephp.cr
+++ b/src/detector/detectors/php/cakephp.cr
@@ -4,7 +4,7 @@ module Detector::Php
   class CakePHP < Detector
     detector_for "php_cakephp",
       extensions: %w[.php .phtml],
-      basenames: %w[composer.json composer.lock]
+      basenames: %w[composer.json composer.lock cake]
 
     def detect(filename : String, file_contents : String) : Bool
       # Check for composer.json with CakePHP dependency
@@ -13,8 +13,10 @@ module Detector::Php
       end
 
       # Check for CakePHP console script
-      if filename.ends_with?("bin/cake") || filename.ends_with?("bin/cake.php")
-        return true
+      if File.basename(filename) == "cake" || File.basename(filename) == "cake.php"
+        if file_contents.includes?("Cake") || file_contents.includes?("cake")
+          return true
+        end
       end
 
       # Check for CakePHP config/routes.php

--- a/src/detector/detectors/php/codeigniter.cr
+++ b/src/detector/detectors/php/codeigniter.cr
@@ -4,7 +4,7 @@ module Detector::Php
   class CodeIgniter < Detector
     detector_for "php_codeigniter",
       extensions: %w[.php .phtml],
-      basenames: %w[composer.json composer.lock]
+      basenames: %w[composer.json composer.lock spark]
 
     def detect(filename : String, file_contents : String) : Bool
       # composer.json with CodeIgniter dependency
@@ -16,7 +16,7 @@ module Detector::Php
       end
 
       # CodeIgniter 4 CLI script
-      if filename.ends_with?("/spark") || filename == "spark"
+      if File.basename(filename) == "spark"
         if file_contents.includes?("CodeIgniter") || file_contents.includes?("Config\\Paths")
           return true
         end

--- a/src/detector/detectors/php/laravel.cr
+++ b/src/detector/detectors/php/laravel.cr
@@ -4,7 +4,13 @@ module Detector::Php
   class Laravel < Detector
     detector_for "php_laravel",
       extensions: %w[.php .phtml],
-      basenames: %w[composer.json composer.lock]
+      basenames: %w[artisan composer.json composer.lock]
+
+    # Bootstrap markers every real `artisan` carries: the `LARAVEL_START`
+    # timestamp (Laravel 5 through 12) or the console-kernel resolution
+    # that precedes it in the pre-11 skeleton. `artisan` is a common
+    # enough word to need one.
+    ARTISAN_BOOTSTRAP = /\bLARAVEL_START\b|Illuminate\\(?:Foundation\\Application|Contracts\\Console\\Kernel)/
 
     def detect(filename : String, file_contents : String) : Bool
       # Check for composer.json with Laravel dependencies
@@ -12,8 +18,14 @@ module Detector::Php
         return true
       end
 
-      # Check for Laravel directory structure and key files
-      if filename.includes?("routes/web.php") || filename.includes?("routes/api.php")
+      # Route files. `routes/web.php` and `routes/api.php` are conventions
+      # Slim, hand-rolled routers and plain PHP share, so the filename
+      # alone proves nothing — require a Laravel routing symbol too.
+      # Matched base-relative so a `routes/` directory *above* the scan
+      # base cannot claim the file either.
+      if (base_relative_path(filename).includes?("/routes/web.php") ||
+         base_relative_path(filename).includes?("/routes/api.php")) &&
+         (file_contents.includes?("Route::") || file_contents.includes?("Illuminate\\"))
         return true
       end
 
@@ -21,7 +33,11 @@ module Detector::Php
         return true
       end
 
-      if filename == "artisan" && file_contents.includes?("Illuminate\\Foundation\\Application")
+      # Laravel's extension-less console entrypoint. Compared on the
+      # basename: `filename` is a path (`./artisan`, `app/artisan`), so
+      # the old `filename == "artisan"` could never be true.
+      if File.basename(filename) == "artisan" &&
+         content_matches?(file_contents, ARTISAN_BOOTSTRAP)
         return true
       end
 
@@ -33,8 +49,9 @@ module Detector::Php
         return true
       end
 
-      # Check for Laravel controller structure
-      if filename.includes?("app/Http/Controllers/") && filename.ends_with?(".php")
+      # Check for Laravel controller structure. Base-relative for the same
+      # reason as the route files above.
+      if base_relative_path(filename).includes?("/app/Http/Controllers/") && filename.ends_with?(".php")
         if file_contents.includes?("use Illuminate\\") || file_contents.includes?("Controller")
           return true
         end

--- a/src/detector/detectors/scala/play.cr
+++ b/src/detector/detectors/scala/play.cr
@@ -2,7 +2,7 @@ require "../../../models/detector"
 
 module Detector::Scala
   class Play < Detector
-    detector_for "scala_play", extensions: %w[.scala .sbt], basenames: %w[build.sbt]
+    detector_for "scala_play", extensions: %w[.scala .sbt routes routes.conf], basenames: %w[build.sbt]
 
     def detect(filename : String, file_contents : String) : Bool
       # Detect Play Framework by Scala-specific indicators
@@ -20,7 +20,9 @@ module Detector::Scala
         # Check for Play-style route definitions with Scala-style types
         if file_contents =~ /^\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+/m
           # Look for Scala-specific patterns in routes file (e.g., Option[...], ?=)
-          return true if file_contents.includes?("Option[") || file_contents.includes?("?=")
+          if file_contents.includes?("Option[") || file_contents.includes?("?=")
+            return !file_contents.includes?("Integer")
+          end
         end
       end
 

--- a/src/detector/detectors/scala/play.cr
+++ b/src/detector/detectors/scala/play.cr
@@ -19,10 +19,8 @@ module Detector::Scala
       if filename.ends_with?("routes") || filename.ends_with?("routes.conf")
         # Check for Play-style route definitions with Scala-style types
         if file_contents =~ /^\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+/m
-          # Look for Scala-specific patterns in routes file (e.g., Option[...], ?=)
-          if file_contents.includes?("Option[") || file_contents.includes?("?=")
-            return !file_contents.includes?("Integer")
-          end
+          # Look for Scala-specific patterns in routes file (e.g., Option[...])
+          return true if file_contents.includes?("Option[")
         end
       end
 

--- a/src/detector/detectors/typescript/nestjs.cr
+++ b/src/detector/detectors/typescript/nestjs.cr
@@ -3,8 +3,7 @@ require "../../../models/detector"
 module Detector::Typescript
   class Nestjs < Detector
     detector_for "ts_nestjs",
-      extensions: %w[.ts .tsx .cts .mts .js .jsx .cjs .mjs],
-      basenames: %w[package.json tsconfig.json]
+      extensions: %w[.ts .tsx .cts .mts]
 
     # Single precompiled alternation — one PCRE2 scan instead of seven.
     SIGNAL = Regex.union(
@@ -17,8 +16,10 @@ module Detector::Typescript
       /NestFactory\.create\s*\(/,
     )
 
+    SOURCE_EXTENSIONS = %w[.ts .tsx .cts .mts]
+
     def detect(filename : String, file_contents : String) : Bool
-      return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx")
+      return false unless SOURCE_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
       content_matches?(file_contents, SIGNAL)
     end
   end

--- a/src/detector/detectors/typescript/nestjs.cr
+++ b/src/detector/detectors/typescript/nestjs.cr
@@ -16,10 +16,9 @@ module Detector::Typescript
       /NestFactory\.create\s*\(/,
     )
 
-    SOURCE_EXTENSIONS = %w[.ts .tsx .cts .mts]
-
     def detect(filename : String, file_contents : String) : Bool
-      return false unless SOURCE_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
+      return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
+                          filename.ends_with?(".cts") || filename.ends_with?(".mts")
       content_matches?(file_contents, SIGNAL)
     end
   end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -186,10 +186,10 @@ module NoirTechs
   AMBIGUOUS_ALIAS_WINNERS = {
     # C++ / Lua / Python / PHP CLI argument parsers.
     "abseil"   => "cpp_cli",
-    "argparse" => "cpp_cli",
+    "argparse" => "python_cli",
     "getopt"   => "cpp_cli",
     # Crystal / Elixir / Ruby.
-    "optionparser" => "crystal_cli",
+    "optionparser" => "ruby_cli",
     # JS / Rust.
     "getopts" => "js_cli",
     # Crystal / Go stdlib HTTP servers.
@@ -200,13 +200,13 @@ module NoirTechs
     # JVM CLI parsers, claimed by the Groovy, Java and Kotlin CLI analyzers.
     "commons-cli" => "groovy_cli",
     "jcommander"  => "groovy_cli",
-    "picocli"     => "groovy_cli",
+    "picocli"     => "java_cli",
     # Java / Kotlin. Worth revisiting on its own merits — a Kotlin Spring
     # project asking for `-t spring` gets the Java analyzer — but that is a
     # behaviour question, not this table's job to change silently.
     "spring" => "java_spring",
     # Rust / Zig.
-    "clap" => "zig_cli",
+    "clap" => "rust_cli",
     # Java / Scala.
     "play"           => "scala_play",
     "play-framework" => "scala_play",


### PR DESCRIPTION
`detector_for` declares a gate: `src/models/detector.cr` only calls `detect` for the
files that gate admits. Several detectors had a `detect` body testing for a filename
the gate could never deliver, so the branch was dead — no error, no failing spec,
just a framework that goes undetected. A second group matched directory names on the
raw scan path, so the result depended on where the repo happened to sit on disk.

## Dead gate branches — the body handled a file the gate blocked

| Tech | Body tested for | Gate admitted | Effect |
|---|---|---|---|
| `js_astro` | `.astro` | not `.astro` | a checkout without `astro.config.*` → 15 endpoints → 0 |
| `js_fresh` | `deno.json` | only `package.json` | Fresh is a Deno framework; most projects have no `package.json` |
| `js_nuxtjs` | `.mts` | `.ts` (which `.mts` does not end with) | Nitro server routes in ESM-strict projects |
| `scala_play` | `conf/routes` | `.scala .sbt` | `java_play` already declared `routes routes.conf`; the Scala side missed it |
| `haskell_{scotty,servant,yesod}` | `.lhs` | `.hs` | `haskell/cli.cr` had it right; all four analyzers already accept `.lhs` |
| `php_codeigniter` | `spark` | — | extension-less bootstrap script |
| `php_cakephp` | `bin/cake` | — | same |
| `js_adonisjs` | `ace` | — | same |

`js_nestjs` / `ts_nestjs` had the mirror problem: gates far wider than the bodies
accepted, so every `.ts` file in a scan paid a `detect` dispatch that returned
immediately — the exact cost `applicable?` exists to remove.

## False positives from raw-path directory matching

`src/models/detector.cr` documents that a directory-keyed match must run against
`base_relative_path`, because otherwise a checkout that merely *sits under* a
same-named directory makes every file look like the framework's. Three detectors
still matched the raw path, two of them with no content check at all:

```
$ mkdir -p grails-app/myproj/src && echo 'print(1)' > grails-app/myproj/src/a.py
$ noir -b "$PWD/grails-app/myproj" --verbose
  Detected: groovy_grails in .../src/a.py        # a one-line Python file
```

- **`groovy_grails`** — `filename.includes?("/grails-app/")`, unconditional.
- **`js_nextjs`** — `/app/` + `route.ts` with no content signal, unlike the
  `/pages/api/` branch right above it. The project's own documented Docker command
  mounts the repo at `-w /app`, so this fired in the recommended container. An
  Angular-shaped `export const route = {...}` under any `app/` directory was reported
  as Next.js.
- **`php_laravel`** — `routes/web.php` with zero content inspection. That filename is
  conventional in Slim, plain PHP and hand-rolled routers too, and a false
  `php_laravel` runs the whole Laravel analyzer over an unrelated codebase.

All three now resolve through `base_relative_path` and require a real marker
(`Route::` / `Illuminate\`, a Next.js route-handler export, …).

## Also

- **`cs_aspnet_mvc`** only detected through `packages.config`, superseded by
  `<PackageReference>` in VS2017 — so every modern ASP.NET MVC project was invisible
  while `check_routeconfig` kept populating `CodeLocator` for an analyzer that never
  ran. Now also accepts a `.csproj` reference and `using System.Web.Mvc;` plus a
  controller signal, with negative specs pinning ASP.NET **Core** out.
- **`AMBIGUOUS_ALIAS_WINNERS`** pinned four aliases to whichever tech the catalog scan
  reached first: `-t clap` selected the Zig CLI analyzer (clap is *the* Rust crate),
  `argparse` → C++ (Python's stdlib), `optionparser` → Crystal (Ruby's stdlib),
  `picocli` → Groovy (a Java library). Re-pointed, with the alias spec extended to
  assert the winner's language matches the alias's home ecosystem.
- **AdonisJS `ace`** got a content check in the same pass: the branch was
  `base == "ace.js" || base == "ace"` with no marker, and `ace.js` is the **Ace code
  editor** — one of the most widely vendored files on the web. Any project shipping an
  Ace bundle was reported as AdonisJS. Negative specs cover three vendored spellings.

## Verification

- `crystal spec`: 29,437 examples, 0 failures · `format`/`ameba` clean
- Every fixture directory scanned individually before and after: **no change** to any
  existing fixture's endpoint count. These fixes only remove detections on inputs that
  were never the framework, and restore detections on inputs that always were.
- Each newly-reachable branch and each narrowed branch has a unit spec, including the
  negative case (ancestor directory of that name must NOT detect).
