### PR TITLE
refactor: replace plain `if !x.nil?` at remaining sites

### DIFF
--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -1288,7 +1288,7 @@ module Analyzer::Python
               current_http_methods = nil
             end
 
-            if !method_function_match.nil?
+            if method_function_match
               method_name = method_function_match[1].upcase
               current_http_methods = [method_name]
               suspicious_http_methods << method_name
@@ -1765,14 +1765,14 @@ module Analyzer::Python
       params.each do |param|
         is_supported_param = false
         support_methods = REQUEST_PARAM_TYPE_MAP.fetch(param.param_type, nil)
-        if !support_methods.nil?
+        if support_methods.nil?
+          is_supported_param = true
+        else
           support_methods.each do |support_method|
             if upper_method == support_method.upcase
               is_supported_param = true
             end
           end
-        else
-          is_supported_param = true
         end
 
         filtered_params.each do |filtered_param|

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -1648,14 +1648,14 @@ module Analyzer::Python
       params.each do |param|
         is_support_param = false
         support_methods = REQUEST_PARAM_TYPES.fetch(param.param_type, nil)
-        if !support_methods.nil?
+        if support_methods.nil?
+          is_support_param = true
+        else
           support_methods.each do |support_method|
             if upper_method == support_method.upcase
               is_support_param = true
             end
           end
-        else
-          is_support_param = true
         end
 
         filtered_params.each do |filtered_param|

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -808,12 +808,12 @@ module Analyzer::Python
       params.each do |param|
         is_support_param = false
         support_methods = REQUEST_PARAM_TYPES.fetch(param.param_type, nil)
-        if !support_methods.nil?
+        if support_methods.nil?
+          is_support_param = true
+        else
           support_methods.each do |support_method|
             is_support_param = true if upper_method == support_method.upcase
           end
-        else
-          is_support_param = true
         end
 
         filtered_params.each do |filtered_param|

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -900,14 +900,14 @@ module Analyzer::Python
       params.each do |param|
         is_support_param = false
         support_methods = REQUEST_PARAM_TYPES.fetch(param.param_type, nil)
-        if !support_methods.nil?
+        if support_methods.nil?
+          is_support_param = true
+        else
           support_methods.each do |support_method|
             if upper_method == support_method.upcase
               is_support_param = true
             end
           end
-        else
-          is_support_param = true
         end
 
         filtered_params.each do |filtered_param|

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -619,10 +619,10 @@ module Noir::ImportGraph::Python
 
         package_type = File.exists?(File.join(package_path, "#{import}.py")) ? PackageType::FILE : PackageType::CODE
 
-        if !alias_name.nil?
-          package_map << {alias_name, py_path, package_type}
-        else
+        if alias_name.nil?
           package_map << {import, py_path, package_type}
+        else
+          package_map << {alias_name, py_path, package_type}
         end
       end
     end


### PR DESCRIPTION
Closes #2651

### Description
Replaces plain `if !x.nil?` single-condition occurrences across the analyzers and miniparsers:
- At the 5 sites with an `else` branch (`import_graph.cr:622`, `sanic.cr:903`, `django.cr:1768`, `flask.cr:1651`, `quart.cr:811`), branches were inverted to `if x.nil? ... else ... end` to avoid `unless/else` per style guidelines (and Ameba's `Style/UnlessElse` rule).
- At `django.cr:1291`, the conditional is part of an `if ... elsif` chain. Because Crystal syntax does not support `unless ... elsif`, this was rewritten to `if method_function_match` to keep the control flow linear and avoid nested conditions, consistent with `any_method_function_match` in the subsequent `elsif`.

Compound conditions and `elsif !second.nil?` were left untouched as specified in #2651.

### Verification
- `just check` (format & Ameba lint) passed: 0 failures
- `crystal spec spec/unit_test` passed: 5571 examples, 0 failures
- `crystal spec spec/functional_test` passed: 24429 examples, 0 failures
