### PR TITLE
fix(analyzer): stop dropping real endpoints and tagging unprotected routes as authenticated

### DIFF
--- a/spec/functional_test/fixtures/crystal/cli_monorepo/alpha/src/main.cr
+++ b/spec/functional_test/fixtures/crystal/cli_monorepo/alpha/src/main.cr
@@ -1,0 +1,8 @@
+require "option_parser"
+
+# Two unrelated programs in one checkout. Neither directory carries a
+# shard.yml, so the binary name can only come from the tree: the immediate
+# parent (`src`) is shared, the one above it is not.
+OptionParser.parse do |parser|
+  parser.on("--alpha-only", "alpha") { }
+end

--- a/spec/functional_test/fixtures/crystal/cli_monorepo/beta/src/main.cr
+++ b/spec/functional_test/fixtures/crystal/cli_monorepo/beta/src/main.cr
@@ -1,0 +1,5 @@
+require "option_parser"
+
+OptionParser.parse do |parser|
+  parser.on("--beta-only", "beta") { }
+end

--- a/spec/functional_test/fixtures/crystal/cli_monorepo_shards/svc-a/shard.yml
+++ b/spec/functional_test/fixtures/crystal/cli_monorepo_shards/svc-a/shard.yml
@@ -1,0 +1,2 @@
+name: svc-a
+version: 0.1.0

--- a/spec/functional_test/fixtures/crystal/cli_monorepo_shards/svc-a/src/tool.cr
+++ b/spec/functional_test/fixtures/crystal/cli_monorepo_shards/svc-a/src/tool.cr
@@ -1,0 +1,7 @@
+require "option_parser"
+
+# Same file stem in both shards, so both programs infer the binary name
+# `tool`. The shard.yml above each one is what tells them apart.
+OptionParser.parse do |parser|
+  parser.on("--only-a", "a") { }
+end

--- a/spec/functional_test/fixtures/crystal/cli_monorepo_shards/svc-b/shard.yml
+++ b/spec/functional_test/fixtures/crystal/cli_monorepo_shards/svc-b/shard.yml
@@ -1,0 +1,2 @@
+name: svc-b
+version: 0.1.0

--- a/spec/functional_test/fixtures/crystal/cli_monorepo_shards/svc-b/src/tool.cr
+++ b/spec/functional_test/fixtures/crystal/cli_monorepo_shards/svc-b/src/tool.cr
@@ -1,0 +1,5 @@
+require "option_parser"
+
+OptionParser.parse do |parser|
+  parser.on("--only-b", "b") { }
+end

--- a/spec/functional_test/fixtures/go/cli_monorepo/go.mod
+++ b/spec/functional_test/fixtures/go/cli_monorepo/go.mod
@@ -1,0 +1,3 @@
+module example.com/mono
+
+go 1.21

--- a/spec/functional_test/fixtures/go/cli_monorepo/services/alpha/cmd/flags.go
+++ b/spec/functional_test/fixtures/go/cli_monorepo/services/alpha/cmd/flags.go
@@ -1,0 +1,9 @@
+package main
+
+import "flag"
+
+// A second file of the same command: its flag must merge onto cli://alpha,
+// and the file must show up in the endpoint's code paths.
+func init() {
+	flag.String("alpha-extra-flag", "", "alpha extra")
+}

--- a/spec/functional_test/fixtures/go/cli_monorepo/services/alpha/cmd/main.go
+++ b/spec/functional_test/fixtures/go/cli_monorepo/services/alpha/cmd/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "flag"
+
+// One go.mod, two commands. Naming both after the module merged their flag
+// sets into a single cli://mono endpoint.
+func main() {
+	flag.String("alpha-only-flag", "", "alpha")
+	flag.Parse()
+}

--- a/spec/functional_test/fixtures/go/cli_monorepo/services/beta/cmd/main.go
+++ b/spec/functional_test/fixtures/go/cli_monorepo/services/beta/cmd/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "flag"
+
+func main() {
+	flag.String("beta-only-flag", "", "beta")
+	flag.Parse()
+}

--- a/spec/functional_test/fixtures/perl/mojolicious_scoping/dancer2app/cpanfile
+++ b/spec/functional_test/fixtures/perl/mojolicious_scoping/dancer2app/cpanfile
@@ -1,0 +1,2 @@
+requires 'perl', '5.020';
+requires 'Dancer2', '>= 1.0.0';

--- a/spec/functional_test/fixtures/perl/mojolicious_scoping/dancer2app/lib/Dancer2App.pm
+++ b/spec/functional_test/fixtures/perl/mojolicious_scoping/dancer2app/lib/Dancer2App.pm
@@ -1,0 +1,27 @@
+package Dancer2App;
+
+# A Dancer2 service that shares a checkout with the Mojolicious app next
+# door. None of it belongs to `perl_mojolicious`: the `query_parameters->get`
+# / `body_parameters->get` accessors are Dancer2 request reads, and the
+# `get '/status'` keyword routes carry Dancer2's own `prefix`.
+use Dancer2;
+
+prefix '/api';
+
+get '/status' => sub {
+    my $page  = query_parameters->get('page');
+    my $limit = query_parameters->get('limit');
+    return { ok => 1 };
+};
+
+get '/dashboard' => sub {
+    my $q = query_parameters->get('q');
+    return { ok => 1 };
+};
+
+post '/settings' => sub {
+    my $email = body_parameters->get('email');
+    return { ok => 1 };
+};
+
+1;

--- a/spec/functional_test/fixtures/perl/mojolicious_scoping/mojoapp/cpanfile
+++ b/spec/functional_test/fixtures/perl/mojolicious_scoping/mojoapp/cpanfile
@@ -1,0 +1,2 @@
+requires 'perl', '5.020';
+requires 'Mojolicious', '>= 9.0';

--- a/spec/functional_test/fixtures/perl/mojolicious_scoping/mojoapp/lib/MojoApp.pm
+++ b/spec/functional_test/fixtures/perl/mojolicious_scoping/mojoapp/lib/MojoApp.pm
@@ -1,0 +1,19 @@
+package MojoApp;
+use Mojo::Base 'Mojolicious', -signatures;
+
+sub startup ($self) {
+    my $r = $self->routes;
+    $r->get('/real')->to('thing#index');
+
+    my $admin = $r->under('/admin')->to('auth#check');
+    $admin->get('/panel')->to('admin#panel');
+
+    # None of these are routes. They are ordinary accessors that happen to
+    # be spelled `->get('literal')`: a Mojo::Cache lookup, a stash read, and
+    # a config read. A string key is the *common* shape for all three.
+    my $ttl  = $cache->get("session_timeout");
+    my $user = $self->stash->get("current_user");
+    my $key  = $self->config->get("secret_name");
+}
+
+1;

--- a/spec/functional_test/testers/crystal/cli_monorepo_shards_spec.cr
+++ b/spec/functional_test/testers/crystal/cli_monorepo_shards_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+build = ->(url : String, params : Array(Param)) do
+  ep = Endpoint.new(url, "CLI", params)
+  ep.protocol = "cli"
+  ep
+end
+
+# Both shards hold a `src/tool.cr`, so both programs infer the same binary
+# name. Keying the endpoint map per project keeps them apart inside the
+# analyzer; the base-relative project path in the URL keeps the optimizer —
+# which dedups by (method, url) and merges params — from stitching them back
+# into one command.
+endpoints = [
+  build.call("cli://svc-a/tool", [Param.new("only-a", "", "flag")]),
+  build.call("cli://svc-b/tool", [Param.new("only-b", "", "flag")]),
+]
+
+tester = FunctionalTester.new("fixtures/crystal/cli_monorepo_shards/", {
+  :endpoints => endpoints.size,
+}, endpoints, {
+  "only_techs" => YAML::Any.new("crystal_cli"),
+})
+tester.perform_tests
+
+it "does not merge two shards that infer the same binary name" do
+  svc_a = tester.endpoints.find! { |endpoint| endpoint.url == "cli://svc-a/tool" }
+  svc_a.params.map(&.name).should_not contain("only-b")
+  svc_a.details.code_paths.map(&.path).each(&.should(contain("svc-a")))
+end

--- a/spec/functional_test/testers/crystal/cli_monorepo_spec.cr
+++ b/spec/functional_test/testers/crystal/cli_monorepo_spec.cr
@@ -1,0 +1,32 @@
+require "../../func_spec.cr"
+
+build = ->(url : String, params : Array(Param)) do
+  ep = Endpoint.new(url, "CLI", params)
+  ep.protocol = "cli"
+  ep
+end
+
+# `alpha/src/main.cr` and `beta/src/main.cr` are two unrelated programs.
+# `cli_binary_name` fell back to the *immediate* parent for a `main` stem, so
+# both became `cli://src` and `fetch_endpoint` merged them into one endpoint
+# carrying both flag sets — with only the first file's code path to show for
+# it.
+endpoints = [
+  build.call("cli://alpha", [Param.new("alpha-only", "", "flag")]),
+  build.call("cli://beta", [Param.new("beta-only", "", "flag")]),
+]
+
+tester = FunctionalTester.new("fixtures/crystal/cli_monorepo/", {
+  :endpoints => endpoints.size,
+}, endpoints, {
+  "only_techs" => YAML::Any.new("crystal_cli"),
+})
+tester.perform_tests
+
+it "keeps each binary's flags on its own command" do
+  alpha = tester.endpoints.find! { |endpoint| endpoint.url == "cli://alpha" }
+  alpha.params.map(&.name).should_not contain("beta-only")
+
+  beta = tester.endpoints.find! { |endpoint| endpoint.url == "cli://beta" }
+  beta.params.map(&.name).should_not contain("alpha-only")
+end

--- a/spec/functional_test/testers/go/cli_monorepo_spec.cr
+++ b/spec/functional_test/testers/go/cli_monorepo_spec.cr
@@ -1,0 +1,39 @@
+require "../../func_spec.cr"
+
+build = ->(url : String, params : Array(Param)) do
+  ep = Endpoint.new(url, "CLI", params)
+  ep.protocol = "cli"
+  ep
+end
+
+# One `go.mod`, two commands. `go_binary_name` named every file in the module
+# after the module, so `services/alpha/cmd` and `services/beta/cmd` both
+# became `cli://mono` and their flag sets merged. Each `package main`
+# directory is its own binary; library packages still take the module name so
+# the cross-file merge this analyzer is built around keeps working.
+endpoints = [
+  build.call("cli://alpha", [
+    Param.new("alpha-only-flag", "", "flag"),
+    Param.new("alpha-extra-flag", "", "flag"),
+  ]),
+  build.call("cli://beta", [Param.new("beta-only-flag", "", "flag")]),
+]
+
+tester = FunctionalTester.new("fixtures/go/cli_monorepo/", {
+  :endpoints => endpoints.size,
+}, endpoints, {
+  "only_techs" => YAML::Any.new("go_cli"),
+})
+tester.perform_tests
+
+it "keeps each command's flags on its own binary" do
+  alpha = tester.endpoints.find! { |endpoint| endpoint.url == "cli://alpha" }
+  alpha.params.map(&.name).should_not contain("beta-only-flag")
+end
+
+it "records every file that contributed to a command" do
+  alpha = tester.endpoints.find! { |endpoint| endpoint.url == "cli://alpha" }
+  paths = alpha.details.code_paths.map { |code_path| File.basename(code_path.path) }
+  paths.should contain("main.go")
+  paths.should contain("flags.go")
+end

--- a/spec/functional_test/testers/perl/mojolicious_scoping_spec.cr
+++ b/spec/functional_test/testers/perl/mojolicious_scoping_spec.cr
@@ -1,0 +1,39 @@
+require "../../func_spec.cr"
+
+# Two Perl services in one checkout: a Dancer2 app and a Mojolicious app.
+#
+# `perl_mojolicious` used to claim both, because `PerlEngine` handed every
+# `.pm` to every Perl analyzer and `FULL_VERB_RE` treated *any*
+# `->get('literal')` as a route. That combination reported Dancer2's
+# `query_parameters->get('page')` reads as `GET /page` (and its real routes
+# a second time, prefix-stripped), and inside the Mojolicious app itself it
+# reported `$cache->get("session_timeout")` as `GET /session_timeout`.
+expected_endpoints = [
+  Endpoint.new("/real", "GET"),
+  Endpoint.new("/admin/panel", "GET"),
+]
+
+tester = FunctionalTester.new("fixtures/perl/mojolicious_scoping/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("perl_mojolicious"),
+})
+tester.perform_tests
+
+it "does not read the neighbouring Dancer2 app as Mojolicious routes" do
+  paths = tester.endpoints.flat_map { |endpoint| endpoint.details.code_paths.map(&.path) }
+  paths.any?(&.includes?("dancer2app")).should be_false
+
+  urls = tester.endpoints.map(&.url)
+  %w[/page /limit /q /email /status /dashboard /settings].each do |stolen|
+    urls.should_not contain(stolen)
+  end
+end
+
+it "does not report data accessors spelled ->get('literal') as routes" do
+  urls = tester.endpoints.map(&.url)
+  urls.should_not contain("/session_timeout")
+  urls.should_not contain("/current_user")
+  urls.should_not contain("/secret_name")
+end

--- a/spec/unit_test/analyzer/perl_mojolicious_route_receiver_spec.cr
+++ b/spec/unit_test/analyzer/perl_mojolicious_route_receiver_spec.cr
@@ -1,0 +1,80 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/perl/mojolicious"
+
+def mojolicious_routes(analyzer : Analyzer::Perl::Mojolicious, source : String) : Array(String)
+  analyzer.analyze_content(source, "MyApp.pm").map { |endpoint| "#{endpoint.method} #{endpoint.url}" }
+end
+
+# `analyze_content` is the level the receiver gate has to be exercised at:
+# it is what builds the route-variable set that `route_receiver?` consults.
+describe Analyzer::Perl::Mojolicious do
+  analyzer = Analyzer::Perl::Mojolicious.new(create_test_options)
+
+  it "keeps every shape of real Mojolicious route" do
+    source = <<-PERL
+      package MyApp;
+      use Mojo::Base 'Mojolicious', -signatures;
+
+      sub startup ($self) {
+        $self->routes->post('/chain/self')->to('a#b');
+        my $r = $self->routes;
+        $r->get('/plain')->to('a#b');
+        $r->websocket('/ws')->to('a#b');
+        $r->route('/legacy')->via('GET')->to('a#b');
+        my $auth = $r->under('/auth')->to('auth#check');
+        $auth->get('')->to('auth#index');
+        $auth->get('/me')->to('auth#me');
+        $r->under('/v2')->get('/health')->to('h#ok');
+      }
+
+      sub _mount ($router) {
+        $router->get('/inner')->to('m#inner');
+      }
+      PERL
+
+    found = mojolicious_routes(analyzer, source)
+    found.should contain("POST /chain/self")
+    found.should contain("GET /plain")
+    found.should contain("GET /ws")
+    found.should contain("GET /legacy")
+    found.should contain("GET /auth")
+    found.should contain("GET /auth/me")
+    found.should contain("GET /v2/health")
+    found.should contain("GET /inner")
+  end
+
+  it "does not read a data accessor with a string key as a route" do
+    source = <<-PERL
+      package MyApp;
+      use Mojo::Base 'Mojolicious', -signatures;
+
+      sub startup ($self) {
+        my $r = $self->routes;
+        $r->get('/real')->to('a#b');
+        my $ttl  = $cache->get("session_timeout");
+        my $user = $self->stash->get("current_user");
+        my $page = $c->req->query_params->get('page');
+        my $any  = $registry->any('/not-a-route');
+        my $rt   = $store->route('/not-a-route-either');
+      }
+      PERL
+
+    mojolicious_routes(analyzer, source).should eq(["GET /real"])
+  end
+
+  it "ignores a Perl file that is not Mojolicious at all" do
+    source = <<-PERL
+      package Dancer2App;
+      use Dancer2;
+
+      prefix '/api';
+
+      get '/status' => sub {
+        my $page = query_parameters->get('page');
+        return { ok => 1 };
+      };
+      PERL
+
+    mojolicious_routes(analyzer, source).should be_empty
+  end
+end

