### PR TITLE
chore: count tree-sitter runtime C sources in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@ docs/tools/cli-capture/**/*.py linguist-vendored=false
 docs/tools/cli-capture/**/*.py linguist-documentation=false
 docs/tools/cli-capture/**/*.sh linguist-vendored=false
 docs/tools/cli-capture/**/*.sh linguist-documentation=false
+src/ext/tree_sitter/runtime/src/*.c linguist-vendored=false


### PR DESCRIPTION
## Description

`.gitattributes` marks everything as `linguist-vendored` and opts specific trees back in, so the vendored tree-sitter **runtime** C sources were invisible to GitHub's language stats. They are a real, compiled part of noir's build, so opt them back in.

Only `src/ext/tree_sitter/runtime/src/*.c` is un-vendored. The generated grammar parsers under `src/ext/tree_sitter/grammars/` stay vendored — they total 40.2 MB (kotlin's `parser.c` alone is 23.6 MB) and would make C the repository's dominant language.

## Measured impact

Run with `github-linguist` 9.5.0 on a clone of this branch, before and after:

| Language | Before | After |
| --- | ---: | ---: |
| Crystal | 99.65% | 95.94% |
| C | — | 3.73% |
| Shell | 0.19% | 0.18% |
| Python | 0.09% | 0.09% |
| Just | 0.03% | 0.03% |
| Nix | 0.03% | 0.03% |

Crystal stays the repository language; C shows up as a second bar.