### PR TITLE
fix(cli): make flags, config keys and probes do what they say

### DIFF
--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -76,4 +76,49 @@ describe "noir CLI surface (built binary)" do
       result.exit_code.should eq(0)
     end
   end
+
+  describe "config" do
+    it "rejects --config-file with no value instead of using the default file" do
+      result = run_noir(["config", "path", "--config-file"])
+      result.stdout.should be_empty
+      result.stderr.should contain("--config-file requires an argument.")
+      result.exit_code.should eq(1)
+    end
+
+    it "expands a leading ~ in --config-file" do
+      result = run_noir(["config", "path", "--config-file=~/noir-spec-nope.yaml"])
+      result.stdout.strip.should eq(File.join(Path.home.to_s, "noir-spec-nope.yaml"))
+      result.exit_code.should eq(0)
+    end
+
+    it "rejects a surplus positional instead of running a different action" do
+      result = run_noir(["config", "path", "init"])
+      result.stdout.should be_empty
+      result.stderr.should contain("Unexpected argument: init")
+      result.exit_code.should eq(1)
+    end
+
+    it "rejects an unknown flag" do
+      result = run_noir(["config", "show", "--bogus-flag"])
+      result.stdout.should be_empty
+      result.stderr.should contain("Unknown option: --bogus-flag")
+      result.exit_code.should eq(1)
+    end
+  end
+
+  describe "completion" do
+    it "rejects a second shell instead of emitting only the first" do
+      result = run_noir(["completion", "zsh", "bash"])
+      result.stdout.should be_empty
+      result.stderr.should contain("Unexpected argument: bash")
+      result.exit_code.should eq(1)
+    end
+
+    it "still emits a single requested script on stdout" do
+      result = run_noir(["completion", "zsh"])
+      result.stdout.should contain("#compdef noir")
+      result.stderr.should be_empty
+      result.exit_code.should eq(0)
+    end
+  end
 end

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -121,4 +121,64 @@ describe "noir CLI surface (built binary)" do
       result.exit_code.should eq(0)
     end
   end
+
+  describe "scan" do
+    it "rejects a -u/--url with no host" do
+      result = run_noir(["scan", FIXTURE, "-u", "http://", "-f", "json", "--no-log"])
+      result.stdout.should be_empty
+      result.stderr.should contain("has no host")
+      result.exit_code.should eq(1)
+    end
+
+    it "rejects a -u/--url whose authority holds whitespace" do
+      result = run_noir(["scan", FIXTURE, "-u", "not a url", "-f", "json", "--no-log"])
+      result.stdout.should be_empty
+      result.stderr.should contain("whitespace or control characters")
+      result.exit_code.should eq(1)
+    end
+
+    it "rejects an --exclude-path glob that would silently match nothing" do
+      {"*.{rb", "{", "", "  "}.each do |pattern|
+        result = run_noir(["scan", FIXTURE, "--exclude-path", pattern, "-f", "json", "--no-log"])
+        result.stdout.should be_empty
+        result.stderr.should contain("--exclude-path")
+        result.exit_code.should eq(1)
+      end
+    end
+
+    it "still fails a CLI-typed --status-codes without a URL" do
+      result = run_noir(["scan", FIXTURE, "--status-codes", "-f", "json", "--no-log"])
+      result.stdout.should be_empty
+      result.stderr.should contain("--status-codes needs a target URL")
+      result.exit_code.should eq(1)
+    end
+
+    it "warns and carries on when the URL-dependent value came from a config file" do
+      # `status_codes:` is a documented config key, so enforcing the URL
+      # dependency after the merge made a plain `noir scan ./app` die,
+      # blaming a flag the user never typed.
+      config = File.tempfile("noir-cli-spec", ".yaml") do |file|
+        file.puts "status_codes: true"
+      end
+
+      begin
+        result = run_noir(["scan", FIXTURE, "--config-file", config.path, "-f", "json", "--no-log"])
+        result.stderr.should contain("config key `status_codes`")
+        result.exit_code.should eq(0)
+        # The warning belongs on stderr — stdout must stay byte-parseable.
+        JSON.parse(result.stdout)["endpoints"].as_a.empty?.should be_false
+      ensure
+        config.delete
+      end
+    end
+
+    it "leaves a well-formed scan untouched" do
+      result = run_noir(["scan", FIXTURE, "-u", "http://localhost:3000", "-f", "json", "--no-log"])
+      result.stderr.should be_empty
+      result.exit_code.should eq(0)
+      urls = JSON.parse(result.stdout)["endpoints"].as_a.map(&.["url"].as_s)
+      urls.empty?.should be_false
+      urls.all?(&.starts_with?("http://localhost:3000/")).should be_true
+    end
+  end
 end

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -1,0 +1,79 @@
+require "../../spec_helper"
+require "json"
+
+# End-to-end specs for the CLI front door, driven through the *built
+# binary*.
+#
+# Everything else in this directory tests a pure parser helper, and
+# `spec/functional_test`'s `FunctionalTester` drives `detect`/`analyze`
+# directly without ever going through the CLI — which is exactly the gap
+# the router/subcommand bugs fixed here lived in. Argv handling, exit
+# codes, and the stdout/stderr split can only be pinned by running the
+# real program, so these examples assert all three separately.
+private REPO_ROOT = File.expand_path(File.join(__DIR__, "..", "..", ".."))
+private BINARY    = File.join(REPO_ROOT, "bin", "noir")
+private FIXTURE   = File.join(REPO_ROOT, "spec", "functional_test", "fixtures", "ruby", "sinatra")
+
+private record CliRun, stdout : String, stderr : String, exit_code : Int32
+
+private def run_noir(args : Array(String)) : CliRun
+  stdout = IO::Memory.new
+  stderr = IO::Memory.new
+  status = Process.run(BINARY, args: args, output: stdout, error: stderr)
+  CliRun.new(stdout: stdout.to_s, stderr: stderr.to_s, exit_code: status.exit_code)
+end
+
+# `bin/noir` is produced by a separate CI job from the one that runs the
+# specs, so it is routinely absent here — and a stale binary would fail
+# these examples for a reason that has nothing to do with the code under
+# test. Both cases skip instead; `shards build` makes them run.
+private def binary_ready? : Bool
+  return false unless File.exists?(BINARY)
+  built_at = File.info(BINARY).modification_time
+  Dir.glob(File.join(REPO_ROOT, "src", "**", "*.cr")).none? do |source|
+    File.info(source).modification_time > built_at
+  end
+end
+
+describe "noir CLI surface (built binary)" do
+  unless binary_ready?
+    pending "needs an up-to-date bin/noir — run `shards build` to exercise these"
+    next
+  end
+
+  describe "terminal-flag rewriting" do
+    it "leaves a subcommand's own -v alone" do
+      # `noir rules update -v` used to print the version and exit 0 —
+      # `-v` was rewritten to the `version` subcommand before the router
+      # ever saw the verb, so the rules were never updated while the
+      # documented `noir rules update && noir scan . -P` precondition
+      # reported success. `rules path` is the network-free stand-in for
+      # the same argv shape.
+      result = run_noir(["rules", "path", "-v"])
+      result.stdout.should contain("passive_rules")
+      result.stdout.strip.should_not match(/\A\d+\.\d+\.\d+\z/)
+      result.exit_code.should eq(0)
+    end
+
+    it "still routes the v0 (verb-less) global flags to `version`" do
+      %w[-v -V --version].each do |flag|
+        result = run_noir([flag])
+        result.stdout.strip.should match(/\A\d+\.\d+\.\d+/)
+        result.stderr.should be_empty
+        result.exit_code.should eq(0)
+      end
+    end
+
+    it "keeps `noir version -v` working" do
+      result = run_noir(["version", "-v"])
+      result.stdout.strip.should match(/\A\d+\.\d+\.\d+/)
+      result.exit_code.should eq(0)
+    end
+
+    it "keeps the v0 terminal flags working after other v0 flags" do
+      result = run_noir(["-b", FIXTURE, "--build-info"])
+      result.stdout.should contain("Crystal:")
+      result.exit_code.should eq(0)
+    end
+  end
+end

--- a/spec/unit_test/cli/completion_command_spec.cr
+++ b/spec/unit_test/cli/completion_command_spec.cr
@@ -16,11 +16,33 @@ describe Noir::CLI::CompletionCommand do
       Noir::CLI::CompletionCommand.parse_argv(["elvish"]).shell.should eq("elvish")
     end
 
-    it "first positional wins over subsequent positionals" do
-      # `noir completion zsh ./extra` is acceptable — extras are
-      # ignored, not silently promoted to the shell slot.
-      parsed = Noir::CLI::CompletionCommand.parse_argv(["zsh", "extra"])
+    it "rejects a surplus positional instead of dropping it" do
+      # `noir completion zsh bash` used to emit the zsh script and exit
+      # 0, leaving the bash completion the user asked for unwritten.
+      parsed = Noir::CLI::CompletionCommand.parse_argv(["zsh", "bash"])
       parsed.shell.should eq("zsh")
+      parsed.error.should eq("Unexpected argument: bash. Usage: noir completion <shell>")
+    end
+
+    it "pluralizes and lists every surplus positional" do
+      parsed = Noir::CLI::CompletionCommand.parse_argv(["zsh", "bash", "fish"])
+      parsed.error.should eq("Unexpected arguments: bash, fish. Usage: noir completion <shell>")
+    end
+
+    it "rejects an unknown flag instead of ignoring it" do
+      parsed = Noir::CLI::CompletionCommand.parse_argv(["zsh", "--oops"])
+      parsed.error.should eq("Unknown option: --oops. Run `noir completion --help`.")
+    end
+
+    it "accepts the router's global flags" do
+      parsed = Noir::CLI::CompletionCommand.parse_argv(["--no-color", "zsh", "--no-spinner"])
+      parsed.shell.should eq("zsh")
+      parsed.error.should be_nil
+    end
+
+    it "reports no error for a well-formed invocation" do
+      Noir::CLI::CompletionCommand.parse_argv(["zsh"]).error.should be_nil
+      Noir::CLI::CompletionCommand.parse_argv([] of String).error.should be_nil
     end
 
     it "flags -h / --help anywhere in argv" do

--- a/spec/unit_test/cli/config_command_spec.cr
+++ b/spec/unit_test/cli/config_command_spec.cr
@@ -77,7 +77,89 @@ describe "Noir::CLI::ConfigCommand.default_editor" do
   end
 end
 
+describe "Noir::CLI::ConfigCommand.parse_argv" do
+  it "captures the action" do
+    parsed = Noir::CLI::ConfigCommand.parse_argv(["show"])
+    parsed.action.should eq("show")
+    parsed.override_path.should be_nil
+    parsed.help.should be_false
+    parsed.error.should be_nil
+  end
+
+  it "captures --config-file in both the spaced and `=` forms" do
+    Noir::CLI::ConfigCommand.parse_argv(["show", "--config-file", "/tmp/a.yaml"])
+      .override_path.should eq("/tmp/a.yaml")
+    Noir::CLI::ConfigCommand.parse_argv(["show", "--config-file=/tmp/a.yaml"])
+      .override_path.should eq("/tmp/a.yaml")
+  end
+
+  it "does not swallow the action that follows --config-file's value" do
+    parsed = Noir::CLI::ConfigCommand.parse_argv(["--config-file", "/tmp/a.yaml", "show"])
+    parsed.action.should eq("show")
+    parsed.override_path.should eq("/tmp/a.yaml")
+    parsed.error.should be_nil
+  end
+
+  it "errors when --config-file has no value" do
+    # `nil` used to fall through to the DEFAULT config path, so
+    # `noir config show --config-file` printed a different file than the
+    # one the user asked to inspect — and `edit` would have created it.
+    Noir::CLI::ConfigCommand.parse_argv(["show", "--config-file"])
+      .error.should eq("--config-file requires an argument.")
+    Noir::CLI::ConfigCommand.parse_argv(["show", "--config-file="])
+      .error.should eq("--config-file requires an argument.")
+    Noir::CLI::ConfigCommand.parse_argv(["--config-file", "--no-color", "show"])
+      .error.should eq("--config-file requires an argument.")
+  end
+
+  it "leaves override_path nil when --config-file is malformed" do
+    Noir::CLI::ConfigCommand.parse_argv(["show", "--config-file"])
+      .override_path.should be_nil
+  end
+
+  it "rejects a surplus positional instead of dropping it" do
+    # `noir config path init` used to run `path` and exit 0, so a typo
+    # ran a different command than the one typed.
+    parsed = Noir::CLI::ConfigCommand.parse_argv(["path", "init"])
+    parsed.action.should eq("path")
+    parsed.error.should eq("Unexpected argument: init. `noir config` takes a single action.")
+  end
+
+  it "pluralizes and lists every surplus positional" do
+    Noir::CLI::ConfigCommand.parse_argv(["path", "init", "show"])
+      .error.should eq("Unexpected arguments: init, show. `noir config` takes a single action.")
+  end
+
+  it "rejects an unknown flag instead of ignoring it" do
+    Noir::CLI::ConfigCommand.parse_argv(["show", "--bogus-flag"])
+      .error.should eq("Unknown option: --bogus-flag. Run `noir config --help`.")
+  end
+
+  it "accepts the router's global flags" do
+    parsed = Noir::CLI::ConfigCommand.parse_argv(["--no-color", "show", "--no-spinner"])
+    parsed.action.should eq("show")
+    parsed.error.should be_nil
+  end
+
+  it "flags -h / --help anywhere in argv" do
+    Noir::CLI::ConfigCommand.parse_argv(["-h"]).help.should be_true
+    Noir::CLI::ConfigCommand.parse_argv(["show", "--help"]).help.should be_true
+  end
+end
+
 describe "Noir::CLI::ConfigCommand.config_path" do
+  it "expands a leading ~ in --config-file" do
+    # Most shells do not expand a tilde after `=`, and Docker/systemd
+    # wrappers never expand one — pre-fix this resolved to a literal `~`
+    # directory under the cwd.
+    expected = File.join(Path.home.to_s, "nope.yaml")
+    Noir::CLI::ConfigCommand.config_path("~/nope.yaml").should eq(expected)
+  end
+
+  it "leaves an absolute --config-file path alone" do
+    Noir::CLI::ConfigCommand.config_path("/tmp/noir-test.yaml").should eq("/tmp/noir-test.yaml")
+  end
+
   it "resolves under NOIR_HOME when set" do
     saved = ENV["NOIR_HOME"]?
     ENV["NOIR_HOME"] = "/tmp/noir-test-home"

--- a/spec/unit_test/cli/router_spec.cr
+++ b/spec/unit_test/cli/router_spec.cr
@@ -35,17 +35,39 @@ describe "Noir::CLI::Legacy.rewrite" do
     Noir::CLI::Legacy.rewrite(["--generate-completion", "bash", "./extra"]).should eq(["completion", "bash"])
   end
 
-  it "rewrites -v and -V to the version subcommand (global anywhere in ARGV)" do
+  it "rewrites -v and -V to the version subcommand in a v0 (verb-less) invocation" do
     Noir::CLI::Legacy.rewrite(["-v"]).should eq(["version"])
     Noir::CLI::Legacy.rewrite(["-V"]).should eq(["version"])
-    Noir::CLI::Legacy.rewrite(["scan", "-v"]).should eq(["version"])
-    Noir::CLI::Legacy.rewrite(["scan", "./app", "-v"]).should eq(["version"])
-    Noir::CLI::Legacy.rewrite(["scan", "./app", "-V"]).should eq(["version"])
+    Noir::CLI::Legacy.rewrite(["-b", "./app", "-v"]).should eq(["version"])
+    Noir::CLI::Legacy.rewrite(["-b", "./app", "-V"]).should eq(["version"])
   end
 
   it "rewrites --version the same way as -v" do
     Noir::CLI::Legacy.rewrite(["--version"]).should eq(["version"])
-    Noir::CLI::Legacy.rewrite(["list", "techs", "--version"]).should eq(["version"])
+    Noir::CLI::Legacy.rewrite(["-b", "./app", "--version"]).should eq(["version"])
+  end
+
+  it "leaves a subcommand's own flags alone" do
+    # The rewrite table is a global argv substitution, so scanning past a
+    # verb let it hijack that subcommand's flags: `noir rules update -v`
+    # printed the version and exited 0 while `noir rules -h` advertises
+    # `-v, --verbose` — the rules were never updated, and the caller of
+    # `noir rules update && noir scan . -P` saw success.
+    Noir::CLI::Legacy.rewrite(["rules", "update", "-v"]).should eq(["rules", "update", "-v"])
+    Noir::CLI::Legacy.rewrite(["scan", "-v"]).should eq(["scan", "-v"])
+    Noir::CLI::Legacy.rewrite(["scan", "./app", "-V"]).should eq(["scan", "./app", "-V"])
+    Noir::CLI::Legacy.rewrite(["list", "techs", "--version"]).should eq(["list", "techs", "--version"])
+    Noir::CLI::Legacy.rewrite(["cache", "clear", "--build-info"]).should eq(["cache", "clear", "--build-info"])
+    Noir::CLI::Legacy.rewrite(["config", "show", "--list-techs"]).should eq(["config", "show", "--list-techs"])
+    Noir::CLI::Legacy.rewrite(["completion", "--generate-completion", "zsh"])
+      .should eq(["completion", "--generate-completion", "zsh"])
+  end
+
+  it "still rewrites when the first token is a path or flag, not a verb" do
+    # v0 had no subcommands at all, so every v0 invocation opens with a
+    # flag or a path — those keep the global-rewrite behaviour.
+    Noir::CLI::Legacy.rewrite(["./app", "--version"]).should eq(["version"])
+    Noir::CLI::Legacy.rewrite(["--no-color", "--build-info"]).should eq(["version", "--verbose"])
   end
 
   it "leaves non-terminal v0 invocations untouched" do
@@ -64,6 +86,15 @@ describe "Noir::CLI::Legacy.rewrite" do
     # routes to.
     Noir::CLI::Legacy.rewrite(["--list-techs", "--build-info"]).should eq(["list", "techs"])
     Noir::CLI::Legacy.rewrite(["--build-info", "--list-techs"]).should eq(["version", "--verbose"])
+  end
+
+  it "reports a v1 verb at the head of argv" do
+    Noir::CLI::Legacy.subcommand_invocation?(["rules", "update"]).should be_true
+    Noir::CLI::Legacy.subcommand_invocation?(["scan"]).should be_true
+    Noir::CLI::Legacy.subcommand_invocation?([] of String).should be_false
+    Noir::CLI::Legacy.subcommand_invocation?(["-b", "./app"]).should be_false
+    # Only the head counts — that is the exact token the router tests.
+    Noir::CLI::Legacy.subcommand_invocation?(["-b", "scan"]).should be_false
   end
 
   it "is idempotent on already-rewritten input" do

--- a/spec/unit_test/cli/scan_command_spec.cr
+++ b/spec/unit_test/cli/scan_command_spec.cr
@@ -50,3 +50,100 @@ describe "structured output formats" do
     Noir::OutputFormats::STRUCTURED_NAMES.size.should eq 11
   end
 end