--- a/spec/unit_test/miniparser/jaxrs_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/jaxrs_extractor_ts_spec.cr
@@ -3,6 +3,42 @@ require "../../../src/models/logger"
 require "../../../src/miniparsers/jaxrs_extractor_ts"
 
 describe Noir::TreeSitterJaxRsExtractor do
+  # A root-mounted resource composes `@Path("/")` with a bare `@GET` through
+  # `URLPath.join_trimmed`, which used to trim the prefix down to `""`. The
+  # route reached the optimizer with an empty URL, and `optimize_endpoints`
+  # skips those — so `GET /` disappeared from every output format with no
+  # warning, while its `@POST @Path("/things")` sibling came through fine.
+  it "keeps the root path for a bare verb on a root-mounted resource" do
+    source = <<-JAVA
+      package com.example.api;
+
+      import jakarta.ws.rs.GET;
+      import jakarta.ws.rs.POST;
+      import jakarta.ws.rs.Path;
+      import jakarta.ws.rs.core.Response;
+
+      @Path("/")
+      public class RootResource {
+          @GET
+          public Response index() {
+              return Response.ok().build();
+          }
+
+          @POST
+          @Path("/things")
+          public Response create() {
+              return Response.ok().build();
+          }
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJaxRsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/"},
+      {"POST", "/things"},
+    ])
+  end
+
   it "extracts application-level base paths from @ApplicationPath" do
     source = <<-JAVA
       package com.example;

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -596,6 +596,121 @@ describe "EndpointOptimizer" do
       result[0].details.code_paths.map(&.path).should eq(["ArticleController.kt", "schema.graphqls"])
     end
 
+    # `merge_graphql_params` used to take `target` by value and assign
+    # `target.details` on that copy. `target.params << …` survived because
+    # `Array` is a reference, so the SDL document replaced the runtime one
+    # (asserted below) while the `graphql_sdl` technology promotion right
+    # underneath it was silently dropped — half the method landed.
+    it "promotes the SDL technology onto the surviving GraphQL duplicate" do
+      optimizer = EndpointOptimizer.new(logger, options)
+
+      runtime_details = Details.new(PathInfo.new("app.js", 12))
+      runtime_details.technology = "javascript_graphql_yoga"
+      runtime_endpoint = Endpoint.new(
+        "/graphql#Query.user", "POST",
+        [Param.new("graphql_query", "query { user { id } }", "json")],
+        runtime_details
+      )
+
+      sdl_details = Details.new(PathInfo.new("schema.graphqls", 4))
+      sdl_details.technology = "graphql_sdl"
+      sdl_endpoint = Endpoint.new(
+        "/graphql#Query.user", "POST",
+        [Param.new("graphql_query", "query SDLVERSION($id: ID!) { user(id: $id) { id } }", "json")],
+        sdl_details
+      )
+
+      # "app.js" sorts before "schema.graphqls", so the runtime endpoint is
+      # the one kept and the SDL one is the source being merged in.
+      result = optimizer.optimize_endpoints([runtime_endpoint, sdl_endpoint])
+
+      result.size.should eq(1)
+      doc_param = result[0].params.find! { |param| param.name == "graphql_query" }
+      doc_param.value.should contain("SDLVERSION")
+      result[0].details.technology.should eq("graphql_sdl")
+    end
+
+    # The dedup merged four collections and threw every scalar the losing
+    # endpoint carried away. `protocol` is the consequential one: taggers run
+    # *after* the optimizer and `WebsocketTagger` keys off exactly this field,
+    # so a `ws` endpoint that lost the source-location tiebreak to a plain
+    # HTTP one at the same path silently stopped being tagged.
+    it "carries the losing duplicate's protocol, metadata and status code" do
+      optimizer = EndpointOptimizer.new(logger, options)
+
+      http_endpoint = Endpoint.new("/chat", "GET", [] of Param, Details.new(PathInfo.new("a_http.py", 3)))
+
+      ws_details = Details.new(PathInfo.new("b_ws.py", 9))
+      ws_details.status_code = 101
+      ws_endpoint = Endpoint.new("/chat", "GET", [] of Param, ws_details)
+      ws_endpoint.protocol = "ws"
+      ws_endpoint.kind = "channel"
+      ws_endpoint.metadata = {"channel" => "room:lobby"}
+
+      # "a_http.py" sorts first, so the HTTP endpoint wins the tiebreak and
+      # the websocket facts are the ones at risk of being dropped.
+      result = optimizer.optimize_endpoints([http_endpoint, ws_endpoint])
+
+      result.size.should eq(1)
+      result[0].protocol.should eq("ws")
+      result[0].kind.should eq("channel")
+      result[0].metadata.should eq({"channel" => "room:lobby"})
+      result[0].details.status_code.should eq(101)
+    end
+
+    it "does not overwrite scalars the surviving duplicate already carries" do
+      optimizer = EndpointOptimizer.new(logger, options)
+
+      winner_details = Details.new(PathInfo.new("a_first.py", 1))
+      winner_details.status_code = 200
+      winner = Endpoint.new("/chat", "GET", [] of Param, winner_details)
+      winner.protocol = "wss"
+      winner.metadata = {"source" => "winner"}
+
+      loser_details = Details.new(PathInfo.new("b_second.py", 1))
+      loser_details.status_code = 101
+      loser = Endpoint.new("/chat", "GET", [] of Param, loser_details)
+      loser.protocol = "ws"
+      loser.metadata = {"source" => "loser"}
+
+      result = optimizer.optimize_endpoints([winner, loser])
+
+      result.size.should eq(1)
+      result[0].protocol.should eq("wss")
+      result[0].metadata.should eq({"source" => "winner"})
+      result[0].details.status_code.should eq(200)
+    end
+
+    # `internal` marks a declaration of a request the app *makes*
+    # (`@FeignClient`, `@HttpExchange`), which `Deliver#skip_probe_target?`
+    # reads to skip probing. Another analyzer finding a real served route at
+    # the same address contradicts that, so it is cleared rather than kept —
+    # otherwise whichever of the two sorted first decided whether a genuine
+    # endpoint got probed.
+    it "clears internal when a served route dedups with an outbound declaration" do
+      optimizer = EndpointOptimizer.new(logger, options)
+
+      client = Endpoint.new("/users", "GET", [] of Param, Details.new(PathInfo.new("a_client.java", 5)), true)
+      served = Endpoint.new("/users", "GET", [] of Param, Details.new(PathInfo.new("b_controller.java", 7)), false)
+
+      result = optimizer.optimize_endpoints([client, served])
+
+      result.size.should eq(1)
+      result[0].internal.should be_false
+    end
+
+    it "keeps internal when both duplicates are outbound declarations" do
+      optimizer = EndpointOptimizer.new(logger, options)
+
+      first = Endpoint.new("/users", "GET", [] of Param, Details.new(PathInfo.new("a_client.java", 5)), true)
+      second = Endpoint.new("/users", "GET", [] of Param, Details.new(PathInfo.new("b_client.java", 7)), true)
+
+      result = optimizer.optimize_endpoints([first, second])
+
+      result.size.should eq(1)
+      result[0].internal.should be_true
+    end
+
     it "still merges Kotlin Spring GraphQL endpoints with SDL when the controller is under a build module" do
       optimizer = EndpointOptimizer.new(logger, options)
       temp_dir = File.join(Dir.tempdir, "noir-optimizer-graphql-#{Process.pid}-#{Time.utc.to_unix_ms}")

--- a/spec/unit_test/tagger/framework_taggers/express_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/express_auth_spec.cr
@@ -198,6 +198,124 @@ describe "ExpressAuthTagger" do
     endpoint.tags[0].description.should contain("app.use()")
   end
 
+  # --- negative cases: a route that nothing protects must never be tagged ---
+
+  it "does not tag the whole app from a sub-router's own use(auth)" do
+    tmpdir = File.tempname("express_subrouter")
+    Dir.mkdir_p(File.join(tmpdir, "routes"))
+
+    app_js = File.join(tmpdir, "app.js")
+    File.write(app_js, [
+      "const express = require('express');",
+      "const app = express();",
+      "const admin = require('./routes/admin');",
+      "app.get('/health', (req, res) => { res.json({ ok: true }); });",
+      "app.use('/admin', admin);",
+    ].join("\n"))
+
+    admin_js = File.join(tmpdir, "routes", "admin.js")
+    File.write(admin_js, [
+      "const express = require('express');",
+      "const router = express.Router();",
+      "router.use(requireAuth);",
+      "router.get('/panel', (req, res) => { res.json({ panel: true }); });",
+    ].join("\n"))
+
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(tmpdir)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{tmpdir}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.register_path(file)
+    end
+
+    health_details = Details.new(PathInfo.new(app_js, 4))
+    health_details.technology = "js_express"
+    health = Endpoint.new("/health", "GET", [] of Param, health_details)
+
+    panel_details = Details.new(PathInfo.new(admin_js, 4))
+    panel_details.technology = "js_express"
+    panel = Endpoint.new("/admin/panel", "GET", [] of Param, panel_details)
+
+    ExpressAuthTagger.new(noir_options).perform([health, panel])
+
+    # `router.use(requireAuth)` guards the sub-router, not the application.
+    health.tags.empty?.should be_true
+    panel.tags.empty?.should be_false
+    panel.tags[0].description.should contain("router.use()")
+
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  it "does not attribute the next route's middleware to the route above it" do
+    tmpdir = File.tempname("express_adjacent")
+    Dir.mkdir_p(tmpdir)
+    app_js = File.join(tmpdir, "app.js")
+    File.write(app_js, [
+      "const express = require('express');",
+      "const app = express();",
+      "app.get('/public/one', (req, res) => { res.json({}); });",
+      "app.get('/secret/two', requireAuth, (req, res) => { res.json({}); });",
+    ].join("\n"))
+
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(tmpdir)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{tmpdir}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.register_path(file)
+    end
+
+    public_details = Details.new(PathInfo.new(app_js, 3))
+    public_details.technology = "js_express"
+    public_endpoint = Endpoint.new("/public/one", "GET", [] of Param, public_details)
+
+    secret_details = Details.new(PathInfo.new(app_js, 4))
+    secret_details.technology = "js_express"
+    secret_endpoint = Endpoint.new("/secret/two", "GET", [] of Param, secret_details)
+
+    ExpressAuthTagger.new(noir_options).perform([public_endpoint, secret_endpoint])
+
+    public_endpoint.tags.empty?.should be_true
+    secret_endpoint.tags.empty?.should be_false
+    secret_endpoint.tags[0].description.should contain("requireAuth")
+
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  it "does not let an app.use('/admin') mount guard /administration" do
+    tmpdir = File.tempname("express_prefix")
+    Dir.mkdir_p(tmpdir)
+    app_js = File.join(tmpdir, "app.js")
+    File.write(app_js, [
+      "const express = require('express');",
+      "const app = express();",
+      "app.use('/admin', requireAuth);",
+      "app.get('/administration/report', (req, res) => { res.json({}); });",
+    ].join("\n"))
+
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(tmpdir)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{tmpdir}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.register_path(file)
+    end
+
+    details = Details.new(PathInfo.new(app_js, 4))
+    details.technology = "js_express"
+    endpoint = Endpoint.new("/administration/report", "GET", [] of Param, details)
+
+    ExpressAuthTagger.new(noir_options).perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+
+    FileUtils.rm_rf(tmpdir)
+  end
+
   it "handles empty code_paths gracefully" do
     noir_options = create_test_options
     noir_options["base"] = YAML::Any.new(fixture_base)

--- a/spec/unit_test/tagger/framework_taggers/ktor_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/ktor_auth_spec.cr
@@ -1,3 +1,4 @@
+require "file_utils"
 require "../../../spec_helper"
 require "../../../../src/tagger/tagger"
 
@@ -124,5 +125,122 @@ describe "KtorAuthTagger" do
     endpoint.tags[0].name.should eq("auth")
     endpoint.tags[0].tagger.should eq("ktor_auth")
     endpoint.tags[0].description.should contain("auth-session")
