### PR TITLE
test: add functional coverage for Vercel specification analyzer

### DIFF
--- a/spec/functional_test/fixtures/specification/vercel/vercel.json
+++ b/spec/functional_test/fixtures/specification/vercel/vercel.json
@@ -1,0 +1,46 @@
+{
+  "rewrites": {
+    "beforeFiles": [
+      {
+        "source": "/before",
+        "destination": "/before-destination"
+      }
+    ],
+    "afterFiles": [
+      {
+        "source": "^/after/(.*)",
+        "destination": "/after-destination/$1"
+      }
+    ],
+    "fallback": [
+      {
+        "source": "/fallback",
+        "destination": "/fallback-destination"
+      }
+    ]
+  },
+  "redirects": [
+    {
+      "source": "/old",
+      "destination": "/new",
+      "permanent": true
+    }
+  ],
+  "routes": [
+    {
+      "src": "^/legacy/(.*)",
+      "dest": "/api/$1"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "x-test",
+          "value": "1"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/functional_test/testers/specification/vercel_spec.cr
+++ b/spec/functional_test/testers/specification/vercel_spec.cr
@@ -2,10 +2,10 @@ require "../../func_spec.cr"
 
 expected_endpoints = [
   Endpoint.new("/before", "ANY"),
-  Endpoint.new("^/after/(.*)", "ANY"),
+  Endpoint.new("/after/(.*)", "ANY"),
   Endpoint.new("/fallback", "ANY"),
   Endpoint.new("/old", "ANY"),
-  Endpoint.new("^/legacy/(.*)", "ANY"),
+  Endpoint.new("/legacy/(.*)", "ANY"),
   Endpoint.new("/(.*)", "ANY"),
 ]
 

--- a/spec/functional_test/testers/specification/vercel_spec.cr
+++ b/spec/functional_test/testers/specification/vercel_spec.cr
@@ -1,0 +1,15 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/before", "ANY"),
+  Endpoint.new("^/after/(.*)", "ANY"),
+  Endpoint.new("/fallback", "ANY"),
+  Endpoint.new("/old", "ANY"),
+  Endpoint.new("^/legacy/(.*)", "ANY"),
+  Endpoint.new("/(.*)", "ANY"),
+]
+
+FunctionalTester.new("fixtures/specification/vercel/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests


### PR DESCRIPTION
Fixes #2652.

## Summary

Adds functional coverage for Noir's Vercel specification analyzer.

The Vercel analyzer already has unit coverage, but there was no end-to-end
functional test covering the full detector → analyzer → endpoint pipeline
against a real `vercel.json` fixture.

This PR adds:

- a root-level `vercel.json` fixture covering:
  - rewrites
  - grouped rewrites
  - redirects
  - routes
  - headers
- a functional tester that verifies:
  - exactly one detected technology (`vercel`)
  - six expected endpoints
  - `ANY` as the method for each endpoint

The change is intentionally limited to the two files requested in #2652.
No production analyzer or detector code is modified, and `mitmproxy` is out of scope.

## Validation

Expected project checks:

- `just build`
- `just test-func-one specification/vercel`
- `crystal spec spec/functional_test`
- `just check`

These could not be run locally because Crystal/Just are not available in the
current environment. The PR is waiting for maintainer approval before the
fork CI workflows can run.