+
+describe "Noir::CLI::ScanCommand.host_error" do
+  # `-u` is the base URL every discovered path is appended to. Pre-fix
+  # only the scheme and the port were validated, so `-u http://` parsed
+  # with an empty host and the concatenation promoted the first
+  # discovered path segment to the authority (`/a` -> `http://a`) — with
+  # `--probe` / `--status-codes` that is a real request at a host the
+  # user never named.
+  it "rejects a URL with no authority" do
+    Noir::CLI::ScanCommand.host_error(URI.parse("http://").host).should eq("has no host")
+    Noir::CLI::ScanCommand.host_error(URI.parse("http://:8080").host).should eq("has no host")
+    Noir::CLI::ScanCommand.host_error(nil).should eq("has no host")
+  end
+
+  it "rejects an authority holding whitespace or control characters" do
+    # `-u "not a url"` gets `https://` prepended and then parses with the
+    # whole string as the host; the unusable URL reached every endpoint in
+    # the JSON/OAS/Postman output.
+    whitespace_error = "has whitespace or control characters in the host"
+    Noir::CLI::ScanCommand.host_error(URI.parse("https://not a url").host).should eq(whitespace_error)
+    Noir::CLI::ScanCommand.host_error(URI.parse("http://a\nb/").host).should eq(whitespace_error)
+    Noir::CLI::ScanCommand.host_error("a\tb").should eq(whitespace_error)
+    Noir::CLI::ScanCommand.host_error("a b").should eq(whitespace_error)
+  end
+
+  it "accepts the host shapes a base URL legitimately takes" do
+    [
+      "http://localhost:3000", "https://example.com", "https://example.com/api/v1",
+      "https://user:pass@example.com:8443/base", "http://127.0.0.1:8080", "http://[::1]:8080",
+    ].each do |url|
+      Noir::CLI::ScanCommand.host_error(URI.parse(url).host).should be_nil
+    end
+  end
+end
+
+describe "Noir::CLI::ScanCommand.glob_error" do
+  # A malformed `--exclude-path` glob is only interpreted deep inside the
+  # detector's file walk. `[` at least aborted the scan; every other
+  # malformed shape matched nothing at all and exited 0, which reads
+  # exactly like an exclusion that worked.
+  it "reports an unterminated brace group" do
+    Noir::CLI::ScanCommand.glob_error("*.{rb").should eq("unterminated `{` group")
+    Noir::CLI::ScanCommand.glob_error("{").should eq("unterminated `{` group")
+    Noir::CLI::ScanCommand.glob_error("a{b,c").should eq("unterminated `{` group")
+  end
+
+  it "reports an unmatched closing brace" do
+    Noir::CLI::ScanCommand.glob_error("}").should eq("unmatched `}`")
+    Noir::CLI::ScanCommand.glob_error("*.rb}").should eq("unmatched `}`")
+  end
+
+  it "still reports Crystal's own character-class error" do
+    Noir::CLI::ScanCommand.glob_error("[").should eq("unterminated character set")
+  end
+
+  it "accepts well-formed globs" do
+    [
+      "*.test.js", "*.{rb,go}", "**/vendor/**", "src/legacy", "[a-z]*.rb",
+      "a{b,{c,d}}e", "spec/*_spec.cr",
+    ].each do |pattern|
+      Noir::CLI::ScanCommand.glob_error(pattern).should be_nil
+    end
+  end
+
+  it "treats a brace inside a character class as a literal" do
+    # `[{]` matches a literal `{` — counting it as a group opener would
+    # reject a valid pattern.
+    Noir::CLI::ScanCommand.glob_error("[{]").should be_nil
+    Noir::CLI::ScanCommand.glob_error("[}]").should be_nil
+  end
+end
+
+describe "Noir::CLI::ScanCommand.cli_flag_names" do
+  # Once the parser has run, a config-file value and a CLI flag are the
+  # same entry in the same hash — argv is the only record of what the
+  # user actually typed, which is what tells a usage error (`--probe`
+  # with no `-u`) from a config key that simply cannot apply this run.
+  it "collects long flags, dropping the `=` value" do
+    names = Noir::CLI::ScanCommand.cli_flag_names(
+      ["scan", "./app", "--probe", "--probe-via=http://127.0.0.1:8080", "-u", "http://x"]
+    )
+    names.includes?("--probe").should be_true
+    names.includes?("--probe-via").should be_true
+    names.includes?("-u").should be_true
+  end
+
+  it "keeps positionals and flag values out" do
+    names = Noir::CLI::ScanCommand.cli_flag_names(["scan", "./app", "-b", "./other"])
+    names.includes?("./app").should be_false
+    names.includes?("./other").should be_false
+    names.includes?("-b").should be_true
+  end
+
+  it "is empty for a flagless invocation" do
+    Noir::CLI::ScanCommand.cli_flag_names(["scan", "./app"]).empty?.should be_true
+  end
+end

--- a/spec/unit_test/cli_validation_spec.cr
+++ b/spec/unit_test/cli_validation_spec.cr
@@ -296,4 +296,89 @@ describe Noir::CliValidation do
       Noir::CliValidation.validate_tech_names!(options)
     end
   end
+
+  # `--passive-scan-severity` is validated by its flag handler in options.cr,
+  # but the identical `passive_scan_severity:` config key reached
+  # `PassiveScanSeverity` untouched — and `meets_threshold?` returns true when
+  # the threshold is unknown. So a config-file typo didn't loosen the filter
+  # by a level, it removed it: the user's intended filter became no filter,
+  # silently. Both sources now pass through this one gate.
+  describe "passive_scan_severity" do
+    it "rejects an unknown severity" do
+      options = create_test_options
+      options["passive_scan_severity"] = YAML::Any.new("bogus")
+
+      expect_raises(Noir::CliValidation::Error, /Invalid passive scan severity "bogus"/) do
+        Noir::CliValidation.validate_passive_scan_severity!(options)
+      end
+    end
+
+    it "rejects an empty severity" do
+      # `passive_scan_severity:` with no value parses to nil -> "", which is
+      # just as unknown to PassiveScanSeverity as a typo is.
+      options = create_test_options
+      options["passive_scan_severity"] = YAML::Any.new("")
+
+      expect_raises(Noir::CliValidation::Error, /Invalid passive scan severity/) do
+        Noir::CliValidation.validate_passive_scan_severity!(options)
+      end
+    end
+
+    it "accepts every documented level" do
+      %w[critical high medium low].each do |level|
+        options = create_test_options
+        options["passive_scan_severity"] = YAML::Any.new(level)
+        Noir::CliValidation.validate_passive_scan_severity!(options)
+        options["passive_scan_severity"].to_s.should eq(level)
+      end
+    end
+
+    it "normalizes case, matching what the CLI flag stores" do
+      options = create_test_options
+      options["passive_scan_severity"] = YAML::Any.new("HIGH")
+      Noir::CliValidation.validate_passive_scan_severity!(options)
+      options["passive_scan_severity"].to_s.should eq("high")
+    end
+  end
+
+  # `--ai-max-token` / `--ai-agent-max-steps` are bounded by
+  # `positive_int_or_die!` on the CLI side; their config twins had no bound at
+  # all. ConfigInitializer coerces the value to an Int, this checks the range.
+  describe "ai integer options" do
+    it "rejects a zero agent step budget" do
+      options = create_test_options
+      options["ai_agent_max_steps"] = YAML::Any.new(0)
+
+      expect_raises(Noir::CliValidation::Error, /Invalid --ai-agent-max-steps '0'/) do
+        Noir::CliValidation.validate_ai_integer_options!(options)
+      end
+    end
+
+    it "rejects a negative token budget" do
+      options = create_test_options
+      options["ai_max_token"] = YAML::Any.new(-1)
+
+      expect_raises(Noir::CliValidation::Error, /Invalid --ai-max-token '-1'/) do
+        Noir::CliValidation.validate_ai_integer_options!(options)
+      end
+    end
+
+    it "accepts ai_max_token 0, the shipped default meaning \"no limit\"" do
+      # `--ai-max-token 0` is rejected on the CLI, but 0 is what
+      # default_options and the generated template both carry, so the config
+      # path must keep accepting it.
+      options = create_test_options
+      Noir::CliValidation.validate_ai_integer_options!(options)
+      options["ai_max_token"].as_i.should eq(0)
+    end
+
+    it "rejects a non-numeric value that survived coercion" do
+      options = create_test_options
+      options["ai_max_token"] = YAML::Any.new("abc")
+
+      expect_raises(Noir::CliValidation::Error, /Invalid --ai-max-token "abc"/) do
+        Noir::CliValidation.validate_ai_integer_options!(options)
+      end
+    end
+  end
 end

--- a/spec/unit_test/config_initializer_spec.cr
+++ b/spec/unit_test/config_initializer_spec.cr
@@ -156,6 +156,86 @@ describe ConfigInitializer do
     end
   end
 
+  # Every consumer of these keys reads them through `YAML::Any#as_i`. A
+  # quoted number parses as a String and used to raise "Cast from String to
+  # Int64 failed" inside the AI analyzer — caught as an analyzer failure, so
+  # the run exited 0 with AI analysis silently skipped. The generated
+  # template models the quoted spelling itself (`concurrency: "…"`), so it is
+  # the shape users copy.
+  describe "INTEGER_CONFIG_KEYS coercion" do
+    it "coerces a quoted ai_max_token into an Int" do
+      with_noir_home("ai_max_token: \"4000\"\n") do |options|
+        options["ai_max_token"].as_i.should eq(4000)
+      end
+    end
+
+    it "coerces a quoted ai_agent_max_steps into an Int" do
+      with_noir_home("ai_agent_max_steps: \"7\"\n") do |options|
+        options["ai_agent_max_steps"].as_i.should eq(7)
+      end
+    end
+
+    it "leaves a real YAML int alone" do
+      with_noir_home("ai_max_token: 1200\n") do |options|
+        options["ai_max_token"].as_i.should eq(1200)
+      end
+    end
+
+    it "falls back to the default for an unparsable integer" do
+      # Same "warn on stderr, keep going with the default" shape as the
+      # invalid-boolean path, so `.as_i` downstream can never raise.
+      with_noir_home("ai_max_token: \"abc\"\n") do |options|
+        options["ai_max_token"].as_i.should eq(0)
+      end
+    end
+  end
+
+  # A YAML sequence is the natural spelling for a list of globs or tech
+  # names, and `base:` / `probe_header:` in the same file *are* sequences.
+  # Untreated, `exclude_path: ["*.py"]` stringified to Crystal's array
+  # inspect, which matches no file — the pattern silently excluded nothing.
+  describe "CSV_CONFIG_KEYS normalization" do
+    it "joins a YAML sequence for exclude_path with commas" do
+      body = <<-YAML
+        exclude_path:
+          - "*.py"
+          - "*_test.go"
+        YAML
+      with_noir_home(body) do |options|
+        options["exclude_path"].to_s.should eq("*.py,*_test.go")
+      end
+    end
+
+    it "normalizes every CSV key, not just exclude_path" do
+      body = <<-YAML
+        exclude_codes: [404, 500]
+        techs: [ruby_sinatra]
+        only_techs: [ruby_rails]
+        exclude_techs: [php_pure]
+        use_taggers: [cors, oauth]
+        YAML
+      with_noir_home(body) do |options|
+        options["exclude_codes"].to_s.should eq("404,500")
+        options["techs"].to_s.should eq("ruby_sinatra")
+        options["only_techs"].to_s.should eq("ruby_rails")
+        options["exclude_techs"].to_s.should eq("php_pure")
+        options["use_taggers"].to_s.should eq("cors,oauth")
+      end
+    end
+
+    it "leaves an existing comma string untouched" do
+      with_noir_home("exclude_path: \"*.py,*.rb\"\n") do |options|
+        options["exclude_path"].to_s.should eq("*.py,*.rb")
+      end
+    end
+
+    it "turns an empty sequence into an empty string" do
+      with_noir_home("use_taggers: []\n") do |options|
+        options["use_taggers"].to_s.should eq("")
+      end
+    end
+  end
+
   describe "generate_config_file" do
     it "documents only_techs and tls_skip_verify (both are live config keys)" do
       body = ConfigInitializer.new.generate_config_file
@@ -234,6 +314,85 @@ describe ConfigInitializer do
         options.has_key?("send_req").should be_false
       ensure
         File.delete(path) if File.exists?(path)
+      end
+    end
+
+    # `Noir::Home.path` calls `Noir::CLI.die` when neither NOIR_HOME nor HOME
+    # is set, and `initialize` used to evaluate it on its first line — above
+    # the override branch. So `--config-file ./f.yaml`, the documented escape
+    # hatch for exactly that environment (distroless images, `--user`
+    # containers, hardened CI runners), died before the override was looked
+    # at, leaving no way to run a scan at all.
+    #
+    # Note what a regression looks like here: the pre-fix code doesn't fail
+    # this example, it `exit(1)`s the whole spec process.
+    it "reads an override file with neither NOIR_HOME nor HOME set" do
+      path = File.tempname("noir-cfg-homeless-")
+      File.write(path, "concurrency: 9\n")
+      saved_home = ENV["HOME"]?
+      saved_noir_home = ENV["NOIR_HOME"]?
+      ENV.delete("HOME")
+      ENV.delete("NOIR_HOME")
+
+      begin
+        options = ConfigInitializer.new(path).read_config
+        options["concurrency"].to_s.should eq("9")
+      ensure
+        ENV["HOME"] = saved_home if saved_home
+        ENV["NOIR_HOME"] = saved_noir_home if saved_noir_home
+        File.delete?(path)
+      end
+    end
+
+    # The escape hatch should open, not make the error disappear: with no
+    # override there is genuinely nowhere to read from, and the clear
+    # "set NOIR_HOME" message is the right answer. `setup` is the part that
+    # would otherwise try to `mkdir` a home that can't be resolved, so pin
+    # that it still walks the Noir::Home path when there's no override.
+    it "still resolves the default config under NOIR_HOME when no override is given" do
+      dir = File.tempname("noir-cfg-default-home-")
+      Dir.mkdir(dir)
+      saved_home = ENV["HOME"]?
+      saved_noir_home = ENV["NOIR_HOME"]?
+      ENV.delete("HOME")
+      ENV["NOIR_HOME"] = dir
+
+      begin
+        ConfigInitializer.new.setup
+        File.exists?(File.join(dir, "config.yaml")).should be_true
+      ensure
+        ENV["HOME"] = saved_home if saved_home
+        if s = saved_noir_home
+          ENV["NOIR_HOME"] = s
+        else
+          ENV.delete("NOIR_HOME")
+        end
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    # `Noir::Home.path` expands a leading `~` on purpose: a path arriving from
+    # a Dockerfile `ENV` / systemd `Environment=` / .env loader never gets the
+    # shell's expansion. `--config-file` is fed from the same kinds of place
+    # and had no expansion at all, so `~/noir.yaml` resolved to a literal
+    # `./~/noir.yaml` under the cwd.
+    it "expands a leading ~ in the override path" do
+      home = File.tempname("noir-cfg-tilde-home-")
+      Dir.mkdir(home)
+      saved_home = ENV["HOME"]?
+      ENV["HOME"] = home
+      File.write(File.join(home, "noir.yaml"), "concurrency: 23\n")
+
+      begin
+        options = ConfigInitializer.new("~/noir.yaml").read_config
+        options["concurrency"].to_s.should eq("23")
+      ensure
+        if s = saved_home
+          ENV["HOME"] = s
+        else
+          ENV.delete("HOME")
+        end
+        FileUtils.rm_rf(home)
       end
     end
 

--- a/spec/unit_test/deliver/probe_url_spec.cr
+++ b/spec/unit_test/deliver/probe_url_spec.cr
@@ -1,0 +1,97 @@
+require "../../spec_helper"
+require "yaml"
+require "../../../src/models/deliver"
+require "../../../src/models/endpoint"
+
+# Filling a path template is pure string work, so it gets direct coverage here
+# rather than being inferred from whatever a capturing server happened to
+# receive. `probe_url` is protected; this subclass is the only reason it can
+# be called from a spec.
+private class ProbeUrlProbe < Deliver
+  def url_for(endpoint : Endpoint, request_method : String = "GET") : String
+    probe_url(endpoint, request_method)
+  end
+end
+
+private def path_endpoint(url : String, *names : String) : Endpoint
+  endpoint = Endpoint.new(url, "GET")
+  names.each { |name| endpoint.params << Param.new(name, "", "path") }
+  endpoint
+end
+
+describe "Deliver#probe_url" do
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(".")])
+  probe = ProbeUrlProbe.new(options)
+
+  describe "the Express-style :name form" do
+    it "fills a lone :name" do
+      probe.url_for(path_endpoint("http://h/users/:id", "id")).should eq("http://h/users/1")
+    end
+
+    # The bug: `:name` has no closing delimiter, so `:id` matched the head of
+    # `:idx`. Params are visited in declaration order, so the shorter name won
+    # and the probe went to `/u/1/1x` — a path the app does not route.
+    it "does not let a shorter param name eat a longer one that starts with it" do
+      endpoint = path_endpoint("http://h/u/:id/:idx", "id", "idx")
+      probe.url_for(endpoint).should eq("http://h/u/1/1")
+    end
+
+    it "fills the same pair correctly with the names declared the other way round" do
+      endpoint = path_endpoint("http://h/u/:idx/:id", "idx", "id")
+      probe.url_for(endpoint).should eq("http://h/u/1/1")
+    end
+
+    # The trailing boundary has to admit the suffixes the no-boundary version
+    # existed to support, so it stops at the first character that cannot be
+    # part of a name rather than requiring `/` or end-of-string.
+    it "still fills Play-style /:lang.json" do
+      probe.url_for(path_endpoint("http://h/:lang.json", "lang")).should eq("http://h/noir.json")
+    end
+
+    it "still fills a :name followed by a - suffix" do
+      probe.url_for(path_endpoint("http://h/posts/:id-preview", "id")).should eq("http://h/posts/1-preview")
+    end
+
+    it "leaves a longer name alone when only the shorter one is declared" do
+      # Only `:id` is a real param here, so `:idx` is not a placeholder this
+      # endpoint knows about and must survive untouched.
+      probe.url_for(path_endpoint("http://h/u/:id/:idx", "id")).should eq("http://h/u/1/:idx")
+    end
+
+    it "treats a name containing regex metacharacters literally" do
+      # `Regex.escape` is what keeps `.` from matching any character; the
+      # trailing lookahead must not undo that.
+      probe.url_for(path_endpoint("http://h/f/:a.b/x", "a.b")).should eq("http://h/f/noir/x")
+      probe.url_for(path_endpoint("http://h/f/:a+b", "a+b")).should eq("http://h/f/noir")
+    end
+
+    it "keeps the port colon and mid-segment text out of it" do
+      endpoint = path_endpoint("http://host:8080/profiles/celeb_:USERNAME", "USERNAME")
+      probe.url_for(endpoint).should eq("http://host:8080/profiles/celeb_:USERNAME")
+    end
+  end
+
+  describe "the delimited forms" do
+    it "fills {name} and <name> without prefix collisions" do
+      braces = path_endpoint("http://h/u/{id}/{idx}", "id", "idx")
+      probe.url_for(braces).should eq("http://h/u/1/1")
+
+      angles = path_endpoint("http://h/u/<id>/<idx>", "id", "idx")
+      probe.url_for(angles).should eq("http://h/u/1/1")
+    end
+  end
+
+  it "leaves the template alone for destructive verbs" do
+    endpoint = path_endpoint("http://h/u/:id/:idx", "id", "idx")
+    probe.url_for(endpoint, "DELETE").should eq("http://h/u/:id/:idx")
+  end
+
+  it "does not touch a param --set-pvalue-path already resolved" do
+    endpoint = Endpoint.new("http://h/u/42/:idx", "GET")
+    endpoint.params << Param.new("id", "42", "path")
+    endpoint.params << Param.new("idx", "", "path")
+
+    probe.url_for(endpoint).should eq("http://h/u/42/1")
+  end
+end

--- a/spec/unit_test/deliver/status_code_spec.cr
+++ b/spec/unit_test/deliver/status_code_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "http/server"
 require "../../../src/deliver/status_code.cr"
 require "../../../src/models/endpoint.cr"
 require "../../../src/utils/http_symbols.cr"
@@ -37,6 +38,137 @@ class TestStatusCodeProbe < StatusCodeProbe
       MockResponse.new(200)
     end
   end
