### PR TITLE
fix(minilexer): keep Token#to_s side-effect free

### DIFF
--- a/spec/unit_test/models/minilexer/token_spec.cr
+++ b/spec/unit_test/models/minilexer/token_spec.cr
@@ -59,6 +59,16 @@ describe "Token" do
       str.should contain("\\t")
       str.should_not contain("\t")
     end
+
+    it "does not mutate the token's value" do
+      ["\n", "\t"].each do |value|
+        token = Token.new(:whitespace, value, 0)
+
+        token.to_s
+
+        token.value.should eq(value)
+      end
+    end
   end
 
   describe "property setters" do

--- a/src/models/minilexer/token.cr
+++ b/src/models/minilexer/token.cr
@@ -17,12 +17,12 @@ class Token
     @type == type
   end
 
-  def to_s
-    if @value == "\n"
-      @value = "\\n"
-    elsif @value == "\t"
-      @value = "\\t"
-    end
-    "#{@type} '#{@value}'"
+  def to_s(io : IO) : Nil
+    display = case @value
+              when "\n" then "\\n"
+              when "\t" then "\\t"
+              else           @value
+              end
+    io << @type << " '" << display << "'"
   end
 end


### PR DESCRIPTION
## Summary

- render newline and tab values without rewriting `@value`
- use Crystal's IO-based `to_s` overload while preserving output
- add a regression test for both escaped whitespace values

## Why

`Token#to_s` escaped display output by assigning back to the token's value, so formatting changed what later readers observed.

## Validation

- `crystal tool format --check`
- Ameba: 2,276 inspected, 0 failures
- focused specs: 11 examples, 0 failures
- unit suite: 5,556 examples, 0 failures, 8 pending
- functional suite: 24,415 examples, 0 failures

Fixes #2646