+  end
+
+  # --- negative cases: a route that nothing protects must never be tagged ---
+
+  it "does not read the next route's handler when this one closes on its own line" do
+    tmpdir = File.tempname("ktor_adjacent")
+    Dir.mkdir_p(tmpdir)
+    kt = File.join(tmpdir, "App.kt")
+    File.write(kt, [
+      "import io.ktor.server.routing.*",
+      "",
+      "fun Application.configureRouting() {",
+      "    routing {",
+      "        get(\"/public\") { call.respondText(\"public\") }",
+      "        get(\"/me\") { val principal = call.principal<JWTPrincipal>() }",
+      "    }",
+      "}",
+    ].join("\n"))
+
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(tmpdir)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{tmpdir}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.register_path(file)
+    end
+
+    public_details = Details.new(PathInfo.new(kt, 5))
+    public_details.technology = "kotlin_ktor"
+    public_endpoint = Endpoint.new("/public", "GET", [] of Param, public_details)
+
+    me_details = Details.new(PathInfo.new(kt, 6))
+    me_details.technology = "kotlin_ktor"
+    me_endpoint = Endpoint.new("/me", "GET", [] of Param, me_details)
+
+    KtorAuthTagger.new(noir_options).perform([public_endpoint, me_endpoint])
+
+    public_endpoint.tags.empty?.should be_true
+    # The one-line handler is now read as its own statement, so the route that
+    # really does extract a principal keeps its tag.
+    me_endpoint.tags.empty?.should be_false
+
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  it "keeps a nested authenticate block off sibling routes and other files" do
+    tmpdir = File.tempname("ktor_scope")
+    Dir.mkdir_p(tmpdir)
+
+    secure = File.join(tmpdir, "Secure.kt")
+    File.write(secure, [
+      "import io.ktor.server.routing.*",             # 1
+      "",                                            # 2
+      "fun Application.secureRouting() {",           # 3
+      "    routing {",                               # 4
+      "        route(\"/api\") {",                   # 5
+      "            route(\"/v1\") {",                # 6
+      "                get(\"/a\") {",               # 7
+      "                    call.respondText(\"a\")", # 8
+      "                }",                           # 9
+      "                authenticate(\"jwt\") {",     # 10
+      "                    get(\"/b\") {",           # 11
+      "                        call.respondText(\"b\")",
+      "                    }",
+      "                }",
+      "            }",
+      "        }",
+      "    }",
+      "}",
+    ].join("\n"))
+
+    public_kt = File.join(tmpdir, "Public.kt")
+    File.write(public_kt, [
+      "import io.ktor.server.routing.*",
+      "",
+      "fun Application.publicRouting() {",
+      "    routing {",
+      "        get(\"/api/public\") {",
+      "            call.respondText(\"public\")",
+      "        }",
+      "    }",
+      "}",
+    ].join("\n"))
+
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(tmpdir)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{tmpdir}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.register_path(file)
+    end
+
+    a_details = Details.new(PathInfo.new(secure, 7))
+    a_details.technology = "kotlin_ktor"
+    a_endpoint = Endpoint.new("/api/v1/a", "GET", [] of Param, a_details)
+
+    b_details = Details.new(PathInfo.new(secure, 11))
+    b_details.technology = "kotlin_ktor"
+    b_endpoint = Endpoint.new("/api/v1/b", "GET", [] of Param, b_details)
+
+    public_details = Details.new(PathInfo.new(public_kt, 5))
+    public_details.technology = "kotlin_ktor"
+    public_endpoint = Endpoint.new("/api/public", "GET", [] of Param, public_details)
+
+    KtorAuthTagger.new(noir_options).perform([a_endpoint, b_endpoint, public_endpoint])
+
+    # `/a` sits in the same route("/v1") block but outside authenticate {}.
+    a_endpoint.tags.empty?.should be_true
+    # Another file entirely, and not even under the block's prefix.
+    public_endpoint.tags.empty?.should be_true
+    # The one route the block really wraps.
+    b_endpoint.tags.empty?.should be_false
+    b_endpoint.tags[0].description.should contain("jwt")
+
+    FileUtils.rm_rf(tmpdir)
   end
 end

--- a/spec/unit_test/tagger/framework_taggers/php_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/php_auth_spec.cr
@@ -45,6 +45,78 @@ describe "PhpAuthTagger" do
     endpoint.tags[0].name.should eq("auth")
   end
 
+  it "does not attribute the next route's middleware to the route above it" do
+    tmpdir = File.tempname("php_adjacent_routes")
+    Dir.mkdir_p(tmpdir)
+    routes = File.join(tmpdir, "web.php")
+    File.write(routes, [
+      "<?php",
+      "",
+      "Route::get('/public', function () { return 'public'; });",
+      "Route::get('/me', function () { return 'me'; })->middleware('auth');",
+    ].join("\n"))
+
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(tmpdir)
+
+    public_details = Details.new(PathInfo.new(routes, 3))
+    public_details.technology = "php_laravel"
+    public_endpoint = Endpoint.new("/public", "GET", [] of Param, public_details)
+
+    me_details = Details.new(PathInfo.new(routes, 4))
+    me_details.technology = "php_laravel"
+    me_endpoint = Endpoint.new("/me", "GET", [] of Param, me_details)
+
+    PhpAuthTagger.new(noir_options).perform([public_endpoint, me_endpoint])
+
+    public_endpoint.tags.empty?.should be_true
+    me_endpoint.tags.empty?.should be_false
+    me_endpoint.tags[0].description.should contain("Laravel auth middleware")
+
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  it "does not sweep the next method's auth check into this action's body" do
+    tmpdir = File.tempname("php_method_body")
+    Dir.mkdir_p(tmpdir)
+    controller = File.join(tmpdir, "ReportController.php")
+    File.write(controller, [
+      "<?php",                                     # 1
+      "",                                          # 2
+      "class ReportController extends Controller", # 3
+      "{",                                         # 4
+      "    public function publicIndex()",         # 5
+      "    {",                                     # 6
+      "        return response()->json(['ok' => true]);",
+      "    }",                        # 8
+      "",                             # 9
+      "    public function secret()", # 10
+      "    {",                        # 11
+      "        $this->authorize('view', Report::class);",
+      "    }",
+      "}",
+    ].join("\n"))
+
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(tmpdir)
+
+    public_details = Details.new(PathInfo.new(controller, 5))
+    public_details.technology = "php_laravel"
+    public_endpoint = Endpoint.new("/reports/public", "GET", [] of Param, public_details)
+
+    secret_details = Details.new(PathInfo.new(controller, 10))
+    secret_details.technology = "php_laravel"
+    secret_endpoint = Endpoint.new("/reports/secret", "GET", [] of Param, secret_details)
+
+    PhpAuthTagger.new(noir_options).perform([public_endpoint, secret_endpoint])
+
+    public_endpoint.tags.empty?.should be_true
+    secret_endpoint.tags.empty?.should be_false
+    secret_endpoint.tags[0].description.should contain("Policy authorization")
+
+    FileUtils.rm_rf(tmpdir)
+  end
+
   it "does not tag public controller" do
     noir_options = create_test_options
     noir_options["base"] = YAML::Any.new(fixture_base)

--- a/spec/unit_test/utils/url_path_spec.cr
+++ b/spec/unit_test/utils/url_path_spec.cr
@@ -51,6 +51,20 @@ describe "Noir::URLPath.join_trimmed" do
     Noir::URLPath.join_trimmed("/api", "").should eq "/api"
   end
 
+  # The regression this file exists to pin: trimming a root-mounted prefix
+  # emptied it, and an endpoint with an empty URL is dropped wholesale by
+  # `EndpointOptimizer#optimize_endpoints`. A JAX-RS `@Path("/")` class with
+  # a bare `@GET` method resolves through exactly this pair.
+  it "keeps the root when trimming would empty a non-empty prefix" do
+    Noir::URLPath.join_trimmed("/", "").should eq "/"
+    Noir::URLPath.join_trimmed("//", "").should eq "/"
+    Noir::URLPath.join_trimmed("///", "").should eq "/"
+  end
+
+  it "still returns the empty string only when both sides are empty" do
+    Noir::URLPath.join_trimmed("", "").should eq ""
+  end
+
   it "returns the suffix untouched when the prefix is empty" do
     Noir::URLPath.join_trimmed("", "/users").should eq "/users"
     Noir::URLPath.join_trimmed("", "users").should eq "users"
@@ -98,9 +112,28 @@ describe "Noir::URLPath.join_absorbing" do
     Noir::URLPath.join_absorbing("", "").should eq ""
   end
 
-  it "differs from join_trimmed on an all-slash prefix" do
-    Noir::URLPath.join_trimmed("/", "").should eq ""
-    Noir::URLPath.join_absorbing("/", "").should eq "/"
+  # They used to disagree here — `join_trimmed("/", "")` was `""` — and that
+  # disagreement was the bug, not a design difference. The two rules coincide
+  # on every input now, and `join_trimmed` delegates; this sweeps the empty /
+  # `"/"` / `"//"` / trailing-slash matrix so a future edit to either cannot
+  # reintroduce a divergence unnoticed.
+  it "agrees with join_trimmed on the whole empty/slash matrix" do
+    sides = ["", "/", "//", "///", "/api", "/api/", "/api//", "users", "/users", "//users", "users/"]
+    sides.each do |prefix|
+      sides.each do |suffix|
+        Noir::URLPath.join_trimmed(prefix, suffix).should eq Noir::URLPath.join_absorbing(prefix, suffix)
+      end
+    end
+  end
+
+  # Neither helper roots a bare suffix — that is `join_rooted`'s job, and the
+  # JVM extractors depend on an unmapped class staying unrooted so the
+  # analyzer above them can apply the context path.
+  it "never emits an empty result unless both sides are empty" do
+    ["/", "//", "/api", "/api/"].each do |prefix|
+      Noir::URLPath.join_absorbing(prefix, "").should_not be_empty
+    end
+    Noir::URLPath.join_absorbing("", "").should eq ""
   end
 end
 
@@ -143,7 +176,8 @@ describe "Noir::URLPath.join_rooted" do
   end
 
   # And why neither of the existing joins could be reused: both emit an
-  # empty URL for the unmapped-class-with-bare-mapping case.
+  # empty URL for the unmapped-class-with-bare-mapping case. (Only for that
+  # case now — `join_trimmed("/", "")` is `"/"`, not `""`.)
   it "differs from join_trimmed and join_absorbing on the empty pair" do
     Noir::URLPath.join_trimmed("", "").should eq ""
     Noir::URLPath.join_absorbing("", "").should eq ""
@@ -178,5 +212,26 @@ describe "Noir::URLPath.absolute_join" do
 
   it "always prepends a leading slash" do
     Noir::URLPath.absolute_join("noslash").should eq("/noslash")
+  end
+
+  # An all-slash segment — Compojure's `(context "/" ...)`, an all-slash
+  # WebFlux prefix — is not empty on entry, so rejecting empties before
+  # trimming left it in the join as an empty component.
+  it "drops a segment that is empty only after trimming" do
+    Noir::URLPath.absolute_join("/api", "/", "users").should eq("/api/users")
+    Noir::URLPath.absolute_join("/api", "//", "users").should eq("/api/users")
+    Noir::URLPath.absolute_join("/", "users").should eq("/users")
+    Noir::URLPath.absolute_join("/api", "/").should eq("/api")
+  end
+
+  it "never emits a double slash from any all-slash segment" do
+    ["/", "//", "///"].each do |slashes|
+      Noir::URLPath.absolute_join("/api", slashes, "users").should_not contain("//")
+    end
+  end
+
+  it "roots an all-slash-only join" do
+    Noir::URLPath.absolute_join("/").should eq("/")
+    Noir::URLPath.absolute_join("", "").should eq("/")
   end
 end

--- a/src/analyzer/analyzers/clojure/cli.cr
+++ b/src/analyzer/analyzers/clojure/cli.cr
@@ -92,15 +92,16 @@ module Analyzer::Clojure
           end
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, File.extname(path))
       if stem == "core" || stem == "main" || stem == "cli" || stem == "app"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/cpp/cli.cr
+++ b/src/analyzer/analyzers/cpp/cli.cr
@@ -103,7 +103,7 @@ module Analyzer::Cpp
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -117,8 +117,9 @@ module Analyzer::Cpp
       stem = File.basename(path)
       EXTS.each { |ext| stem = stem[0...-ext.size] if stem.ends_with?(ext) }
       if stem == "main" || stem == "app" || stem == "cli"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/crystal/cli.cr
+++ b/src/analyzer/analyzers/crystal/cli.cr
@@ -44,7 +44,7 @@ module Analyzer::Crystal
           next
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -93,8 +93,9 @@ module Analyzer::Crystal
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, ".cr")
       if stem == "main" || stem == "cli" || stem == "app"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/csharp/cli.cr
+++ b/src/analyzer/analyzers/csharp/cli.cr
@@ -93,7 +93,7 @@ module Analyzer::CSharp
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -116,8 +116,9 @@ module Analyzer::CSharp
       end
       stem = File.basename(path, ".cs")
       if stem == "Program" || stem == "Main" || stem == "Cli" || stem == "App"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/dart/cli.cr
+++ b/src/analyzer/analyzers/dart/cli.cr
@@ -43,7 +43,7 @@ module Analyzer::Dart
           next
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -90,8 +90,9 @@ module Analyzer::Dart
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, ".dart")
       if stem == "main" || stem == "cli" || stem == "app"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/elixir/cli.cr
+++ b/src/analyzer/analyzers/elixir/cli.cr
@@ -58,15 +58,16 @@ module Analyzer::Elixir
           next
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, File.extname(path))
       if stem == "main" || stem == "cli" || stem == "app"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/go/cli.cr
+++ b/src/analyzer/analyzers/go/cli.cr
@@ -165,7 +165,7 @@ module Analyzer::Go
           content = GoEngine.strip_comments(raw)
           next unless cli_evidence?(content)
 
-          binary = go_binary_name(modules, path)
+          binary = go_binary_name(modules, path, content)
           root_url = "cli://#{binary}"
           lines = content.lines
           framework_cli = content.matches?(FRAMEWORK_IMPORTS_RE)
@@ -200,7 +200,7 @@ module Analyzer::Go
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -239,10 +239,23 @@ module Analyzer::Go
       content_matches?(content, OS_ARGS_RE)
     end
 
-    private def go_binary_name(modules : Array(Tuple(String, String)), path : String) : String
+    # A Go module can hold many commands — `cmd/foo`, `services/bar/cmd` —
+    # and each `package main` directory is a separate binary. Naming every
+    # one of them after the module merged unrelated programs' flags into a
+    # single `cli://<module>` endpoint. Library packages keep the module
+    # name, so the cross-file merge this analyzer is built around still
+    # works for the helper files a command pulls its flags from.
+    PACKAGE_MAIN_RE = /^\s*package\s+main\b/m
+
+    private def go_binary_name(modules : Array(Tuple(String, String)), path : String, content : String) : String
       expanded = File.expand_path(File.dirname(path))
       modules.each do |module_path, module_dir|
         if expanded == module_dir || expanded.starts_with?("#{module_dir}/")
+          if expanded != module_dir && content.matches?(PACKAGE_MAIN_RE)
+            if name = cli_directory_binary_name(path)
+              return name
+            end
+          end
           return File.basename(module_path)
         end
       end

--- a/src/analyzer/analyzers/groovy/cli.cr
+++ b/src/analyzer/analyzers/groovy/cli.cr
@@ -137,7 +137,7 @@ module Analyzer::Groovy
           next
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -232,8 +232,9 @@ module Analyzer::Groovy
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, ".groovy")
       if stem == "main" || stem == "cli" || stem == "app"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/haskell/cli.cr
+++ b/src/analyzer/analyzers/haskell/cli.cr
@@ -108,15 +108,16 @@ module Analyzer::Haskell
           end
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, File.extname(path))
       if stem == "Main" || stem == "main" || stem == "Cli" || stem == "App"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/java/cli.cr
+++ b/src/analyzer/analyzers/java/cli.cr
@@ -99,7 +99,7 @@ module Analyzer::Java
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 

--- a/src/analyzer/analyzers/javascript/cli.cr
+++ b/src/analyzer/analyzers/javascript/cli.cr
@@ -148,7 +148,7 @@ module Analyzer::Javascript
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       Fiber.yield
       @result
     end

--- a/src/analyzer/analyzers/kotlin/cli.cr
+++ b/src/analyzer/analyzers/kotlin/cli.cr
@@ -76,7 +76,7 @@ module Analyzer::Kotlin
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 