+end
+
+# In-process server on an ephemeral port that counts what it was actually
+# asked for. A redirect chain needs two of these, and the whole point of the
+# redirect assertions is *which* server got a request.
+private class CountingServer
+  getter address : Socket::IPAddress
+  getter paths : Array(String)
+
+  def initialize(@status : Int32 = 200, location : String? = nil)
+    @paths = [] of String
+    @mutex = Mutex.new
+    status = @status
+    mutex = @mutex
+    paths = @paths
+    @server = HTTP::Server.new do |ctx|
+      resource = ctx.request.resource
+      path = if resource.starts_with?("http://") || resource.starts_with?("https://")
+               URI.parse(resource).request_target
+             else
+               resource
+             end
+      mutex.synchronize { paths << path }
+      ctx.response.headers["Location"] = location if location
+      ctx.response.status_code = status
+      ctx.response.print "ok"
+    end
+    @address = @server.bind_tcp("127.0.0.1", 0)
+    spawn { @server.listen }
+    # Yield once so the listen fiber is accepting before the first request,
+    # otherwise a cold run can connect-refuse intermittently.
+    Fiber.yield
+  end
+
+  def count : Int32
+    @mutex.synchronize { @paths.size }
+  end
+
+  def url_for(path : String) : String
+    "http://#{@address.address}:#{@address.port}#{path}"
+  end
+
+  def close
+    @server.close
+  end
+end
+
+# Accepts the connection and then never answers, releasing only on close — a
+# wedged or blackholed host. A bare `sleep` would keep running past `close`
+# and wake inside whatever spec file was executing by then.
+private class StallingStatusServer
+  getter address : Socket::IPAddress
+
+  def initialize
+    @release = Channel(Nil).new
+    release = @release
+    @server = HTTP::Server.new do |ctx|
+      release.receive?
+      ctx.response.print "late"
+    end
+    @address = @server.bind_tcp("127.0.0.1", 0)
+    spawn { @server.listen }
+    Fiber.yield
+  end
+
+  def url_for(path : String) : String
+    "http://#{@address.address}:#{@address.port}#{path}"
+  end
+
+  def close
+    @server.close
+    @release.close
+  end
+end
+
+# Records the high-water mark of simultaneously in-flight requests, so the
+# --concurrency bound is assertable rather than assumed.
+private class ConcurrencyWatchingServer
+  getter address : Socket::IPAddress
+  getter peak : Int32
+
+  def initialize
+    @in_flight = 0
+    @peak = 0
+    @mutex = Mutex.new
+    @server = HTTP::Server.new do |ctx|
+      @mutex.synchronize do
+        @in_flight += 1
+        @peak = @in_flight if @in_flight > @peak
+      end
+      # Hold the request open briefly so overlapping probes really do overlap.
+      sleep 20.milliseconds
+      @mutex.synchronize { @in_flight -= 1 }
+      ctx.response.print "ok"
+    end
+    @address = @server.bind_tcp("127.0.0.1", 0)
+    spawn { @server.listen }
+    Fiber.yield
+  end
+
+  def url_for(path : String) : String
+    "http://#{@address.address}:#{@address.port}#{path}"
+  end
+
+  def close
+    @server.close
+  end
+end
+
+# The shipped read timeout is 5s; overriding keeps the stall spec fast while
+# still exercising the real plumbing into Crest.
+private class ImpatientStatusCodeProbe < StatusCodeProbe
+  protected def read_timeout : Time::Span
+    200.milliseconds
+  end
+end
+
+private class ExposedStatusCodeProbe < StatusCodeProbe
+  def exposed_connect_timeout : Time::Span
+    connect_timeout
+  end
+end
+
+private def base_probe_options : Hash(String, YAML::Any)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new("noir")])
+  options
+end
+
+private def probe_for(options : Hash(String, YAML::Any)) : StatusCodeProbe
+  StatusCodeProbe.new(options, NoirLogger.new(false, false, false, true))
 end
 
 describe StatusCodeProbe do
@@ -134,5 +266,117 @@ describe StatusCodeProbe do
     result.size.should eq(3)
     runner.last_request_method.should be_nil
     result.each(&.details.status_code.should(be_nil))
+  end
+
+  # Everything below drives the real `perform_request` at a local server: the
+  # bugs are in what noir hands Crest, so a canned-response probe cannot see
+  # them.
+  describe "against a real server" do
+    it "reports the redirect's own code and does not follow it" do
+      final = CountingServer.new(200)
+      begin
+        redirector = CountingServer.new(302, final.url_for("/final"))
+        begin
+          endpoint = Endpoint.new(redirector.url_for("/redirect"), "GET")
+          result = probe_for(base_probe_options).apply([endpoint])
+
+          # Crest's max_redirects defaults to 10 and `Redirector#follow` only
+          # stops at `<= 0`, so pre-fix the probe silently walked to /final
+          # and reported *its* 200 for /redirect.
+          result.size.should eq(1)
+          result.first.details.status_code.should eq(302)
+          redirector.count.should eq(1)
+          # A cross-host absolute Location let the scanned app aim noir's
+          # probes at a third party. The target of a probe is what the user
+          # asked for, not what the server says.
+          final.count.should eq(0)
+        ensure
+          redirector.close
+        end
+      ensure
+        final.close
+      end
+    end
+
+    it "lets --exclude-codes filter a 3xx now that the 3xx is visible" do
+      final = CountingServer.new(200)
+      begin
+        redirector = CountingServer.new(302, final.url_for("/final"))
+        begin
+          options = base_probe_options
+          options["exclude_codes"] = YAML::Any.new("302")
+          result = probe_for(options).apply([Endpoint.new(redirector.url_for("/redirect"), "GET")])
+
+          # Pre-fix `excluded.includes?(response.status_code)` was handed the
+          # 200 from the redirect target, so --exclude-codes 302 did nothing.
+          result.should be_empty
+        ensure
+          redirector.close
+        end
+      ensure
+        final.close
+      end
+    end
+
+    it "keeps the catalog in input order while probing concurrently" do
+      server = CountingServer.new(200)
+      begin
+        endpoints = (1..12).map { |i| Endpoint.new(server.url_for("/r#{i}"), "GET") }
+
+        result = probe_for(base_probe_options).apply(endpoints)
+
+        result.map(&.url).should eq(endpoints.map(&.url))
+        result.each(&.details.status_code.should(eq(200)))
+      ensure
+        server.close
+      end
+    end
+
+    # `apply` used to walk endpoints one at a time with no bound and no
+    # connect timeout, so an unreachable host cost every endpoint its own
+    # full timeout in series — hours before any report was written.
+    it "probes stalled endpoints concurrently instead of one after another" do
+      server = StallingStatusServer.new
+      begin
+        endpoints = (1..8).map { |i| Endpoint.new(server.url_for("/hang#{i}"), "GET") }
+
+        options = base_probe_options
+        options["concurrency"] = YAML::Any.new("8")
+        started = Time.instant
+        result = ImpatientStatusCodeProbe.new(options, NoirLogger.new(false, false, false, true)).apply(endpoints)
+        elapsed = Time.instant - started
+
+        # 8 endpoints x a 200ms read timeout is 1.6s sequentially; run eight
+        # at a time it is one timeout plus change. The bound is deliberately
+        # loose — the assertion is "not serialized", not a latency budget.
+        elapsed.should be < 1.second
+        # Every endpoint still comes back (a timeout is logged, not dropped).
+        result.size.should eq(8)
+      ensure
+        server.close
+      end
+    end
+
+    it "bounds in-flight probes by --concurrency" do
+      server = ConcurrencyWatchingServer.new
+      begin
+        endpoints = (1..12).map { |i| Endpoint.new(server.url_for("/c#{i}"), "GET") }
+
+        options = base_probe_options
+        options["concurrency"] = YAML::Any.new("3")
+        probe_for(options).apply(endpoints)
+
+        server.peak.should be <= 3
+      ensure
+        server.close
+      end
+    end
+
+    it "sends a connect timeout so a host that drops SYNs can't hold the scan" do
+      # Crest defaults connect_timeout to nil — no timeout at all — which fell
+      # back to the OS TCP timeout of roughly 75s per endpoint.
+      ExposedStatusCodeProbe.new(base_probe_options, NoirLogger.new(false, false, false, true))
+        .exposed_connect_timeout.should eq(Deliver::PROBE_CONNECT_TIMEOUT)
+    end
   end
 end

--- a/spec/unit_test/deliver/status_code_spec.cr
+++ b/spec/unit_test/deliver/status_code_spec.cr
@@ -303,9 +303,9 @@ describe StatusCodeProbe do
       begin
         redirector = CountingServer.new(302, final.url_for("/final"))
         begin
-          options = base_probe_options
-          options["exclude_codes"] = YAML::Any.new("302")
-          result = probe_for(options).apply([Endpoint.new(redirector.url_for("/redirect"), "GET")])
+          probe_options = base_probe_options
+          probe_options["exclude_codes"] = YAML::Any.new("302")
+          result = probe_for(probe_options).apply([Endpoint.new(redirector.url_for("/redirect"), "GET")])
 
           # Pre-fix `excluded.includes?(response.status_code)` was handed the
           # 200 from the redirect target, so --exclude-codes 302 did nothing.
@@ -340,10 +340,10 @@ describe StatusCodeProbe do
       begin
         endpoints = (1..8).map { |i| Endpoint.new(server.url_for("/hang#{i}"), "GET") }
 
-        options = base_probe_options
-        options["concurrency"] = YAML::Any.new("8")
+        probe_options = base_probe_options
+        probe_options["concurrency"] = YAML::Any.new("8")
         started = Time.instant
-        result = ImpatientStatusCodeProbe.new(options, NoirLogger.new(false, false, false, true)).apply(endpoints)
+        result = ImpatientStatusCodeProbe.new(probe_options, NoirLogger.new(false, false, false, true)).apply(endpoints)
         elapsed = Time.instant - started
 
         # 8 endpoints x a 200ms read timeout is 1.6s sequentially; run eight
@@ -362,9 +362,9 @@ describe StatusCodeProbe do
       begin
         endpoints = (1..12).map { |i| Endpoint.new(server.url_for("/c#{i}"), "GET") }
 
-        options = base_probe_options
-        options["concurrency"] = YAML::Any.new("3")
-        probe_for(options).apply(endpoints)
+        probe_options = base_probe_options
+        probe_options["concurrency"] = YAML::Any.new("3")
+        probe_for(probe_options).apply(endpoints)
 
         server.peak.should be <= 3
       ensure

--- a/spec/unit_test/llm/adapter_spec.cr
+++ b/spec/unit_test/llm/adapter_spec.cr
@@ -132,19 +132,71 @@ describe LLM::AdapterFactory do
       adapter.should be_a(LLM::ACPAdapter)
     end
 
-    it "returns an OllamaAdapter when the provider mentions ollama" do
+    it "returns an OllamaAdapter for the ollama alias" do
       adapter = LLM::AdapterFactory.for("ollama", "llama3")
       adapter.should be_a(LLM::OllamaAdapter)
     end
 
-    it "returns an OllamaAdapter for an ollama:// URL form" do
-      adapter = LLM::AdapterFactory.for("http://example.com/ollama", "llama3")
+    it "returns an OllamaAdapter for a URL whose host is an ollama server" do
+      adapter = LLM::AdapterFactory.for("http://ollama.internal:11434", "llama3")
       adapter.should be_a(LLM::OllamaAdapter)
+    end
+
+    it "does not route an OpenAI-compatible gateway to Ollama because of its path" do
+      # The path belongs to whoever runs the gateway. Matching "ollama"
+      # anywhere in the provider string handed this URL Ollama's native API
+      # and its body shape, and posted them to
+      # `http://127.0.0.1:18085/ollama/v1/api/generate`; the 404 came back
+      # as an empty AI result rather than an error.
+      adapter = LLM::AdapterFactory.for("http://127.0.0.1:18085/ollama/v1", "gpt-4o")
+      adapter.should be_a(LLM::GeneralAdapter)
     end
 
     it "returns a GeneralAdapter for any non-ACP / non-ollama provider" do
       adapter = LLM::AdapterFactory.for("openai", "gpt-4o", "sk-fake")
       adapter.should be_a(LLM::GeneralAdapter)
+    end
+  end
+
+  describe ".ollama_native?" do
+    it "matches the exact alias" do
+      LLM::AdapterFactory.ollama_native?("ollama").should be_true
+      LLM::AdapterFactory.ollama_native?("  OLLAMA ").should be_true
+    end
+
+    it "matches on the host, not on the path" do
+      LLM::AdapterFactory.ollama_native?("http://ollama:11434").should be_true
+      LLM::AdapterFactory.ollama_native?("http://my-ollama.lan:11434").should be_true
+      LLM::AdapterFactory.ollama_native?("http://127.0.0.1:18085/ollama/v1").should be_false
+      LLM::AdapterFactory.ollama_native?("https://gateway.example/proxy/ollama").should be_false
+    end
+
+    it "leaves an explicit OpenAI-compatible path on an ollama host alone" do
+      LLM::AdapterFactory.ollama_native?("http://ollama:11434/v1/chat/completions").should be_false
+    end
+
+    it "does not treat a non-ollama provider as native" do
+      LLM::AdapterFactory.ollama_native?("openai").should be_false
+      LLM::AdapterFactory.ollama_native?("http://localhost:11434").should be_false
+      LLM::AdapterFactory.ollama_native?("not a url at all").should be_false
+    end
+  end
+
+  describe ".ollama_base_url" do
+    it "defaults the bare alias to the local server" do
+      LLM::AdapterFactory.ollama_base_url("ollama").should eq("http://localhost:11434")
+    end
+
+    it "drops the OpenAI-compatible /v1 mount the CLI help advertises" do
+      # `LLM::Ollama` appends `/api/generate`, so keeping `/v1` produced
+      # `http://ollama:11434/v1/api/generate` — a 404 on every request.
+      LLM::AdapterFactory.ollama_base_url("http://ollama:11434/v1").should eq("http://ollama:11434")
+      LLM::AdapterFactory.ollama_base_url("http://ollama:11434/v1/").should eq("http://ollama:11434")
+    end
+
+    it "keeps a plain server URL as-is" do
+      LLM::AdapterFactory.ollama_base_url("http://ollama:11434").should eq("http://ollama:11434")
+      LLM::AdapterFactory.ollama_base_url("http://ollama:11434/").should eq("http://ollama:11434")
     end
   end
 

--- a/spec/unit_test/llm/native_tool_calling_spec.cr
+++ b/spec/unit_test/llm/native_tool_calling_spec.cr
@@ -33,6 +33,21 @@ describe LLM::NativeToolCalling do
     it "keeps unknown providers as normalized lowercase strings" do
       LLM::NativeToolCalling.canonical_provider(" CustomProvider ").should eq("customprovider")
     end
+
+    it "matches on the host rather than anywhere in the URL" do
+      # The path is chosen by whoever runs the gateway, so a substring test
+      # over the whole URL canonicalized these to a provider the operator
+      # never named — and, in `AdapterFactory`, picked the wrong API for it.
+      LLM::NativeToolCalling.canonical_provider("http://127.0.0.1:18085/ollama/v1")
+        .should eq("http://127.0.0.1:18085/ollama/v1")
+      LLM::NativeToolCalling.canonical_provider("https://gw.internal/openai/v1/chat/completions")
+        .should eq("https://gw.internal/openai/v1/chat/completions")
+    end
+
+    it "still matches a host-only form that carries no scheme" do
+      LLM::NativeToolCalling.canonical_provider("api.openai.com").should eq("openai")
+      LLM::NativeToolCalling.canonical_provider("api.x.ai").should eq("xai")
+    end
   end
 
   describe ".normalize_allowlist" do

--- a/spec/unit_test/llm/response_cleanup_spec.cr
+++ b/spec/unit_test/llm/response_cleanup_spec.cr
@@ -12,5 +12,34 @@ describe LLM do
       input = "  {\"key\": \"value\"}  "
       LLM.strip_json_fences(input).should eq("{\"key\": \"value\"}")
     end
+
+    it "strips a fence whatever language tag the model chose" do
+      # The old rule only knew the exact lowercase `json` tag, so any other
+      # spelling left the bare language word in front of the payload,
+      # `JSON.parse` failed, and the caller returned "" — which the analyzer
+      # reads as "this code defines no endpoints".
+      ["JSON", "Json", "javascript", "js", ""].each do |tag|
+        LLM.strip_json_fences("```#{tag}\n{\"key\": \"value\"}\n```")
+          .should eq("{\"key\": \"value\"}")
+      end
+    end
+
+    it "keeps backticks that belong to the data" do
+      # The model quotes code it was asked to read; a `snippet` or
+      # `description` value carrying backticks used to have them deleted
+      # from the payload by a whole-string gsub.
+      input = %({"snippet": "run `ls` first", "fence": "```json"})
+      LLM.strip_json_fences(input).should eq(input)
+    end
+
+    it "keeps interior backticks when the payload is also fenced" do
+      input = "```json\n" + %({"snippet": "use ``` to fence"}) + "\n```"
+      LLM.strip_json_fences(input).should eq(%({"snippet": "use ``` to fence"}))
+    end
+
+    it "leaves a fence-free payload that merely ends with backticks alone" do
+      input = %({"snippet": "trailing ```"})
+      LLM.strip_json_fences(input).should eq(input)
+    end
   end
 end

--- a/spec/unit_test/models/passive_scan_spec.cr
+++ b/spec/unit_test/models/passive_scan_spec.cr
@@ -32,7 +32,11 @@ describe "PassiveScan" do
       info = PassiveScan::Info.new(yaml)
 
       info.name.should eq("Minimal Info")
-      info.severity.should eq("low")
+      # Left empty rather than defaulted — see `PassiveScan#validation_errors`,
+      # which rejects the rule by name. Any default below the `high` the
+      # `--passive-scan-severity` option ships with would silently filter the
+      # rule out instead.
+      info.severity.should eq("")
       info.description.should eq("")
       info.author.should eq([] of YAML::Any)
       info.reference.should eq([] of YAML::Any)
@@ -208,7 +212,7 @@ describe "PassiveScan" do
       scan.valid?.should be_true
     end
 
-    it "defaults missing severity to 'low'" do
+    it "rejects a rule with no declared severity, naming the field" do
       yaml_str = <<-YAML
         id: "test-default-sev"
         info:
@@ -227,8 +231,14 @@ describe "PassiveScan" do
       yaml = YAML.parse(yaml_str)
       scan = PassiveScan.new(yaml)
 
-      scan.info.severity.should eq("low")
-      scan.valid?.should be_true
+      # A rule that declares no severity cannot be filtered meaningfully:
+      # the default `--passive-scan-severity` threshold is `high`, so any
+      # default the loader picked below that would drop the rule from every
+      # report without saying so. Rejecting it at load is the visible
+      # failure — `load_rules` warns and the count excludes it.
+      scan.info.severity.should eq("")
+      scan.valid?.should be_false
+      scan.validation_errors.should contain("missing 'info.severity' (expected critical, high, medium, low)")
     end
 
     it "normalizes uppercase matchers-condition to lowercase" do

--- a/spec/unit_test/models/passive_scan_spec.cr
+++ b/spec/unit_test/models/passive_scan_spec.cr
@@ -32,7 +32,7 @@ describe "PassiveScan" do
       info = PassiveScan::Info.new(yaml)
 
       info.name.should eq("Minimal Info")
-      info.severity.should eq("info")
+      info.severity.should eq("low")
       info.description.should eq("")
       info.author.should eq([] of YAML::Any)
       info.reference.should eq([] of YAML::Any)
