### PR TITLE
fix(tagger): ignore a trailing slash on a guarded prefix

### DIFF
--- a/spec/unit_test/tagger/framework_taggers/prefix_scope_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/prefix_scope_spec.cr
@@ -1,0 +1,42 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/framework_taggers/prefix_scope"
+
+describe PrefixScope do
+  describe ".prefix_covers?" do
+    it "covers the prefix itself" do
+      PrefixScope.prefix_covers?("/web", "/web").should be_true
+    end
+
+    it "covers a child path" do
+      PrefixScope.prefix_covers?("/web", "/web/x").should be_true
+    end
+
+    it "does not cover a longer sibling segment" do
+      PrefixScope.prefix_covers?("/admin", "/administration/report").should be_false
+      PrefixScope.prefix_covers?("/web", "/website").should be_false
+    end
+
+    it "treats the root prefix as covering everything" do
+      PrefixScope.prefix_covers?("/", "/anything/at/all").should be_true
+      PrefixScope.prefix_covers?("/", "").should be_true
+    end
+
+    it "does not cover an unrelated url" do
+      PrefixScope.prefix_covers?("/api", "/admin/users").should be_false
+    end
+
+    it "handles prefixes with a trailing slash" do
+      PrefixScope.prefix_covers?("/web/", "/web/").should be_true
+      PrefixScope.prefix_covers?("/web/", "/web/x").should be_false
+    end
+
+    it "handles an empty url" do
+      PrefixScope.prefix_covers?("/web", "").should be_false
+    end
+
+    it "is case sensitive" do
+      PrefixScope.prefix_covers?("/web", "/WEB/x").should be_false
+      PrefixScope.prefix_covers?("/WEB", "/web").should be_false
+    end
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/prefix_scope_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/prefix_scope_spec.cr
@@ -19,15 +19,24 @@ describe PrefixScope do
     it "treats the root prefix as covering everything" do
       PrefixScope.prefix_covers?("/", "/anything/at/all").should be_true
       PrefixScope.prefix_covers?("/", "").should be_true
+      PrefixScope.prefix_covers?("", "/anything/at/all").should be_true
     end
 
     it "does not cover an unrelated url" do
       PrefixScope.prefix_covers?("/api", "/admin/users").should be_false
     end
 
-    it "handles prefixes with a trailing slash" do
+    # `app.use('/web/', auth)` mounts what `'/web'` does, and Express hands the
+    # path over unnormalized, so the trailing slash must not narrow coverage.
+    it "ignores a trailing slash on the prefix" do
+      PrefixScope.prefix_covers?("/web/", "/web").should be_true
       PrefixScope.prefix_covers?("/web/", "/web/").should be_true
-      PrefixScope.prefix_covers?("/web/", "/web/x").should be_false
+      PrefixScope.prefix_covers?("/web/", "/web/x").should be_true
+      PrefixScope.prefix_covers?("/web/", "/website").should be_false
+    end
+
+    it "covers a url with a trailing slash" do
+      PrefixScope.prefix_covers?("/web", "/web/").should be_true
     end
 
     it "handles an empty url" do

--- a/src/tagger/framework_taggers/prefix_scope.cr
+++ b/src/tagger/framework_taggers/prefix_scope.cr
@@ -16,8 +16,15 @@ module PrefixScope
   # True when `prefix` guards `url` on a segment boundary, so `/web` covers
   # `/web` and `/web/x` but not `/website`. The root prefix `/` covers every
   # endpoint.
+  #
+  # A trailing slash on the prefix is not a boundary of its own: `app.use(
+  # '/admin/', requireAuth)` mounts exactly what `'/admin'` does, and Express
+  # hands that string over verbatim. Without stripping it, `/admin/` matched
+  # neither `/admin` nor `/admin/users` and every endpoint behind that
+  # middleware was reported as unguarded.
   def prefix_covers?(prefix : String, url : String) : Bool
-    return true if prefix == "/"
-    url == prefix || url.starts_with?("#{prefix}/")
+    normalized = prefix.rstrip('/')
+    return true if normalized.empty?
+    url == normalized || url.starts_with?("#{normalized}/")
   end
 end


### PR DESCRIPTION
Closes #2650

### Description
Adds `spec/unit_test/tagger/framework_taggers/prefix_scope_spec.cr` to directly verify `PrefixScope.prefix_covers?`.

Covers:
- Covering the prefix itself
- Child path containment
- Rejection of longer sibling segments (e.g. `/admin` vs `/administration/report`, `/web` vs `/website`)
- Root prefix `/` covering all endpoints (including empty string)
- Rejection of unrelated paths
- Trailing slash behavior on prefixes
- Empty URL handling
- Case sensitivity

### Follow-up fix (maintainer)
Writing the trailing-slash case surfaced a real bug, so the second commit fixes it: `prefix_covers?` compared the prefix verbatim, so `app.use('/admin/', requireAuth)` — which in Express mounts exactly what `'/admin'` does — matched neither `/admin` nor `/admin/users`, and every endpoint behind that middleware was reported as unguarded. Trailing slashes are now stripped before the segment-boundary compare, and the spec asserts the corrected behavior (plus a url-side trailing slash and an empty prefix). Go and Ktor normalize their prefixes upstream (`join_prefix` / `normalize_prefix`), so only Express changes behavior.

### Verification
- `just check` passed
- `crystal spec spec/unit_test` passed (5565 examples, 0 failures)
- `crystal spec spec/functional_test` passed (24429 examples, 0 failures)