--- a/src/analyzer/analyzers/lua/cli.cr
+++ b/src/analyzer/analyzers/lua/cli.cr
@@ -116,7 +116,7 @@ module Analyzer::Lua
           next
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -139,8 +139,9 @@ module Analyzer::Lua
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, ".lua")
       if stem == "main" || stem == "cli" || stem == "init"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/perl/cli.cr
+++ b/src/analyzer/analyzers/perl/cli.cr
@@ -100,7 +100,7 @@ module Analyzer::Perl
           end
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -111,8 +111,9 @@ module Analyzer::Perl
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, File.extname(path))
       if stem == "main" || stem == "cli" || stem == "app"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -11,9 +11,12 @@ module Analyzer::Perl
     LITE_ANY_RE  = /^\s*any\s+(?:\[([^\]]+)\]\s*=>\s*)?['"]([^'"]+)['"]/
     # Leaf path may be empty (`$r->get('')`) — a Mojolicious idiom for a
     # route that *is* its receiver's prefix (e.g. `$auth->get('')`), so the
-    # capture is `[^'"]*` rather than `+`. A bare `$x->get(` with no string
-    # argument (a data accessor like `$backend->get($id)`) still never
-    # matches because the leading quote is required.
+    # capture is `[^'"]*` rather than `+`.
+    #
+    # A quoted argument does NOT make the call a route: `$cache->get("ttl")`
+    # and `$self->stash->get("current_user")` are ordinary data accessors and
+    # are the *common* shape, not an exotic one. Every `->verb(...)` match is
+    # therefore additionally gated on `route_receiver?`.
     FULL_VERB_RE  = /->\s*(get|post|put|patch|delete|del|options|head|websocket)\s*\(\s*['"]([^'"]*)['"]/
     FULL_ANY_RE   = /->\s*any\s*\(\s*(?:\[([^\]]+)\]\s*,?\s*=?>?\s*)?['"]([^'"]*)['"]/
     FULL_ROUTE_RE = /->\s*route\s*\(\s*['"]([^'"]*)['"]\s*\)(?:\s*->\s*via\s*\(\s*([^)]+)\))?/
@@ -30,8 +33,37 @@ module Analyzer::Perl
     # them to the sigil form (`:id`, `#id`, `*id`) so URLs read consistently
     # and the path-param scanner picks them up.
     ANGLE_PLACEHOLDER_RE = /<([:#*]?)([A-Za-z_]\w*)(?::[^<>]*)?>/
+    # A receiver chain that names the router itself: `$self->routes->get(…)`,
+    # `$app->routes->any(…)`, `shift->routes->under(…)`.
+    ROUTES_ACCESSOR_RE = /->\s*routes\b/
+    # A receiver chain that is already building a route: `$r->under('/v2')->get(…)`.
+    CHAIN_ROUTE_CALL_RE = /->\s*(?:under|any|route)\s*\(/
+    # The bare `$var` sitting immediately left of the call, with nothing
+    # between it and the `->`: the `$cache` of `$cache->get("ttl")`.
+    TRAILING_VAR_RE = /\$([A-Za-z_]\w*)\s*$/
+    # Mojolicious names its route object `$r` (or `$routes`/`$route`/`$router`)
+    # by universal convention, including in helper subs that receive it as an
+    # argument (`sub _api ($r) { $r->get('/x') }`) where no assignment exists
+    # for `build_prefix_maps` to record. Accepted on top of the assignments it
+    # does see.
+    CONVENTIONAL_ROUTE_VARS = Set{"r", "route", "routes", "router"}
+    # The file has to be Mojolicious before any of its `->get(…)` calls can be
+    # a Mojolicious route. `Mojolicious` covers `use Mojolicious`,
+    # `Mojolicious::Lite`, `Mojo::Base 'Mojolicious…'`, and the
+    # Plugin/Controller base classes; `Mojo::Base` covers a controller that
+    # subclasses another one of the app's controllers.
+    MOJO_MARKERS = ["Mojolicious", "Mojo::Base"]
     alias ControllerActionKey = Tuple(String, String)
     alias ControllerCalleeIndex = Hash(ControllerActionKey, Array(Noir::PerlCalleeExtractor::Entry))
+
+    # Only look at files belonging to a project that actually depends on
+    # Mojolicious. In a repo holding a Dancer2 service beside a Mojolicious
+    # one, this keeps this analyzer out of the Dancer2 tree entirely. A
+    # project with no manifest at all is still scanned — see
+    # `PerlEngine#path_under_perl_roots?`.
+    protected def cpan_dependencies : Array(String)
+      ["Mojolicious"]
+    end
 
     def analyze
       include_callee = callees_needed?
@@ -69,20 +101,28 @@ module Analyzer::Perl
                         include_callee : Bool = false,
                         controller_callees : ControllerCalleeIndex = ControllerCalleeIndex.new) : Array(Endpoint)
       endpoints = [] of Endpoint
+      # A Mojolicious route is only ever declared inside a Mojolicious file.
+      # Without this the `->verb('literal')` matchers below fire on any Perl
+      # source in the scan, so a Dancer2 app sitting beside a Mojolicious one
+      # had 14 of its lines reported as `perl_mojolicious` endpoints.
+      return endpoints unless mojolicious_file?(content)
+
       raw_lines = content.lines
       sanitized_lines = sanitize_perl_lines(raw_lines)
       offsets = line_offsets(content)
       last_endpoint : Endpoint? = nil
       # Resolve route-prefix variables (`my $api = $r->any('/api')`) up front,
       # joining multi-line `my $x\n  = ...;` assignments so the prefix is known
-      # before the route lines that consume it are visited.
-      var_prefix, path_vars = build_prefix_maps(sanitized_lines)
+      # before the route lines that consume it are visited. The same pass
+      # records which variables hold a route object at all, so `$cache->get(…)`
+      # can be told apart from `$admin->get(…)`.
+      var_prefix, path_vars, route_vars = build_prefix_maps(sanitized_lines)
 
       sanitized_lines.each_with_index do |line, index|
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?('#')
 
-        line_endpoints = line_to_endpoints(line, var_prefix, path_vars)
+        line_endpoints = line_to_endpoints(line, var_prefix, path_vars, route_vars)
         line_endpoints.each do |endpoint|
           endpoint.details = Details.new(PathInfo.new(file_path, index + 1))
           extract_path_params(endpoint).each { |p| push_unique_param(endpoint, p) }
@@ -119,6 +159,7 @@ module Analyzer::Perl
         ext = File.extname(path)
         next unless ext == ".pl" || ext == ".pm" || ext == ".psgi" || ext == ".t"
         next if perl_test_path?(path, ext)
+        next unless path_under_perl_roots?(path)
         # Controllers always declare `package …::Controller::…`; skip the
         # full strip/scan on files that can't contribute action callees.
         content = read_file_content(path)
@@ -133,6 +174,12 @@ module Analyzer::Perl
       callees
     end
 
+    # True when `content` is Mojolicious source. Cheap substring probes, run
+    # once per file before any of the route regexes.
+    private def mojolicious_file?(content : String) : Bool
+      MOJO_MARKERS.any? { |marker| content.includes?(marker) }
+    end
+
     def line_to_endpoints(line : String) : Array(Endpoint)
       line_to_endpoints(line, {} of String => String, {} of String => String)
     end
@@ -144,6 +191,13 @@ module Analyzer::Perl
     def line_to_endpoints(line : String,
                           var_prefix : Hash(String, String),
                           path_vars : Hash(String, String)) : Array(Endpoint)
+      line_to_endpoints(line, var_prefix, path_vars, Set(String).new)
+    end
+
+    def line_to_endpoints(line : String,
+                          var_prefix : Hash(String, String),
+                          path_vars : Hash(String, String),
+                          route_vars : Set(String)) : Array(Endpoint)
       result = [] of Endpoint
 
       # Routes always carry a quoted path (including empty `''`). Most
@@ -176,7 +230,7 @@ module Analyzer::Perl
       return result unless line.includes?("->")
 
       # Full app: `$r->get('/path')` etc.
-      if m = line.match(FULL_VERB_RE)
+      if (m = line.match(FULL_VERB_RE)) && route_receiver?(line, m.begin(0) || 0, route_vars)
         leaf = m[2]
         unless disallowed_route_url?(leaf)
           prefix = compute_chain_prefix(line, m.begin(0) || 0, var_prefix, path_vars)
@@ -189,7 +243,7 @@ module Analyzer::Perl
       end
 
       # Full app: `$r->any(['GET','POST'] => '/path')` or `$r->any('/path')`
-      if m = line.match(FULL_ANY_RE)
+      if (m = line.match(FULL_ANY_RE)) && route_receiver?(line, m.begin(0) || 0, route_vars)
         leaf = m[2]
         unless disallowed_route_url?(leaf)
           methods_str = m[1]?
@@ -202,7 +256,7 @@ module Analyzer::Perl
       end
 
       # Full app: `$r->route('/path')->via('GET')` or `via(qw(GET POST))`
-      if m = line.match(FULL_ROUTE_RE)
+      if (m = line.match(FULL_ROUTE_RE)) && route_receiver?(line, m.begin(0) || 0, route_vars)
         leaf = m[1]
         unless disallowed_route_url?(leaf)
           via_str = m[2]?
@@ -232,6 +286,35 @@ module Analyzer::Perl
         leading.starts_with?("delete") || leading.starts_with?("del") ||
         leading.starts_with?("options") || leading.starts_with?("head") ||
         leading.starts_with?("websocket") || leading.starts_with?("any")
+    end
+
+    # True when the receiver of the `->verb(…)` call starting at `call_start`
+    # is a Mojolicious route object rather than an arbitrary expression.
+    #
+    # `FULL_VERB_RE` on its own reads `$cache->get("session_timeout")` and
+    # `$self->stash->get("current_user")` — a `Mojo::Cache` lookup and a stash
+    # accessor — as routes, and a data accessor with a *string* key is the
+    # common shape in a real app, not a corner case.
+    private def route_receiver?(line : String, call_start : Int32, route_vars : Set(String)) : Bool
+      prelude = call_start > 0 ? line[0, call_start] : ""
+
+      # `$self->routes->get(…)` / `$app->routes->any(…)`.
+      return true if prelude.matches?(ROUTES_ACCESSOR_RE)
+      # `$r->under('/v2')->get(…)` — the chain is already building a route.
+      return true if prelude.matches?(CHAIN_ROUTE_CALL_RE)
+      # A continuation line (`$r->under('/api')\n  ->get('/x')`) carries no
+      # receiver at all. Accepting it keeps a real route rather than dropping
+      # it; the false-positive shapes all name their receiver inline.
+      return true if prelude.blank?
+
+      # `$admin->get(…)`: the receiver is a variable, and it has to be one
+      # known — or conventionally named — to hold a route object.
+      if m = prelude.match(TRAILING_VAR_RE)
+        name = m[1]
+        return route_vars.includes?(name) || CONVENTIONAL_ROUTE_VARS.includes?(name)
+      end
+
+      false
     end
 
     # `$ua->get('http://example.com/foo')` is a `Mojo::UserAgent` HTTP
@@ -270,9 +353,17 @@ module Analyzer::Perl
     # string scalar. `my $var` assignments split across lines are stitched
     # back together (up to a small line cap) so chains like
     # `my $api_auth_admin\n  = $api_public->under('/')->...` resolve.
-    private def build_prefix_maps(lines : Array(String)) : Tuple(Hash(String, String), Hash(String, String))
+    #
+    # The third map is the set of variables that hold a route object at all —
+    # `my $r = $self->routes`, `my $admin = $r->any('/admin')` — which is what
+    # tells `$admin->get('/users')` (a route) apart from `$cache->get('ttl')`
+    # (a cache lookup). It is tracked separately from `var_prefix` because a
+    # route object can carry an *empty* prefix (`my $auth = $r->under('')`)
+    # and still be a router.
+    private def build_prefix_maps(lines : Array(String)) : Tuple(Hash(String, String), Hash(String, String), Set(String))
       var_prefix = {} of String => String
       path_vars = {} of String => String
+      route_vars = Set(String).new
 
       index = 0
       while index < lines.size
@@ -290,16 +381,17 @@ module Analyzer::Perl
           statement += " " + lines[last].strip
         end
 
-        update_var_prefix(statement, var_prefix, path_vars)
+        update_var_prefix(statement, var_prefix, path_vars, route_vars)
         index = last + 1
       end
 
-      {var_prefix, path_vars}
+      {var_prefix, path_vars, route_vars}
     end
 
     private def update_var_prefix(line : String,
                                   var_prefix : Hash(String, String),
-                                  path_vars : Hash(String, String))
+                                  path_vars : Hash(String, String),
+                                  route_vars : Set(String))
       # `my $p = '/tests/<id:num>';` — a scalar holding a path string that a
       # later `$r->any($p)` uses as a route prefix. Record it so the prefix
       # resolves instead of collapsing to the top level.
@@ -310,6 +402,16 @@ module Analyzer::Perl
       return unless m = line.match(ASSIGNMENT_HEAD_RE)
       var = m[1]
       rhs = m[2]
+
+      # `my $r = $self->routes;`, `my $admin = $r->any('/admin');`,
+      # `my $sub = $admin->under('/x')->to(...)` — anything whose right-hand
+      # side names the router or continues a route chain hands back a route
+      # object. Recorded even when the resulting prefix is empty.
+      if rhs.matches?(ROUTES_ACCESSOR_RE) || rhs.matches?(CHAIN_ROUTE_CALL_RE)
+        route_vars << var
+      elsif (rm = rhs.match(CHAIN_RECEIVER_RE)) && route_vars.includes?(rm[1])
+        route_vars << var
+      end
 
       segments = [] of String
       each_prefix_segment(rhs, path_vars) { |seg| segments << seg }

--- a/src/analyzer/analyzers/php/cli.cr
+++ b/src/analyzer/analyzers/php/cli.cr
@@ -105,7 +105,7 @@ module Analyzer::Php
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 

--- a/src/analyzer/analyzers/python/cli.cr
+++ b/src/analyzer/analyzers/python/cli.cr
@@ -108,7 +108,7 @@ module Analyzer::Python
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       Fiber.yield
       @result
     end
@@ -138,8 +138,9 @@ module Analyzer::Python
       end
       stem = File.basename(path, ".py")
       if stem == "__main__" || stem == "__init__"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/ruby/cli.cr
+++ b/src/analyzer/analyzers/ruby/cli.cr
@@ -132,7 +132,7 @@ module Analyzer::Ruby
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       Fiber.yield
       @result
     end
@@ -150,8 +150,9 @@ module Analyzer::Ruby
       end
       stem = File.basename(path, ".rb")
       if stem == "main" || stem == "cli" || stem == "app"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/rust/cli.cr
+++ b/src/analyzer/analyzers/rust/cli.cr
@@ -78,7 +78,7 @@ module Analyzer::Rust
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 

--- a/src/analyzer/analyzers/scala/cli.cr
+++ b/src/analyzer/analyzers/scala/cli.cr
@@ -172,15 +172,16 @@ module Analyzer::Scala
           next
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, ".scala")
       if stem == "Main" || stem == "main" || stem == "Cli" || stem == "App"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/analyzers/swift/cli.cr