@@ -103,6 +103,7 @@ describe "PassiveScan" do
       matcher = PassiveScan::Matcher.new(yaml)
 
       matcher.valid?.should be_false
+      matcher.validation_errors.should contain("invalid type \"keyword\" (expected 'word' or 'regex')")
     end
 
     it "rejects invalid matcher condition" do
@@ -116,6 +117,7 @@ describe "PassiveScan" do
       matcher = PassiveScan::Matcher.new(yaml)
 
       matcher.valid?.should be_false
+      matcher.validation_errors.should contain("invalid condition \"xor\" (expected 'and' or 'or')")
     end
 
     it "rejects empty patterns list" do
@@ -128,6 +130,7 @@ describe "PassiveScan" do
       matcher = PassiveScan::Matcher.new(yaml)
 
       matcher.valid?.should be_false
+      matcher.validation_errors.should contain("missing or empty 'patterns'")
     end
 
     it "sets regex_compile_failed for invalid regex patterns" do
@@ -205,6 +208,29 @@ describe "PassiveScan" do
       scan.valid?.should be_true
     end
 
+    it "defaults missing severity to 'low'" do
+      yaml_str = <<-YAML
+        id: "test-default-sev"
+        info:
+          name: "Default Severity Rule"
+          author: []
+          description: ""
+          reference: []
+        matchers:
+          - type: "word"
+            patterns:
+              - "secret"
+            condition: "or"
+        category: "security"
+        techs: []
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.info.severity.should eq("low")
+      scan.valid?.should be_true
+    end
+
     it "normalizes uppercase matchers-condition to lowercase" do
       yaml_str = <<-YAML
         id: "test-upper-condition"
@@ -260,6 +286,30 @@ describe "PassiveScan" do
       scan.valid?.should be_true
     end
 
+    it "rejects scan with unrecognized severity" do
+      yaml_str = <<-YAML
+        id: "test-bad-sev"
+        info:
+          name: "Bad Severity Rule"
+          author: []
+          severity: "unknown_level"
+          description: ""
+          reference: []
+        matchers:
+          - type: "word"
+            patterns:
+              - "secret"
+            condition: "or"
+        category: "security"
+        techs: []
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.valid?.should be_false
+      scan.validation_errors.should contain("invalid severity \"unknown_level\" (expected critical, high, medium, low)")
+    end
+
     it "rejects scan with invalid matcher type (e.g. keyword)" do
       yaml_str = <<-YAML
         id: "test-invalid-type"
@@ -283,6 +333,7 @@ describe "PassiveScan" do
       scan = PassiveScan.new(yaml)
 
       scan.valid?.should be_false
+      scan.validation_errors.should contain("matcher[0]: invalid type \"keyword\" (expected 'word' or 'regex')")
     end
 
     it "rejects scan with invalid matchers-condition" do
@@ -309,6 +360,7 @@ describe "PassiveScan" do
       scan = PassiveScan.new(yaml)
 
       scan.valid?.should be_false
+      scan.validation_errors.should contain("invalid matchers-condition \"invalid\" (expected 'and' or 'or')")
     end
 
     it "rejects scan with empty id" do
@@ -332,6 +384,7 @@ describe "PassiveScan" do
       scan = PassiveScan.new(yaml)
 
       scan.valid?.should be_false
+      scan.validation_errors.should contain("missing or empty 'id'")
     end
 
     it "rejects scan with empty info name" do
@@ -355,6 +408,7 @@ describe "PassiveScan" do
       scan = PassiveScan.new(yaml)
 
       scan.valid?.should be_false
+      scan.validation_errors.should contain("missing or empty 'info.name'")
     end
 
     it "rejects scan with empty matchers" do
@@ -374,6 +428,7 @@ describe "PassiveScan" do
       scan = PassiveScan.new(yaml)
 
       scan.valid?.should be_false
+      scan.validation_errors.should contain("missing or empty 'matchers'")
     end
   end
 

--- a/spec/unit_test/models/passive_scan_spec.cr
+++ b/spec/unit_test/models/passive_scan_spec.cr
@@ -24,6 +24,19 @@ describe "PassiveScan" do
       info.author.size.should eq(1)
       info.reference.size.should eq(1)
     end
+    it "handles missing optional fields with defaults" do
+      yaml_str = <<-YAML
+        name: "Minimal Info"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      info = PassiveScan::Info.new(yaml)
+
+      info.name.should eq("Minimal Info")
+      info.severity.should eq("info")
+      info.description.should eq("")
+      info.author.should eq([] of YAML::Any)
+      info.reference.should eq([] of YAML::Any)
+    end
   end
 
   describe "Matcher" do
@@ -40,6 +53,95 @@ describe "PassiveScan" do
       matcher.type.should eq("regex")
       matcher.patterns.size.should eq(1)
       matcher.condition.should eq("or")
+      matcher.valid?.should be_true
+      matcher.regex_compile_failed?.should be_false
+      matcher.compiled_regex.should_not be_nil
+    end
+
+    it "normalizes uppercase type and condition to lowercase" do
+      yaml_str = <<-YAML
+        type: "REGEX"
+        patterns:
+          - "test.*pattern"
+        condition: "OR"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      matcher = PassiveScan::Matcher.new(yaml)
+
+      matcher.type.should eq("regex")
+      matcher.condition.should eq("or")
+      matcher.valid?.should be_true
+      matcher.compiled_regex.should_not be_nil
+    end
+
+    it "compiles individual regexes for condition: and" do
+      yaml_str = <<-YAML
+        type: "regex"
+        patterns:
+          - "pattern1"
+          - "pattern2"
+        condition: "AND"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      matcher = PassiveScan::Matcher.new(yaml)
+
+      matcher.type.should eq("regex")
+      matcher.condition.should eq("and")
+      matcher.valid?.should be_true
+      matcher.compiled_regexes.should_not be_nil
+      matcher.compiled_regexes.try(&.size).should eq(2)
+    end
+
+    it "rejects invalid matcher type" do
+      yaml_str = <<-YAML
+        type: "keyword"
+        patterns:
+          - "test"
+        condition: "or"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      matcher = PassiveScan::Matcher.new(yaml)
+
+      matcher.valid?.should be_false
+    end
+
+    it "rejects invalid matcher condition" do
+      yaml_str = <<-YAML
+        type: "word"
+        patterns:
+          - "test"
+        condition: "xor"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      matcher = PassiveScan::Matcher.new(yaml)
+
+      matcher.valid?.should be_false
+    end
+
+    it "rejects empty patterns list" do
+      yaml_str = <<-YAML
+        type: "word"
+        patterns: []
+        condition: "or"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      matcher = PassiveScan::Matcher.new(yaml)
+
+      matcher.valid?.should be_false
+    end
+
+    it "sets regex_compile_failed for invalid regex patterns" do
+      yaml_str = <<-YAML
+        type: "regex"
+        patterns:
+          - "[unterminated"
+        condition: "or"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      matcher = PassiveScan::Matcher.new(yaml)
+
+      matcher.regex_compile_failed?.should be_true
+      matcher.compiled_regex.should be_nil
     end
   end
 
@@ -74,6 +176,61 @@ describe "PassiveScan" do
       scan.matchers.size.should eq(1)
       scan.category.should eq("security")
       scan.techs.size.should eq(1)
+      scan.valid?.should be_true
+    end
+
+    it "defaults missing matchers-condition to 'or'" do
+      yaml_str = <<-YAML
+        id: "test-single-matcher"
+        info:
+          name: "Single Matcher Rule"
+          author:
+            - "Test Author"
+          severity: "high"
+          description: "Test description"
+          reference: []
+        matchers:
+          - type: "word"
+            patterns:
+              - "secret"
+            condition: "or"
+        category: "security"
+        techs:
+          - "javascript"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.matchers_condition.should eq("or")
+      scan.valid?.should be_true
+    end
+
+    it "normalizes uppercase matchers-condition to lowercase" do
+      yaml_str = <<-YAML
+        id: "test-upper-condition"
+        info:
+          name: "Upper Condition Rule"
+          author:
+            - "Test Author"
+          severity: "high"
+          description: "Test description"
+          reference: []
+        matchers-condition: "AND"
+        matchers:
+          - type: "word"
+            patterns:
+              - "secret"
+            condition: "OR"
+        category: "security"
+        techs:
+          - "javascript"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.matchers_condition.should eq("and")
+      scan.matchers[0].condition.should eq("or")
+      scan.valid?.should be_true
     end
 
     it "validates valid scan" do
@@ -101,6 +258,122 @@ describe "PassiveScan" do
       scan = PassiveScan.new(yaml)
 
       scan.valid?.should be_true
+    end
+
+    it "rejects scan with invalid matcher type (e.g. keyword)" do
+      yaml_str = <<-YAML
+        id: "test-invalid-type"
+        info:
+          name: "Invalid Type Rule"
+          author:
+            - "Test Author"
+          severity: "high"
+          description: "Test description"
+          reference: []
+        matchers:
+          - type: "keyword"
+            patterns:
+              - "secret"
+            condition: "or"
+        category: "security"
+        techs:
+          - "javascript"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.valid?.should be_false
+    end
+
+    it "rejects scan with invalid matchers-condition" do
+      yaml_str = <<-YAML
+        id: "test-invalid-condition"
+        info:
+          name: "Invalid Condition Rule"
+          author:
+            - "Test Author"
+          severity: "high"
+          description: "Test description"
+          reference: []
+        matchers-condition: "invalid"
+        matchers:
+          - type: "word"
+            patterns:
+              - "secret"
+            condition: "or"
+        category: "security"
+        techs:
+          - "javascript"
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.valid?.should be_false
+    end
+
+    it "rejects scan with empty id" do
+      yaml_str = <<-YAML
+        id: ""
+        info:
+          name: "Test Rule"
+          author: []
+          severity: "high"
+          description: ""
+          reference: []
+        matchers:
+          - type: "word"
+            patterns:
+              - "secret"
+            condition: "or"
+        category: "security"
+        techs: []
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.valid?.should be_false
+    end
+
+    it "rejects scan with empty info name" do
+      yaml_str = <<-YAML
+        id: "test-id"
+        info:
+          name: ""
+          author: []
+          severity: "high"
+          description: ""
+          reference: []
+        matchers:
+          - type: "word"
+            patterns:
+              - "secret"
+            condition: "or"
+        category: "security"
+        techs: []
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.valid?.should be_false
+    end
+
+    it "rejects scan with empty matchers" do
+      yaml_str = <<-YAML
+        id: "test-id"
+        info:
+          name: "Test Rule"
+          author: []
+          severity: "high"
+          description: ""
+          reference: []
+        matchers: []
+        category: "security"
+        techs: []
+        YAML
+      yaml = YAML.parse(yaml_str)
+      scan = PassiveScan.new(yaml)
+
+      scan.valid?.should be_false
     end
   end
 

--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -3,6 +3,25 @@ require "../../src/tagger/tagger"
 require "../../src/techs/techs"
 require "../../src/options.cr"
 
+# Runs `run_options_parser` against a temporary `--config-file` plus the given
+# CLI arguments, so a spec can pin the config-vs-CLI precedence of one flag.
+# ARGV and the temp file are restored/removed either way.
+private def with_config_argv(config_body : String, args : Array(String), &)
+  config_path = File.tempname("noir-precedence-", ".yaml")
+  File.write(config_path, config_body)
+  original_argv = ARGV.dup
+
+  ARGV.clear
+  ARGV.concat(["-b", "./app", "--config-file", config_path] + args)
+  begin
+    yield run_options_parser
+  ensure
+    ARGV.clear
+    ARGV.concat(original_argv)
+    File.delete?(config_path)
+  end
+end
+
 describe "default_options" do
   it "init" do
     noir_options = create_test_options
@@ -402,6 +421,121 @@ describe "run_options_parser" do
     ensure
       ARGV.clear
       ARGV.concat(original_argv)
+    end
+  end
+
+  # `append_to_csv_option`'s own comment states the rule — "First CLI
+  # occurrence of this flag replaces any config-file value outright (CLI wins
+  # over config, not `config,cli`)" — but `reset_seen:` was passed at exactly
+  # one call site. Every other CSV flag concatenated onto the config value.
+  # For `--only-techs` that *inverted* the flag: the CLI widened the
+  # restriction instead of replacing it, and there was no way to override a
+  # config-file `only_techs` from the command line at all.
+  #
+  # The four cases below are the whole contract: the reset is per-flag and
+  # fires once, on the transition from config to CLI. A second occurrence of
+  # the same flag on one command line must still accumulate.
+  describe "CSV flags override the config file rather than appending to it" do
+    csv_cases = [
+      {flag: "--exclude-codes", key: "exclude_codes", config: "404", first: "500", second: "418"},
+      {flag: "--exclude-path", key: "exclude_path", config: "*.md", first: "*.js", second: "*.ts"},
+      {flag: "--use-taggers", key: "use_taggers", config: "cors", first: "oauth", second: "hunt"},
+      {flag: "-t", key: "techs", config: "ruby_rails", first: "python_flask", second: "php_pure"},
+      {flag: "--only-techs", key: "only_techs", config: "ruby_rails", first: "python_flask", second: "php_pure"},
+      {flag: "--exclude-techs", key: "exclude_techs", config: "ruby_rails", first: "python_flask", second: "php_pure"},
+    ]
+
+    csv_cases.each do |c|
+      it "#{c[:flag]}: config-only value is kept when the flag is absent" do
+        with_config_argv("#{c[:key]}: \"#{c[:config]}\"\n", [] of String) do |options|
+          options[c[:key]].to_s.should eq(c[:config])
+        end
+      end
+
+      it "#{c[:flag]}: one CLI occurrence replaces the config value" do
+        with_config_argv("#{c[:key]}: \"#{c[:config]}\"\n", [c[:flag], c[:first]]) do |options|
+          options[c[:key]].to_s.should eq(c[:first])
+        end
+      end
+
+      it "#{c[:flag]}: two CLI occurrences accumulate with each other, not with the config" do
+        args = [c[:flag], c[:first], c[:flag], c[:second]]
+        with_config_argv("#{c[:key]}: \"#{c[:config]}\"\n", args) do |options|
+          options[c[:key]].to_s.should eq("#{c[:first]},#{c[:second]}")
+        end
+      end
+
+      it "#{c[:flag]}: repeated CLI flags still accumulate with no config file" do
+        original_argv = ARGV.dup
+        ARGV.clear
+        ARGV.concat(["-b", "./app", c[:flag], c[:first], c[:flag], c[:second]])
+        begin
+          run_options_parser[c[:key]].to_s.should eq("#{c[:first]},#{c[:second]}")
+        ensure
+          ARGV.clear
+          ARGV.concat(original_argv)
+        end
+      end
+    end
+
+    # The reset is keyed per flag, so one flag's first occurrence must not
+    # clear a different flag's config value.
+    it "resets only the flag that was actually passed" do
+      body = "only_techs: \"ruby_rails\"\nexclude_path: \"*.md\"\n"
+      with_config_argv(body, ["--only-techs", "python_flask"]) do |options|
+        options["only_techs"].to_s.should eq("python_flask")
+        options["exclude_path"].to_s.should eq("*.md")
+      end
+    end
+  end
+
+  # In v0 these were real `parser.on "--set-pvalue VALUE"` entries, so
+  # Crystal's OptionParser accepted both spellings. The v1 hand-rolled
+  # extractor only matched the bare token, so the `=` form fell through to
+  # `invalid_option` and hard-failed — while
+  # `Noir::CLI::Legacy.translate_flag_aliases` *does* handle `=` for the
+  # probe aliases, leaving the two legacy layers disagreeing.
+  describe "legacy --set-pvalue= (equals form)" do
+    it "accepts the = form for every LEGACY_PVALUE_TARGETS entry" do
+      Noir::OptionsParsing::LEGACY_PVALUE_TARGETS.each do |flag, key|
+        opts = create_test_options
+        remaining = Noir::OptionsParsing.extract_legacy_aliases(["#{flag}=EQ_VALUE"], opts)
+        remaining.should be_empty
+        opts[key].as_a.map(&.to_s).should eq(["EQ_VALUE"])
+      end
+    end
+
+    it "splits on the first = only, so a VALUE containing = survives" do
+      opts = create_test_options
+      Noir::OptionsParsing.extract_legacy_aliases(["--set-pvalue-query=key=val"], opts)
+      opts["set_pvalue_query"].as_a.map(&.to_s).should eq(["key=val"])
+    end
+
+    it "mixes with the bare form and accumulates" do
+      opts = create_test_options
+      Noir::OptionsParsing.extract_legacy_aliases(
+        ["--set-pvalue", "BARE", "--set-pvalue=EQ"],
+        opts,
+      )
+      opts["set_pvalue"].as_a.map(&.to_s).should eq(["BARE", "EQ"])
+    end
+
+    it "leaves an unrelated = token for OptionParser" do
+      opts = create_test_options
+      remaining = Noir::OptionsParsing.extract_legacy_aliases(["--format=json"], opts)
+      remaining.should eq(["--format=json"])
+    end
+
+    it "reaches noir_options through the full parser" do
+      original_argv = ARGV.dup
+      ARGV.clear
+      ARGV.concat(["-b", "./app", "--set-pvalue=abc"])
+      begin
+        run_options_parser["set_pvalue"].as_a.map(&.to_s).should eq(["abc"])
+      ensure
+        ARGV.clear
+        ARGV.concat(original_argv)
+      end
     end
   end
 

--- a/spec/unit_test/passive_scan/detect_spec.cr
+++ b/spec/unit_test/passive_scan/detect_spec.cr
@@ -49,6 +49,31 @@ describe NoirPassiveScan do
       filtered.size.should eq(1)
       filtered.first.info.name.should eq("High Rule")
     end
+
+    it "filters out a rule with no declared severity when min_severity is critical (defaults to low)" do
+      no_sev_rule_yaml = <<-YAML
+        id: test-no-sev
+        category: sec
+        techs: []
+        info:
+          name: No Severity Rule
+          author: []
+          description: no severity specified
+          reference: []
+        matchers:
+          - type: word
+            condition: or
+            patterns:
+              - secret
+        matchers-condition: or
+        YAML
+
+      no_sev_rule = PassiveScan.new(YAML.parse(no_sev_rule_yaml))
+      no_sev_rule.info.severity.should eq("low")
+
+      filtered = NoirPassiveScan.filter_rules_by_severity([no_sev_rule], "critical")
+      filtered.should be_empty
+    end
   end
 
   describe ".detect" do

--- a/spec/unit_test/passive_scan/detect_spec.cr
+++ b/spec/unit_test/passive_scan/detect_spec.cr
@@ -50,7 +50,7 @@ describe NoirPassiveScan do
       filtered.first.info.name.should eq("High Rule")
     end
 
-    it "filters out a rule with no declared severity when min_severity is critical (defaults to low)" do
+    it "treats a rule with no declared severity as invalid rather than filtering it silently" do
       no_sev_rule_yaml = <<-YAML
         id: test-no-sev
         category: sec
@@ -69,10 +69,12 @@ describe NoirPassiveScan do
         YAML
 
       no_sev_rule = PassiveScan.new(YAML.parse(no_sev_rule_yaml))
-      no_sev_rule.info.severity.should eq("low")
 
-      filtered = NoirPassiveScan.filter_rules_by_severity([no_sev_rule], "critical")
-      filtered.should be_empty
+      # `load_rules` drops it and warns, so it never reaches the severity
+      # filter at all. That is the point: a rule silently filtered out reads
+      # exactly like a rule that found nothing.
+      no_sev_rule.info.severity.should eq("")
+      no_sev_rule.valid?.should be_false
     end
   end
 

--- a/spec/unit_test/passive_scan/detect_spec.cr
+++ b/spec/unit_test/passive_scan/detect_spec.cr
@@ -107,5 +107,74 @@ describe NoirPassiveScan do
       results = NoirPassiveScan.detect("config.py", content, [rule], logger)
       results.size.should eq(1)
     end
