### PR TITLE
fix(output): color the QUERY method in plain text output

### DIFF
--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -84,12 +84,16 @@ class OutputBuilderCommon < OutputBuilder
     endpoints.each do |endpoint|
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
+      # Hues mirror the HTML report's method badges so the two outputs read
+      # alike: QUERY is cyan there (`--m-query`), and safe-but-bodied, so it
+      # gets its own hue rather than falling through to the uncolored default.
       r_method_color = case endpoint.method
                        when "GET"    then :green
                        when "POST"   then :blue
                        when "PUT"    then Colorize::Color256.new(208)
                        when "PATCH"  then Colorize::Color256.new(208)
                        when "DELETE" then :red
+                       when "QUERY"  then :cyan
                        else               :default
                        end
 


### PR DESCRIPTION
## Problem

`noir scan` plain-text output colorizes GET/POST/PUT/PATCH/DELETE and lets every other verb fall through to `:default`, so `QUERY` printed uncolored — even though the HTML report already had a dedicated `method-query` badge.

## Fix

`src/output_builder/common.cr` now maps `QUERY` to cyan, matching the HTML report's `--m-query` token (`#0e7490` light / `#22d3ee` dark) so the two outputs read alike.

HEAD/OPTIONS stay hueless, matching the HTML report's deliberate choice for non-primary verbs.

## Verification

```
GET    /a   -> \e[32m
POST   /b   -> \e[34m
QUERY  /c   -> \e[36m   <- new
DELETE /d   -> \e[31m
```

`crystal spec spec/unit_test/output_builder/` — 235 examples, 0 failures.

No color-assertion spec was added: `@is_color` requires `STDOUT.tty?`, which is always false under the spec runner (every existing spec here passes `color => false`).