+++ b/src/analyzer/analyzers/swift/cli.cr
@@ -52,7 +52,7 @@ module Analyzer::Swift
         end
       end
 
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 

--- a/src/analyzer/analyzers/zig/cli.cr
+++ b/src/analyzer/analyzers/zig/cli.cr
@@ -137,7 +137,7 @@ module Analyzer::Zig
           next
         end
       end
-      endpoints.each_value { |ep| @result << ep }
+      @result.concat(cli_endpoints(endpoints))
       @result
     end
 
@@ -227,8 +227,9 @@ module Analyzer::Zig
     private def cli_binary_name(path : String) : String
       stem = File.basename(path, ".zig")
       if stem == "main" || stem == "cli" || stem == "app"
-        parent = File.basename(File.dirname(path))
-        return parent unless parent.empty?
+        if name = cli_directory_binary_name(path)
+          return name
+        end
       end
       stem
     end

--- a/src/analyzer/engines/cli_endpoint_support.cr
+++ b/src/analyzer/engines/cli_endpoint_support.cr
@@ -1,8 +1,9 @@
 require "../../models/endpoint"
 
 # Shared by the 21 `src/analyzer/analyzers/{lang}/cli.cr` analyzers, which all
-# build the same thing: a set of `cli://<binary>` endpoints keyed by URL, so
-# that flags and env vars discovered in different files merge onto one command.
+# build the same thing: a set of `cli://<binary>` endpoints, one per
+# (sub)command, so that flags and env vars discovered in different files merge
+# onto one command.
 #
 # It is a mixin rather than an inherited method because the CLI analyzers have
 # no common base below `Analyzer`: 17 extend `Analyzer` directly, while the Go,
@@ -10,22 +11,190 @@ require "../../models/endpoint"
 # onto `Analyzer` itself would hand a `cli://`-specific constructor to all ~200
 # analyzers, so the mixin is included by exactly the 21 that want it.
 #
-# Deliberately just this one method. The other helpers those files carry —
-# `cli_test_path?`, `cli_binary_name`, `cli_evidence?` — each read a per-class
-# constant whose *value* differs by language (Perl's test tree is `/t/`, Scala's
-# is `/it/`, Groovy's is `spec.groovy`; the binary-name stem lists disagree too).
-# Several are therefore textually identical while resolving to different
-# regexes, so folding them on name would be a silent behaviour change. They stay
-# where they are.
+# The other helpers those files carry — `cli_test_path?`, `<lang>_binary_name`,
+# `cli_evidence?` — each read a per-class constant whose *value* differs by
+# language (Perl's test tree is `/t/`, Scala's is `/it/`, Groovy's is
+# `spec.groovy`; the binary-name stem lists disagree too). Several are
+# therefore textually identical while resolving to different regexes, so
+# folding them on name would be a silent behaviour change. They stay where
+# they are — but the *fallback* half of `<lang>_binary_name`, which is genuine
+# duplication, lives here as `cli_directory_binary_name`.
 module CliEndpointSupport
+  # Separator inside the endpoint-map key. A NUL can appear in neither a path
+  # nor a URL, so the three parts of the key (configured base, project
+  # directory, URL) can never be confused for one another.
+  KEY_SEP = Char::ZERO
+
+  # Directory names that describe a project's layout rather than name the
+  # program inside it.
+  CLI_LAYOUT_DIRS = Set{
+    "src", "source", "sources", "bin", "cmd", "cmds", "command", "commands",
+    "lib", "libs", "app", "apps", "main", "cli", "script", "scripts",
+    "tool", "tools", "internal", "pkg", "exe", "console", "program",
+    "programs", "code", "packages", "project", "projects", "test", "tests",
+  }
+
+  # Files that mark a project root. A CLI file's nearest enclosing manifest is
+  # the program it belongs to; two files under different manifests are two
+  # programs even when their inferred binary names collide.
+  #
+  # Deliberately excludes `CMakeLists.txt` / `meson.build`: those are written
+  # per *subdirectory* in a normal build tree, so they mark layout rather than
+  # a project boundary and would split one program into many.
+  CLI_MANIFEST_BASENAMES = %w[
+    shard.yml go.mod Cargo.toml package.json deno.json deno.jsonc jsr.json
+    pubspec.yaml mix.exs build.sbt build.sc pom.xml build.gradle
+    build.gradle.kts settings.gradle settings.gradle.kts composer.json
+    pyproject.toml setup.py setup.cfg Pipfile Gemfile stack.yaml package.yaml
+    cabal.project deps.edn project.clj bb.edn Package.swift build.zig
+    build.zig.zon cpanfile Makefile.PL dist.ini
+  ]
+
+  # Manifests named after the project rather than by a fixed basename.
+  CLI_MANIFEST_EXTENSIONS = %w[.cabal .csproj .fsproj .vbproj .gemspec .rockspec .nimble]
+
   # Fetches (or lazily creates) the endpoint for a URL, so flags scattered
   # across files/blocks merge onto one command.
+  #
+  # Merging is keyed on the URL *within one project*, never globally. The URL
+  # comes from `<lang>_binary_name`, which for a generic stem (`main`, `cli`,
+  # `app`, `Program`, ...) falls back to a directory name — so in a monorepo
+  # two unrelated binaries could land on the same URL and collapse into a
+  # single endpoint carrying both flag sets, with only the first file's
+  # `code_path` to show for it.
   private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,
                              path : String, line_no : Int32) : Endpoint
-    endpoints[url] ||= begin
+    endpoint = endpoints[cli_endpoint_key(path, url)] ||= begin
       ep = Endpoint.new(url, "CLI", Details.new(PathInfo.new(path, line_no)))
       ep.protocol = "cli"
       ep
     end
+
+    # Every file that contributed a flag, argument or env var to this command
+    # is part of its definition. Recording only the first made a merge across
+    # files invisible in the output.
+    unless endpoint.details.code_paths.any? { |code_path| code_path.path == path }
+      endpoint.details.add_path(PathInfo.new(path, line_no))
+    end
+
+    endpoint
+  end
+
+  # Collects what `fetch_endpoint` built, disambiguating any URL that two
+  # different projects both claim. Every CLI analyzer ends its `analyze` with
+  # this instead of draining the hash directly.
+  #
+  # Keying the map per project is not enough on its own: the optimizer dedups
+  # endpoints by (method, url) and merges their params, so two same-named
+  # binaries in one monorepo would be stitched back into a single command
+  # carrying both flag sets no matter how the analyzer kept them apart.
+  # Prefixing the contested projects' URLs with their base-relative project
+  # path keeps them distinct all the way to the output.
+  #
+  # Order-independent: which URLs are contested depends only on the *set* of
+  # (project, url) pairs, so a scan always produces the same URLs.
+  private def cli_endpoints(endpoints : Hash(String, Endpoint)) : Array(Endpoint)
+    projects_by_url = Hash(String, Set(String)).new
+    endpoints.each do |key, endpoint|
+      (projects_by_url[endpoint.url] ||= Set(String).new) << cli_key_project(key)
+    end
+
+    contested = Set(String).new
+    projects_by_url.each_value { |projects| contested.concat(projects) if projects.size > 1 }
+
+    result = [] of Endpoint
+    endpoints.each do |key, endpoint|
+      prefix = cli_key_project_path(key)
+      if !prefix.empty? && contested.includes?(cli_key_project(key))
+        endpoint.url = endpoint.url.sub("cli://", "cli://#{prefix}/")
+      end
+      result << endpoint
+    end
+    result
+  end
+
+  private def cli_endpoint_key(path : String, url : String) : String
+    base, dir = cli_project_scope(path)
+    "#{base}#{KEY_SEP}#{dir}#{KEY_SEP}#{url}"
+  end
+
+  # The `base + project directory` half of an endpoint key.
+  private def cli_key_project(key : String) : String
+    index = key.rindex(KEY_SEP)
+    index ? key[0, index] : key
+  end
+
+  # The project directory half of an endpoint key, ready to prefix a URL with.
+  private def cli_key_project_path(key : String) : String
+    parts = key.split(KEY_SEP)
+    parts.size >= 2 ? parts[1].strip('/') : ""
+  end
+
+  # The project a CLI file belongs to: the nearest enclosing directory holding
+  # a project manifest, qualified by the configured base that owns the file so
+  # two bases with the same internal layout stay apart. Falls back to the base
+  # root when the scan holds no manifest above the file — a bare script
+  # directory is one project.
+  private def cli_project_scope(path : String) : Tuple(String, String)
+    roots = cli_manifest_dirs
+    base = configured_base_for(path)
+    dir = File.dirname(base_relative_path(path))
+
+    loop do
+      return {base, dir} if roots.includes?("#{base}#{KEY_SEP}#{dir}")
+      break if dir.empty? || dir == "/" || dir == "."
+      dir = File.dirname(dir)
+    end
+
+    {base, ""}
+  end
+
+  @cli_manifest_dirs : Set(String)?
+
+  # Base-relative directories holding a project manifest, qualified by their
+  # configured base. Built from the basename/extension indexes rather than a
+  # walk of `all_files`, so this costs a handful of hash lookups per analyzer.
+  private def cli_manifest_dirs : Set(String)
+    @cli_manifest_dirs ||= begin
+      dirs = Set(String).new
+      CLI_MANIFEST_BASENAMES.each do |basename|
+        get_files_by_basename(basename).each { |file| dirs << cli_manifest_dir_key(file) }
+      end
+      CLI_MANIFEST_EXTENSIONS.each do |extension|
+        get_files_by_extension(extension).each { |file| dirs << cli_manifest_dir_key(file) }
+      end
+      dirs
+    end
+  end
+
+  private def cli_manifest_dir_key(file : String) : String
+    "#{configured_base_for(file)}#{KEY_SEP}#{File.dirname(base_relative_path(file))}"
+  end
+
+  # Shared fallback for every `<lang>_binary_name`: the program's name when
+  # the file stem is a generic entry point (`main`, `cli`, `app`, `Program`,
+  # `core`, `__main__`, ...) and so names nothing.
+  #
+  # Every one of those methods used to take the *immediate* parent directory,
+  # which is how `mono/alpha/src/main.cr` and `mono/beta/src/main.cr` both
+  # became `cli://src`. Walk up past directories that describe layout instead,
+  # and stop at the scan base rather than climbing out of the project.
+  #
+  # Returns nil only when nothing — not even the base directory — yields a
+  # name, leaving the caller on its own stem.
+  private def cli_directory_binary_name(path : String) : String?
+    segments = base_relative_path(path).split('/').reject(&.empty?)
+    segments.pop? # the filename itself
+
+    while name = segments.pop?
+      return name unless CLI_LAYOUT_DIRS.includes?(name.downcase)
+    end
+
+    # Everything between the file and the scan base describes layout, so the
+    # base directory itself is the best name available.
+    base = configured_base_for(path)
+    base = File.dirname(path) if base.empty?
+    name = File.basename(File.expand_path(base))
+    name.empty? ? nil : name
   end
 end

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../utils/path_scope"
 
 require "./file_scan_engine"
 
@@ -11,8 +12,83 @@ module Analyzer::Perl
     # regular files — no per-path `File.exists?` / `File.directory?`.
     PERL_SOURCE_EXTENSIONS = [".pl", ".pm", ".psgi", ".t"]
 
+    # Perl dependency manifests. `cpanfile` and `Makefile.PL` are the common
+    # pair; `Build.PL`, `dist.ini` and the generated `META.*` cover the
+    # Module::Build / Dist::Zilla layouts.
+    PERL_MANIFEST_BASENAMES = %w[cpanfile cpanfile.snapshot Makefile.PL Build.PL dist.ini META.json META.yml META.yaml]
+
     protected def scan_target_files : Array(String)
       get_files_by_extensions(PERL_SOURCE_EXTENSIONS)
+    end
+
+    # The CPAN distributions that identify this analyzer's framework. An
+    # analyzer that declares one is only shown files from a project whose
+    # dependency manifest requires it. Without that gate every Perl analyzer
+    # sees every `.pm`/`.pl`/`.psgi` in the scan, so a repo holding a Dancer2
+    # app next to a Mojolicious one has each analyzer reading the other's
+    # files. Default is empty, meaning no gate — mirrors `CrystalEngine`'s
+    # `shard_dependencies` and `RustEngine`'s `crate_dependencies`.
+    protected def cpan_dependencies : Array(String)
+      [] of String
+    end
+
+    protected def scan_accepts?(path : String) : Bool
+      path_under_perl_roots?(path)
+    end
+
+    # A file belongs to this analyzer's framework when it sits under a
+    # project whose manifest requires one of `cpan_dependencies` — or under
+    # no manifested project at all. That second clause matters for Perl in a
+    # way it doesn't for Crystal or Rust: a great many Perl projects are a
+    # bare script directory with no `cpanfile`, and dropping them the moment
+    # some *other* directory in the scan happens to carry a manifest would
+    # cost real routes.
+    protected def path_under_perl_roots?(path : String) : Bool
+      return true if cpan_dependencies.empty?
+
+      framework_roots = perl_framework_roots
+      expanded = File.expand_path(path)
+      return true if framework_roots.any? { |root| Noir::PathScope.under_normalized_root?(expanded, root) }
+
+      perl_manifest_roots.none? { |root| Noir::PathScope.under_normalized_root?(expanded, root) }
+    end
+
+    @perl_manifest_roots : Array(String)?
+    @perl_framework_roots : Array(String)?
+
+    # Directories holding any Perl dependency manifest.
+    private def perl_manifest_roots : Array(String)
+      @perl_manifest_roots ||= collect_manifest_roots { true }
+    end
+
+    # Directories holding a manifest that requires one of `cpan_dependencies`.
+    private def perl_framework_roots : Array(String)
+      @perl_framework_roots ||= begin
+        dependencies = cpan_dependencies
+        if dependencies.empty?
+          [] of String
+        else
+          collect_manifest_roots { |content| dependencies.any? { |name| content.includes?(name) } }
+        end
+      end
+    end
+
+    private def collect_manifest_roots(&accept : String -> Bool) : Array(String)
+      roots = [] of String
+      PERL_MANIFEST_BASENAMES.each do |basename|
+        get_files_by_basename(basename).each do |file|
+          begin
+            content = read_file_content(file)
+          rescue e
+            logger.debug "perl manifest #{file}: #{e}"
+            next
+          end
+          next unless accept.call(content)
+          root = Noir::PathScope.normalize_root(File.dirname(file))
+          roots << root unless roots.includes?(root)
+        end
+      end
+      roots
     end
 
     # Perl test files live in `.t` scripts or under a `/t/` directory.

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -143,50 +143,60 @@ class EndpointOptimizer
         end
       end
 