+
+    it "detects matches with omitted matchers-condition on single matcher" do
+      rule_yaml = <<-YAML
+        id: test-single
+        category: sec
+        techs: []
+        info:
+          name: Single Matcher Rule
+          author: []
+          severity: high
+          description: single matcher
+          reference: []
+        matchers:
+          - type: word
+            condition: or
+            patterns:
+              - MY_SECRET_TOKEN
+        YAML
+      rule = PassiveScan.new(YAML.parse(rule_yaml))
+      content = "MY_SECRET_TOKEN = 'abc123xyz'"
+
+      results = NoirPassiveScan.detect("config.py", content, [rule], logger)
+      results.size.should eq(1)
+      results.first.extract.should contain("MY_SECRET_TOKEN")
+    end
+
+    it "detects matches with uppercase condition: OR and type: WORD / REGEX" do
+      word_rule_yaml = <<-YAML
+        id: test-upper-word
+        category: sec
+        techs: []
+        info:
+          name: Upper Word Rule
+          author: []
+          severity: high
+          description: uppercase condition
+          reference: []
+        matchers-condition: OR
+        matchers:
+          - type: WORD
+            condition: OR
+            patterns:
+              - TARGET_STRING
+        YAML
+      regex_rule_yaml = <<-YAML
+        id: test-upper-regex
+        category: sec
+        techs: []
+        info:
+          name: Upper Regex Rule
+          author: []
+          severity: high
+          description: uppercase regex
+          reference: []
+        matchers-condition: OR
+        matchers:
+          - type: REGEX
+            condition: OR
+            patterns:
+              - "TOKEN_[A-Z0-9]{8}"
+        YAML
+      word_rule = PassiveScan.new(YAML.parse(word_rule_yaml))
+      regex_rule = PassiveScan.new(YAML.parse(regex_rule_yaml))
+      content = "TARGET_STRING\nTOKEN_ABCD1234"
+
+      results = NoirPassiveScan.detect("test.txt", content, [word_rule, regex_rule], logger)
+      results.size.should eq(2)
+      results.map(&.id).should eq(["test-upper-word", "test-upper-regex"])
+    end
   end
 end

--- a/spec/unit_test/passive_scan/rules_spec.cr
+++ b/spec/unit_test/passive_scan/rules_spec.cr
@@ -143,5 +143,145 @@ describe NoirPassiveScan do
         FileUtils.rm_rf(temp_dir)
       end
     end
+
+    it "loads a single-matcher rule omitting matchers-condition" do
+      temp_dir = File.tempname
+      Dir.mkdir(temp_dir)
+      begin
+        yaml = <<-YAML
+          id: single-matcher-rule
+          info:
+            name: Single Matcher Rule
+            author: [me]
+            severity: low
+            description: A test rule without matchers-condition
+            reference: []
+          matchers:
+            - type: word
+              patterns:
+                - test
+              condition: or
+          category: info
+          techs:
+            - '*'
+          YAML
+
+        File.write(File.join(temp_dir, "rule.yaml"), yaml)
+
+        logger = NoirLogger.new(false, false, false, true)
+        rules = NoirPassiveScan.load_rules(temp_dir, logger)
+
+        rules.size.should eq(1)
+        rules[0].id.should eq("single-matcher-rule")
+        rules[0].matchers_condition.should eq("or")
+      ensure
+        FileUtils.rm_rf(temp_dir)
+      end
+    end
+
+    it "loads a rule with uppercase condition: OR" do
+      temp_dir = File.tempname
+      Dir.mkdir(temp_dir)
+      begin
+        yaml = <<-YAML
+          id: upper-or-rule
+          info:
+            name: Upper OR Rule
+            author: [me]
+            severity: low
+            description: A test rule with uppercase condition
+            reference: []
+          matchers-condition: OR
+          matchers:
+            - type: WORD
+              patterns:
+                - test
+              condition: OR
+          category: info
+          techs:
+            - '*'
+          YAML
+
+        File.write(File.join(temp_dir, "rule.yaml"), yaml)
+
+        logger = NoirLogger.new(false, false, false, true)
+        rules = NoirPassiveScan.load_rules(temp_dir, logger)
+
+        rules.size.should eq(1)
+        rules[0].id.should eq("upper-or-rule")
+        rules[0].matchers_condition.should eq("or")
+        rules[0].matchers[0].condition.should eq("or")
+      ensure
+        FileUtils.rm_rf(temp_dir)
+      end
+    end
+
+    it "skips an invalid rule with mistyped matcher type (e.g. keyword)" do
+      temp_dir = File.tempname
+      Dir.mkdir(temp_dir)
+      begin
+        yaml = <<-YAML
+          id: invalid-type-rule
+          info:
+            name: Invalid Type Rule
+            author: [me]
+            severity: low
+            description: A test rule with invalid matcher type
+            reference: []
+          matchers-condition: and
+          matchers:
+            - type: keyword
+              patterns:
+                - test
+              condition: or
+          category: info
+          techs:
+            - '*'
+          YAML
+
+        File.write(File.join(temp_dir, "rule.yaml"), yaml)
+
+        logger = NoirLogger.new(false, false, false, true)
+        rules = NoirPassiveScan.load_rules(temp_dir, logger)
+
+        rules.size.should eq(0)
+      ensure
+        FileUtils.rm_rf(temp_dir)
+      end
+    end
+
+    it "skips an invalid rule with mistyped matcher condition" do
+      temp_dir = File.tempname
+      Dir.mkdir(temp_dir)
+      begin
+        yaml = <<-YAML
+          id: invalid-condition-rule
+          info:
+            name: Invalid Condition Rule
+            author: [me]
+            severity: low
+            description: A test rule with invalid condition
+            reference: []
+          matchers-condition: and
+          matchers:
+            - type: word
+              patterns:
+                - test
+              condition: xor
+          category: info
+          techs:
+            - '*'
+          YAML
+
+        File.write(File.join(temp_dir, "rule.yaml"), yaml)
+
+        logger = NoirLogger.new(false, false, false, true)
+        rules = NoirPassiveScan.load_rules(temp_dir, logger)
+
+        rules.size.should eq(0)
+      ensure
+        FileUtils.rm_rf(temp_dir)
+      end
+    end
   end
 end

--- a/src/cli/commands/completion.cr
+++ b/src/cli/commands/completion.cr
@@ -9,28 +9,63 @@ module Noir::CLI::CompletionCommand
   SHELLS = Noir::CLI::Catalog::SHELLS
 
   # Parsed argv. Extracted from `run` so the parser stays unit-testable
-  # without going through the `exit`/`die` side effects.
-  record Parsed, shell : String?, help : Bool
+  # without going through the `exit`/`die` side effects. `error` is
+  # recorded rather than raised so `run` can turn it into a clean
+  # `Noir::CLI.die` line.
+  record Parsed, shell : String?, help : Bool, error : String?
 
   def self.parse_argv(argv : Array(String)) : Parsed
     shell = nil
     help = false
+    error = nil
+    rest = [] of String
+
     argv.each do |a|
       case a
       when "-h", "--help"
         help = true
+      when "--no-color", "--no-spinner"
+        # Global flags — the router consumes both before dispatching here.
+        # Accepted (not rejected as unknown) so a direct `run` call and a
+        # future router change both behave.
       else
-        # Shell names are matched case-insensitively (`ZSH` == `zsh`).
-        shell ||= a.downcase
+        if a.starts_with?("-")
+          # Silently ignoring an unknown flag meant `noir completion zsh
+          # --oops` emitted a script and exited 0, hiding the typo.
+          error ||= "Unknown option: #{a}. Run `noir completion --help`."
+        elsif shell.nil?
+          # Shell names are matched case-insensitively (`ZSH` == `zsh`).
+          shell = a.downcase
+        else
+          rest << a
+        end
       end
     end
-    Parsed.new(shell: shell, help: help)
+
+    # `noir completion zsh bash` used to emit zsh only, exit 0, and leave
+    # the user's bash completion silently unwritten. `cache` and `rules`
+    # already reject surplus positionals; so does this now.
+    if error.nil? && !rest.empty?
+      plural = rest.size > 1 ? "s" : ""
+      error = "Unexpected argument#{plural}: #{rest.join(", ")}. Usage: noir completion <shell>"
+    end
+
+    Parsed.new(shell: shell, help: help, error: error)
   end
 
   def self.run(argv : Array(String))
     parsed = parse_argv(argv)
 
-    if parsed.help || parsed.shell.nil?
+    if parsed.help
+      print_help
+      exit
+    end
+
+    if err = parsed.error
+      Noir::CLI.die(err)
+    end
+
+    if parsed.shell.nil?
       print_help
       exit
     end

--- a/src/cli/commands/config.cr
+++ b/src/cli/commands/config.cr
@@ -11,33 +11,100 @@ require "../../utils/home"
 module Noir::CLI::ConfigCommand
   ACTIONS = Noir::CLI::Catalog::CONFIG_ACTIONS
 
-  def self.run(argv : Array(String))
+  # Parsed argv. Extracted from `run` (mirroring `CacheCommand.parse_argv`)
+  # so the parsing rules stay unit-testable — `run` keeps the `exit`/`die`
+  # side effects. `error` is recorded rather than raised so `run` can turn
+  # it into a clean `Noir::CLI.die` line.
+  record Parsed,
+    action : String?,
+    override_path : String?,
+    help : Bool,
+    error : String?
+
+  def self.parse_argv(argv : Array(String)) : Parsed
     action = nil
     override_path = nil
+    help = false
+    error = nil
+    rest = [] of String
+
     i = 0
     while i < argv.size
       a = argv[i]
       case a
       when "-h", "--help"
-        print_help
-        exit
+        help = true
+      when "--no-color", "--no-spinner"
+        # Global flags — the router consumes both before dispatching here.
+        # Accepted (not rejected as unknown) so a direct `run` call and a
+        # future router change both behave.
       when "--config-file"
         # Honor the global --config-file flag inside the subcommand so
         # `noir config show --config-file X` reads X, not the default path.
-        override_path = argv[i + 1]?
-        i += 1
+        #
+        # A missing value used to fall through as `nil` and silently
+        # resolve the DEFAULT path — so `noir config show --config-file`
+        # printed a different file than the one the user asked to inspect,
+        # and `edit` would have created it. Every other --config-file
+        # consumer errors here; so does this one now.
+        value = argv[i + 1]?
+        if value.nil? || value.empty? || value.starts_with?("-")
+          error ||= "--config-file requires an argument."
+        else
+          override_path = value
+          i += 1
+        end
       when .starts_with?("--config-file=")
-        override_path = a.split("=", 2)[1]
+        value = a.split("=", 2)[1]
+        if value.empty?
+          error ||= "--config-file requires an argument."
+        else
+          override_path = value
+        end
       else
-        action ||= a
+        if a.starts_with?("-")
+          # An unknown flag used to be taken as a positional and then
+          # dropped, so `noir config show --bogus` ran `show` and exited 0.
+          error ||= "Unknown option: #{a}. Run `noir config --help`."
+        elsif action.nil?
+          action = a
+        else
+          rest << a
+        end
       end
       i += 1
     end
 
+    # Surplus positionals were dropped too: `noir config path init` quietly
+    # ran only `path`. Surface them instead of guessing which was meant —
+    # `cache` and `rules` already do.
+    if error.nil? && !rest.empty?
+      plural = rest.size > 1 ? "s" : ""
+      error = "Unexpected argument#{plural}: #{rest.join(", ")}. `noir config` takes a single action."
+    end
+
+    Parsed.new(action: action, override_path: override_path, help: help, error: error)
+  end
+
+  def self.run(argv : Array(String))
+    parsed = parse_argv(argv)
+
+    if parsed.help
+      print_help
+      exit
+    end
+
+    if err = parsed.error
+      Noir::CLI.die(err)
+    end
+
+    action = parsed.action
     if action.nil?
       print_help
       exit
     end
+
+    override_path = parsed.override_path
 
     case action
     when "show" then show(override_path)
@@ -206,8 +273,14 @@ module Noir::CLI::ConfigCommand
     end
   end
 
+  # `home: true` for the same reason `Noir::Home.path` uses it: a leading
+  # `~` only gets expanded by an interactive shell, and `--config-file`
+  # values routinely arrive from places that never do — the `=` form
+  # (`--config-file=~/x.yaml`) is not tilde-expanded by most shells, and
+  # Docker/systemd/CI wrappers don't expand at all. Without it the path
+  # resolved to a literal `~` directory under the cwd.
   def self.config_path(override : String? = nil) : String
-    return File.expand_path(override) if override && !override.empty?
+    return File.expand_path(override, home: true) if override && !override.empty?
     File.expand_path(File.join(Noir::Home.path, "config.yaml"))
   end
 

--- a/src/cli/commands/help.cr
+++ b/src/cli/commands/help.cr
@@ -81,7 +81,8 @@ module Noir::CLI::HelpCommand
       #{green.call("GLOBAL FLAGS:")}
         --no-color        Strip ANSI color from every command's output (NO_COLOR env also works)
         --no-spinner      Disable loading spinner animations while keeping normal logs
