### PR TITLE
fix(scan): give specification documents their own size budget

### DIFF
--- a/spec/unit_test/detector/silent_loss_reporting_spec.cr
+++ b/spec/unit_test/detector/silent_loss_reporting_spec.cr
@@ -3,6 +3,7 @@ require "../../spec_helper"
 require "../../../src/detector/detector"
 require "../../../src/models/analyzer"
 require "../../../src/models/code_locator"
+require "../../../src/models/locator_keys"
 require "../../../src/models/logger"
 require "../../../src/models/skipped_files"
 require "../../../src/utils/media_filter"
@@ -120,6 +121,36 @@ describe "detection walk coverage reporting" do
       gaps.first.tech.should eq(Noir::SkippedFiles::DETECT_SCOPE)
       gaps.first.message.should contain(huge)
       gaps.first.message.should contain("file too large")
+    ensure
+      FileUtils.rm_rf(temp_dir)
+    end
+  end
+
+  # The other side of that ceiling. An oversize `.py` is a generated blob and
+  # skipping it is the filter working; an oversize `openapi.json` is the
+  # document the scan exists to read. NetBox ships a 12.35MB
+  # `contrib/openapi.json` with 308 paths in it, and the media cap dropped
+  # every one of them.
+  it "reads an oversize specification document instead of reporting it as a gap" do
+    temp_dir = File.tempname("noir_oversize_spec")
+    Dir.mkdir_p(temp_dir)
+
+    begin
+      spec_path = File.join(temp_dir, "openapi.json")
+      # Padded in the description of a real path, so the document stays valid
+      # OpenAPI at more than MAX_FILE_SIZE bytes — the shape a generated spec
+      # with thousands of schemas arrives in.
+      padding = "generated schema documentation. " * 512
+      File.open(spec_path, "w") do |io|
+        io << %({"openapi":"3.0.3","info":{"title":"Big","version":"1"},"paths":{"/oversize":{"get":{"description":")
+        ((MediaFilter::MAX_FILE_SIZE // padding.bytesize) + 1).times { io << padding }
+        io << %(","responses":{"200":{"description":"ok"}}}}}})
+      end
+
+      gaps = scan_gaps(temp_dir)
+
+      gaps.should be_empty
+      CodeLocator.instance.all(Noir::LocatorKeys::OAS3_JSON).should contain(spec_path)
     ensure
       FileUtils.rm_rf(temp_dir)
     end

--- a/spec/unit_test/utils/media_filter_spec.cr
+++ b/spec/unit_test/utils/media_filter_spec.cr
@@ -6,6 +6,17 @@ require "../../../src/utils/media_filter"
 #   is_file_too_large? -> file_too_large?
 # Tests updated accordingly.
 
+# A file that reports `size` bytes without writing them: `truncate` leaves a
+# hole, so the size gate can be exercised at 10MB+ without a 10MB write per
+# example. The bytes it reads back are NUL, which is why the callers below
+# pass `sniff_binary: false` — the same way the detector walk calls
+# `skip_check`.
+private def sparse_file(extension : String, size : Int64) : String
+  path = File.tempname("noir_size_budget", extension)
+  File.open(path, "w", &.truncate(size))
+  path
+end
+
 describe MediaFilter do
   describe ".media_file?" do
     it "should detect image files" do
@@ -207,6 +218,99 @@ describe MediaFilter do
         MediaFilter.skip_check(temp).should be_nil
       ensure
         File.delete(temp) if File.exists?(temp)
+      end
+    end
+  end
+
+  describe ".spec_document?" do
+    it "recognizes specification and structured document extensions" do
+      MediaFilter.spec_document?("openapi.json").should be_true
+      MediaFilter.spec_document?("swagger.YAML").should be_true # Case insensitive
+      MediaFilter.spec_document?("service.wsdl").should be_true
+      MediaFilter.spec_document?("burp-export.xml").should be_true
+      MediaFilter.spec_document?("schema.graphql").should be_true
+    end
+
+    it "does not treat source code or media as a specification document" do
+      MediaFilter.spec_document?("bundle.js").should be_false
+      MediaFilter.spec_document?("views.py").should be_false
+      MediaFilter.spec_document?("logo.png").should be_false
+    end
+  end
+
+  describe ".max_size_for" do
+    it "gives specification documents the larger budget" do
+      MediaFilter::MAX_SPEC_FILE_SIZE.should be >= MediaFilter::MAX_FILE_SIZE
+      MediaFilter.max_size_for("openapi.json").should eq(MediaFilter::MAX_SPEC_FILE_SIZE)
+      MediaFilter.max_size_for("k8s/ingress.yaml").should eq(MediaFilter::MAX_SPEC_FILE_SIZE)
+    end
+
+    it "keeps everything else on the media cap" do
+      MediaFilter.max_size_for("app.py").should eq(MediaFilter::MAX_FILE_SIZE)
+      MediaFilter.max_size_for("logo.png").should eq(MediaFilter::MAX_FILE_SIZE)
+    end
+  end
+
+  describe "specification document budget" do
+    it "reads a specification document past the media cap" do
+      # The NetBox case: a 12MB generated `openapi.json` describing 308
+      # paths was dropped by a filter meant to keep PNGs out of the scan.
+      path = sparse_file(".json", MediaFilter::MAX_FILE_SIZE.to_i64 + 1)
+      begin
+        MediaFilter.skip_check(path, sniff_binary: false).should be_nil
+      ensure
+        File.delete(path) if File.exists?(path)
+      end
+    end
+
+    it "still applies the media cap to source files of the same size" do
+      path = sparse_file(".py", MediaFilter::MAX_FILE_SIZE.to_i64 + 1)
+      begin
+        reason = MediaFilter.skip_check(path, sniff_binary: false)
+        reason.should_not be_nil
+        reason.as(String).should contain("file too large")
+      ensure
+        File.delete(path) if File.exists?(path)
+      end
+    end
+
+    it "reports the budget that was actually applied" do
+      path = sparse_file(".json", MediaFilter::MAX_SPEC_FILE_SIZE.to_i64 + 1)
+      begin
+        reason = MediaFilter.skip_check(path, sniff_binary: false)
+        reason.should_not be_nil
+        expected_mb = (MediaFilter::MAX_SPEC_FILE_SIZE / (1024.0 * 1024.0)).round(2)
+        reason.as(String).should contain("file too large")
+        reason.as(String).should contain("> #{expected_mb}MB")
+      ensure
+        File.delete(path) if File.exists?(path)
+      end
+    end
+  end
+
+  describe ".env_size" do
+    it "returns the default when the variable is unset" do
+      ENV.delete("NOIR_SPEC_ENV_SIZE_TEST")
+      MediaFilter.env_size("NOIR_SPEC_ENV_SIZE_TEST", 1234).should eq(1234)
+    end
+
+    it "parses the same value syntax as NOIR_MAX_FILE_SIZE" do
+      ENV["NOIR_SPEC_ENV_SIZE_TEST"] = "16MB"
+      begin
+        MediaFilter.env_size("NOIR_SPEC_ENV_SIZE_TEST", 1234).should eq(16 * 1024 * 1024)
+      ensure
+        ENV.delete("NOIR_SPEC_ENV_SIZE_TEST")
+      end
+    end
+
+    it "falls back to the default on unparsable or non-positive values" do
+      ["not-a-size", "0", "-5"].each do |value|
+        ENV["NOIR_SPEC_ENV_SIZE_TEST"] = value
+        begin
+          MediaFilter.env_size("NOIR_SPEC_ENV_SIZE_TEST", 1234).should eq(1234)
+        ensure
+          ENV.delete("NOIR_SPEC_ENV_SIZE_TEST")
+        end
       end
     end
   end

--- a/spec/unit_test/utils/media_filter_spec.cr
+++ b/spec/unit_test/utils/media_filter_spec.cr
@@ -254,7 +254,7 @@ describe MediaFilter do
   describe "specification document budget" do
     it "reads a specification document past the media cap" do
       # The NetBox case: a 12MB generated `openapi.json` describing 308
-      # paths was dropped by a filter meant to keep PNGs out of the scan.
+      # paths was dropped by a filter meant to keep image files out of the scan.
       path = sparse_file(".json", MediaFilter::MAX_FILE_SIZE.to_i64 + 1)
       begin
         MediaFilter.skip_check(path, sniff_binary: false).should be_nil

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -220,8 +220,10 @@ module Noir::TreeSitter
   # spends minutes inside `ts_parser__recover` before returning. Nothing
   # in noir can interrupt that — the parse is one blocking C call, so the
   # scan simply stops, with no output and no way to tell which file did
-  # it. Files are capped at `MediaFilter::MAX_FILE_SIZE` (10 MB) and a
-  # well-formed file that size parses in well under a second, so ten
+  # it. Source files are capped at `MediaFilter::MAX_FILE_SIZE` (10 MB) —
+  # the larger `MAX_SPEC_FILE_SIZE` covers only specification documents,
+  # which no vendored grammar parses — and a well-formed file that size
+  # parses in well under a second, so ten
   # seconds is ~100x headroom over any legitimate input while still
   # bounding the pathological case.
   #

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -15,8 +15,9 @@ class Analyzer
 
   DEFAULT_CHANNEL_CAPACITY = 128
   # Detector reader → worker content channel. Each buffered entry holds a
-  # full file's content (up to MAX_FILE_SIZE), so this bounds worst-case
-  # unreclaimable memory as capacity * MAX_FILE_SIZE.
+  # full file's content (up to the size budget the media filter applied —
+  # MAX_FILE_SIZE, or MAX_SPEC_FILE_SIZE for specification documents), so
+  # this bounds worst-case unreclaimable memory as capacity * that budget.
   #
   # Was raised 16 -> 64 under the theory that the single reader fiber was
   # blocking on send and stalling disk I/O. Re-measured (#2362) on a

--- a/src/utils/media_filter.cr
+++ b/src/utils/media_filter.cr
@@ -1,22 +1,42 @@
 require "file"
 
 module MediaFilter
-  # Maximum file size for processing (default 10MB).
+  # Maximum file size for processing (default 10MB). Specification
+  # documents have their own budget — see MAX_SPEC_FILE_SIZE below.
   # Can be overridden with the environment variable NOIR_MAX_FILE_SIZE.
   # Supported formats for NOIR_MAX_FILE_SIZE:
   #   * Plain bytes integer (e.g., 5242880)
   #   * Human-readable with unit suffix (K, KB, M, MB, G, GB) e.g., 5MB, 500K, 1G
   # Invalid / unparsable values fall back to the default (10MB).
-  MAX_FILE_SIZE = begin
-    if size_str = ENV["NOIR_MAX_FILE_SIZE"]?
-      parsed = MediaFilter.parse_size(size_str)
-      parsed > 0 ? parsed : 10 * 1024 * 1024
-    else
-      10 * 1024 * 1024
-    end
-  rescue
-    10 * 1024 * 1024
-  end
+  MAX_FILE_SIZE = MediaFilter.env_size("NOIR_MAX_FILE_SIZE", 10 * 1024 * 1024)
+
+  # Size budget for specification documents, overridable with
+  # NOIR_MAX_SPEC_FILE_SIZE (same value syntax as NOIR_MAX_FILE_SIZE).
+  #
+  # `MAX_FILE_SIZE` exists to keep images, archives and compiled blobs out
+  # of the scan, and 10MB is a sensible ceiling for that. Applying it to
+  # API descriptions was collateral damage: those are plain text, they are
+  # the highest-value input noir has, and generated ones routinely pass
+  # 10MB. NetBox ships a 12.35MB `contrib/openapi.json` describing 308
+  # paths, and every one of them was dropped — not because the document
+  # was unreadable, but because a filter aimed at PNGs measured it.
+  #
+  # The budget still has to be bounded, because the document is read whole,
+  # held in the content cache, and parsed into a JSON/YAML tree that peaks
+  # at roughly 5x its size in memory. Measured with a release build:
+  # NetBox's 12.35MB document costs 0.18s and 81MB peak RSS for the whole
+  # scan; a 76MB variant of it (same document, component schemas
+  # multiplied, forced through with the override) costs 0.90s and 392MB.
+  # 64MB is the ceiling because it keeps one document under a second and a
+  # few hundred MB while leaving 5x headroom over the largest generated
+  # spec observed in the wild. Past that a `.json` is a data dump, not an
+  # API description.
+  #
+  # Floored at MAX_FILE_SIZE so that raising the general cap past 64MB
+  # lifts specification documents with it rather than capping them below
+  # everything else. Lowering the general cap does not lower this budget;
+  # use NOIR_MAX_SPEC_FILE_SIZE for that.
+  MAX_SPEC_FILE_SIZE = {MediaFilter.env_size("NOIR_MAX_SPEC_FILE_SIZE", 64 * 1024 * 1024), MAX_FILE_SIZE}.max
 
   # Common media file extensions that should be skipped
   MEDIA_EXTENSIONS = [
@@ -52,6 +72,38 @@ module MediaFilter
   # path — every file in the project is checked once.
   MEDIA_EXTENSION_SET = MEDIA_EXTENSIONS.to_set
 
+  # Extensions that carry an API description or a structured document
+  # noir reads as one. These get MAX_SPEC_FILE_SIZE instead of the media
+  # cap.
+  #
+  # The list mirrors the file gates of `src/detector/detectors/specification/*`
+  # (`grep -h "detector_for" src/detector/detectors/specification/*.cr`)
+  # with two deliberate omissions. Binary container formats get no relief:
+  # mitmproxy's `.flow` dumps are NUL-bearing blobs the walk drops on
+  # content regardless of size. Neither do the source extensions the AWS
+  # CDK detector reads (`.ts`, `.js`, `.py`, …) — a 12MB `.js` or `.py` is
+  # a bundled or generated artifact, where a 12MB `.json` is usually
+  # exactly the document the scan is looking for.
+  #
+  # The list is by extension rather than by content because a document's
+  # own marker (`"openapi"`, `"swagger"`) can sit anywhere in it, and a
+  # prefix sniff that misses one is a silent loss again. The cost of being
+  # wrong the other way is small: a 32MB `package-lock.json` matches no
+  # specification marker, so the walk reads it and drops every spec
+  # detector without parsing — 0.08s more than skipping it outright.
+  SPEC_DOCUMENT_EXTENSIONS = [
+    # Structured document formats: OpenAPI/Swagger, AsyncAPI, OpenRPC,
+    # Postman, HAR, k8s/Istio/Envoy/Kong manifests, CloudFormation,
+    # Terraform, WSDL and Burp/ZAP exports all arrive as one of these.
+    ".json", ".yaml", ".yml", ".xml", ".toml", ".tf",
+
+    # Format-specific extensions.
+    ".har", ".raml", ".wsdl", ".smithy", ".tsp", ".proto", ".bru",
+    ".graphql", ".gql", ".graphqls", ".http", ".rest",
+  ]
+
+  SPEC_DOCUMENT_EXTENSION_SET = SPEC_DOCUMENT_EXTENSIONS.to_set
+
   # Cache for parsed size strings
   @@size_cache : Hash(String, Int32) = Hash(String, Int32).new
 
@@ -84,20 +136,51 @@ module MediaFilter
     result
   end
 
+  # Byte budget read from `name`, falling back to `default` when the
+  # variable is unset, unparsable or non-positive.
+  #
+  # Split out of the constant initializers so both budgets resolve the same
+  # way and a spec can exercise the parsing without reloading the module —
+  # the constants read ENV once, at first use.
+  def self.env_size(name : String, default : Int32) : Int32
+    raw = ENV[name]?
+    return default if raw.nil?
+    parsed = parse_size(raw)
+    parsed > 0 ? parsed : default
+  rescue
+    default
+  end
+
   # Check if a file should be skipped based on extension
   def self.media_file?(file_path : String) : Bool
     extension = File.extname(file_path).downcase
     MEDIA_EXTENSION_SET.includes?(extension)
   end
 
-  # Check if a file is too large to process
-  def self.file_too_large?(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : Bool
+  # True when the path names a specification document (see
+  # SPEC_DOCUMENT_EXTENSIONS), which is read under the larger budget.
+  def self.spec_document?(file_path : String) : Bool
+    SPEC_DOCUMENT_EXTENSION_SET.includes?(File.extname(file_path).downcase)
+  end
+
+  # The size budget that applies to `file_path`.
+  def self.max_size_for(file_path : String) : Int32
+    max_size_for_extension(File.extname(file_path).downcase)
+  end
+
+  private def self.max_size_for_extension(extension : String) : Int32
+    SPEC_DOCUMENT_EXTENSION_SET.includes?(extension) ? MAX_SPEC_FILE_SIZE : MAX_FILE_SIZE
+  end
+
+  # Check if a file is too large to process. `max_size` defaults to the
+  # budget for the file's own kind — pass one only to override it.
+  def self.file_too_large?(file_path : String, max_size : Int32? = nil) : Bool
     # Gracefully handle missing or unreadable files
     return false unless File.exists?(file_path)
     begin
       size = File.size(file_path)
       return false unless size
-      size > max_size
+      size > (max_size || max_size_for(file_path))
     rescue
       false
     end
@@ -111,9 +194,14 @@ module MediaFilter
   # When the caller has already obtained a `File::Info` (e.g. the
   # detector walker stats each entry with `follow_symlinks: false`), it
   # can be passed as `info` to skip the size stat entirely.
-  def self.skip_check(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil, sniff_binary : Bool = true) : String?
+  #
+  # `max_size` defaults to the budget for the file's own kind, so the
+  # reported ceiling is the one that was actually applied.
+  def self.skip_check(file_path : String, max_size : Int32? = nil, info : File::Info? = nil, sniff_binary : Bool = true) : String?
     extension = File.extname(file_path).downcase
     return "media file (#{extension})" if MEDIA_EXTENSION_SET.includes?(extension)
+
+    limit = max_size || max_size_for_extension(extension)
 
     size = if info
              info.size
@@ -125,9 +213,9 @@ module MediaFilter
              end
            end
 
-    if size && size > max_size
+    if size && size > limit
       size_mb = (size / (1024.0 * 1024.0)).round(2)
-      max_mb = (max_size / (1024.0 * 1024.0)).round(2)
+      max_mb = (limit / (1024.0 * 1024.0)).round(2)
       return "file too large (#{size_mb}MB > #{max_mb}MB)"
     end
 
@@ -182,13 +270,13 @@ module MediaFilter
   # Combined check - returns true if file should be skipped. Prefer
   # {skip_check} on hot paths: it returns the reason in the same call
   # so the caller does not re-stat to log.
-  def self.should_skip_file?(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil, sniff_binary : Bool = true) : Bool
+  def self.should_skip_file?(file_path : String, max_size : Int32? = nil, info : File::Info? = nil, sniff_binary : Bool = true) : Bool
     !skip_check(file_path, max_size, info, sniff_binary).nil?
   end
 
   # Get a human-readable reason why a file was skipped. Kept for
   # backwards compatibility; new callers should use {skip_check}.
-  def self.skip_reason(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil, sniff_binary : Bool = true) : String?
+  def self.skip_reason(file_path : String, max_size : Int32? = nil, info : File::Info? = nil, sniff_binary : Bool = true) : String?
     skip_check(file_path, max_size, info, sniff_binary)
   end
 end

--- a/src/utils/media_filter.cr
+++ b/src/utils/media_filter.cr
@@ -19,7 +19,7 @@ module MediaFilter
   # the highest-value input noir has, and generated ones routinely pass
   # 10MB. NetBox ships a 12.35MB `contrib/openapi.json` describing 308
   # paths, and every one of them was dropped — not because the document
-  # was unreadable, but because a filter aimed at PNGs measured it.
+  # was unreadable, but because a filter aimed at image files measured it.
   #
   # The budget still has to be bounded, because the document is read whole,
   # held in the content cache, and parsed into a JSON/YAML tree that peaks


### PR DESCRIPTION
## What was broken

One 10MB cap, `MediaFilter::MAX_FILE_SIZE`, was applied to every file noir reads. It exists to keep images, archives and compiled blobs out of the scan — but it also silently excluded large **API specification documents**, which are plain text and are exactly the input noir most wants.

Reproduced on NetBox (`git clone --depth 1 https://github.com/netbox-community/netbox`), whose `contrib/openapi.json` is 12.35MB of OpenAPI 3.0.3 with 308 paths / 1193 operations:

```
$ noir -b netbox/contrib -f json
⚬ Skipped 1 media/large files out of 9 total files
✔ Identified 4 endpoints in total.
▲ 1 coverage gap reported; results may be incomplete.
  └── detect: skipped 1 file: .../contrib/openapi.json; first error: file too large (12.35MB > 10.0MB)
```

Four endpoints, all from the nginx/Apache configs sitting next to it. The 308 API paths were lost. Generated OpenAPI documents pass 10MB as a matter of course on a sizeable Django/DRF or gRPC-gateway project, so this is not an edge case.

## What changed

`src/utils/media_filter.cr` now resolves a size budget per file kind instead of applying one number to everything:

- **`MAX_SPEC_FILE_SIZE`, default 64MB**, applies to specification and structured-document extensions (`.json`, `.yaml`, `.yml`, `.xml`, `.toml`, `.tf`, `.har`, `.raml`, `.wsdl`, `.smithy`, `.tsp`, `.proto`, `.bru`, `.graphql`, `.gql`, `.graphqls`, `.http`, `.rest`). The list mirrors the file gates of `src/detector/detectors/specification/*`, minus binary containers (mitmproxy `.flow` dumps, which the walk drops on content anyway) and minus the source extensions the AWS CDK detector reads.
- **`MAX_FILE_SIZE` (10MB) is unchanged** and still governs everything else, source code included. A 12MB `.js` is a bundle; a 12MB `.json` is usually the document the scan is looking for.
- **Overridable with `NOIR_MAX_SPEC_FILE_SIZE`**, same value syntax `NOIR_MAX_FILE_SIZE` already accepts (`64MB`, `500K`, raw bytes; invalid/non-positive falls back to the default). The parsing moved into a shared `MediaFilter.env_size` so both budgets resolve identically.
- The spec budget is **floored at `MAX_FILE_SIZE`**, so raising the general cap past 64MB lifts specification documents with it rather than capping them below everything else.
- `skip_check` / `should_skip_file?` / `file_too_large?` / `skip_reason` take `max_size : Int32? = nil` and default to the budget for the file's own kind; an explicit argument still overrides.

Two comments elsewhere that asserted the old single-cap invariant were corrected: the content-channel memory bound in `src/models/analyzer.cr` and the tree-sitter parse-timeout rationale in `src/ext/tree_sitter/tree_sitter.cr` (no vendored grammar parses a specification document, so its 10MB premise still holds for the files it covers).

### Why 64MB

Bounded on purpose. The document is read whole, held in the content cache, and parsed into a JSON/YAML tree that peaks at roughly 5x its size in memory. Measured with `--release` builds:

| Input | Wall clock | Peak RSS | Endpoints |
|---|---|---|---|
| NetBox `openapi.json`, 12.35MB | 0.18s | 81MB | 1197 |
| Same, schemas x5 → 19.26MB | 0.26s | 130MB | 1193 |
| Same, schemas x26 → 75.93MB (over budget, forced with the override) | 0.90s | 392MB | 1193 |

64MB keeps one document under a second and a few hundred MB, with ~5x headroom over the largest generated spec observed in the wild. Past that a `.json` is a data dump, not an API description.

Widening by extension rather than by content sniffing is deliberate: a document's own marker (`"openapi"`, `"swagger"`) can sit anywhere in the file, and a prefix sniff that misses one is a silent loss all over again. The cost of being wrong the other way is small — a 32MB `package-lock.json` matches no specification marker, so the walk reads it and drops every spec detector without parsing: 0.10s vs 0.02s for skipping it outright.

### Reporting is preserved

Whatever still exceeds the new budget is reported the same way, now naming the budget that was actually applied:

```
first error: file too large (75.93MB > 64.0MB)
```

and it still lands in `errors` / the coverage-gap warning / `--strict`.

## Verification

- **NetBox, before → after**: 4 endpoints → **1197** — `{apache_httpd: 3, nginx: 1, oas3: 1193}`, **308 distinct oas3 paths**, matching the document's 308 paths / 1193 operations exactly. `errors: []`.
- **No scan regression**: `spec/functional_test/fixtures` (2387 files), `--release` builds interleaved over six rounds — baseline mean 0.705s, patched mean 0.707s; endpoint count identical at 3189 over six runs each.
- **Full spec suite**: `crystal spec` → **30020 examples, 0 failures, 0 errors, 0 pending**.
- **Lint/format**: `just check` (`crystal tool format --check` + ameba) → 2279 inspected, 0 failures.

New coverage in `spec/`:

- `spec/unit_test/utils/media_filter_spec.cr` — `spec_document?`, `max_size_for`, `env_size` (default / `16MB` / unparsable / non-positive), and `skip_check` on sparse 10MB+ files: a `.json` passes, the same size as `.py` is still skipped, and an over-budget `.json` reports the spec budget in its message.
- `spec/unit_test/detector/silent_loss_reporting_spec.cr` — end-to-end through the detector walk: an oversize but valid `openapi.json` produces no coverage gap and is registered under `LocatorKeys::OAS3_JSON`, alongside the existing test that an oversize `.py` still is reported.