+      # An endpoint with no URL is not addressable, so it cannot be reported.
+      # But reaching here means an analyzer or a path-composition helper
+      # produced one, which is a bug upstream rather than something to
+      # swallow: `join_trimmed` returning `""` for a root-mounted prefix hid
+      # exactly that for every root-mapped JAX-RS / http4k / Micronaut /
+      # Elysia / AdonisJS route. Debug level so normal runs stay quiet.
+      if tiny_tmp.url.empty?
+        @logger.debug_sub "  - Dropping endpoint with an empty URL: '#{tiny_tmp.method}' (#{tiny_tmp.details.technology || "unknown"})"
+        next
+      end
+
       # Duplicate check
-      unless tiny_tmp.url.empty?
-        absolute_url = tiny_tmp.url.matches?(ABSOLUTE_URL_RE)
+      absolute_url = tiny_tmp.url.matches?(ABSOLUTE_URL_RE)
 
-        # Ensure a leading slash for relative URLs. Compare against the
-        # `'/'` char literal — comparing the `Char` returned by `[]` to
-        # the `"/"` string is always true, which would prepend a slash
-        # even to already-rooted URLs (the double-slash collapse below
-        # papered over it). Mobile deep links are exempt: an unresolved
-        # `@string/...://` or `${...}://` scheme isn't a relative path, so
-        # rooting it (`/@string/...`) would corrupt the URL.
-        if !absolute_url && tiny_tmp.url[0] != '/' && !tiny_tmp.non_http?
-          tiny_tmp.url = "/#{tiny_tmp.url}"
-        end
+      # Ensure a leading slash for relative URLs. Compare against the
+      # `'/'` char literal — comparing the `Char` returned by `[]` to
+      # the `"/"` string is always true, which would prepend a slash
+      # even to already-rooted URLs (the double-slash collapse below
+      # papered over it). Mobile deep links are exempt: an unresolved
+      # `@string/...://` or `${...}://` scheme isn't a relative path, so
+      # rooting it (`/@string/...`) would corrupt the URL.
+      if !absolute_url && tiny_tmp.url[0] != '/' && !tiny_tmp.non_http?
+        tiny_tmp.url = "/#{tiny_tmp.url}"
+      end
 
-        # Mobile deep-link URLs are kept verbatim: a `${...}` there is an
-        # unresolved gradle manifest placeholder, not a JS template literal
-        # for the shape-normalizer to rewrite.
-        tiny_tmp.url = normalize_url_shape(tiny_tmp.url) unless tiny_tmp.non_http?
-        dedup_url = tiny_tmp.non_http? ? tiny_tmp.url : normalize_url_shape(tiny_tmp.url, collection_endpoint?(tiny_tmp))
+      # Mobile deep-link URLs are kept verbatim: a `${...}` there is an
+      # unresolved gradle manifest placeholder, not a JS template literal
+      # for the shape-normalizer to rewrite.
+      tiny_tmp.url = normalize_url_shape(tiny_tmp.url) unless tiny_tmp.non_http?
+      dedup_url = tiny_tmp.non_http? ? tiny_tmp.url : normalize_url_shape(tiny_tmp.url, collection_endpoint?(tiny_tmp))
 
-        key = {tiny_tmp.method, dedup_url, endpoint_source_scope(tiny_tmp, cross_tech_keys)}
+      key = {tiny_tmp.method, dedup_url, endpoint_source_scope(tiny_tmp, cross_tech_keys)}
 
-        if final_map.has_key?(key)
-          dup = final_map[key]
-          @logger.debug_sub "  - Found duplicated endpoint: #{tiny_tmp.method} #{tiny_tmp.url}"
-          duplicate_count += 1
-          if graphql_endpoint?(dup) || graphql_endpoint?(tiny_tmp)
-            merge_graphql_params(dup, tiny_tmp)
-          else
-            merge_params(dup, tiny_tmp, source_collection_pair?(dup, tiny_tmp))
-          end
-          tiny_tmp.tags.each { |tag| merge_tag(dup, tag) }
-          tiny_tmp.callees.each do |callee|
-            dup.push_callee(callee)
-          end
-          tiny_tmp.details.code_paths.each do |path_info|
-            dup.details.add_path(path_info) unless dup.details.code_paths.any? { |existing| existing == path_info }
-          end
-          dup = promote_source_context(dup, tiny_tmp)
-          final_map[key] = dup
+      if final_map.has_key?(key)
+        dup = final_map[key]
+        @logger.debug_sub "  - Found duplicated endpoint: #{tiny_tmp.method} #{tiny_tmp.url}"
+        duplicate_count += 1
+        if graphql_endpoint?(dup) || graphql_endpoint?(tiny_tmp)
+          dup = merge_graphql_params(dup, tiny_tmp)
         else
-          final_map[key] = tiny_tmp
+          merge_params(dup, tiny_tmp, source_collection_pair?(dup, tiny_tmp))
         end
+        tiny_tmp.tags.each { |tag| merge_tag(dup, tag) }
+        tiny_tmp.callees.each do |callee|
+          dup.push_callee(callee)
+        end
+        tiny_tmp.details.code_paths.each do |path_info|
+          dup.details.add_path(path_info) unless dup.details.code_paths.any? { |existing| existing == path_info }
+        end
+        dup = promote_source_context(dup, tiny_tmp)
+        dup = promote_scalar_context(dup, tiny_tmp)
+        final_map[key] = dup
+      else
+        final_map[key] = tiny_tmp
       end
     end
 
@@ -307,7 +317,7 @@ class EndpointOptimizer
 
   private def merge_endpoint_context(target : Endpoint, source : Endpoint) : Endpoint
     if graphql_endpoint?(target) || graphql_endpoint?(source)
-      merge_graphql_params(target, source)
+      target = merge_graphql_params(target, source)
     else
       merge_params(target, source, source_collection_pair?(target, source))
     end
@@ -348,6 +358,47 @@ class EndpointOptimizer
     details.code_paths = promoted
     target.details = details
     target.params.reject! { |param| collection_noise_header_param?(param) }
+    target
+  end
+
+  # Carry the losing duplicate's scalar fields onto the winner.
+  #
+  # The dedup merges four collections (params, tags, callees, code_paths) and
+  # used to discard everything else the loser knew. Which of two endpoints
+  # with the same `(method, url, scope)` wins is decided by source location,
+  # so the facts below were kept or lost depending on which file happened to
+  # sort first:
+  #
+  # - `protocol`: ~20 analyzers set `ws` on endpoints that also have an
+  #   ordinary HTTP path (`python/fastapi.cr`, `python/starlette.cr`,
+  #   `java/spring.cr`, `elixir/phoenix_channel.cr`, …). `WebsocketTagger`
+  #   keys off exactly this field and the taggers run *after* the optimizer,
+  #   so losing it dropped the `websocket` tag from the report.
+  # - `metadata`: the mobile deep-link facts (action/category/host/package).
+  # - `details.status_code`: recorded by spec/capture-derived analyzers.
+  # - `kind`: Next.js marks server actions here; the plain report prints it.
+  #
+  # `internal` moves the other way. It means "the app declares this request,
+  # it does not serve it" (`@FeignClient` / `@HttpExchange`), and `Deliver`
+  # reads it to skip probing. Another analyzer finding a real served route at
+  # the same address contradicts that, so the merge clears the flag instead
+  # of OR-ing it — otherwise a probe of a genuine endpoint would be
+  # suppressed by whichever declaration sorted first.
+  #
+  # Returns the endpoint: `Endpoint` is a struct, so these writes land on a
+  # copy unless the caller assigns the result back.
+  private def promote_scalar_context(target : Endpoint, source : Endpoint) : Endpoint
+    target.protocol = source.protocol if target.protocol == "http" && source.protocol != "http"
+    target.metadata = source.metadata if target.metadata.nil?
+    target.kind = source.kind if target.kind.empty?
+    target.internal = false if target.internal && !source.internal
+
+    if target.details.status_code.nil? && (status_code = source.details.status_code)
+      details = target.details
+      details.status_code = status_code
+      target.details = details
+    end
+
     target
   end
 

--- a/src/optimizer/optimizer/graphql.cr
+++ b/src/optimizer/optimizer/graphql.cr
@@ -51,7 +51,16 @@ class EndpointOptimizer
     url.split('#', 2).first
   end
 
-  private def merge_graphql_params(target : Endpoint, source : Endpoint) : Nil
+  # Merge `source`'s GraphQL params into `target` and return the result.
+  #
+  # It has to *return* the endpoint, like `promote_source_context` and
+  # `merge_endpoint_context` next door: `Endpoint` is a struct, so `target`
+  # is a copy of the caller's value. `target.params << …` lands anyway
+  # because `Array` is itself a reference, but the `target.details = …`
+  # promotion below wrote only the copy — which is why an SDL-derived
+  # endpoint could hand over its `graphql_query` document (params survived)
+  # while its `graphql_sdl` technology was silently discarded (scalar lost).
+  private def merge_graphql_params(target : Endpoint, source : Endpoint) : Endpoint
     target_sdl = graphql_sdl_endpoint?(target)
     source_sdl = graphql_sdl_endpoint?(source)
 
@@ -75,6 +84,8 @@ class EndpointOptimizer
       details.technology = source.details.technology
       target.details = details
     end
+
+    target
   end
 
   private def graphql_endpoint?(endpoint : Endpoint) : Bool

--- a/src/tagger/framework_taggers/go/group_scope.cr
+++ b/src/tagger/framework_taggers/go/group_scope.cr
@@ -1,3 +1,5 @@
+require "../prefix_scope"
+
 # Shared Go route-group scope resolution for the Go framework taggers.
 #
 # Both `go_auth` and `go_security` answer the same question: a middleware
@@ -28,6 +30,11 @@
 # callers can decline to tag, matching `spring_security`'s treatment of a
 # filter chain scoped only by a matcher it cannot resolve.
 module GoRouteGroupScope
+  # `prefix_covers?` — the segment-aware match a resolved group prefix is
+  # tested with. Shared with the Express and Ktor taggers, which used to
+  # compare with a bare `starts_with?`.
+  include PrefixScope
+
   # What a receiver / middleware registration resolves to.
   #
   #   Global  — no enclosing group; an engine-level `.Use` guards everything
@@ -161,12 +168,5 @@ module GoRouteGroupScope
   def self.join_prefix(base : String, seg : String) : String
     parts = "#{base}/#{seg}".split("/").reject(&.empty?)
     parts.empty? ? "/" : "/" + parts.join("/")
-  end
-
-  # Segment-aware prefix match so "/web" guards "/web/x" but not "/website".
-  # The root scope "/" guards every endpoint.
-  def prefix_covers?(prefix : String, url : String) : Bool
-    return true if prefix == "/"
-    url == prefix || url.starts_with?("#{prefix}/")
   end
 end

--- a/src/tagger/framework_taggers/javascript/express_auth.cr
+++ b/src/tagger/framework_taggers/javascript/express_auth.cr
@@ -1,8 +1,11 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
+require "../prefix_scope"
 
 @[Noir::TaggerFor(key: "express_auth", name: "Express Auth Tagger", desc: "Identifies Express.js authentication patterns (Passport, JWT, auth middleware)", order: 40)]
 class ExpressAuthTagger < FrameworkTagger
+  include PrefixScope
+
   PASSPORT_PATTERNS = [
     /passport\.authenticate\s*\(/,
   ]
@@ -25,9 +28,27 @@ class ExpressAuthTagger < FrameworkTagger
     /\bcheckAuth\b/,
   ]
 