-        -v, -V, --version Print the noir version and exit (alias for `noir version`)
+        -v, -V, --version Print the noir version and exit; after a verb, use `noir version`
+                          (a subcommand's own -v is its own — e.g. `noir rules update -v`)
         -h, --help        Show this overview, or, after a verb, that command's help
 
       Run `noir help <command>` (or `noir <command> -h`) for command-specific flags.

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -45,15 +45,33 @@ module Noir::CLI::ScanCommand
       ARGV.concat(saved)
     end
 
-    execute(noir_options)
+    # `args_copy`, not `noir_options`, is what says which settings the user
+    # typed on this command line: by the time the parser returns, a
+    # config-file value and a CLI flag are the same entry in the same hash.
+    execute(noir_options, args_copy)
   end
 
-  private def self.execute(noir_options : Hash(String, YAML::Any))
+  # Long-flag tokens present on the command line, with `--flag=value`
+  # reduced to `--flag`. The only question asked of it is "did the user
+  # type this flag?", which is why the values are dropped.
+  def self.cli_flag_names(argv : Array(String)) : Set(String)
+    names = Set(String).new
+    argv.each do |arg|
+      next unless arg.starts_with?("-")
+      names << (arg.index('=') ? arg.split("=", 2)[0] : arg)
+    end
+    names
+  end
+
+  private def self.execute(noir_options : Hash(String, YAML::Any), argv : Array(String))
+    cli_flags = cli_flag_names(argv)
+
     apply_cache_flags(noir_options)
     apply_prompt_overrides(noir_options)
     normalize_url!(noir_options)
     normalize_probe_via!(noir_options)
-    validate_url_dependent_flags(noir_options)
+    validate_url_dependent_flags(noir_options, cli_flags)
+    validate_exclude_path!(noir_options, argv)
     validate_options!(noir_options)
 
     if noir_options["nolog"] == false
@@ -127,6 +145,11 @@ module Noir::CLI::ScanCommand
     # crashes deep in the socket layer with an opaque error.
     begin
       parsed = URI.parse(url)
+
+      if host_problem = host_error(parsed.host)
+        Noir::CLI.die("-u/--url #{host_problem} in #{url.inspect}. Expected a base URL like http://localhost:3000.")
+      end
+
       if port = parsed.port
         unless (1..65535).includes?(port)
           Noir::CLI.die("-u/--url port #{port} is out of range (1-65535) in '#{url}'.")
@@ -148,6 +171,28 @@ module Noir::CLI::ScanCommand
       STDERR.puts "WARNING: -u/--url should be a base URL — query string / fragment '#{dropped}' would corrupt the per-endpoint URL. Stripping.".colorize(WARNING_COLOR)
       noir_options["url"] = YAML::Any.new(stripped)
     end
+  end
+
+  # Why `-u` needs an authority, not just a scheme: it is the *base* URL
+  # every discovered path is appended to. `URI.parse` is happy without a
+  # host — `-u http://` parses with an empty one — and the concatenation
+  # then promotes the first discovered path segment to the authority, so
+  # `/a` becomes `http://a`. With `--probe` or `--status-codes` that
+  # fires real HTTP requests at a host the user never named.
+  #
+  # Whitespace and control characters are rejected for the same reason
+  # `normalize_probe_via!` rejects a missing host: `-u "not a url"` and
+  # `-u $'http://a\nb/'` are accepted today and baked into every endpoint
+  # of the JSON/OAS/Postman output as an unusable URL.
+  #
+  # Returns nil when the host is usable, otherwise the reason (phrased to
+  # slot into the `-u/--url <reason> in <url>` message).
+  def self.host_error(host : String?) : String?
+    return "has no host" if host.nil? || host.empty?
+    if host.each_char.any? { |c| c.whitespace? || c.control? }
+      return "has whitespace or control characters in the host"
+    end
+    nil
   end
 
   # `--probe-via` is handed to Crest as a `p_addr` / `p_port` pair, and
@@ -207,35 +252,74 @@ module Noir::CLI::ScanCommand
     end
   end
 
-  private def self.validate_url_dependent_flags(noir_options : Hash(String, YAML::Any))
+  # A url-dependent setting the user did NOT type on this command line
+  # came from the config file, which cannot know whether this particular
+  # run has a target URL. Aborting on it bricked every URL-less scan for
+  # anyone with `status_codes:`/`probe:` in their config — a documented
+  # key the generated template lists — and blamed a flag they never
+  # typed. A CLI flag stays a hard usage error; a config value is
+  # downgraded to a warning and switched off for this run.
+  private def self.require_url_or_disable!(noir_options : Hash(String, YAML::Any),
+                                           cli_flags : Set(String),
+                                           flag : String,
+                                           key : String,
+                                           example : String,
+                                           disabled : YAML::Any)
+    if cli_flags.includes?(flag)
+      Noir::CLI.die("#{flag} needs a target URL. Pass it with -u/--url, e.g. `#{example}`.")
+    end
+
+    STDERR.puts "WARNING: config key `#{key}` (#{flag}) needs a target URL; none was given, so it is disabled for this scan. Pass one with -u/--url, or drop `#{key}` from the config file.".colorize(WARNING_COLOR)
+    noir_options[key] = disabled
+  end
+
+  private def self.validate_url_dependent_flags(noir_options : Hash(String, YAML::Any),
+                                                cli_flags : Set(String))
     url = noir_options["url"].to_s
 
-    if noir_options["status_codes"] == true && url.empty?
-      Noir::CLI.die("--status-codes needs a target URL. Pass it with -u/--url, e.g. `noir scan ./app --status-codes -u http://localhost:3000`.")
+    if url.empty?
+      if noir_options["status_codes"] == true
+        require_url_or_disable!(noir_options, cli_flags,
+          flag: "--status-codes", key: "status_codes",
+          example: "noir scan ./app --status-codes -u http://localhost:3000",
+          disabled: YAML::Any.new(false))
+      end
+
+      # `--probe` and `--probe-via` both fire HTTP requests against
+      # `endpoint.url`, which is just the discovered path (e.g. `/sign`)
+      # until `-u/--url` prepends a base. Without `-u` the request URL is
+      # malformed and Crest raises — but the SendReq / SendWithProxy
+      # delivery loops catch + log to debug level only, so the user sees
+      # the normal JSON output with zero requests sent and no warning.
+      # Fail early instead.
+      if noir_options["probe"]? == YAML::Any.new(true)
+        require_url_or_disable!(noir_options, cli_flags,
+          flag: "--probe", key: "probe",
+          example: "noir scan ./app --probe -u http://localhost:3000",
+          disabled: YAML::Any.new(false))
+      end
+
+      probe_via = noir_options["probe_via"]?.try(&.to_s) || ""
+      unless probe_via.empty?
+        require_url_or_disable!(noir_options, cli_flags,
+          flag: "--probe-via", key: "probe_via",
+          example: "noir scan ./app --probe-via #{probe_via} -u http://localhost:3000",
+          disabled: YAML::Any.new(""))
+      end
+
+      unless noir_options["exclude_codes"].to_s.empty?
+        require_url_or_disable!(noir_options, cli_flags,
+          flag: "--exclude-codes", key: "exclude_codes",
+          example: "noir scan ./app --exclude-codes 404,500 -u http://localhost:3000",
+          disabled: YAML::Any.new(""))
+      end
     end
 
-    # `--probe` and `--probe-via` both fire HTTP requests against
-    # `endpoint.url`, which is just the discovered path (e.g. `/sign`)
-    # until `-u/--url` prepends a base. Without `-u` the request URL is
-    # malformed and Crest raises — but the SendReq / SendWithProxy
-    # delivery loops catch + log to debug level only, so the user sees
-    # the normal JSON output with zero requests sent and no warning.
-    # Fail early instead.
-    if noir_options["probe"]? == YAML::Any.new(true) && url.empty?
-      Noir::CLI.die("--probe needs a target URL. Pass it with -u/--url, e.g. `noir scan ./app --probe -u http://localhost:3000`.")
-    end
-
-    probe_via = noir_options["probe_via"]?.try(&.to_s) || ""
-    if !probe_via.empty? && url.empty?
-      Noir::CLI.die("--probe-via needs a target URL. Pass it with -u/--url, e.g. `noir scan ./app --probe-via #{probe_via} -u http://localhost:3000`.")
-    end
-
+    # Runs whether or not a URL was given: a malformed value is a typo
+    # worth reporting even on the config-sourced path above (which leaves
+    # the key empty, so this loop then has nothing to check).
     exclude_codes = noir_options["exclude_codes"].to_s
     return if exclude_codes.empty?
-
-    if url.empty?
-      Noir::CLI.die("--exclude-codes needs a target URL. Pass it with -u/--url, e.g. `noir scan ./app --exclude-codes 404,500 -u http://localhost:3000`.")
-    end
 
     exclude_codes.split(",").each do |code|
       begin
@@ -243,6 +327,85 @@ module Noir::CLI::ScanCommand
       rescue
         Noir::CLI.die("--exclude-codes only accepts comma-separated numbers; got '#{code}'.")
       end
+    end
+  end
+
+  # `--exclude-path` patterns are only interpreted deep inside the
+  # detector's file walk, so a malformed one either aborts the scan
+  # halfway (an unterminated `[`, which at least reports itself) or
+  # silently matches nothing — `'*.{rb'`, `'{'`, `''` and `'  '` were all
+  # accepted and excluded exactly zero files, which from the outside is
+  # indistinguishable from an exclusion that worked. Validate the whole
+  # list at parse time instead, before a single file is read.
+  private def self.validate_exclude_path!(noir_options : Hash(String, YAML::Any),
+                                          argv : Array(String))
+    if blank_exclude_path_arg?(argv)
+      Noir::CLI.die("--exclude-path needs a glob pattern; the value given is empty.")
+    end
+
+    raw = noir_options["exclude_path"]?.try(&.to_s) || ""
+    return if raw.empty?
+
+    raw.split(",").each do |entry|
+      # Normalized exactly the way `Noir::ExcludePath` normalizes it, so
+      # what is validated is what will run.
+      pattern = entry.strip.gsub('\\', '/')
+      if pattern.empty?
+        Noir::CLI.die("--exclude-path contains a blank pattern in #{raw.inspect}; every comma-separated entry must be a glob.")
+      end
+
+      if problem = glob_error(pattern)
+        Noir::CLI.die("--exclude-path contains an invalid glob pattern (#{problem}): #{pattern.inspect}.")
+      end
+    end
+  end
+
+  # `--exclude-path ''` and `--exclude-path=` both collapse to the same
+  # empty string the option carries when it was never passed at all (and
+  # `exclude_path: ""` is in the generated config template), so the fully
+  # blank case can only be read off argv.
+  private def self.blank_exclude_path_arg?(argv : Array(String)) : Bool
+    argv.each_with_index do |arg, i|
+      if arg == "--exclude-path"
+        value = argv[i + 1]?
+        # A missing value is OptionParser's error to report, not ours.
+        return true if value && value.strip.empty?
+      elsif arg.starts_with?("--exclude-path=")
+        return true if arg.split("=", 2)[1].strip.empty?
+      end
+    end
+    false
+  end
+
+  # Returns nil for a usable glob, otherwise the reason it is broken.
+  #
+  # `File.match?` parses the pattern itself, so character-class errors
+  # come back from Crystal with its own wording. Brace groups it accepts
+  # and then never matches (`*.{rb` matches nothing at all), so the
+  # `{`/`}` balance is checked here — skipping over character classes,
+  # inside which a brace is an ordinary character.
+  def self.glob_error(pattern : String) : String?
+    depth = 0
+    in_class = false
+    pattern.each_char do |char|
+      if in_class
+        in_class = false if char == ']'
+      elsif char == '['
+        in_class = true
+      elsif char == '{'
+        depth += 1
+      elsif char == '}'
+        depth -= 1
+        return "unmatched `}`" if depth < 0
+      end
+    end
+    return "unterminated `{` group" if depth > 0
+
+    begin
+      File.match?(pattern, "noir")
+      nil
+    rescue ex : File::BadPatternError
+      ex.message || "invalid pattern"
     end
   end
 

--- a/src/cli/commands/version.cr
+++ b/src/cli/commands/version.cr
@@ -21,6 +21,11 @@ module Noir::CLI::VersionCommand
         help = true
       when "--verbose"
         verbose = true
+      when "-v", "-V", "--version"
+        # The v0 spellings of this very command. They no longer get
+        # rewritten once a verb opens ARGV (see `Legacy.rewrite`), so
+        # accept them here rather than making `noir version -v` — a
+        # redundant but harmless thing to type — die as an unknown option.
       else
         unknown ||= a
       end

--- a/src/cli/legacy.cr
+++ b/src/cli/legacy.cr
@@ -14,11 +14,10 @@ require "./common"
 # them via its own OptionParser. That keeps `noir -b ./app -P` working
 # exactly as it did in v0.
 module Noir::CLI::Legacy
-  # Global short-circuits. The first time any of these appear anywhere
-  # in ARGV the entire invocation is rewritten to the canonical v1
-  # subcommand call, so flags that are inherently global (`-v`,
-  # `--version`) behave the same no matter whether the user typed them
-  # before, after, or in place of a verb.
+  # Global short-circuits for *v0-shaped* invocations. v0 had no verb,
+  # so these flags could sit anywhere in ARGV; the first one found
+  # rewrites the whole invocation to the canonical v1 subcommand call.
+  # A v1 invocation that opens with a verb is exempt — see `rewrite`.
   TERMINAL_REWRITES = {
     "--list-techs"   => ["list", "techs"],
     "--list-taggers" => ["list", "taggers"],
@@ -45,9 +44,34 @@ module Noir::CLI::Legacy
     "--use-filters"  => "--probe-skip",
   }
 
+  # True when ARGV opens with a v1 verb, i.e. exactly the shape the
+  # router dispatches to a subcommand (`head` must be in
+  # `KNOWN_COMMANDS`). Everything after that verb is that subcommand's
+  # own argv and must reach its own parser untouched.
+  def self.subcommand_invocation?(argv : Array(String)) : Bool
+    head = argv.first?
+    return false if head.nil?
+    Noir::CLI::KNOWN_COMMANDS.includes?(head)
+  end
+
   # Returns a possibly-rewritten ARGV. If a terminal v0 flag is found,
   # the entire ARGV is replaced with the equivalent v1 invocation.
+  #
+  # The scan stops before it starts on a v1 subcommand invocation. The
+  # rewrite table is a *global* argv substitution, so scanning past a
+  # verb let it hijack that subcommand's own flags: `noir rules update
+  # -v` matched `-v => ["version"]`, printed the version and exited 0
+  # while `noir rules --help` advertises `-v, --verbose` and the rules
+  # were never updated — silently turning the documented
+  # `noir rules update && noir scan . -P` precondition into a no-op that
+  # reports success. `-V`, `--version`, `--list-techs`, `--build-info`,
+  # `--help-all` and `--generate-completion` had the identical exposure,
+  # so the rule itself is scoped rather than the one entry. v0
+  # invocations are unaffected: they have no verb to open with (v0 had
+  # no subcommands), so `noir -b ./app --list-techs` still rewrites.
   def self.rewrite(argv : Array(String)) : Array(String)
+    return argv if subcommand_invocation?(argv)
+
     argv.each_with_index do |arg, i|
       if rewrite = TERMINAL_REWRITES[arg]?
         return rewrite.dup

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -5,6 +5,7 @@ require "./techs/techs"
 require "./llm/acp/targets"
 require "./llm/native_tool_calling"
 require "./output_builder/formats"
+require "./passive_scan/severity"
 
 module Noir::CliValidation
   class Error < Exception
@@ -19,6 +20,8 @@ module Noir::CliValidation
     validate_config_file!(options)
     validate_tech_names!(options)
     validate_passive_scan_paths!(options)
+    validate_passive_scan_severity!(options)
+    validate_ai_integer_options!(options)
     validate_ai_provider_pair!(options)
     validate_ai_native_tools_allowlist!(options)
     warn_about_unused_delivery_flags(options)
@@ -119,6 +122,55 @@ module Noir::CliValidation
       next if path.empty?
       raise Error.new("--passive-scan-path does not exist: #{path}") unless File.exists?(path)
       raise Error.new("--passive-scan-path is not a directory: #{path}") unless File.directory?(path)
+    end
+  end
+
+  # `--passive-scan-severity` is checked by its own flag handler in
+  # options.cr, but the identical `passive_scan_severity:` config key reached
+  # `PassiveScanSeverity` untouched — and `meets_threshold?` treats an
+  # unrecognized threshold as "include everything" (`return true if
+  # min_level.nil?`). So a typo in the config file didn't loosen the filter
+  # by one level, it removed it, silently, in the direction the user least
+  # wanted. Gate both sources here, in the one place config and CLI meet.
+  def self.validate_passive_scan_severity!(options : Hash(String, YAML::Any))
+    value = options["passive_scan_severity"]?
+    return if value.nil? # library caller that never set the key
+
+    severity = value.to_s
+    unless PassiveScanSeverity.valid?(severity)
+      raise Error.new("Invalid passive scan severity #{severity.inspect}. Valid: #{PassiveScanSeverity.valid_levels.join(", ")}")
+    end
+
+    # The flag handler stores a downcased value; do the same for the config
+    # path so downstream comparisons see one spelling.
+    options["passive_scan_severity"] = YAML::Any.new(severity.downcase)
+  end
+
+  # `--ai-max-token` / `--ai-agent-max-steps` are bounded by
+  # `positive_int_or_die!` on the CLI side. Their config-file twins had no
+  # bound at all, so a negative or zero step budget went straight into the
+  # agent loop. ConfigInitializer has already coerced the value to an Int by
+  # this point; all that's left is the range.
+  #
+  # Zero is meaningful for `ai_max_token` only — it is the shipped default
+  # and the generated template's own value, documented as "no limit" — so it
+  # is accepted here even though `--ai-max-token 0` is not.
+  def self.validate_ai_integer_options!(options : Hash(String, YAML::Any))
+    {"ai_max_token" => 0, "ai_agent_max_steps" => 1}.each do |key, minimum|
+      value = options[key]?
+      next if value.nil?
+
+      raw = value.raw
+      number = raw.is_a?(Int) ? raw.to_i64 : raw.to_s.strip.to_i64?
+      flag = "--#{key.tr("_", "-")}"
+
+      if number.nil?
+        raise Error.new("Invalid #{flag} #{value.to_s.inspect}. Must be an integer.")
+      end
+
+      if number < minimum
+        raise Error.new("Invalid #{flag} '#{number}'. Must be #{minimum == 0 ? "0 or greater (0 = no limit)" : "a positive integer"}.")
+      end
     end
   end
 

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -34,6 +34,36 @@ class ConfigInitializer
     cache_clear
   ]
 
