### PR TITLE
fix(kotlin/ktor): stop a documented query parameter from becoming a QUERY route

### DIFF
--- a/spec/functional_test/fixtures/kotlin/ktor/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor/Application.kt
@@ -96,6 +96,21 @@ fun Application.configureRouting() {
         options("/settings") {
             call.respond(HttpStatusCode.OK)
         }
+
+        // The OpenAPI description DSL: `query("chunk_size")` names a query
+        // parameter of this GET route, it does not declare a QUERY route.
+        get("/stream-bytes") {
+            call.respondText("streaming")
+        }.describe {
+            tag("Dynamic data")
+            summary = "Streams n random bytes at a given chunk size"
+            parameters {
+                query("chunk_size") {
+                    description = "in bytes"
+                }
+                query("seed") { }
+            }
+        }
     }
 }
 

--- a/spec/functional_test/testers/kotlin/ktor_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_spec.cr
@@ -37,6 +37,9 @@ expected_endpoints = [
     Param.new("id", "", "path"),
   ]),
   Endpoint.new("/settings", "OPTIONS"),
+  # Documented with the OpenAPI DSL: one GET route, and no QUERY route per
+  # documented query parameter.
+  Endpoint.new("/stream-bytes", "GET"),
 ]
 
 FunctionalTester.new("fixtures/kotlin/ktor/", {

--- a/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
@@ -564,6 +564,37 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
     end
   end
 
+  it "does not read a documented query parameter as a QUERY route" do
+    # `.describe { parameters { query("name") { } } }` documents an endpoint;
+    # it does not declare one. The parameter sub-DSL has the same shape as the
+    # QUERY verb call — a name and a trailing lambda, inside routing — so
+    # every documented query parameter used to surface as a route named after
+    # the parameter. The route the block hangs off must survive.
+    source = <<-KT
+      routing {
+          get("/stream-bytes") {
+              call.respondText("ok")
+          }.describe {
+              tag("Dynamic data")
+              summary = "Streams n random bytes"
+              parameters {
+                  query("chunk_size") {
+                      description = "in bytes"
+                  }
+                  query("seed") { }
+              }
+          }
+          query("/search") { }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/stream-bytes"},
+      {"QUERY", "/search"},
+    ])
+  end
+
   it "ignores a commented-out const val shadowing the live declaration" do
     # `constants[name] ||= value` is first-wins, and the declaration regex used
     # to run over the raw source: a dead constant left above the real one

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -77,6 +77,27 @@ module Noir
       "port",
     }
 
+    # API-documentation DSL blocks. They hang off a route
+    # (`get("/x") { }.describe { ... }`) or nest inside one, and they
+    # describe an endpoint rather than declaring one — no route is ever
+    # registered inside them.
+    #
+    # They have to be skipped because the parameter sub-DSL names a query
+    # parameter with `query("name") { ... }`, which is exactly the shape of
+    # the QUERY verb call (RFC 10008): a name, a trailing lambda, inside the
+    # routing scope. Without this, every documented query parameter became a
+    # QUERY route named after the parameter — `query("chunk_size")` in Ktor's
+    # own httpbin sample surfaced as `QUERY /chunk_size`.
+    #
+    # Only the lambda is skipped, never the receiver: the block is chained
+    # onto the very route it documents, so dropping the whole call would take
+    # the real route with it.
+    DOC_DSL_NAMES = Set{
+      "describe",
+      "documentation",
+      "parameters",
+    }
+
     struct Route
       getter verb : String
       getter path : String
@@ -518,6 +539,17 @@ module Noir
       if ty == "call_expression"
         name = call_name(node, source)
         case
+        when DOC_DSL_NAMES.includes?(name)
+          # Documentation, not routing (see `DOC_DSL_NAMES`). Walk everything
+          # except the call suffix — that is where the trailing lambda lives,
+          # and where a documented `query("name")` would otherwise be read as
+          # a QUERY route. The receiver stays on the walk, so the route the
+          # block documents is still emitted.
+          Noir::TreeSitter.each_named_child(node) do |child|
+            next if Noir::TreeSitter.node_type(child) == "call_suffix"
+            walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, active, resource_paths)
+          end
+          return
         when active && HTTP_VERB_NAMES.has_key?(name)
           type_name = call_type_argument_name(node, source)
           path_arg = call_string_argument(node, source, string_constants, local_string_constants)


### PR DESCRIPTION
Found while A/B-testing v1.2.1 against `main` before the next release.

## The bug

Ktor's OpenAPI description DSL names a query parameter with `query("chunk_size") { ... }` — a name, a trailing lambda, inside the routing scope. That is exactly the shape of the QUERY verb call added in #2574, and `walk`'s `active` flag is sticky, so the `.describe { }` lambda was still walked as routing:

```kotlin
get("/stream-bytes") { ... }.describe {
    parameters {
        query("chunk_size") { description = "in bytes" }   // documentation, not a route
    }
}
```

Every documented query parameter surfaced as a route named after itself. On Ktor's own [ktor-samples](https://github.com/ktorio/ktor-samples) httpbin app that meant ten false positives — `QUERY /chunk_size`, `QUERY /seed`, `QUERY /freeform`, … — and not one real QUERY route.

## The fix

A documentation block never registers a route, so `describe`, `documentation` and `parameters` now have their call suffix — where the trailing lambda lives — left out of the walk.

The receiver stays on the walk. The block is chained onto the very route it documents, so skipping the whole call would take the real route with it.

## Verification

- `ktor-samples` now returns exactly what v1.2.1 returned: 103 endpoints, the ten false positives gone, no real route moved.
- A/B over the 657-directory fixture corpus and eleven other OSS repositories (discourse, gitea, jellyfin, nest, koel, mall, flaskbb, express, …): unchanged.
- New unit spec fails without the fix (emits `QUERY /chunk_size`, `QUERY /seed`) and passes with it; the ktor functional fixture gains the documented route, and its exact-count assertion is what guards against the QUERY routes coming back.
- `crystal spec`: 5570 unit + 24415 functional, 0 failures. `crystal tool format --check` clean.