+  # `app.use('/prefix', authMiddleware)` — the guarded path is spelled out, so
+  # the rule can be matched against endpoint URLs anywhere in the scan (the
+  # routes it guards are usually mounted from another file).
+  MOUNTED_USE = /(?:app|router)\.use\s*\(\s*['"]([^'"]+)['"]/
+
+  # `x.use(authMiddleware)` — no path argument. Which routes this guards is a
+  # property of the *object* `x`, not of any URL, so the receiver is captured.
+  BARE_USE = /\b(\w+)\.use\s*\(/
+
+  # A route registration, and who it was registered on: `app.get('/x', …)`,
+  # `router.post(…)`, `app.route('/x')`.
+  ROUTE_RECEIVER = /\b(\w+)\s*\.\s*(?:get|post|put|patch|delete|options|head|all|use|route)\s*\(/
+
+  # The start of a route registration, used as a statement boundary so a
+  # window around one route never reads the next one's middleware.
+  ROUTE_DECLARATION = /\.\s*(?:get|post|put|patch|delete|options|head|all|use|route)\s*\(/
+
   def initialize(options : Hash(String, YAML::Any))
     super
-    @app_use_auth_patterns = [] of {prefix: String, description: String}
+    @mounted_auth_rules = [] of {prefix: String, description: String}
+    @receiver_auth_rules = [] of {file: String, receiver: String, line: Int32, description: String}
   end
 
   def self.target_techs : Array(String)
@@ -47,7 +68,8 @@ class ExpressAuthTagger < FrameworkTagger
   end
 
   private def pre_scan_app_use_auth
-    @app_use_auth_patterns.clear
+    @mounted_auth_rules.clear
+    @receiver_auth_rules.clear
 
     extensions = [".js", ".ts", ".mjs", ".cjs"]
     extensions.each do |ext|
@@ -55,23 +77,29 @@ class ExpressAuthTagger < FrameworkTagger
       files.each do |file|
         lines = read_file_lines(file)
         next if lines.nil?
-        lines.each do |line|
+        expanded = File.expand_path(file)
+
+        lines.each_with_index do |line, idx|
           stripped = line.strip
+          next unless stripped.includes?(".use")
+          next unless has_auth_middleware_in_line?(stripped)
 
-          # Match app.use('/prefix', authMiddleware)
-          match = stripped.match(/(?:app|router)\.use\s*\(\s*['"]([^'"]+)['"]/)
-          if match
+          if match = stripped.match(MOUNTED_USE)
             prefix = match[1]
-            if has_auth_middleware_in_line?(stripped)
-              @app_use_auth_patterns << {prefix: prefix, description: "Protected by Express app.use() auth middleware on #{prefix}"}
-            end
-          end
-
-          # Match app.use(authMiddleware) without prefix (applies to all routes)
-          if stripped.matches?(/(?:app|router)\.use\s*\(/) && !match
-            if has_auth_middleware_in_line?(stripped)
-              @app_use_auth_patterns << {prefix: "/", description: "Protected by Express global auth middleware"}
-            end
+            @mounted_auth_rules << {prefix: prefix, description: "Protected by Express app.use() auth middleware on #{prefix}"}
+          elsif match = stripped.match(BARE_USE)
+            # A path-less `use(auth)` guards the routes registered on THIS
+            # object, below THIS line — nothing else. Registering it as a
+            # global `prefix: "/"` rule (what this used to do) meant one
+            # `router.use(requireAuth)` in `routes/admin.js` reported every
+            # endpoint in the project as protected, including `/login`.
+            receiver = match[1]
+            @receiver_auth_rules << {
+              file:        expanded,
+              receiver:    receiver,
+              line:        idx + 1,
+              description: "Protected by Express #{receiver}.use() auth middleware",
+            }
           end
         end
       end
@@ -79,6 +107,8 @@ class ExpressAuthTagger < FrameworkTagger
   end
 
   private def check_endpoint(endpoint : Endpoint)
+    receiver_description = nil
+
     # Check route definition line for auth patterns
     endpoint.details.code_paths.each do |path_info|
       lines = read_file_lines(path_info.path)
@@ -117,10 +147,13 @@ class ExpressAuthTagger < FrameworkTagger
           return
         end
       end
+
+      receiver_description ||= check_receiver_use_auth(path_info.path, lines, line_num - 1)
     end
 
-    # Check app.use() level auth for route prefix matching
-    description = check_app_use_auth(endpoint)
+    # Check app.use() level auth: the router this route was registered on
+    # first, then a path-scoped mount.
+    description = receiver_description || check_mounted_use_auth(endpoint)
     if description
       endpoint.add_tag(Tag.new("auth", description, "express_auth"))
     end
@@ -133,39 +166,81 @@ class ExpressAuthTagger < FrameworkTagger
     result = [lines[line_idx]]
 
     # Look at preceding lines that might be part of the same statement
-    # (e.g., chained method calls)
-    i = line_idx - 1
-    while i >= 0 && i >= line_idx - 2
-      stripped = lines[i].strip
-      break if stripped.empty? || stripped.ends_with?(";")
-      # Only include if this looks like part of the route definition
-      if stripped.matches?(/\.(get|post|put|patch|delete|all|use)\s*\(/) ||
-         stripped.includes?("passport") || stripped.includes?("expressjwt")
-        result.unshift(lines[i])
-      else
-        break
+    # (e.g., chained method calls). Skipped when the referenced line already
+    # starts a route registration — walking back from there can only reach
+    # the *previous* route, whose middleware is not this route's.
+    unless lines[line_idx].matches?(ROUTE_DECLARATION)
+      i = line_idx - 1
+      while i >= 0 && i >= line_idx - 2
+        stripped = lines[i].strip
+        break if stripped.empty? || stripped.ends_with?(";")
+        # Only include if this looks like part of the route definition
+        if stripped.matches?(ROUTE_DECLARATION)
+          result.unshift(lines[i])
+          break
+        elsif stripped.includes?("passport") || stripped.includes?("expressjwt")
+          result.unshift(lines[i])
+        else
+          break
+        end
+        i -= 1
       end
-      i -= 1
     end
 
-    # Look at following lines that might complete the statement
+    # Look at following lines that might complete the statement — but only
+    # while the statement is actually still open. The route line's own
+    # parentheses say whether it is: `app.get('/x', (req, res) => { … });`
+    # closes on itself, and reading one line past it attributed the NEXT
+    # route's `requireAuth` to this one.
+    depth = paren_depth(lines[line_idx])
     i = line_idx + 1
-    while i < lines.size && i <= line_idx + 3
+    while depth > 0 && i < lines.size && i <= line_idx + 3
       stripped = lines[i].strip
       break if stripped.empty?
+      break if stripped.matches?(ROUTE_DECLARATION)
       result << lines[i]
-      break if stripped.includes?(");") || stripped.ends_with?(")")
+      depth += paren_depth(lines[i])
       i += 1
     end
 
     result
   end
 
-  private def check_app_use_auth(endpoint : Endpoint) : String?
+  private def paren_depth(line : String) : Int32
+    line.count('(') - line.count(')')
+  end
+
+  # A path-less `x.use(auth)` guards the routes registered on `x`, in the same
+  # file, after that line.
+  private def check_receiver_use_auth(path : String, lines : Array(String), line_idx : Int32) : String?
+    return if @receiver_auth_rules.empty?
+    return if line_idx < 0 || line_idx >= lines.size
+
+    # Which object the route was registered on. Unreadable (a multi-line
+    # registration whose receiver sits above the referenced line) means we
+    # cannot tell app from sub-router, so decline rather than guess: a false
+    # "protected" is the failure that gets an endpoint skipped in review.
+    receiver = lines[line_idx].match(ROUTE_RECEIVER).try &.[1]
+    return if receiver.nil?
+
+    expanded = File.expand_path(path)
+    line_num = line_idx + 1
+
+    @receiver_auth_rules.each do |rule|
+      next unless rule[:receiver] == receiver
+      next unless rule[:file] == expanded
+      next unless rule[:line] < line_num
+      return rule[:description]
+    end
+
+    nil
+  end
+
+  private def check_mounted_use_auth(endpoint : Endpoint) : String?
     url = endpoint.url
 
-    @app_use_auth_patterns.each do |rule|
-      if url.starts_with?(rule[:prefix])
+    @mounted_auth_rules.each do |rule|
+      if prefix_covers?(rule[:prefix], url)
         return rule[:description]
       end
     end

--- a/src/tagger/framework_taggers/kotlin/ktor_auth.cr
+++ b/src/tagger/framework_taggers/kotlin/ktor_auth.cr
@@ -1,8 +1,11 @@
 require "../../../models/framework_tagger"
 require "../../../models/endpoint"
+require "../prefix_scope"
 
 @[Noir::TaggerFor(key: "ktor_auth", name: "Ktor Auth Tagger", desc: "Identifies Ktor authentication patterns (authenticate blocks, principals)", order: 200)]
 class KtorAuthTagger < FrameworkTagger
+  include PrefixScope
+
   # Ktor authenticate block patterns
   AUTHENTICATE_BLOCK_PATTERNS = [
     {/authenticate\s*\(/, "Ktor authenticate block"},
@@ -17,9 +20,21 @@ class KtorAuthTagger < FrameworkTagger
     {/sessions\.get</, "Ktor session check"},
   ]
 
+  # `route("/api") {` — a nested URL-prefix block.
+  ROUTE_BLOCK = /route\s*\(\s*"([^"]+)"/
+
+  # The start of a route handler (`get("/x") {`, `post {`). Used as a
+  # boundary so a handler-body scan stops before the next route.
+  ROUTE_HANDLER = /^(?:get|post|put|patch|delete|head|options)\s*[({]/
+
+  # One `authenticate {}` block found by the pre-scan: which file it is in,
+  # the line range its braces span, and the `route()` prefix it sits under.
+  alias AuthScope = NamedTuple(file: String, start_line: Int32, end_line: Int32,
+    prefix: String, description: String)
+
   def initialize(options : Hash(String, YAML::Any))
     super
-    @auth_scopes = [] of {prefix: String, description: String}
+    @auth_scopes = [] of AuthScope
   end
 
   def self.target_techs : Array(String)
@@ -45,44 +60,71 @@ class KtorAuthTagger < FrameworkTagger
       next if content.nil?
       next unless content.includes?("authenticate")
 
-      scan_auth_blocks(content)
+      scan_auth_blocks(File.expand_path(file), content)
     end
   end
 
-  private def scan_auth_blocks(content : String)
-    lines = content.split("\n")
-    # Stack-based prefix tracking for nested route() blocks
-    prefix_stack = [] of String
+  # Record every `authenticate {}` block in `content` with the line range it
+  # covers and the `route()` prefix it is nested under.
+  #
+  # Both stacks are keyed on real brace depth. Popping a `route()` prefix on
+  # "any line that is just `}`" — what this used to do — retired the prefix
+  # when a `get {}` handler closed, so a block nested two `route()` levels
+  # deep was recorded one level up and its tag spilled onto sibling routes,
+  # and onto other files entirely. `GoRouteGroupScope#each_group_scoped_line`
+  # tracks the same thing the same way.
+  private def scan_auth_blocks(file : String, content : String)
+    route_frames = [] of NamedTuple(threshold: Int32, prefix: String)
+    auth_frames = [] of NamedTuple(threshold: Int32, start_line: Int32, prefix: String, description: String)
+    depth = 0
 
-    lines.each do |line|
+    content.split("\n").each_with_index do |line, idx|
+      line_num = idx + 1
       stripped = line.strip
 
-      # Track route() prefix nesting
-      route_match = stripped.match(/route\s*\(\s*"([^"]+)"/)
-      if route_match
-        prefix_stack << route_match[1]
+      if route_match = stripped.match(ROUTE_BLOCK)
+        route_frames << {threshold: depth, prefix: route_match[1]}
       end
 
-      # Detect authenticate block (only record if route prefix is known)
-      if !prefix_stack.empty?
-        AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, _desc|
-          if stripped.matches?(pattern)
-            auth_match = stripped.match(/authenticate\s*\(\s*"([^"]+)"/)
-            auth_name = auth_match ? auth_match[1] : "default"
-            prefix = normalize_prefix(prefix_stack)
-            @auth_scopes << {
-              prefix:      prefix,
-              description: "Protected by Ktor authenticate(\"#{auth_name}\") block",
-            }
-          end
-        end
+      # Only record a block whose route prefix is known.
+      if !route_frames.empty? && AUTHENTICATE_BLOCK_PATTERNS.any? { |pattern, _desc| stripped.matches?(pattern) }
+        auth_match = stripped.match(/authenticate\s*\(\s*"([^"]+)"/)
+        auth_name = auth_match ? auth_match[1] : "default"
+        auth_frames << {
+          threshold:   depth,
+          start_line:  line_num,
+          prefix:      normalize_prefix(route_frames.map(&.[:prefix])),
+          description: "Protected by Ktor authenticate(\"#{auth_name}\") block",
+        }
       end
 
-      # Pop prefix on closing brace (end of route block)
-      if (stripped == "}" || stripped == "})") && !prefix_stack.empty?
-        prefix_stack.pop
+      depth += line.count('{') - line.count('}')
+
+      while !route_frames.empty? && depth <= route_frames.last[:threshold]
+        route_frames.pop
+      end
+      while !auth_frames.empty? && depth <= auth_frames.last[:threshold]
+        close_auth_frame(file, auth_frames.pop, line_num)
       end
     end
+
+    # A block whose brace never closed (truncated or unparseable file) runs
+    # to the end of the file.
+    while frame = auth_frames.pop?
+      close_auth_frame(file, frame, Int32::MAX)
+    end
+  end
+
+  private def close_auth_frame(file : String,
+                               frame : NamedTuple(threshold: Int32, start_line: Int32, prefix: String, description: String),
+                               end_line : Int32)
+    @auth_scopes << {
+      file:        file,
+      start_line:  frame[:start_line],
+      end_line:    end_line,
+      prefix:      frame[:prefix],
+      description: frame[:description],
+    }
   end
 
   private def normalize_prefix(segments : Array(String)) : String
@@ -154,21 +196,36 @@ class KtorAuthTagger < FrameworkTagger
     nil
   end
 
+  # Scan the route's own handler body — and only it — for principal/session
+  # access.
+  #
+  # This used to start one line *below* the route with `brace_depth = 1`,
+  # assuming the handler's `{` was still open. For `get("/public") { … }`,
+  # closed on its own line, that assumption is false and the walk marched
+  # straight into the next route's body: a public route inherited its
+  # neighbour's `call.principal<…>()`. Seed the depth from the route line
+  # instead, and scan that line too so a one-line handler is read at all.
   private def check_route_auth(lines : Array(String), route_line : Int32) : String?
-    idx = route_line + 1
+    idx = route_line
     end_idx = [route_line + 15, lines.size - 1].min
-    brace_depth = 1 # Inside the route handler's opening {
+    brace_depth = 0
+    entered = false
 
     while idx <= end_idx
       current = lines[idx]
       stripped = current.strip
+
+      # The next route declaration ends this handler no matter what the
+      # braces looked like.
+      break if idx > route_line && stripped.matches?(ROUTE_HANDLER)
 
       ROUTE_AUTH_PATTERNS.each do |pattern, desc|
         return desc if stripped.matches?(pattern)
       end
 
       brace_depth += current.count('{') - current.count('}')
-      break if brace_depth <= 0
+      entered = true if current.includes?('{')
+      break if entered && brace_depth <= 0
 
       idx += 1
     end
@@ -176,11 +233,28 @@ class KtorAuthTagger < FrameworkTagger
     nil
   end
 
+  # An `authenticate {}` block found by the pre-scan guards this endpoint when
+  # the route is declared inside the block's braces. For a route declared in
+  # another file — Ktor's `route("/admin") { adminRoutes() }` extension-function
+  # split — the braces say nothing, so fall back to the block's `route()`
+  # prefix, matched on a segment boundary.
   private def check_scope_auth(endpoint : Endpoint) : String?
+    return if @auth_scopes.empty?
+
     url = endpoint.url
+    locations = endpoint.details.code_paths.map { |info| {File.expand_path(info.path), info.line} }
+
     @auth_scopes.each do |scope|
-      return scope[:description] if url.starts_with?(scope[:prefix])
+      local = locations.select { |path, _| path == scope[:file] }
+
+      if local.empty?
+        next if scope[:prefix] == "/"
+        return scope[:description] if prefix_covers?(scope[:prefix], url)
+      elsif local.any? { |_, line| !line.nil? && line >= scope[:start_line] && line <= scope[:end_line] }
+        return scope[:description]
+      end
     end
+
     nil
   end
 end

--- a/src/tagger/framework_taggers/php/php_auth.cr
+++ b/src/tagger/framework_taggers/php/php_auth.cr
@@ -3,14 +3,21 @@ require "../../../models/endpoint"
 
 @[Noir::TaggerFor(key: "php_auth", name: "PHP Auth Tagger", desc: "Identifies PHP authentication patterns (Laravel, Symfony, CakePHP)", order: 140)]
 class PhpAuthTagger < FrameworkTagger
-  # Laravel middleware patterns
+  # Laravel middleware patterns.
+  #
+  # `(?:->|::)` so the leading form is recognized too: `Route::middleware('auth')
+  # ->get('/x', …)` is as common as the chained `->middleware('auth')`, and
+  # only the chained one used to match. That gap was invisible while the
+  # ±3-line window happened to reach the *previous* route's `->middleware(…)`
+  # — a route tagged correctly by accident is still a tagger that cannot read
+  # the form in front of it.
   LARAVEL_ROUTE_MIDDLEWARE = [
-    {/->middleware\s*\(\s*['"]auth['"]/, "Laravel auth middleware"},
-    {/->middleware\s*\(\s*['"]auth:api['"]/, "Laravel auth:api middleware"},
-    {/->middleware\s*\(\s*['"]auth:sanctum['"]/, "Laravel Sanctum auth"},
-    {/->middleware\s*\(\s*['"]auth:web['"]/, "Laravel web auth"},
-    {/->middleware\s*\(\s*['"]verified['"]/, "Laravel verified middleware"},
-    {/->middleware\s*\(\s*\[.*['"]auth['"]/, "Laravel auth middleware"},
+    {/(?:->|::)middleware\s*\(\s*['"]auth['"]/, "Laravel auth middleware"},
+    {/(?:->|::)middleware\s*\(\s*['"]auth:api['"]/, "Laravel auth:api middleware"},
+    {/(?:->|::)middleware\s*\(\s*['"]auth:sanctum['"]/, "Laravel Sanctum auth"},
+    {/(?:->|::)middleware\s*\(\s*['"]auth:web['"]/, "Laravel web auth"},
+    {/(?:->|::)middleware\s*\(\s*['"]verified['"]/, "Laravel verified middleware"},
+    {/(?:->|::)middleware\s*\(\s*\[.*['"]auth['"]/, "Laravel auth middleware"},
   ]
 
   # Laravel controller middleware
@@ -75,6 +82,21 @@ class PhpAuthTagger < FrameworkTagger
     {/\bauthFilter\b/i, "CodeIgniter authFilter"},
   ]
 
+  # A line that starts a *different* route or method than the one being
+  # inspected: `Route::get('/x', …)`, `$app->post('/x', …)`, `Route::resource`,
+  # a named `function foo(` declaration. Anonymous closures (`function () {`)
+  # are deliberately excluded — those are part of the current route statement.
+  #
+  # Every window this tagger scans is bounded by it. A fixed ±N-line window is
+  # not a statement: two one-line routes stacked on top of each other put the
+  # second's `->middleware('auth')` inside the first's window, and the public
+  # route came back tagged as protected.
+  #
+  # The `$app->get(…)` form requires a path literal starting with `/` so that
+  # an ordinary body call — `$request->get('id')` — is not mistaken for the
+  # start of the next route and does not cut a scan short.
+  STATEMENT_BOUNDARY = /(?:Route|Router)::(?:get|post|put|patch|delete|options|head|any|query|match|addRoute|resource|apiResource)\s*\(|\$\w+\s*->\s*(?:get|post|put|patch|delete|options|head|any|query|map|group)\s*\(\s*['"]\/|\bfunction\s+\w+\s*\(/i
+
   def self.target_techs : Array(String)
     [
       "php_laravel", "php_symfony", "php_cakephp", "php_pure",
@@ -127,10 +149,7 @@ class PhpAuthTagger < FrameworkTagger
   private def check_patterns_near_line(lines : Array(String), line_idx : Int32,
                                        patterns : Array(Tuple(Regex, String)),
                                        window : Int32) : String?
-    start_idx = [line_idx - window, 0].max
-    end_idx = [line_idx + window, lines.size - 1].min
-
-    (start_idx..end_idx).each do |idx|
+    (statement_start(lines, line_idx, window)..statement_end(lines, line_idx, window)).each do |idx|
       line = lines[idx]
       patterns.each do |pattern, desc|
         return desc if line.matches?(pattern)
@@ -138,6 +157,49 @@ class PhpAuthTagger < FrameworkTagger
     end
 
     nil
+  end
+
+  # First line of the window: walk back at most `window` lines, stopping
+  # *before* anything that belongs to the previous statement — another route
+  # or method declaration, or a line that already terminated one (`});`,
+  # `})->middleware('auth');`). Only an unterminated line above (`Route::
+  # middleware('auth')->group(function () {`) is really part of this route.
+  private def statement_start(lines : Array(String), line_idx : Int32, window : Int32) : Int32
+    idx = line_idx - 1
+    limit = [line_idx - window, 0].max
+
+    while idx >= limit
+      stripped = lines[idx].strip
+      break if stripped.empty?
+      break if stripped.matches?(STATEMENT_BOUNDARY)
+      break if stripped.ends_with?(";") || stripped.ends_with?("}")
+      idx -= 1
+    end
+
+    idx + 1
+  end
+
+  # Last line of the window: the route statement's own lines. Stops after the
+  # line that closes it (balanced brackets, terminating `;`) and never reaches
+  # the next route declaration.
+  private def statement_end(lines : Array(String), line_idx : Int32, window : Int32) : Int32
+    limit = [line_idx + window, lines.size - 1].min
+    depth = bracket_depth(lines[line_idx])
+    idx = line_idx
+
+    while idx < limit
+      break if depth <= 0 && lines[idx].strip.ends_with?(";")
+      nxt = lines[idx + 1].strip
+      break if nxt.matches?(STATEMENT_BOUNDARY)
+      idx += 1
+      depth += bracket_depth(lines[idx])
+    end
+
+    idx
+  end
+
+  private def bracket_depth(line : String) : Int32
+    (line.count('(') + line.count('{')) - (line.count(')') + line.count('}'))
   end
 
   private def check_controller_middleware(lines : Array(String), action_line : Int32) : String?
@@ -174,16 +236,31 @@ class PhpAuthTagger < FrameworkTagger
     nil
   end
 
+  # Scan the handler's own body for auth calls.
+  #
+  # `brace_count` used to start at 0 on the line *after* the signature, so the
+  # body's opening `{` was never counted and the count balanced back to 0 at
+  # the closing `}` without the loop noticing — it only broke on `< 0`. The
+  # walk then ran to its 15-line cap through the *next* method, and that
+  # method's `$this->authorize(...)` was reported as this endpoint's guard.
+  # Seed the depth from the signature line and stop as soon as the body it
+  # opened closes again.
   private def check_method_body(lines : Array(String), method_line : Int32) : String?
     idx = method_line + 1
     end_idx = [method_line + 15, lines.size - 1].min
-    brace_count = 0
+    signature = lines[method_line]
+    brace_count = signature.count('{') - signature.count('}')
+    entered = signature.includes?('{')
 
     while idx <= end_idx
       current = lines[idx]
       stripped = current.strip
 
+      break if entered && brace_count <= 0
+      break if stripped.matches?(STATEMENT_BOUNDARY)
+
       brace_count += current.count('{') - current.count('}')
+      entered = true if current.includes?('{')
       break if brace_count < 0
 
       all_patterns = LARAVEL_AUTH_CHECKS + CAKEPHP_PATTERNS + GENERIC_PATTERNS + SLIM_YII_CI_PATTERNS

--- a/src/tagger/framework_taggers/prefix_scope.cr
+++ b/src/tagger/framework_taggers/prefix_scope.cr
@@ -1,0 +1,23 @@
+# Segment-aware URL-prefix containment, shared by every framework tagger that
+# resolves a scoped middleware registration ("this guard covers prefix P — does
+# it cover endpoint U?").
+#
+# The naive `url.starts_with?(prefix)` is wrong in the direction that matters
+# most for a security tool: `/admin` then "guards" `/administration/report`,
+# and a reviewer skips an endpoint that nothing protects. Compare on a path
+# segment boundary instead.
+#
+# This lived on `GoRouteGroupScope`, where the Go taggers had it right and the
+# Express/Ktor ones each carried their own `starts_with?`. It is a property of
+# URLs, not of Go, so it belongs somewhere all three can reach.
+module PrefixScope
+  extend self
+
+  # True when `prefix` guards `url` on a segment boundary, so `/web` covers
+  # `/web` and `/web/x` but not `/website`. The root prefix `/` covers every
+  # endpoint.
+  def prefix_covers?(prefix : String, url : String) : Bool
+    return true if prefix == "/"
+    url == prefix || url.starts_with?("#{prefix}/")
+  end
+end

--- a/src/utils/url_path.cr
+++ b/src/utils/url_path.cr
@@ -54,10 +54,19 @@ module Noir
     # trailing slashes that must not survive into the emitted URL; use `join`
     # where the segments are already normalised and a trailing slash is
     # meaningful.
+    #
+    # It used to return the raw `prefix.rstrip('/')` for an empty suffix,
+    # which turns a root-mounted prefix into the empty string:
+    # `join_trimmed("/", "")` was `""`, so a JAX-RS resource with
+    # `@Path("/")` on the class and a bare `@GET` on the method emitted an
+    # endpoint with no URL — and `EndpointOptimizer#optimize_endpoints`
+    # silently skips those, so the route vanished from every output format.
+    # Closing that hole makes this rule identical to `join_absorbing`'s, so
+    # it delegates rather than carrying a second copy that can drift; the
+    # two names are kept because the call sites read differently (a prefix
+    # stack that must not leak slashes vs. Spring's mapping composition).
     def self.join_trimmed(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
+      join_absorbing(prefix, suffix)
     end
 
     # Spring's mapping-composition rule, shared by the Java and Kotlin
@@ -69,9 +78,10 @@ module Noir
     # through to the seam join. Only an all-slash class prefix
     # (`@RequestMapping("/")`) keeps the root `/`.
     #
-    # Not `join_trimmed`: that keeps an empty-prefix suffix untouched but
-    # trims a trailing slash when the *suffix* is empty without the
-    # root-`/` restore this rule needs.
+    # This is also what `join_trimmed` resolves to — the JVM/JS prefix-stack
+    # rule and Spring's composition rule agree on every input once the
+    # root-`/` restore below is in place. `join_absorbing` is the
+    # implementation of record; see `join_trimmed` for why both names exist.
     def self.join_absorbing(prefix : String, path : String) : String
       return path if prefix.empty?
       if path.empty?
@@ -124,10 +134,19 @@ module Noir
     #
     # Used by the Clojure analyzers, whose route DSLs compose bare
     # segments, and by Kotlin Spring's WebFlux path assembly.
+    #
+    # The trim runs *before* the reject: a segment that is only slashes
+    # (`(context "/" ...)` in Compojure, an all-slash WebFlux prefix) is not
+    # empty on entry but becomes empty once trimmed, and rejecting first left
+    # it in the join as an empty component — `absolute_join("/api", "/",
+    # "users")` produced `"/api//users"`. `collapse_path_slashes` hides that
+    # for ordinary HTTP endpoints, but not for URLs that skip normalization
+    # (`normalize_url_shape` returns early on `\/`, and `non_http?` endpoints
+    # are never normalized at all).
     def self.absolute_join(*segments : String) : String
       path = segments
-        .reject(&.empty?)
         .map(&.chomp("/").lstrip("/"))
+        .reject(&.empty?)
         .join("/")
 
       path.starts_with?("/") ? path : "/#{path}"


### PR DESCRIPTION
Endpoints that exist but are not reported, fields that are dropped when two
endpoints merge, and — the one that matters most for a security tool — routes tagged
`auth` that nothing protects.

## Auth taggers said "protected" about routes that are not

This is the worst failure direction there is: a reviewer sees the tag and moves on.

**One sub-router's `router.use(auth)` marked the entire application.**
`pre_scan_app_use_auth` registered any prefix-less `use(<auth middleware>)` as a rule
with `prefix: "/"`, matched against every endpoint URL in the scan — so a
`router.use(requireAuth)` that protects only `routes/admin.js` covered everything:

```
             main                        this PR
GET /health  ['auth']                    []
GET /login   ['auth']                    []
GET /admin/panel ['auth']                ['auth']   ← the only real one
```

**Fixed windows bled into the neighbouring route.** php_auth scanned `line ± 3`
unconditionally; express_auth pushed a line *before* testing the terminator, so
`N+1` was always included; ktor_auth started a one-line handler at `brace_depth = 1`
and walked straight into the next route's body. All three now bound at the next route
declaration.

```
Route::get('/public', fn () => 'public');
Route::get('/me', fn () => 'me')->middleware('auth');
   main:  /public ['auth']       this PR:  /public []
```

**Ktor's prefix stack popped on any `}`**, including the brace closing a `get {}`, so
a recorded `authenticate` scope was shorter than the real one and spilled across
files — `/api/public` in a different file inherited a `authenticate("jwt")` block it
was never inside.

**Prefix matching was not segment-aware**, so `app.use('/admin', requireAuth)` guarded
`/administration/report`. `GoRouteGroupScope#prefix_covers?` already had this right;
it is now a shared `PrefixScope` module used by all three.

## Endpoints dropped or hollowed out

- **`URLPath.join_trimmed("/", "")` returned `""`**, and the optimizer silently skips
  empty-URL endpoints — so a JAX-RS resource with `@Path("/")` on the class and a bare
  `@GET` on the method vanished from every output format. `join_rooted`'s comment
  already documented this hole; `join_trimmed` never got the guard. It now delegates
  to `join_absorbing`, which differs only in returning `/` for that case.
- **Dedup discarded the loser's scalar fields.** Params, tags, callees and code_paths
  were merged; `protocol`, `metadata`, `details.status_code` and `kind` were thrown
  away. `protocol` is the consequential one — ~20 analyzers set `ws` on endpoints with
  an ordinary HTTP path, `WebsocketTagger` keys on that field, and taggers run *after*
  the optimizer, so losing a sort tiebreak dropped the `websocket` tag from the
  report. `internal` is promoted the other way: a real served route at the same
  address contradicts "declared but not served", so the flag is cleared rather than
  OR-ed, which stops a genuine endpoint's probe being suppressed.
- **`merge_graphql_params` wrote `details` on a by-value struct parameter.** `Endpoint`
  is a struct, so the array mutations survived (Array is a reference) while the
  scalar promotion landed on a copy — an SDL-derived endpoint handed over its
  `graphql_query` document but its `graphql_sdl` technology was silently discarded.
- **`absolute_join` rejected empty segments before trimming**, so a `"/"` segment
  survived as an empty join component: `absolute_join("/api", "/", "users")` →
  `/api//users`.

## Cross-framework theft

`PerlEngine` handed every `.pm`/`.pl`/`.psgi` to every Perl analyzer with no manifest
gate, and Mojolicious's `FULL_VERB_RE` matched **any** `->get('string')`. The inline
comment claimed a data accessor "never matches because the leading quote is
required" — but a string key is the common shape. In a directory holding a Dancer2
app and a Mojolicious app:

```
main (15):  7 endpoints tagged perl_mojolicious whose code_paths point into
            Dancer2App.pm, plus /current_user, /secret_name, /session_timeout
            harvested from $cache->get("…") and $self->stash->get("…")
this PR (5): the 2 real Mojolicious routes + the 3 real Dancer2 routes
```

Existing Perl fixtures are **unchanged** — that was the false-negative risk and it is
the thing to re-check here.

## CLI endpoints from unrelated binaries merged into one

`fetch_endpoint` merges by URL, and the URL came from `cli_binary_name`, which for
`main`/`cli`/`app` stems fell back to the parent directory name alone. Two unrelated
binaries in a monorepo collapsed into one endpoint carrying both flag sets, with only
the first file's `code_path` surviving — so the merge was invisible in the output.
The key is now project-scoped (nearest manifest root), and every contributing file is
appended to `details.code_paths`.

```
main:    cli://src   ['alpha-only', 'beta-only']   path: alpha/src/main.cr
this PR: cli://alpha ['alpha-only'] · cli://beta ['beta-only']
```

## Verification

- `crystal spec`: 29,445 examples, 0 failures · `format`/`ameba` clean
- Fixture sweep: no existing fixture lost an endpoint. New fixtures cover the
  monorepo and cross-framework cases.
- Every auth fix ships the **negative** assertion (the adjacent / unrelated route must
  NOT be tagged) — that is the assertion whose absence let all five live.