+  # Keys whose value must end up an Int, because every consumer reads
+  # them through `YAML::Any#as_i`. A quoted number (`ai_max_token:
+  # "4000"`) parses as a String and blew up at the cast — and the
+  # generated template itself models the quoted spelling with
+  # `concurrency: "…"`, so that is the shape users copy. The equivalent
+  # CLI flags run through `positive_int_or_die!`; these had neither
+  # coercion nor validation. Bounds are checked afterwards in
+  # `Noir::CliValidation`, the shared CLI+config gate.
+  INTEGER_CONFIG_KEYS = %w[
+    ai_max_token
+    ai_agent_max_steps
+  ]
+
+  # Keys stored as one comma-separated String, because the CLI flags
+  # that feed them accumulate into that shape. A YAML sequence is the
+  # natural spelling for a list of globs or tech names — and `base:` /
+  # `probe_header:` in the same file *are* sequences — so accept it and
+  # join. Untreated, `exclude_path: ["*.py"]` stringified to Crystal's
+  # array inspect (`["*.py"]`), matched no file and excluded nothing
+  # silently; the tech keys at least failed loudly, but with that same
+  # inspect string quoted back at the user.
+  CSV_CONFIG_KEYS = %w[
+    exclude_path
+    exclude_codes
+    techs
+    only_techs
+    exclude_techs
+    use_taggers
+  ]
+
   # Keys whose value should always end up as an Array(YAML::Any) so
   # callers can iterate without per-call type checks.
   ARRAY_CONFIG_KEYS = %w[
@@ -78,21 +108,52 @@ class ConfigInitializer
   # post-CLI merge inside NoirRunner that re-overwrote everything
   # the CLI had just set.
   def initialize(override_path : String? = nil)
-    @config_dir = Noir::Home.path
-
     if override_path && !override_path.empty?
-      @config_file = override_path
+      # Resolve the override *without* touching Noir::Home. `Noir::Home.path`
+      # calls `Noir::CLI.die` when neither NOIR_HOME nor HOME is set, and it
+      # used to run on the first line of this method — so `--config-file
+      # ./f.yaml`, the documented escape hatch for exactly that environment,
+      # died before the override was ever looked at. Distroless images,
+      # `--user`-run containers and hardened CI runners routinely have no
+      # HOME, which left no way to run a scan at all. The default home is
+      # only required when the default config is what we are about to read.
+      @config_file = expand_config_path(override_path)
+      # Only used by `setup`, which no-ops for an override. Kept in sync
+      # with the file so the field never points somewhere unrelated.
+      @config_dir = File.dirname(@config_file)
       @is_override = true
     else
-      @config_file = File.join(@config_dir, "config.yaml")
+      @config_dir = File.expand_path(Noir::Home.path)
+      @config_file = File.expand_path(File.join(@config_dir, "config.yaml"))
       @is_override = false
     end
+  end
 
-    @config_dir = File.expand_path(@config_dir)
-    @config_file = File.expand_path(@config_file)
+  # Expand `~` in a user-supplied `--config-file` path, matching
+  # `Noir::Home.path`'s deliberate `home: true`: a value that arrives from a
+  # Dockerfile `ENV`, a systemd `Environment=` or a .env loader never gets
+  # the shell's tilde expansion, so a literal `~/noir.yaml` would otherwise
+  # resolve to a bogus `./~/noir.yaml` under the cwd. Guarded on the leading
+  # `~` so the HOME-less case — the whole reason this branch skips
+  # Noir::Home — can't be reintroduced through `Path.home`.
+  private def expand_config_path(path : String) : String
+    return File.expand_path(path, home: true) if path.starts_with?('~')
+    File.expand_path(path)
   end
 
   def setup
+    # `--config-file PATH` names a file the user already created, so nothing
+    # under the default home is needed for that run — not the directory
+    # scaffolding below, and not the template write. Bailing out first is
+    # what lets `--config-file` work in an environment with no HOME at all:
+    # `@config_dir` there is just the override's own directory, and creating
+    # it would be a side effect the user never asked for.
+    #
+    # A missing --config-file path is a user error, surfaced by
+    # CliValidation later; auto-creating a default template there would
+    # silently mask the typo with a generated file.
+    return if @is_override
+
     # Create the directory if it doesn't exist. 0700, not the default 0755:
     # everything Noir keeps here is private to the user — the 0600 config
     # below with its `ai_key`, and the AI response cache, whose entries are
@@ -102,17 +163,9 @@ class ConfigInitializer
     Dir.mkdir(@config_dir, 0o700) unless Dir.exists?(@config_dir)
     Dir.mkdir("#{@config_dir}/passive_rules", 0o700) unless Dir.exists?("#{@config_dir}/passive_rules")
 
-    # Create the config file if it doesn't exist — but only when this
-    # is the *default* config path. When the user passed
-    # `--config-file PATH`, a missing file is a user error and is
-    # surfaced by CliValidation later; auto-creating a default
-    # template at the user-supplied path would silently mask the
-    # typo with a generated file.
-    #
     # Written 0600: the file carries an `ai_key` field documented as
     # where real provider API keys go, so it should never be created
     # world-readable on a shared box (matches ssh/aws-cli/gh).
-    return if @is_override
     File.write(@config_file, generate_config_file, perm: 0o600) unless File.exists?(@config_file)
   rescue e
     # A silently-swallowed failure here (unwritable NOIR_HOME, disk full)
@@ -171,6 +224,39 @@ class ConfigInitializer
           STDERR.puts "WARNING: config key '#{key}' has invalid boolean value #{value.to_s.inspect}; expected true/false/yes/no. Treating as false.".colorize(:yellow)
           symbolized_hash[key] = YAML::Any.new(false)
         end
+      end
+
+      # Coerce quoted / stringified numbers into a real Int so the
+      # `YAML::Any#as_i` reads downstream can't raise. An unparsable value
+      # drops the key entirely so the merge below restores the default —
+      # the same "warn, then fall back" shape as the boolean pass above.
+      # (Range checks live in CliValidation, which both the CLI flag and
+      # this path go through.)
+      INTEGER_CONFIG_KEYS.each do |key|
+        value = symbolized_hash[key]?
+        next if value.nil?
+        next if value.raw.is_a?(Int) # already a real YAML int
+
+        parsed = value.to_s.strip.to_i64?
+        if parsed.nil?
+          STDERR.puts "WARNING: config key '#{key}' has invalid integer value #{value.to_s.inspect}; using the default.".colorize(:yellow)
+          symbolized_hash.delete(key)
+        else
+          symbolized_hash[key] = YAML::Any.new(parsed)
+        end
+      end
+
+      # Accept a YAML sequence for the comma-separated string keys and join
+      # it, so `exclude_path: ["*.py"]` means the same thing as
+      # `exclude_path: "*.py"` instead of stringifying to an inspect form
+      # that matches nothing.
+      CSV_CONFIG_KEYS.each do |key|
+        value = symbolized_hash[key]?
+        next if value.nil?
+        raw = value.raw
+        next unless raw.is_a?(Array)
+
+        symbolized_hash[key] = YAML::Any.new(raw.map(&.to_s.strip).reject(&.empty?).join(","))
       end
 
       # Normalize array-style keys: empty string → empty array,

--- a/src/deliver/status_code.cr
+++ b/src/deliver/status_code.cr
@@ -1,8 +1,10 @@
+require "../models/deliver"
 require "../models/endpoint"
 require "../models/logger"
 require "../utils/http_symbols"
 require "../utils/utils"
 require "crest"
+require "wait_group"
 
 # Fills in `details.status_code` for every endpoint (`--status-codes`) and
 # drops the ones whose code the user excluded (`--exclude-codes`).
@@ -14,6 +16,8 @@ require "crest"
 # and with what", not to replay traffic. Inheriting the sender base would
 # quietly give it all three.
 class StatusCodeProbe
+  include ProbeConcurrency
+
   @options : Hash(String, YAML::Any)
   @logger : NoirLogger
 
@@ -24,9 +28,20 @@ class StatusCodeProbe
     @logger.sub "➔ Updating status codes."
 
     excluded = excluded_codes
-    final = [] of Endpoint
+    # One slot per input endpoint, filled in place and compacted at the end,
+    # so probing concurrently does not reorder the catalog the user reads.
+    #
+    # Pre-fix this loop was strictly sequential and unbounded: against a host
+    # that drops SYNs, every endpoint waited out its own connect timeout one
+    # after another, so a few hundred endpoints stalled the scan for hours
+    # before any report was written. SendReq / SendWithProxy already bound
+    # their fan-out with --concurrency; the status probe is bounded the same
+    # way rather than with a second, differently-shaped mechanism.
+    slots = Array(Endpoint?).new(endpoints.size, nil)
+    wg = WaitGroup.new
+    sem = Channel(Nil).new(concurrency_limit)
 
-    endpoints.each do |endpoint|
+    endpoints.each_with_index do |endpoint, index|
       # Mobile deep links (`myapp://`, `intent://`, `content://`), CLI
       # command surfaces (`cli://`) and realtime `ws://` event surfaces are
       # not HTTP requests — the same guard SendReq / SendWithProxy already
@@ -35,27 +50,39 @@ class StatusCodeProbe
       # with --status-codes printed dozens of `Failed to get status code`
       # errors for endpoints that can never have one.
       if endpoint.non_http?
-        final << endpoint
+        slots[index] = endpoint
         next
       end
 
       request_method = requestable_http_methods(endpoint.method).first?
       unless request_method
-        final << endpoint
+        slots[index] = endpoint
         next
       end
 
-      begin
-        response = request_for(endpoint, request_method)
-        endpoint.details.status_code = response.status_code
-        final << endpoint unless excluded.includes?(response.status_code)
-      rescue e
-        @logger.error "Failed to get status code for #{endpoint.url} (#{e.message})."
-        final << endpoint
+      # Copied into a fresh local: `request_method` is reassigned on every
+      # iteration, so a fiber closing over it would race the next endpoint's
+      # value (and lose the nil-check narrowing besides).
+      probe_method = request_method
+      wg.add(1)
+      sem.send(nil) # acquire a slot (blocks once `concurrency_limit` are in flight)
+      spawn do
+        begin
+          response = request_for(endpoint, probe_method)
+          endpoint.details.status_code = response.status_code
+          slots[index] = endpoint unless excluded.includes?(response.status_code)
+        rescue e
+          @logger.error "Failed to get status code for #{endpoint.url} (#{e.message})."
+          slots[index] = endpoint
+        ensure
+          sem.receive # release the slot
+          wg.done
+        end
       end
     end
 
-    final
+    wg.wait
+    slots.compact
   end
 
   private def request_for(endpoint : Endpoint, request_method : String)
@@ -100,6 +127,26 @@ class StatusCodeProbe
             OpenSSL::SSL::Context::Client.new
           end
 
+    # `handle_errors: false, max_redirects: 0` — the same pair SendReq and
+    # SendWithProxy send, and for the same reasons.
+    #
+    # `handle_errors` defaults to true in Crest, which raises on any non-2xx.
+    # A probe that answered 404 or 500 has answered; that is the code to
+    # report, not an exception.
+    #
+    # `max_redirects` defaults to 10, and `Redirector#follow` only stops at
+    # `max_redirects <= 0`, so the probe used to follow `Location`
+    # transparently. Three things were wrong with that: the reported
+    # `status_code` was the redirect *target's* (302 /redirect -> 200 /final
+    # was reported as 200), `--exclude-codes 302` could never match because
+    # the 302 was never seen, and an absolute cross-host `Location` let the
+    # scanned app steer noir's probes at a third party the user never named.
+    # The target of a probe is what the user asked for, not what the server
+    # says.
+    #
+    # The two must travel together: `Redirector#check_max_redirects` raises
+    # when `max_redirects <= 0 && handle_errors`, so turning redirects off on
+    # its own would make every 3xx a rescued "Failed to get status code" line.
     Crest::Request.execute(
       method: method,
       url: url,
@@ -109,7 +156,28 @@ class StatusCodeProbe
       form: form,
       json: json,
       handle_errors: false,
-      read_timeout: 5.second
+      max_redirects: 0,
+      connect_timeout: connect_timeout,
+      read_timeout: read_timeout
     )
+  end
+
+  # Crest defaults `connect_timeout` to nil, i.e. no timeout at all, so a host
+  # that drops SYNs fell back to the OS TCP timeout — around 75 seconds, per
+  # endpoint. `Deliver::PROBE_CONNECT_TIMEOUT` is the value the senders
+  # already settled on for exactly this; reused rather than duplicated.
+  #
+  # The read timeout stays at the status probe's own 5s. A status probe only
+  # needs the response line, so it can be stricter than a delivery probe,
+  # whose job is to hand a slow-but-working target its full request.
+  #
+  # Both are accessors so a spec can subclass with sub-second values and still
+  # exercise the real plumbing into Crest.
+  protected def connect_timeout : Time::Span
+    Deliver::PROBE_CONNECT_TIMEOUT
+  end
+
+  protected def read_timeout : Time::Span
+    5.seconds
   end
 end

--- a/src/llm/adapter.cr
+++ b/src/llm/adapter.cr
@@ -4,6 +4,7 @@
 # - LLM::General (OpenAI-compatible chat APIs)
 # - LLM::Ollama (Ollama local API with optional KV context reuse)
 
+require "uri"
 require "./general/client"
 require "./ollama/ollama"
 require "./acp/client"
@@ -161,6 +162,45 @@ module LLM
       active_allowlist.includes?(LLM::NativeToolCalling.canonical_provider(provider))
     end
 
+    # Ollama's native API (`POST /api/generate`) is a different protocol and a
+    # different body shape from the OpenAI-compatible `/v1/chat/completions`
+    # every other provider speaks, so this decision has to be precise.
+    #
+    # It used to be `provider.downcase.includes?("ollama")` tested against the
+    # *whole* provider string. A path segment is chosen by whoever runs the
+    # gateway, so an OpenAI-compatible endpoint mounted at
+    # `http://gw.example/ollama/v1` was handed the wrong API — and, because
+    # the same full string is used as the base URL, the request went to
+    # `http://gw.example/ollama/v1/api/generate`. The 404 came back as an
+    # empty result rather than an error.
+    #
+    # Only the exact alias and the *host* decide now. A host named `ollama`
+    # that is explicitly serving the compatibility path is still an
+    # OpenAI-compatible endpoint.
+    def self.ollama_native?(provider : String) : Bool
+      prov = provider.strip.downcase
+      return true if prov == "ollama"
+      return false unless prov.includes?("://")
+
+      uri = URI.parse(prov)
+      host = uri.host
+      return false if host.nil? || !host.includes?("ollama")
+
+      !uri.path.to_s.chomp("/").ends_with?("/chat/completions")
+    rescue URI::Error
+      false
+    end
+
+    # The native API lives at the server root. The CLI's own help prints
+    # `ollama -> http://localhost:11434/v1`, and that `/v1` is the
+    # OpenAI-compatible mount: appending `/api/generate` to it yields a 404,
+    # so it is dropped before `LLM::Ollama` builds the endpoint URL.
+    def self.ollama_base_url(provider : String) : String
+      prov = provider.strip
+      return "http://localhost:11434" unless prov.includes?("://")
+      prov.chomp("/").rchop("/v1").chomp("/")
+    end
+
     def self.for(
       provider : String,
       model : String,
@@ -172,9 +212,8 @@ module LLM
       if LLM::ACPClient.acp_provider?(prov)
         acp_model = LLM::ACPClient.default_model(provider, model)
         ACPAdapter.new(LLM::ACPClient.new(provider, acp_model, event_sink))
-      elsif prov.includes?("ollama")
-        url = provider.includes?("://") ? provider : "http://localhost:11434"
-        OllamaAdapter.new(LLM::Ollama.new(url, model))
+      elsif ollama_native?(prov)
+        OllamaAdapter.new(LLM::Ollama.new(ollama_base_url(provider), model))
       else
         native_tool_calling = native_tool_calling_enabled_for_provider?(provider, native_tool_calling_allowlist)
         GeneralAdapter.new(LLM::General.new(provider, model, api_key), native_tool_calling)

--- a/src/llm/native_tool_calling.cr
+++ b/src/llm/native_tool_calling.cr
@@ -1,3 +1,5 @@
+require "uri"
+
 module LLM::NativeToolCalling
   DEFAULT_ALLOWLIST = ["openai", "xai", "github"]
 
@@ -20,18 +22,31 @@ module LLM::NativeToolCalling
 
   def self.canonical_provider(provider : String) : String
     p = provider.downcase.strip
+    return p unless p.includes?("://") || p.includes?(".")
 
-    if p.includes?("://") || p.includes?(".")
-      return "openai" if p.includes?("openai")
-      return "xai" if p.includes?("x.ai") || p.includes?("xai")
-      return "github" if p.includes?("github")
-      return "azure" if p.includes?("azure")
-      return "ollama" if p.includes?("ollama")
-      return "vllm" if p.includes?("vllm")
-      return "lmstudio" if p.includes?("lmstudio")
-    end
+    # Match on the host, not on the whole URL. The path is chosen by whoever
+    # runs the gateway, so `https://gw.internal/ollama/v1` used to canonicalize
+    # to a provider the operator never named — the same substring bug that sent
+    # such a URL to Ollama's native API in `AdapterFactory`. A host-less form
+    # ("openai.com", "api.x.ai") still matches on the string itself.
+    haystack = host_of(p) || p
+
+    return "openai" if haystack.includes?("openai")
+    return "xai" if haystack.includes?("x.ai") || haystack.includes?("xai")
+    return "github" if haystack.includes?("github")
+    return "azure" if haystack.includes?("azure")
+    return "ollama" if haystack.includes?("ollama")
+    return "vllm" if haystack.includes?("vllm")
+    return "lmstudio" if haystack.includes?("lmstudio")
 
     p
+  end
+
+  private def self.host_of(provider : String) : String?
+    return unless provider.includes?("://")
+    URI.parse(provider).host
+  rescue URI::Error
+    nil
   end
 
   def self.normalize_allowlist(allowlist : Array(String)? = nil) : Array(String)

--- a/src/llm/response_cleanup.cr
+++ b/src/llm/response_cleanup.cr
@@ -1,8 +1,28 @@
 module LLM
+  # A markdown fence only ever wraps the *whole* payload, so both patterns
+  # are anchored. The previous `gsub("```json", "").gsub("```", "")` ran over
+  # the entire response and was wrong in both directions:
+  #
+  #   * backticks the model quoted from the code it was reading (inside a
+  #     `snippet` or `description` string value) were deleted from the data,
+  #     silently corrupting it;
+  #   * only the exact lowercase `json` tag was recognised, so ```` ```JSON ````
+  #     or ```` ```javascript ```` left the bare language word in front of the
+  #     JSON — `JSON.parse` then failed and the caller returned "", which the
+  #     analyzer reads as "this code defines no endpoints".
+  #
+  # The tag is matched case-insensitively and generically (any language word),
+  # since which one the model picks is not something we control.
+  LEADING_FENCE  = /\A```[A-Za-z0-9_+.\-]*[^\S\n]*\r?\n?/
+  TRAILING_FENCE = /\r?\n?[^\S\n]*```\s*\z/
+
   # Strip the markdown ```json / ``` code fences that LLM providers sometimes
   # wrap JSON responses in, and trim surrounding whitespace. Shared by every
   # provider client so the cleanup rule has a single home.
   def self.strip_json_fences(text : String) : String
-    text.gsub("```json", "").gsub("```", "").strip
+    stripped = text.strip
+    return stripped unless stripped.starts_with?("```")
+
+    stripped.sub(LEADING_FENCE, "").sub(TRAILING_FENCE, "").strip
   end
 end

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -230,8 +230,14 @@ class Deliver
     return endpoint.url unless PROBE_PATH_FILL_METHODS.includes?(request_method.upcase)
 
     url = endpoint.url
-    endpoint.params.each do |param|
-      next unless param.param_type == "path"
+    # Longest name first. The `:name` form has no closing delimiter, so a
+    # param whose name merely *starts with* another's used to be eaten by the
+    # shorter substitution in declaration order: Express `/u/:id/:idx` with
+    # params [id, idx] was probed as `/u/1/1x`, a path the app does not route.
+    path_params = endpoint.params.select { |param| param.param_type == "path" }
+    path_params.sort_by! { |param| -param.name.size }
+
+    path_params.each do |param|
       # A non-empty value means --set-pvalue-path already applied and the
       # optimizer substituted it; nothing left to fill.
       next unless param.value.empty?
@@ -244,9 +250,11 @@ class Deliver
       url = url.gsub("<#{param.name}>", filler)
       # `:name` only counts at a segment boundary. Anchoring to a preceding
       # `/` keeps the scheme/port colon in `http://host:8080` and embedded
-      # example text like `/profiles/celeb_:USERNAME` out of it. No trailing
-      # anchor, so Play-style `/:lang.json` fills correctly.
-      url = url.gsub(/(\A|\/):#{escaped}/) { "#{$1}#{filler}" }
+      # example text like `/profiles/celeb_:USERNAME` out of it. The trailing
+      # lookahead ends the name at the first character that can't be part of
+      # one, so `:id` no longer matches the head of `:idx` while Play-style
+      # `/:lang.json` and `/:id-suffix` still fill.
+      url = url.gsub(/(\A|\/):#{escaped}(?![A-Za-z0-9_])/) { "#{$1}#{filler}" }
     end
 
     url

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -5,7 +5,28 @@ require "../utils/utils"
 require "../utils/http_symbols"
 require "../utils/url_origin"
 
+# Max concurrent in-flight probe requests, shared by every class that fires
+# requests at discovered endpoints. Bounds the fiber/socket fan-out so a large
+# endpoint set can't exhaust file descriptors. Backed by the validated
+# --concurrency value (already clamped to a sane ceiling).
+#
+# A module rather than a `Deliver` method because `StatusCodeProbe` is
+# deliberately not a `Deliver` subclass (see its class comment) yet has to
+# bound its fan-out exactly the same way. Keeping the rule in one place is what
+# stops the two from drifting again: the status probe was strictly sequential
+# for exactly as long as this lived on `Deliver` alone.
+module ProbeConcurrency
+  DEFAULT_PROBE_CONCURRENCY = 16
+
+  protected def concurrency_limit : Int32
+    n = @options["concurrency"]?.try(&.to_s.to_i?) || 0
+    n > 0 ? n : DEFAULT_PROBE_CONCURRENCY
+  end
+end
+
 class Deliver
+  include ProbeConcurrency
+
   @logger : NoirLogger
   @options : Hash(String, YAML::Any)
   @is_debug : Bool
@@ -345,14 +366,6 @@ class Deliver
 
   protected def export_read_timeout : Time::Span
     EXPORT_READ_TIMEOUT
-  end
-
-  # Max concurrent in-flight probe requests. Bounds the fiber/socket fan-out
-  # so a large endpoint set can't exhaust file descriptors. Backed by the
-  # validated --concurrency value (already clamped to a sane ceiling).
-  protected def concurrency_limit : Int32
-    n = @options["concurrency"]?.try(&.to_s.to_i?) || 0
-    n > 0 ? n : 16
   end
 
   # TLS context for outbound delivery. Verifying (secure) by default; the

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -30,7 +30,6 @@ class NoirRunner
   @no_spinner : Bool
   @concurrency : Int32
   @config_file : String
-  @noir_home : String
   @passive_scans : Array(PassiveScan)
   @passive_results : Array(PassiveScanResult)
   # Tech analyzers that raised during the last `analyze`. Empty is the
@@ -43,7 +42,13 @@ class NoirRunner
   def initialize(options)
     @options = options
     @config_file = @options["config_file"].to_s
-    @noir_home = Noir::Home.path
+    # `@noir_home = Noir::Home.path` used to run here. Nothing ever read the
+    # field, but `Noir::Home.path` dies when neither NOIR_HOME nor HOME is
+    # set — so every scan in a HOME-less environment (distroless image,
+    # `--user` container, hardened CI runner) died on this line even with an
+    # explicit `--config-file`. The callers that genuinely need the home
+    # directory (LLM cache, `-f html` template, passive rules) resolve it
+    # themselves, at the point of use.
     @passive_scans = [] of PassiveScan
     @passive_results = [] of PassiveScanResult
 

--- a/src/models/passive_scan.cr
+++ b/src/models/passive_scan.cr
@@ -1,4 +1,5 @@
 require "./logger"
+require "../passive_scan/severity"
 require "yaml"
 require "json"
 require "log"
@@ -15,7 +16,8 @@ struct PassiveScan
 
     def initialize(yaml : YAML::Any)
       @name = yaml["name"]?.try(&.as_s?) || yaml["name"]?.try(&.to_s) || ""
-      @severity = yaml["severity"]?.try(&.as_s?) || yaml["severity"]?.try(&.to_s) || "info"
+      raw_severity = yaml["severity"]?.try(&.as_s?) || yaml["severity"]?.try(&.to_s) || ""
+      @severity = raw_severity.empty? ? "low" : raw_severity.downcase
       @description = yaml["description"]?.try(&.as_s?) || yaml["description"]?.try(&.to_s) || ""
       @reference = if ref_node = yaml["reference"]?
                      ref_node.as_a? || [ref_node] of YAML::Any
@@ -61,14 +63,6 @@ struct PassiveScan
       @condition = raw_condition.downcase
       @regex_compile_failed = false
 
-      if !ALLOWED_TYPES.includes?(@type)
-        Log.warn { "Passive scan matcher has invalid type: #{@type.inspect} (expected 'word' or 'regex')" }
-      end
-
-      if !ALLOWED_CONDITIONS.includes?(@condition)
-        Log.warn { "Passive scan matcher has invalid condition: #{@condition.inspect} (expected 'and' or 'or')" }
-      end
-
       if @type == "regex" && ALLOWED_CONDITIONS.includes?(@condition)
         if @condition == "or"
           begin
@@ -90,11 +84,16 @@ struct PassiveScan
       end
     end
 
+    def validation_errors : Array(String)
+      errors = [] of String
+      errors << "invalid type #{@type.inspect} (expected 'word' or 'regex')" unless ALLOWED_TYPES.includes?(@type)
+      errors << "invalid condition #{@condition.inspect} (expected 'and' or 'or')" unless ALLOWED_CONDITIONS.includes?(@condition)
+      errors << "missing or empty 'patterns'" if @patterns.empty? || @string_patterns.empty?
+      errors
+    end
+
     def valid? : Bool
-      ALLOWED_TYPES.includes?(@type) &&
-        ALLOWED_CONDITIONS.includes?(@condition) &&
-        !@patterns.empty? &&
-        !@string_patterns.empty?
+      validation_errors.empty?
     end
   end
 
@@ -127,21 +126,36 @@ struct PassiveScan
              else
                [] of YAML::Any
              end
+  end
 
-    if !ALLOWED_MATCHERS_CONDITIONS.includes?(@matchers_condition)
-      Log.warn { "Passive scan rule #{@id.inspect} has invalid matchers-condition: #{@matchers_condition.inspect} (expected 'and' or 'or')" }
+  def validation_errors : Array(String)
+    errors = [] of String
+    errors << "missing or empty 'id'" if @id.empty?
+    errors << "missing or empty 'info.name'" if @info.name.empty?
+    errors << "invalid severity #{@info.severity.inspect} (expected #{PassiveScanSeverity.valid_levels.join(", ")})" unless PassiveScanSeverity.valid?(@info.severity)
+    errors << "missing or empty 'matchers'" if @matchers.empty?
+    errors << "invalid matchers-condition #{@matchers_condition.inspect} (expected 'and' or 'or')" unless ALLOWED_MATCHERS_CONDITIONS.includes?(@matchers_condition)
+    @matchers.each_with_index do |matcher, idx|
+      matcher.validation_errors.each do |err|
+        errors << "matcher[#{idx}]: #{err}"
+      end
     end
+    errors
   end
 
   # A rule is usable when it has an id, a non-empty info name, at
   # least one matcher, all matchers are valid (allowed type, condition,
-  # non-empty patterns), and matchers_condition is 'and' or 'or'.
+  # non-empty patterns), valid severity, and matchers_condition is 'and' or 'or'.
   def valid? : Bool
-    !@id.empty? &&
-      !@info.name.empty? &&
-      !@matchers.empty? &&
-      @matchers.all?(&.valid?) &&
-      ALLOWED_MATCHERS_CONDITIONS.includes?(@matchers_condition)
+    errors = validation_errors
+    if !errors.empty?
+      rule_label = @id.empty? ? "<unknown id>" : "rule '#{@id}'"
+      errors.each do |err|
+        Log.warn { "Passive scan #{rule_label} is invalid: #{err}" }
+      end
+      return false
+    end
+    true
   end
 end
 

--- a/src/models/passive_scan.cr
+++ b/src/models/passive_scan.cr
@@ -14,15 +14,26 @@ struct PassiveScan
     property reference : Array(YAML::Any)
 
     def initialize(yaml : YAML::Any)
-      @name = yaml["name"].as_s
-      @severity = yaml["severity"].as_s
-      @description = yaml["description"].as_s
-      @reference = yaml["reference"].as_a
-      @author = yaml["author"].as_a
+      @name = yaml["name"]?.try(&.as_s?) || yaml["name"]?.try(&.to_s) || ""
+      @severity = yaml["severity"]?.try(&.as_s?) || yaml["severity"]?.try(&.to_s) || "info"
+      @description = yaml["description"]?.try(&.as_s?) || yaml["description"]?.try(&.to_s) || ""
+      @reference = if ref_node = yaml["reference"]?
+                     ref_node.as_a? || [ref_node] of YAML::Any
+                   else
+                     [] of YAML::Any
+                   end
+      @author = if author_node = yaml["author"]?
+                  author_node.as_a? || [author_node] of YAML::Any
+                else
+                  [] of YAML::Any
+                end
     end
   end
 
   struct Matcher
+    ALLOWED_TYPES      = {"word", "regex"}
+    ALLOWED_CONDITIONS = {"and", "or"}
+
     property type : String
     property patterns : Array(YAML::Any)
     # Pre-stringified patterns. detect.cr's hot path used to call
@@ -38,13 +49,27 @@ struct PassiveScan
     property? regex_compile_failed : Bool
 
     def initialize(yaml : YAML::Any)
-      @type = yaml["type"].as_s
-      @patterns = yaml["patterns"].as_a
+      raw_type = yaml["type"]?.try(&.as_s?) || yaml["type"]?.try(&.to_s) || ""
+      @type = raw_type.downcase
+      @patterns = if patterns_node = yaml["patterns"]?
+                    patterns_node.as_a? || [patterns_node] of YAML::Any
+                  else
+                    [] of YAML::Any
+                  end
       @string_patterns = @patterns.map(&.to_s)
-      @condition = yaml["condition"].as_s
+      raw_condition = yaml["condition"]?.try(&.as_s?) || yaml["condition"]?.try(&.to_s) || "or"
+      @condition = raw_condition.downcase
       @regex_compile_failed = false
 
-      if @type == "regex"
+      if !ALLOWED_TYPES.includes?(@type)
+        Log.warn { "Passive scan matcher has invalid type: #{@type.inspect} (expected 'word' or 'regex')" }
+      end
+
+      if !ALLOWED_CONDITIONS.includes?(@condition)
+        Log.warn { "Passive scan matcher has invalid condition: #{@condition.inspect} (expected 'and' or 'or')" }
+      end
+
+      if @type == "regex" && ALLOWED_CONDITIONS.includes?(@condition)
         if @condition == "or"
           begin
             @compiled_regex = Regex.union(@string_patterns.map { |p| Regex.new(p) })
@@ -64,7 +89,16 @@ struct PassiveScan
         end
       end
     end
+
+    def valid? : Bool
+      ALLOWED_TYPES.includes?(@type) &&
+        ALLOWED_CONDITIONS.includes?(@condition) &&
+        !@patterns.empty? &&
+        !@string_patterns.empty?
+    end
   end
+
+  ALLOWED_MATCHERS_CONDITIONS = {"and", "or"}
 
   property id : String
   property info : Info
@@ -74,22 +108,40 @@ struct PassiveScan
   property techs : Array(YAML::Any)
 
   def initialize(yaml : YAML::Any)
-    @id = yaml["id"].as_s
-    @info = Info.new(yaml["info"])
-    @matchers = yaml["matchers"].as_a.map { |matcher| Matcher.new(matcher) }
-    @matchers_condition = yaml["matchers-condition"].to_s
-    @category = yaml["category"].as_s
-    @techs = yaml["techs"].as_a
+    @id = yaml["id"]?.try(&.as_s?) || yaml["id"]?.try(&.to_s) || ""
+    @info = if info_yaml = yaml["info"]?
+              Info.new(info_yaml)
+            else
+              Info.new(YAML::Any.new({} of YAML::Any => YAML::Any))
+            end
+    @matchers = if matchers_yaml = yaml["matchers"]?.try(&.as_a?)
+                  matchers_yaml.map { |matcher| Matcher.new(matcher) }
+                else
+                  [] of Matcher
+                end
+    raw_matchers_condition = yaml["matchers-condition"]?.try(&.as_s?) || yaml["matchers-condition"]?.try(&.to_s) || "or"
+    @matchers_condition = raw_matchers_condition.downcase
+    @category = yaml["category"]?.try(&.as_s?) || yaml["category"]?.try(&.to_s) || ""
+    @techs = if techs_yaml = yaml["techs"]?
+               techs_yaml.as_a? || [techs_yaml] of YAML::Any
+             else
+               [] of YAML::Any
+             end
+
+    if !ALLOWED_MATCHERS_CONDITIONS.includes?(@matchers_condition)
+      Log.warn { "Passive scan rule #{@id.inspect} has invalid matchers-condition: #{@matchers_condition.inspect} (expected 'and' or 'or')" }
+    end
   end
 
-  # A rule is usable when it has an id, a non-empty info name, and at
-  # least one matcher. The earlier `@info != ""` check compared an
-  # Info struct against a String, which is always true and therefore a
-  # no-op; the rewrite checks `@info.name` instead so rules with an
-  # empty name (effectively unusable for SARIF / human output) are
-  # dropped during load.
-  def valid?
-    !@id.empty? && !@info.name.empty? && !@matchers.empty?
+  # A rule is usable when it has an id, a non-empty info name, at
+  # least one matcher, all matchers are valid (allowed type, condition,
+  # non-empty patterns), and matchers_condition is 'and' or 'or'.
+  def valid? : Bool
+    !@id.empty? &&
+      !@info.name.empty? &&
+      !@matchers.empty? &&
+      @matchers.all?(&.valid?) &&
+      ALLOWED_MATCHERS_CONDITIONS.includes?(@matchers_condition)
   end
 end
 

--- a/src/models/passive_scan.cr
+++ b/src/models/passive_scan.cr
@@ -16,8 +16,15 @@ struct PassiveScan
 
     def initialize(yaml : YAML::Any)
       @name = yaml["name"]?.try(&.as_s?) || yaml["name"]?.try(&.to_s) || ""
+      # Left empty when absent rather than defaulted, so `validation_errors`
+      # can reject it by name. Defaulting is not available here: the default
+      # `--passive-scan-severity` threshold is `high`, so any default below
+      # that silently filters the rule out — "Loaded 1 valid passive scan
+      # rules" followed by no findings, which is the same invisible
+      # false negative as the unknown-severity-includes-everything bug this
+      # replaced, only pointing the other way.
       raw_severity = yaml["severity"]?.try(&.as_s?) || yaml["severity"]?.try(&.to_s) || ""
-      @severity = raw_severity.empty? ? "low" : raw_severity.downcase
+      @severity = raw_severity.downcase
       @description = yaml["description"]?.try(&.as_s?) || yaml["description"]?.try(&.to_s) || ""
       @reference = if ref_node = yaml["reference"]?
                      ref_node.as_a? || [ref_node] of YAML::Any
@@ -132,7 +139,11 @@ struct PassiveScan
     errors = [] of String
     errors << "missing or empty 'id'" if @id.empty?
     errors << "missing or empty 'info.name'" if @info.name.empty?
-    errors << "invalid severity #{@info.severity.inspect} (expected #{PassiveScanSeverity.valid_levels.join(", ")})" unless PassiveScanSeverity.valid?(@info.severity)
+    if @info.severity.empty?
+      errors << "missing 'info.severity' (expected #{PassiveScanSeverity.valid_levels.join(", ")})"
+    elsif !PassiveScanSeverity.valid?(@info.severity)
+      errors << "invalid severity #{@info.severity.inspect} (expected #{PassiveScanSeverity.valid_levels.join(", ")})"
+    end
     errors << "missing or empty 'matchers'" if @matchers.empty?
     errors << "invalid matchers-condition #{@matchers_condition.inspect} (expected 'and' or 'or')" unless ALLOWED_MATCHERS_CONDITIONS.includes?(@matchers_condition)
     @matchers.each_with_index do |matcher, idx|

--- a/src/options.cr
+++ b/src/options.cr
@@ -192,6 +192,17 @@ module Noir::OptionsParsing
         end
         append_to_yaml_array(noir_options, pvalue_key, args[i + 1])
         i += 2
+      elsif (eq_idx = arg.index('=')) && (eq_pvalue_key = LEGACY_PVALUE_TARGETS[arg[0...eq_idx]]?)
+        # `--set-pvalue=VALUE`. In v0 these were real `parser.on
+        # "--set-pvalue VALUE"` entries, so Crystal's OptionParser accepted
+        # both spellings; this hand-rolled extractor only matched the bare
+        # token, and the `=` form fell through to `invalid_option` and hard
+        # failed. `Noir::CLI::Legacy.translate_flag_aliases` handles `=` for
+        # the probe aliases, so the two legacy layers also disagreed.
+        # Split on the *first* `=` only, so `--set-pvalue=key=val` keeps
+        # "key=val" as the value.
+        append_to_yaml_array(noir_options, eq_pvalue_key, arg[(eq_idx + 1)..])
+        i += 1
       else
         result << arg
         i += 1
@@ -395,15 +406,19 @@ def run_options_parser
       # Accumulate same as --exclude-path / --use-taggers / -t etc.
       # so users can repeat the flag (`--exclude-codes 404
       # --exclude-codes 500`) without losing the first value.
-      append_to_csv_option(noir_options, "exclude_codes", v)
+      # `reset_seen` scopes that accumulation to this command line: the
+      # first occurrence replaces a config-file value outright.
+      append_to_csv_option(noir_options, "exclude_codes", v, reset_seen: csv_reset_seen)
     end
     parser.on "--exclude-path PATTERN", "Exclude files by glob (e.g. *.test.js,*_test.go; repeatable)" do |v|
       # Storage is a comma-separated string (the detector splits on
       # `,` per-file). Pre-fix, the second `--exclude-path` clobbered
       # the first via plain `=`. Concatenate instead so users can
       # repeat the flag OR pack patterns into one comma list — both
-      # shapes accumulate to the same final list.
-      append_to_csv_option(noir_options, "exclude_path", v)
+      # shapes accumulate to the same final list. `reset_seen` keeps
+      # that accumulation inside the command line: a config-file
+      # `exclude_path` is replaced, not extended.
+      append_to_csv_option(noir_options, "exclude_path", v, reset_seen: csv_reset_seen)
     end
     parser.on "--include LIST", "Enrich plain output (comma-separated: path,techs,callee)" do |v|
       Noir::OptionsParsing.apply_include_list(noir_options, v)
@@ -467,8 +482,10 @@ def run_options_parser
       # (`NoirTaggers.run_tagger`) gets the union, not just the last
       # `--use-taggers` value. Pre-fix `--use-taggers hunt
       # --use-taggers cors` silently dropped `hunt` because the
-      # second assignment overwrote the first.
-      append_to_csv_option(noir_options, "use_taggers", v)
+      # second assignment overwrote the first. `reset_seen` keeps the
+      # union scoped to the command line, so a config-file
+      # `use_taggers` is replaced rather than added to.
+      append_to_csv_option(noir_options, "use_taggers", v, reset_seen: csv_reset_seen)
     end
 
     # PROBE — fire HTTP requests against the endpoints noir just
@@ -594,14 +611,20 @@ def run_options_parser
     # masked only when auto-detection happened to re-surface the
     # dropped tech. `--only-techs` and `--exclude-techs` had the
     # same shape.
+    #
+    # All three pass `reset_seen` so accumulation stops at the config
+    # file: the first CLI occurrence replaces whatever the file set.
+    # `--only-techs` is where that mattered most — appending *widened*
+    # the restriction the flag exists to impose, and left no way to
+    # override a config-file `only_techs` from the command line at all.
     parser.on "-t LIST", "--techs rails,php", "Add these techs to the analyzer set (in addition to auto-detected ones; repeatable)" do |v|
-      append_to_csv_option(noir_options, "techs", v)
+      append_to_csv_option(noir_options, "techs", v, reset_seen: csv_reset_seen)
     end
     parser.on "--only-techs LIST", "Restrict auto-detection to these tech detectors (repeatable)" do |v|
-      append_to_csv_option(noir_options, "only_techs", v)
+      append_to_csv_option(noir_options, "only_techs", v, reset_seen: csv_reset_seen)
     end
     parser.on "--exclude-techs LIST", "Drop these techs from the final result after detection (repeatable)" do |v|
-      append_to_csv_option(noir_options, "exclude_techs", v)
+      append_to_csv_option(noir_options, "exclude_techs", v, reset_seen: csv_reset_seen)
     end
 
     parser.separator "\n CONFIG:".colorize(:blue)


### PR DESCRIPTION
Flags that did something other than what they say, config keys that were a weaker
second door than the equivalent flag, and outbound requests that went somewhere the
user did not ask for.

## `noir rules update -v` printed the version and exited 0

`Legacy.rewrite` scanned the **whole** argv for a v0 terminal flag and replaced the
entire invocation, so it hijacked a subcommand's own flags — while `noir rules --help`
advertises `-v, --verbose`. The idiom the code itself recommends
(`noir rules update && noir scan . -P`, per the `exit(1)` rationale in `rules.cr`)
silently became a no-op that reported success:

```
$ noir rules update -v
1.2.1                                          # rules untouched, exit 0
```

`-V`, `--version`, `--list-techs`, `--build-info`, `--help-all` and
`--generate-completion` had the identical exposure, so the rule is scoped rather than
the one entry: the rewrite is skipped when argv opens with a known verb. v0-shaped
invocations have no verb, so `noir -b ./app --list-techs` is unaffected — verified
along with the rest of the CLI surface.

## Argv that was accepted and then ignored

`cache`, `rules`, `list` and `version` were fixed for this previously; `config` and
`completion` were left behind, so a typo ran a different command with exit 0:

```
main → this PR
noir config show --config-file    prints the DEFAULT config, rc 0  →  rc 1, "requires an argument"
noir config path init             runs `path`, ignores `init`, rc 0 →  rc 1
noir completion zsh bash          emits zsh only, rc 0              →  rc 1
noir scan ./app -u 'http://'      url becomes "http://a" (the path  →  rc 1
                                  segment promoted to the host)
noir scan ./app --exclude-path '' silently matches nothing, rc 0    →  rc 1
```

The `-u` one matters beyond cosmetics: `--probe` and `--status-codes` then fire real
requests at whatever the malformed authority resolves to. `normalize_probe_via!` had
this check for exactly that reason; `normalize_url!` did not.

## Config keys were a weaker door than the flags

| | via flag | via config file (before) |
|---|---|---|
| `--only-techs` etc. | replaces | **appended** to the config value — so the CLI could only *widen* a restriction, never override it |
| `--ai-max-token` | `positive_int_or_die!` | `"4000"` (the spelling the generated template itself uses) reached `as_i` and killed the whole AI analyzer with a cast error, exit 0 |
| `--passive-scan-severity` | rejects `bogus` | accepted, and `meets_threshold?` treats an unknown threshold as "include everything" — the filter silently inverted |
| `exclude_path` as a YAML list | — | stringified to `["*.py"]`, matched nothing, no warning |

`--config-file` also could not rescue a HOME-less environment: `ConfigInitializer`
resolved `Noir::Home.path` on its first line, before looking at the override, so
distroless containers and hardened CI runners could not run a scan at all even with
an explicit config path. And `--set-pvalue=VALUE` (the `=` spelling, which v0's
`OptionParser` accepted) had regressed to "not a valid option" while the sibling
legacy layer handled `=` correctly.

## `--status-codes` followed redirects

`perform_request` passed `handle_errors: false` but never `max_redirects: 0`, and
Crest's default is 10. Three consequences:

1. the reported code was the redirect *target's* — a 302 → 200 chain reported 200
2. `--exclude-codes 302` could never match, because the 302 was never seen
3. an absolute cross-host `Location` let the **scanned application steer noir's
   probes at a third party**: a server on :18088 redirecting to :18089 produced a real
   `GET /pwned` against a host the user never named

`SendReq`/`SendWithProxy` already set `max_redirects: 0` with a comment explaining
why; the status probe was left out of that fix. The two flags have to travel together
— `check_max_redirects` raises when `max_redirects <= 0 && handle_errors`, so turning
redirects off alone would turn every 3xx into a rescued error.

The probe also had no connect timeout (falling back to the OS' ~75 s per endpoint
against a host that drops SYNs) and ran strictly sequentially; it now reuses
`Deliver::PROBE_CONNECT_TIMEOUT` and the same `--concurrency` bound as the senders.
Separately, path-param filling substituted in declaration order with no trailing
boundary, so `:id` ate the head of `:idx` and `/u/:id/:idx` was probed as `/u/1/1x`.

## LLM clients

Any provider URL *containing* the substring `ollama` was routed to Ollama's native
`/api/generate` — including `http://gw.example/ollama/v1`, an OpenAI-compatible
gateway, whose 404 then surfaced as an empty result. The decision now keys on the
alias or the URI host. `strip_json_fences` also ran a global substring delete, so
backticks the model quoted from source were removed from the data, while a
```` ```JSON ```` tag was not recognised at all and left the language word in front of
the JSON.

## Passive rules

A matcher with a mistyped `type` or `condition` loaded as "valid" and matched nothing
— with not even the load-time warning a bad regex produces. `valid?` now checks the
vocabularies and names the offending field. A missing `info.severity` is rejected
rather than defaulted: the default `--passive-scan-severity` threshold is `high`, so
*any* default below it would filter the rule out of every report while still counting
it as loaded — the same invisible false negative, pointing the other way.

## Verification

- `crystal spec`: 29,525 examples, 0 failures · `format`/`ameba` clean
- The whole CLI surface walked by hand (v0 and v1 spellings, every subcommand, exit
  codes checked separately from output)
- Fixture sweep: no endpoint-count change
- `spec/functional_test`'s `FunctionalTester` does not exercise the CLI, which is why
  most of this survived — the new specs run the built binary and assert stdout,
  stderr and exit code separately.
