### PR TITLE
feat(specification): read the operations a split OpenAPI document refs

### DIFF
--- a/spec/functional_test/fixtures/specification/oas3/split_document/openapi.yaml
+++ b/spec/functional_test/fixtures/specification/oas3/split_document/openapi.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.1
+info:
+  title: Split Document API
+  version: '1'
+servers:
+  - url: /api
+paths:
+  # The standard split shape: the path string stays here, the operations live
+  # one file away.
+  /pets:
+    $ref: './paths/pets.yaml'
+  # File plus JSON Pointer, for a file that holds more than one path item.
+  /pets/{petId}:
+    $ref: './paths/shared.yaml#/PetById'
+  # Refs noir declines to follow. None of them may cost the paths around it.
+  /remote:
+    $ref: 'https://specs.example.com/paths/remote.yaml'
+  /escape:
+    $ref: '../../../../../../../../etc/passwd'
+  /missing:
+    $ref: './paths/missing.yaml'
+  # Two files that name each other. Resolution has to stop, not recurse.
+  /loop:
+    $ref: './paths/loop_a.yaml'
+components:
+  parameters:
+    Fields:
+      $ref: './parameters/fields.yaml'
+    PetId:
+      name: petId
+      in: path
+      required: true
+      schema:
+        type: string
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        tag:
+          type: string

--- a/spec/functional_test/fixtures/specification/oas3/split_document/parameters/fields.yaml
+++ b/spec/functional_test/fixtures/specification/oas3/split_document/parameters/fields.yaml
@@ -1,0 +1,6 @@
+name: fields
+in: query
+required: false
+description: Fields to return.
+schema:
+  type: string

--- a/spec/functional_test/fixtures/specification/oas3/split_document/paths/loop_a.yaml
+++ b/spec/functional_test/fixtures/specification/oas3/split_document/paths/loop_a.yaml
@@ -1,0 +1,1 @@
+$ref: './loop_b.yaml'

--- a/spec/functional_test/fixtures/specification/oas3/split_document/paths/loop_b.yaml
+++ b/spec/functional_test/fixtures/specification/oas3/split_document/paths/loop_b.yaml
@@ -1,0 +1,1 @@
+$ref: './loop_a.yaml'

--- a/spec/functional_test/fixtures/specification/oas3/split_document/paths/pets.yaml
+++ b/spec/functional_test/fixtures/specification/oas3/split_document/paths/pets.yaml
@@ -1,0 +1,25 @@
+get:
+  operationId: listPets
+  summary: List pets
+  parameters:
+    # Back into the entry document, which refs a third file for the parameter
+    # itself: each hop resolves from the file that wrote it.
+    - $ref: '../openapi.yaml#/components/parameters/Fields'
+    - name: limit
+      in: query
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+post:
+  operationId: createPet
+  summary: Create a pet
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../openapi.yaml#/components/schemas/Pet'
+  responses:
+    '201':
+      description: Created

--- a/spec/functional_test/fixtures/specification/oas3/split_document/paths/shared.yaml
+++ b/spec/functional_test/fixtures/specification/oas3/split_document/paths/shared.yaml
@@ -1,0 +1,18 @@
+PetById:
+  parameters:
+    - $ref: '../openapi.yaml#/components/parameters/PetId'
+  get:
+    operationId: showPet
+    responses:
+      '200':
+        description: OK
+  delete:
+    operationId: deletePet
+    parameters:
+      - name: X-Reason
+        in: header
+        schema:
+          type: string
+    responses:
+      '204':
+        description: No Content

--- a/spec/functional_test/testers/specification/oas3_spec.cr
+++ b/spec/functional_test/testers/specification/oas3_spec.cr
@@ -104,6 +104,37 @@ FunctionalTester.new("fixtures/specification/oas3/param_in_path/", {
   ]),
 ]).perform_tests
 
+# A document split across files: the path strings stay in `openapi.yaml` and
+# each operation lives one `$ref` away, which is the layout Redocly, Stoplight
+# and swagger-cli all recommend for anything large. The parameters ride a
+# second hop — path file back into the entry document, entry document out to
+# the parameter's own file — so each ref has to resolve from the file that
+# wrote it rather than from the document the scan started at.
+#
+# The fixture also carries the four refs noir does not follow (remote,
+# escaping the scan base, missing, and a two-file cycle). None of them may cost
+# the paths around them, which is what the count asserts.
+FunctionalTester.new("fixtures/specification/oas3/split_document/", {
+  :techs     => 1,
+  :endpoints => 4,
+}, [
+  Endpoint.new("/api/pets", "GET", [
+    Param.new("fields", "", "query"),
+    Param.new("limit", "", "query"),
+  ]),
+  Endpoint.new("/api/pets", "POST", [
+    Param.new("name", "", "json"),
+    Param.new("tag", "", "json"),
+  ]),
+  Endpoint.new("/api/pets/{petId}", "GET", [
+    Param.new("petId", "", "path"),
+  ]),
+  Endpoint.new("/api/pets/{petId}", "DELETE", [
+    Param.new("petId", "", "path"),
+    Param.new("X-Reason", "", "header"),
+  ]),
+]).perform_tests
+
 FunctionalTester.new("fixtures/specification/oas3/security_schemes/", {
   :techs     => 1,
   :endpoints => 4,

--- a/spec/unit_test/analyzer/specification/oas_external_refs_spec.cr
+++ b/spec/unit_test/analyzer/specification/oas_external_refs_spec.cr
@@ -1,0 +1,288 @@
+require "file_utils"
+require "../../../spec_helper"
+require "../../../../src/analyzer/analyzers/specification/oas2"
+require "../../../../src/analyzer/analyzers/specification/oas3"
+require "../../../../src/models/code_locator"
+require "../../../../src/models/locator_keys"
+require "../../../../src/models/skipped_files"
+
+# A `$ref` in the `paths` map points at another file, and until that is
+# followed a split document yields nothing at all: the path strings are in the
+# entry document, the operations are one file away. These specs pin the three
+# limits that resolution runs under — local files only, contained inside the
+# scan base, and terminating on a cycle — plus the promise that a ref noir
+# will not follow costs only itself.
+
+private def spec_options(base : String) : Hash(String, YAML::Any)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(base)])
+  options
+end
+
+private def analyze_oas3(base : String, entry : String) : Array(Endpoint)
+  CodeLocator.instance.clear_all
+  CodeLocator.instance.push(Noir::LocatorKeys::OAS3_YAML, entry)
+  Analyzer::Specification::Oas3.new(spec_options(base)).analyze
+end
+
+private def analyze_oas2(base : String, entry : String) : Array(Endpoint)
+  CodeLocator.instance.clear_all
+  CodeLocator.instance.push(Noir::LocatorKeys::SWAGGER_YAML, entry)
+  Analyzer::Specification::Oas2.new(spec_options(base)).analyze
+end
+
+private def skip_messages : Array(String)
+  Noir::SkippedFiles.failures(Noir::SkippedFiles::Phase::Analysis).map(&.message)
+end
+
+private def with_temp_dir(name : String, &)
+  dir = File.tempname(name)
+  Dir.mkdir_p(dir)
+  begin
+    yield dir
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end
+
+describe "OpenAPI external $ref resolution" do
+  before_each { Noir::SkippedFiles.clear }
+  after_each do
+    Noir::SkippedFiles.clear
+    CodeLocator.instance.clear_all
+  end
+
+  it "reads operations out of the file a path item refs" do
+    with_temp_dir("noir_oas_split") do |dir|
+      Dir.mkdir_p(File.join(dir, "paths"))
+      entry = File.join(dir, "openapi.yaml")
+      File.write(entry, <<-YAML)
+        openapi: 3.0.1
+        info:
+          title: Split
+          version: '1'
+        paths:
+          /pets:
+            $ref: './paths/pets.yaml'
+        components:
+          parameters:
+            Fields:
+              name: fields
+              in: query
+              schema:
+                type: string
+        YAML
+      File.write(File.join(dir, "paths", "pets.yaml"), <<-YAML)
+        get:
+          operationId: listPets
+          parameters:
+            - $ref: '../openapi.yaml#/components/parameters/Fields'
+        YAML
+
+      endpoints = analyze_oas3(dir, entry)
+
+      endpoints.size.should eq(1)
+      endpoints[0].method.should eq("GET")
+      endpoints[0].url.should eq("/pets")
+      # The fragment after the file name is followed too: declining it would
+      # read the operation and lose every parameter it declares.
+      endpoints[0].params.map(&.name).should contain("fields")
+    end
+  end
+
+  it "refuses a ref that resolves outside the scan base" do
+    with_temp_dir("noir_oas_escape") do |dir|
+      project = File.join(dir, "project")
+      Dir.mkdir_p(project)
+
+      # A perfectly valid path item, and readable — only the containment rule
+      # stands between it and the scan.
+      File.write(File.join(dir, "secrets.yaml"), <<-YAML)
+        get:
+          operationId: leak
+        YAML
+      File.write(File.join(project, "inside.yaml"), <<-YAML)
+        get:
+          operationId: listPets
+        YAML
+
+      entry = File.join(project, "openapi.yaml")
+      File.write(entry, <<-YAML)
+        openapi: 3.0.1
+        info:
+          title: Escape
+          version: '1'
+        paths:
+          /pets:
+            $ref: './inside.yaml'
+          /leak:
+            $ref: '../secrets.yaml'
+        YAML
+
+      endpoints = analyze_oas3(project, entry)
+
+      endpoints.map(&.url).should eq(["/pets"])
+      skip_messages.join("\n").should contain("outside the scan base")
+    end
+  end
+
+  it "does not follow a symlinked ref target" do
+    with_temp_dir("noir_oas_symlink") do |dir|
+      project = File.join(dir, "project")
+      Dir.mkdir_p(project)
+
+      File.write(File.join(dir, "secrets.yaml"), <<-YAML)
+        get:
+          operationId: leak
+        YAML
+      # The link itself sits inside the scan base, so the textual containment
+      # check passes; only refusing to follow it keeps the scan in the tree.
+      File.symlink(File.join(dir, "secrets.yaml"), File.join(project, "link.yaml"))
+      File.write(File.join(project, "inside.yaml"), <<-YAML)
+        get:
+          operationId: listPets
+        YAML
+
+      entry = File.join(project, "openapi.yaml")
+      File.write(entry, <<-YAML)
+        openapi: 3.0.1
+        info:
+          title: Symlink
+          version: '1'
+        paths:
+          /pets:
+            $ref: './inside.yaml'
+          /leak:
+            $ref: './link.yaml'
+        YAML
+
+      endpoints = analyze_oas3(project, entry)
+
+      endpoints.map(&.url).should eq(["/pets"])
+      skip_messages.join("\n").should contain("symbolic link")
+    end
+  end
+
+  it "does not fetch a remote ref" do
+    with_temp_dir("noir_oas_remote") do |dir|
+      File.write(File.join(dir, "inside.yaml"), <<-YAML)
+        get:
+          operationId: listPets
+        YAML
+
+      entry = File.join(dir, "openapi.yaml")
+      File.write(entry, <<-YAML)
+        openapi: 3.0.1
+        info:
+          title: Remote
+          version: '1'
+        paths:
+          /pets:
+            $ref: './inside.yaml'
+          /remote:
+            $ref: 'https://specs.example.com/paths/remote.yaml'
+        YAML
+
+      endpoints = analyze_oas3(dir, entry)
+
+      endpoints.map(&.url).should eq(["/pets"])
+      skip_messages.join("\n").should contain("remote target is not fetched")
+    end
+  end
+
+  it "terminates on a cycle between two files" do
+    with_temp_dir("noir_oas_cycle") do |dir|
+      File.write(File.join(dir, "a.yaml"), "$ref: './b.yaml'\n")
+      File.write(File.join(dir, "b.yaml"), "$ref: './a.yaml'\n")
+      File.write(File.join(dir, "params.yaml"), <<-YAML)
+        $ref: './params.yaml'
+        YAML
+
+      entry = File.join(dir, "openapi.yaml")
+      File.write(entry, <<-YAML)
+        openapi: 3.0.1
+        info:
+          title: Cycle
+          version: '1'
+        paths:
+          /loop:
+            $ref: './a.yaml'
+          /pets:
+            get:
+              operationId: listPets
+              parameters:
+                - $ref: './params.yaml'
+        YAML
+
+      endpoints = analyze_oas3(dir, entry)
+
+      # Reaching this line at all is the assertion: an unbroken cycle either
+      # hangs or exhausts the stack.
+      endpoints.map(&.url).should eq(["/pets"])
+      endpoints[0].params.should be_empty
+    end
+  end
+
+  it "keeps the paths it already read when a target is missing" do
+    with_temp_dir("noir_oas_missing") do |dir|
+      File.write(File.join(dir, "inside.yaml"), <<-YAML)
+        get:
+          operationId: listPets
+        YAML
+
+      entry = File.join(dir, "openapi.yaml")
+      File.write(entry, <<-YAML)
+        openapi: 3.0.1
+        info:
+          title: Missing
+          version: '1'
+        paths:
+          /gone:
+            $ref: './nowhere.yaml'
+          /pets:
+            $ref: './inside.yaml'
+        YAML
+
+      endpoints = analyze_oas3(dir, entry)
+
+      endpoints.map(&.url).should eq(["/pets"])
+      messages = skip_messages.join("\n")
+      messages.should contain("./nowhere.yaml")
+      messages.should contain("target not found")
+    end
+  end
+
+  it "resolves a split Swagger 2.0 document the same way" do
+    with_temp_dir("noir_oas2_split") do |dir|
+      Dir.mkdir_p(File.join(dir, "paths"))
+      entry = File.join(dir, "swagger.yaml")
+      File.write(entry, <<-YAML)
+        swagger: '2.0'
+        info:
+          title: Split
+          version: '1'
+        basePath: /v1
+        paths:
+          /pets:
+            $ref: './paths/pets.yaml'
+        parameters:
+          Fields:
+            name: fields
+            in: query
+            type: string
+        YAML
+      File.write(File.join(dir, "paths", "pets.yaml"), <<-YAML)
+        get:
+          operationId: listPets
+          parameters:
+            - $ref: '../swagger.yaml#/parameters/Fields'
+        YAML
+
+      endpoints = analyze_oas2(dir, entry)
+
+      endpoints.size.should eq(1)
+      endpoints[0].url.should eq("/v1/pets")
+      endpoints[0].params.map(&.name).should contain("fields")
+    end
+  end
+end

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -8,18 +8,18 @@ module Analyzer::Specification
     HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
 
     # Walks a body schema and emits a Param per top-level property.
-    private def collect_body_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+    private def collect_body_props_json(doc : SpecDoc(JSON::Any), schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
       if ref = schema["$ref"]?.try(&.as_s?)
-        return if seen.includes?(ref)
-        seen << ref
-        if resolved = resolve_ref_json(root, ref)
-          collect_body_props_json(root, resolved, param_type, params, seen)
+        return unless seen.add?(ref_key(doc, ref))
+        if resolved = resolve_ref_json(doc, ref)
+          node, ref_doc = resolved
+          collect_body_props_json(ref_doc, node, param_type, params, seen)
         end
         return
       end
 
       if items = schema["items"]?
-        collect_body_props_json(root, items, param_type, params, seen)
+        collect_body_props_json(doc, items, param_type, params, seen)
       end
 
       if props = schema["properties"]?.try(&.as_h?)
@@ -29,32 +29,32 @@ module Analyzer::Specification
       end
 
       if all_of = schema["allOf"]?.try(&.as_a?)
-        all_of.each { |s| collect_body_props_json(root, s, param_type, params, seen) }
+        all_of.each { |s| collect_body_props_json(doc, s, param_type, params, seen) }
       end
 
       if one_of = schema["oneOf"]?.try(&.as_a?)
-        one_of.each { |s| collect_body_props_json(root, s, param_type, params, seen) }
+        one_of.each { |s| collect_body_props_json(doc, s, param_type, params, seen) }
       end
 
       if any_of = schema["anyOf"]?.try(&.as_a?)
-        any_of.each { |s| collect_body_props_json(root, s, param_type, params, seen) }
+        any_of.each { |s| collect_body_props_json(doc, s, param_type, params, seen) }
       end
     end
 
-    private def collect_body_props_yaml(root : YAML::Any, schema : YAML::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+    private def collect_body_props_yaml(doc : SpecDoc(YAML::Any), schema : YAML::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
       if ref_node = schema[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
-          return if seen.includes?(ref)
-          seen << ref
-          if resolved = resolve_ref_yaml(root, ref)
-            collect_body_props_yaml(root, resolved, param_type, params, seen)
+          return unless seen.add?(ref_key(doc, ref))
+          if resolved = resolve_ref_yaml(doc, ref)
+            node, ref_doc = resolved
+            collect_body_props_yaml(ref_doc, node, param_type, params, seen)
           end
         end
         return
       end
 
       if items_node = schema[YAML::Any.new("items")]?
-        collect_body_props_yaml(root, items_node, param_type, params, seen)
+        collect_body_props_yaml(doc, items_node, param_type, params, seen)
       end
 
       if props_node = schema[YAML::Any.new("properties")]?
@@ -67,19 +67,19 @@ module Analyzer::Specification
 
       if all_of_node = schema[YAML::Any.new("allOf")]?
         if all_of = all_of_node.as_a?
-          all_of.each { |s| collect_body_props_yaml(root, s, param_type, params, seen) }
+          all_of.each { |s| collect_body_props_yaml(doc, s, param_type, params, seen) }
         end
       end
 
       if one_of_node = schema[YAML::Any.new("oneOf")]?
         if one_of = one_of_node.as_a?
-          one_of.each { |s| collect_body_props_yaml(root, s, param_type, params, seen) }
+          one_of.each { |s| collect_body_props_yaml(doc, s, param_type, params, seen) }
         end
       end
 
       if any_of_node = schema[YAML::Any.new("anyOf")]?
         if any_of = any_of_node.as_a?
-          any_of.each { |s| collect_body_props_yaml(root, s, param_type, params, seen) }
+          any_of.each { |s| collect_body_props_yaml(doc, s, param_type, params, seen) }
         end
       end
     end
@@ -95,11 +95,15 @@ module Analyzer::Specification
       end
     end
 
-    private def extract_param_json(root : JSON::Any, param_obj : JSON::Any, consumes : Array(String), params : Array(Param))
+    # `seen` breaks a ref that leads back to itself, directly or through
+    # another document.
+    private def extract_param_json(doc : SpecDoc(JSON::Any), param_obj : JSON::Any, consumes : Array(String), params : Array(Param), seen : Set(String) = Set(String).new)
       # Parameters can themselves be $ref'd.
       if ref = param_obj["$ref"]?.try(&.as_s?)
-        if resolved = resolve_ref_json(root, ref)
-          extract_param_json(root, resolved, consumes, params)
+        return unless seen.add?(ref_key(doc, ref))
+        if resolved = resolve_ref_json(doc, ref)
+          node, ref_doc = resolved
+          extract_param_json(ref_doc, node, consumes, params, seen)
         end
         return
       end
@@ -109,7 +113,7 @@ module Analyzer::Specification
       case location
       when "body"
         if schema = param_obj["schema"]?
-          collect_body_props_json(root, schema, param_type_for_body(consumes), params)
+          collect_body_props_json(doc, schema, param_type_for_body(consumes), params)
         end
       else
         return if name.empty?
@@ -124,11 +128,13 @@ module Analyzer::Specification
       end
     end
 
-    private def extract_param_yaml(root : YAML::Any, param_obj : YAML::Any, consumes : Array(String), params : Array(Param))
+    private def extract_param_yaml(doc : SpecDoc(YAML::Any), param_obj : YAML::Any, consumes : Array(String), params : Array(Param), seen : Set(String) = Set(String).new)
       if ref_node = param_obj[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
-          if resolved = resolve_ref_yaml(root, ref)
-            extract_param_yaml(root, resolved, consumes, params)
+          return unless seen.add?(ref_key(doc, ref))
+          if resolved = resolve_ref_yaml(doc, ref)
+            node, ref_doc = resolved
+            extract_param_yaml(ref_doc, node, consumes, params, seen)
           end
         end
         return
@@ -139,7 +145,7 @@ module Analyzer::Specification
       case location
       when "body"
         if schema = param_obj[YAML::Any.new("schema")]?
-          collect_body_props_yaml(root, schema, param_type_for_body(consumes), params)
+          collect_body_props_yaml(doc, schema, param_type_for_body(consumes), params)
         end
       else
         return if name.empty?
@@ -238,23 +244,33 @@ module Analyzer::Specification
       end
     end
 
-    private def resolve_path_item_json(root : JSON::Any, path_obj : JSON::Any, seen : Set(String) = Set(String).new) : JSON::Any
-      return path_obj unless path_obj_h = path_obj.as_h?
-      return path_obj unless ref = path_obj_h["$ref"]?.try(&.as_s?)
-      return path_obj if seen.includes?(ref)
-      seen << ref
-      resolved = resolve_ref_json(root, ref)
-      resolved ? resolve_path_item_json(root, resolved, seen) : path_obj
+    # Resolves the `$ref` a Path Item may stand in for, and reports which
+    # document the result came from — a ref inside an operation that arrived
+    # from `./paths/pets.yaml` resolves from that file, not from the entry
+    # document that named it.
+    private def resolve_path_item_json(doc : SpecDoc(JSON::Any), path_obj : JSON::Any, seen : Set(String) = Set(String).new) : Tuple(JSON::Any, SpecDoc(JSON::Any))
+      return {path_obj, doc} unless path_obj_h = path_obj.as_h?
+      return {path_obj, doc} unless ref = path_obj_h["$ref"]?.try(&.as_s?)
+      return {path_obj, doc} unless seen.add?(ref_key(doc, ref))
+      if resolved = resolve_ref_json(doc, ref)
+        node, ref_doc = resolved
+        resolve_path_item_json(ref_doc, node, seen)
+      else
+        {path_obj, doc}
+      end
     end
 
-    private def resolve_path_item_yaml(root : YAML::Any, path_obj : YAML::Any, seen : Set(String) = Set(String).new) : YAML::Any
-      return path_obj unless path_obj_h = path_obj.as_h?
-      return path_obj unless ref_node = path_obj_h[YAML::Any.new("$ref")]?
-      return path_obj unless ref = ref_node.as_s?
-      return path_obj if seen.includes?(ref)
-      seen << ref
-      resolved = resolve_ref_yaml(root, ref)
-      resolved ? resolve_path_item_yaml(root, resolved, seen) : path_obj
+    private def resolve_path_item_yaml(doc : SpecDoc(YAML::Any), path_obj : YAML::Any, seen : Set(String) = Set(String).new) : Tuple(YAML::Any, SpecDoc(YAML::Any))
+      return {path_obj, doc} unless path_obj_h = path_obj.as_h?
+      return {path_obj, doc} unless ref_node = path_obj_h[YAML::Any.new("$ref")]?
+      return {path_obj, doc} unless ref = ref_node.as_s?
+      return {path_obj, doc} unless seen.add?(ref_key(doc, ref))
+      if resolved = resolve_ref_yaml(doc, ref)
+        node, ref_doc = resolved
+        resolve_path_item_yaml(ref_doc, node, seen)
+      else
+        {path_obj, doc}
+      end
     end
 
     private def consumes_json(root : JSON::Any, method_obj : JSON::Any) : Array(String)
@@ -308,30 +324,38 @@ module Analyzer::Specification
         @logger.debug_sub e
       end
 
+      # `basePath`, `consumes` and `securityDefinitions` stay bound to the
+      # entry document below: they are document-level declarations, and a file
+      # the `paths` map refs is a fragment of this document, not one of its
+      # own. Only the path items and what hangs off them travel.
+      doc = SpecDoc.new(json_obj, swagger_json)
       schemes = security_schemes_json(json_obj)
       global_security = json_obj["security"]?
       begin
         paths = json_obj["paths"].as_h
         paths.each do |path, path_obj|
-          path_item = resolve_path_item_json(json_obj, path_obj)
+          path_item, item_doc = resolve_path_item_json(doc, path_obj)
+          # A Path Item that did not resolve to a mapping costs itself and
+          # nothing else: `as_h` on it would raise past this loop and take
+          # every path after it with it.
+          next unless path_item_h = path_item.as_h?
+
           path_level_params = [] of JSON::Any
-          if path_obj_h = path_item.as_h?
-            if shared = path_obj_h["parameters"]?.try(&.as_a?)
-              path_level_params.concat(shared)
-            end
+          if shared = path_item_h["parameters"]?.try(&.as_a?)
+            path_level_params.concat(shared)
           end
 
-          path_item.as_h.each do |method, method_obj|
+          path_item_h.each do |method, method_obj|
             next unless HTTP_METHODS.includes?(method.to_s.downcase)
             params = [] of Param
             consumes = consumes_json(json_obj, method_obj)
             path_level_params.each do |param_obj|
-              extract_param_json(json_obj, param_obj, consumes, params)
+              extract_param_json(item_doc, param_obj, consumes, params)
             end
 
             if method_params = method_obj["parameters"]?.try(&.as_a?)
               method_params.each do |param_obj|
-                extract_param_json(json_obj, param_obj, consumes, params)
+                extract_param_json(item_doc, param_obj, consumes, params)
               end
             end
 
@@ -375,33 +399,38 @@ module Analyzer::Specification
         @logger.debug_sub e
       end
 
+      # See `process_json` on why the document-level declarations keep reading
+      # from the entry document.
+      doc = SpecDoc.new(yaml_obj, swagger_yaml)
       schemes = security_schemes_yaml(yaml_obj)
       global_security = yaml_obj[YAML::Any.new("security")]?
       begin
         paths = yaml_obj["paths"].as_h
         paths.each do |path, path_obj|
-          path_item = resolve_path_item_yaml(yaml_obj, path_obj)
+          path_item, item_doc = resolve_path_item_yaml(doc, path_obj)
+          # See `process_json`: a Path Item that is not a mapping must not
+          # take the paths after it down with it.
+          next unless path_item_h = path_item.as_h?
+
           path_level_params = [] of YAML::Any
-          if path_obj_h = path_item.as_h?
-            if shared_node = path_obj_h[YAML::Any.new("parameters")]?
-              if shared = shared_node.as_a?
-                path_level_params.concat(shared)
-              end
+          if shared_node = path_item_h[YAML::Any.new("parameters")]?
+            if shared = shared_node.as_a?
+              path_level_params.concat(shared)
             end
           end
 
-          path_item.as_h.each do |method, method_obj|
+          path_item_h.each do |method, method_obj|
             next unless HTTP_METHODS.includes?(method.to_s.downcase)
             params = [] of Param
             consumes = consumes_yaml(yaml_obj, method_obj)
             path_level_params.each do |param_obj|
-              extract_param_yaml(yaml_obj, param_obj, consumes, params)
+              extract_param_yaml(item_doc, param_obj, consumes, params)
             end
 
             if method_params_node = method_obj[YAML::Any.new("parameters")]?
               if method_params = method_params_node.as_a?
                 method_params.each do |param_obj|
-                  extract_param_yaml(yaml_obj, param_obj, consumes, params)
+                  extract_param_yaml(item_doc, param_obj, consumes, params)
                 end
               end
             end

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -63,21 +63,21 @@ module Analyzer::Specification
     # Walks an OAS3 schema, emitting one Param per top-level property.
     # Follows `$ref` and flattens `allOf` so referenced/composed schemas
     # surface their members.
-    private def collect_schema_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+    private def collect_schema_props_json(doc : SpecDoc(JSON::Any), schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
       # JSON Schema allows boolean `items` etc.; a scalar node makes the
       # `["..."]?` subscripts below raise "Expected Hash".
       return unless schema.as_h?
       if ref = schema["$ref"]?.try(&.as_s?)
-        return if seen.includes?(ref)
-        seen << ref
-        if resolved = resolve_ref_json(root, ref)
-          collect_schema_props_json(root, resolved, param_type, params, seen)
+        return unless seen.add?(ref_key(doc, ref))
+        if resolved = resolve_ref_json(doc, ref)
+          node, ref_doc = resolved
+          collect_schema_props_json(ref_doc, node, param_type, params, seen)
         end
         return
       end
 
       if items = schema["items"]?
-        collect_schema_props_json(root, items, param_type, params, seen)
+        collect_schema_props_json(doc, items, param_type, params, seen)
       end
 
       if props = schema["properties"]?.try(&.as_h?)
@@ -87,35 +87,35 @@ module Analyzer::Specification
       end
 
       if all_of = schema["allOf"]?.try(&.as_a?)
-        all_of.each { |s| collect_schema_props_json(root, s, param_type, params, seen) }
+        all_of.each { |s| collect_schema_props_json(doc, s, param_type, params, seen) }
       end
 
       if one_of = schema["oneOf"]?.try(&.as_a?)
-        one_of.each { |s| collect_schema_props_json(root, s, param_type, params, seen) }
+        one_of.each { |s| collect_schema_props_json(doc, s, param_type, params, seen) }
       end
 
       if any_of = schema["anyOf"]?.try(&.as_a?)
-        any_of.each { |s| collect_schema_props_json(root, s, param_type, params, seen) }
+        any_of.each { |s| collect_schema_props_json(doc, s, param_type, params, seen) }
       end
     end
 
-    private def collect_schema_props_yaml(root : YAML::Any, schema : YAML::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+    private def collect_schema_props_yaml(doc : SpecDoc(YAML::Any), schema : YAML::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
       # JSON Schema allows boolean `items` etc.; a scalar node makes the
       # `[...]?` subscripts below raise "Expected Hash".
       return unless schema.as_h?
       if ref_node = schema[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
-          return if seen.includes?(ref)
-          seen << ref
-          if resolved = resolve_ref_yaml(root, ref)
-            collect_schema_props_yaml(root, resolved, param_type, params, seen)
+          return unless seen.add?(ref_key(doc, ref))
+          if resolved = resolve_ref_yaml(doc, ref)
+            node, ref_doc = resolved
+            collect_schema_props_yaml(ref_doc, node, param_type, params, seen)
           end
         end
         return
       end
 
       if items_node = schema[YAML::Any.new("items")]?
-        collect_schema_props_yaml(root, items_node, param_type, params, seen)
+        collect_schema_props_yaml(doc, items_node, param_type, params, seen)
       end
 
       if props_node = schema[YAML::Any.new("properties")]?
@@ -128,27 +128,32 @@ module Analyzer::Specification
 
       if all_of_node = schema[YAML::Any.new("allOf")]?
         if all_of = all_of_node.as_a?
-          all_of.each { |s| collect_schema_props_yaml(root, s, param_type, params, seen) }
+          all_of.each { |s| collect_schema_props_yaml(doc, s, param_type, params, seen) }
         end
       end
 
       if one_of_node = schema[YAML::Any.new("oneOf")]?
         if one_of = one_of_node.as_a?
-          one_of.each { |s| collect_schema_props_yaml(root, s, param_type, params, seen) }
+          one_of.each { |s| collect_schema_props_yaml(doc, s, param_type, params, seen) }
         end
       end
 
       if any_of_node = schema[YAML::Any.new("anyOf")]?
         if any_of = any_of_node.as_a?
-          any_of.each { |s| collect_schema_props_yaml(root, s, param_type, params, seen) }
+          any_of.each { |s| collect_schema_props_yaml(doc, s, param_type, params, seen) }
         end
       end
     end
 
-    private def extract_param_json(root : JSON::Any, param_obj : JSON::Any, params : Array(Param))
+    # `seen` is not optional bookkeeping here: a parameter may be a `$ref` to
+    # a parameter that is itself a `$ref`, and two documents that name each
+    # other would otherwise recurse until the stack ran out.
+    private def extract_param_json(doc : SpecDoc(JSON::Any), param_obj : JSON::Any, params : Array(Param), seen : Set(String) = Set(String).new)
       if ref = param_obj["$ref"]?.try(&.as_s?)
-        if resolved = resolve_ref_json(root, ref)
-          extract_param_json(root, resolved, params)
+        return unless seen.add?(ref_key(doc, ref))
+        if resolved = resolve_ref_json(doc, ref)
+          node, ref_doc = resolved
+          extract_param_json(ref_doc, node, params, seen)
         end
         return
       end
@@ -166,11 +171,13 @@ module Analyzer::Specification
       end
     end
 
-    private def extract_param_yaml(root : YAML::Any, param_obj : YAML::Any, params : Array(Param))
+    private def extract_param_yaml(doc : SpecDoc(YAML::Any), param_obj : YAML::Any, params : Array(Param), seen : Set(String) = Set(String).new)
       if ref_node = param_obj[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
-          if resolved = resolve_ref_yaml(root, ref)
-            extract_param_yaml(root, resolved, params)
+          return unless seen.add?(ref_key(doc, ref))
+          if resolved = resolve_ref_yaml(doc, ref)
+            node, ref_doc = resolved
+            extract_param_yaml(ref_doc, node, params, seen)
           end
         end
         return
@@ -194,25 +201,25 @@ module Analyzer::Specification
     # token schemes (`http` bearer/basic, `oauth2`, `openIdConnect`) ride on the
     # `Authorization` header. This mirrors how the Insomnia analyzer turns auth
     # config into params, so a documented requirement isn't a false negative.
-    private def security_schemes_json(root : JSON::Any) : Hash(String, Param)
+    private def security_schemes_json(doc : SpecDoc(JSON::Any)) : Hash(String, Param)
       result = {} of String => Param
-      return result unless components = root["components"]?.try(&.as_h?)
+      return result unless components = doc.root["components"]?.try(&.as_h?)
       return result unless schemes = components["securitySchemes"]?.try(&.as_h?)
       schemes.each do |name, obj|
-        if param = security_scheme_param_json(root, obj)
+        if param = security_scheme_param_json(doc, obj)
           result[name.to_s] = param
         end
       end
       result
     end
 
-    private def security_scheme_param_json(root : JSON::Any, obj : JSON::Any, seen : Set(String) = Set(String).new) : Param?
+    private def security_scheme_param_json(doc : SpecDoc(JSON::Any), obj : JSON::Any, seen : Set(String) = Set(String).new) : Param?
       return unless obj_h = obj.as_h?
       if ref = obj_h["$ref"]?.try(&.as_s?)
-        return if seen.includes?(ref)
-        seen << ref
-        if resolved = resolve_ref_json(root, ref)
-          return security_scheme_param_json(root, resolved, seen)
+        return unless seen.add?(ref_key(doc, ref))
+        if resolved = resolve_ref_json(doc, ref)
+          node, ref_doc = resolved
+          return security_scheme_param_json(ref_doc, node, seen)
         end
         return
       end
@@ -248,26 +255,26 @@ module Analyzer::Specification
       end
     end
 
-    private def security_schemes_yaml(root : YAML::Any) : Hash(String, Param)
+    private def security_schemes_yaml(doc : SpecDoc(YAML::Any)) : Hash(String, Param)
       result = {} of String => Param
-      return result unless components = root[YAML::Any.new("components")]?.try(&.as_h?)
+      return result unless components = doc.root[YAML::Any.new("components")]?.try(&.as_h?)
       return result unless schemes = components[YAML::Any.new("securitySchemes")]?.try(&.as_h?)
       schemes.each do |name, obj|
-        if param = security_scheme_param_yaml(root, obj)
+        if param = security_scheme_param_yaml(doc, obj)
           result[name.to_s] = param
         end
       end
       result
     end
 
-    private def security_scheme_param_yaml(root : YAML::Any, obj : YAML::Any, seen : Set(String) = Set(String).new) : Param?
+    private def security_scheme_param_yaml(doc : SpecDoc(YAML::Any), obj : YAML::Any, seen : Set(String) = Set(String).new) : Param?
       return unless obj_h = obj.as_h?
       if ref_node = obj_h[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
-          return if seen.includes?(ref)
-          seen << ref
-          if resolved = resolve_ref_yaml(root, ref)
-            return security_scheme_param_yaml(root, resolved, seen)
+          return unless seen.add?(ref_key(doc, ref))
+          if resolved = resolve_ref_yaml(doc, ref)
+            node, ref_doc = resolved
+            return security_scheme_param_yaml(ref_doc, node, seen)
           end
         end
         return
@@ -301,30 +308,42 @@ module Analyzer::Specification
       end
     end
 
-    private def resolve_path_item_json(root : JSON::Any, path_obj : JSON::Any, seen : Set(String) = Set(String).new) : JSON::Any
-      return path_obj unless path_obj_h = path_obj.as_h?
-      return path_obj unless ref = path_obj_h["$ref"]?.try(&.as_s?)
-      return path_obj if seen.includes?(ref)
-      seen << ref
-      resolved = resolve_ref_json(root, ref)
-      resolved ? resolve_path_item_json(root, resolved, seen) : path_obj
+    # Resolves the `$ref` a Path Item may stand in for, and reports which
+    # document the result came from: with the operations in
+    # `./paths/activity/activities.yaml`, every ref inside them resolves from
+    # that file, not from the entry document that named it.
+    private def resolve_path_item_json(doc : SpecDoc(JSON::Any), path_obj : JSON::Any, seen : Set(String) = Set(String).new) : Tuple(JSON::Any, SpecDoc(JSON::Any))
+      return {path_obj, doc} unless path_obj_h = path_obj.as_h?
+      return {path_obj, doc} unless ref = path_obj_h["$ref"]?.try(&.as_s?)
+      return {path_obj, doc} unless seen.add?(ref_key(doc, ref))
+      if resolved = resolve_ref_json(doc, ref)
+        node, ref_doc = resolved
+        resolve_path_item_json(ref_doc, node, seen)
+      else
+        {path_obj, doc}
+      end
     end
 
-    private def resolve_path_item_yaml(root : YAML::Any, path_obj : YAML::Any, seen : Set(String) = Set(String).new) : YAML::Any
-      return path_obj unless path_obj_h = path_obj.as_h?
-      return path_obj unless ref_node = path_obj_h[YAML::Any.new("$ref")]?
-      return path_obj unless ref = ref_node.as_s?
-      return path_obj if seen.includes?(ref)
-      seen << ref
-      resolved = resolve_ref_yaml(root, ref)
-      resolved ? resolve_path_item_yaml(root, resolved, seen) : path_obj
+    private def resolve_path_item_yaml(doc : SpecDoc(YAML::Any), path_obj : YAML::Any, seen : Set(String) = Set(String).new) : Tuple(YAML::Any, SpecDoc(YAML::Any))
+      return {path_obj, doc} unless path_obj_h = path_obj.as_h?
+      return {path_obj, doc} unless ref_node = path_obj_h[YAML::Any.new("$ref")]?
+      return {path_obj, doc} unless ref = ref_node.as_s?
+      return {path_obj, doc} unless seen.add?(ref_key(doc, ref))
+      if resolved = resolve_ref_yaml(doc, ref)
+        node, ref_doc = resolved
+        resolve_path_item_yaml(ref_doc, node, seen)
+      else
+        {path_obj, doc}
+      end
     end
 
-    private def extract_request_body_json(root : JSON::Any, request_body : JSON::Any, params : Array(Param))
+    private def extract_request_body_json(doc : SpecDoc(JSON::Any), request_body : JSON::Any, params : Array(Param), seen : Set(String) = Set(String).new)
       # The requestBody object itself can be $ref'd to components.requestBodies.
       if ref = request_body["$ref"]?.try(&.as_s?)
-        if resolved = resolve_ref_json(root, ref)
-          extract_request_body_json(root, resolved, params)
+        return unless seen.add?(ref_key(doc, ref))
+        if resolved = resolve_ref_json(doc, ref)
+          node, ref_doc = resolved
+          extract_request_body_json(ref_doc, node, params, seen)
         end
         return
       end
@@ -332,16 +351,18 @@ module Analyzer::Specification
       content.each do |content_type, content_obj|
         next unless param_type = param_type_for_content(content_type.to_s)
         if schema = content_obj["schema"]?
-          collect_schema_props_json(root, schema, param_type, params)
+          collect_schema_props_json(doc, schema, param_type, params)
         end
       end
     end
 
-    private def extract_request_body_yaml(root : YAML::Any, request_body : YAML::Any, params : Array(Param))
+    private def extract_request_body_yaml(doc : SpecDoc(YAML::Any), request_body : YAML::Any, params : Array(Param), seen : Set(String) = Set(String).new)
       if ref_node = request_body[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
-          if resolved = resolve_ref_yaml(root, ref)
-            extract_request_body_yaml(root, resolved, params)
+          return unless seen.add?(ref_key(doc, ref))
+          if resolved = resolve_ref_yaml(doc, ref)
+            node, ref_doc = resolved
+            extract_request_body_yaml(ref_doc, node, params, seen)
           end
         end
         return
@@ -351,7 +372,7 @@ module Analyzer::Specification
       content.each do |content_type, content_obj|
         next unless param_type = param_type_for_content(content_type.to_s)
         if schema_node = content_obj[YAML::Any.new("schema")]?
-          collect_schema_props_yaml(root, schema_node, param_type, params)
+          collect_schema_props_yaml(doc, schema_node, param_type, params)
         end
       end
     end
@@ -369,7 +390,7 @@ module Analyzer::Specification
           @logger.debug_sub e
         end
 
-        process_paths_json(json_obj, base_path, details, oas3_json)
+        process_paths_json(SpecDoc.new(json_obj, oas3_json), base_path, details)
       end
 
       each_spec_file_with_details(Noir::LocatorKeys::OAS3_YAML) do |oas3_yaml, details|
@@ -384,28 +405,33 @@ module Analyzer::Specification
           @logger.debug_sub e
         end
 
-        process_paths_yaml(yaml_obj, base_path, details, oas3_yaml)
+        process_paths_yaml(SpecDoc.new(yaml_obj, oas3_yaml), base_path, details)
       end
 
       @result
     end
 
-    private def process_paths_json(json_obj : JSON::Any, base_path : String, details : Details, source : String)
-      schemes = security_schemes_json(json_obj)
-      global_security = json_obj["security"]?
-      paths = json_obj["paths"].as_h
+    private def process_paths_json(doc : SpecDoc(JSON::Any), base_path : String, details : Details)
+      schemes = security_schemes_json(doc)
+      global_security = doc.root["security"]?
+      paths = doc.root["paths"].as_h
       paths.each do |path, path_obj|
-        path_item = resolve_path_item_json(json_obj, path_obj)
+        path_item, item_doc = resolve_path_item_json(doc, path_obj)
+        # A Path Item that did not resolve to a mapping — a ref to a scalar,
+        # a `null` entry — costs itself and nothing else. Calling `as_h` on
+        # it below would raise past the loop and take every path after it,
+        # which is precisely how one unreadable ref used to lose a whole
+        # document.
+        next unless path_item_h = path_item.as_h?
+
         path_level_params = [] of Param
-        if path_obj_h = path_item.as_h?
-          if shared = path_obj_h["parameters"]?.try(&.as_a?)
-            shared.each do |param_obj|
-              extract_param_json(json_obj, param_obj, path_level_params)
-            end
+        if shared = path_item_h["parameters"]?.try(&.as_a?)
+          shared.each do |param_obj|
+            extract_param_json(item_doc, param_obj, path_level_params)
           end
         end
 
-        path_item.as_h.each do |method, method_obj|
+        path_item_h.each do |method, method_obj|
           next unless HTTP_METHODS.includes?(method.to_s.downcase)
           params = path_level_params.dup
           effective_security = global_security
@@ -414,18 +440,18 @@ module Analyzer::Specification
             if method_obj_h = method_obj.as_h?
               if method_params = method_obj_h["parameters"]?.try(&.as_a?)
                 method_params.each do |param_obj|
-                  extract_param_json(json_obj, param_obj, params)
+                  extract_param_json(item_doc, param_obj, params)
                 end
               end
 
               if request_body = method_obj_h["requestBody"]?
-                extract_request_body_json(json_obj, request_body, params)
+                extract_request_body_json(item_doc, request_body, params)
               end
 
               effective_security = method_obj_h["security"] if method_obj_h.has_key?("security")
             end
           rescue e
-            @logger.debug "Exception of #{source}/paths/method/parameters"
+            @logger.debug "Exception of #{item_doc.path}/paths/method/parameters"
             @logger.debug_sub e
           end
 
@@ -437,33 +463,35 @@ module Analyzer::Specification
             @result << Endpoint.new(base_path + path, method.upcase, details)
           end
         rescue e
-          @logger.debug "Exception of #{source}/paths/endpoint"
+          @logger.debug "Exception of #{doc.path}/paths/endpoint"
           @logger.debug_sub e
         end
       end
     rescue e
-      @logger.debug "Exception of #{source}/paths"
+      @logger.debug "Exception of #{doc.path}/paths"
       @logger.debug_sub e
     end
 
-    private def process_paths_yaml(yaml_obj : YAML::Any, base_path : String, details : Details, source : String)
-      schemes = security_schemes_yaml(yaml_obj)
-      global_security = yaml_obj[YAML::Any.new("security")]?
-      paths = yaml_obj["paths"].as_h
+    private def process_paths_yaml(doc : SpecDoc(YAML::Any), base_path : String, details : Details)
+      schemes = security_schemes_yaml(doc)
+      global_security = doc.root[YAML::Any.new("security")]?
+      paths = doc.root["paths"].as_h
       paths.each do |path, path_obj|
-        path_item = resolve_path_item_yaml(yaml_obj, path_obj)
+        path_item, item_doc = resolve_path_item_yaml(doc, path_obj)
+        # See `process_paths_json`: a Path Item that is not a mapping must
+        # not take the paths after it down with it.
+        next unless path_item_h = path_item.as_h?
+
         path_level_params = [] of Param
-        if path_obj_h = path_item.as_h?
-          if shared_node = path_obj_h[YAML::Any.new("parameters")]?
-            if shared = shared_node.as_a?
-              shared.each do |param_obj|
-                extract_param_yaml(yaml_obj, param_obj, path_level_params)
-              end
+        if shared_node = path_item_h[YAML::Any.new("parameters")]?
+          if shared = shared_node.as_a?
+            shared.each do |param_obj|
+              extract_param_yaml(item_doc, param_obj, path_level_params)
             end
           end
         end
 
-        path_item.as_h.each do |method, method_obj|
+        path_item_h.each do |method, method_obj|
           next unless HTTP_METHODS.includes?(method.to_s.downcase)
           params = path_level_params.dup
           effective_security = global_security
@@ -473,19 +501,19 @@ module Analyzer::Specification
               if method_params_node = method_obj_h[YAML::Any.new("parameters")]?
                 if method_params = method_params_node.as_a?
                   method_params.each do |param_obj|
-                    extract_param_yaml(yaml_obj, param_obj, params)
+                    extract_param_yaml(item_doc, param_obj, params)
                   end
                 end
               end
 
               if request_body = method_obj_h[YAML::Any.new("requestBody")]?
-                extract_request_body_yaml(yaml_obj, request_body, params)
+                extract_request_body_yaml(item_doc, request_body, params)
               end
 
               effective_security = method_obj_h[YAML::Any.new("security")] if method_obj_h.has_key?(YAML::Any.new("security"))
             end
           rescue e
-            @logger.debug "Exception of #{source}/paths/method/parameters"
+            @logger.debug "Exception of #{item_doc.path}/paths/method/parameters"
             @logger.debug_sub e
           end
 
@@ -497,12 +525,12 @@ module Analyzer::Specification
             @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
           end
         rescue e
-          @logger.debug "Exception of #{source}/paths/endpoint"
+          @logger.debug "Exception of #{doc.path}/paths/endpoint"
           @logger.debug_sub e
         end
       end
     rescue e
-      @logger.debug "Exception of #{source}/paths"
+      @logger.debug "Exception of #{doc.path}/paths"
       @logger.debug_sub e
     end
   end

--- a/src/analyzer/engines/specification_engine.cr
+++ b/src/analyzer/engines/specification_engine.cr
@@ -5,8 +5,28 @@ require "uri"
 require "json"
 require "yaml"
 require "../../models/locator_keys"
+require "../../utils/media_filter"
+require "../../utils/yaml"
 
 module Analyzer::Specification
+  # A parsed specification document together with the path it was read from.
+  #
+  # A `$ref` is relative to the file that writes it, not to the document the
+  # scan started from: once an operation has been pulled in from
+  # `paths/activity/activities.yaml`, its
+  # `../../openapi.yaml#/components/parameters/Fields` has to resolve from
+  # *that* file's directory. A node carried across a file boundary therefore
+  # has to carry its origin with it, which is precisely what passing the entry
+  # root alone — all the analyzers needed while every ref was same-document —
+  # cannot express.
+  struct SpecDoc(T)
+    getter root : T
+    getter path : String
+
+    def initialize(@root : T, @path : String)
+    end
+  end
+
   # Base for the specification-format analyzers (OpenAPI, Postman, HAR,
   # Terraform, k8s manifests, proxy exports, …).
   #
@@ -34,6 +54,20 @@ module Analyzer::Specification
   # the log wording differed everywhere. `each_spec_file` is that drain,
   # once.
   abstract class SpecificationEngine < Analyzer
+    # `scheme://host/…` and protocol-relative `//host/…` ref targets.
+    REMOTE_REF = /\A(?:[A-Za-z][A-Za-z0-9+.\-]*:)?\/\//
+
+    # Documents pulled in by a file `$ref`, keyed by expanded path. Directus's
+    # 70 split path files hold 640 refs back into the entry document; without
+    # this it would be parsed 640 times.
+    #
+    # A nil entry is a negative cache: a target that was missing, out of scope
+    # or unparsable stays that way for the rest of the run, so a broken ref
+    # costs one failed read rather than one per occurrence.
+    @external_json_docs = {} of String => SpecDoc(JSON::Any)?
+    @external_yaml_docs = {} of String => SpecDoc(YAML::Any)?
+    @reported_refs = Set(String).new
+
     # Yield every registered path for `key`, skipping paths that no longer
     # resolve and containing per-file failures.
     #
@@ -175,31 +209,15 @@ module Analyzer::Specification
       end
     end
 
-    # Follows a local JSON Pointer — OAS2's `#/definitions/Name`, OAS3's
-    # `#/components/schemas/Name`, AsyncAPI's `#/components/messages/Name`
-    # — against the document root.
+    # Same-document `$ref` resolution, for the analyzers that have only a
+    # document root to resolve against.
     #
-    # Only same-document refs are resolved: a ref that does not start with
-    # `#/` points at another file (or an external URL) that the analyzer
-    # never loaded, so it returns nil rather than guessing.
-    #
-    # `~1` and `~0` are unescaped per RFC 6901, in that order — `~0` must be
-    # decoded last or a literal `~1` in a key would be corrupted by the `~`
-    # produced from `~0`.
-    #
-    # Returns nil at the first segment that is not a mapping or is absent,
-    # which is what lets callers treat a dangling ref as "no schema" instead
-    # of raising mid-walk.
+    # A ref that names a file is not resolved here: the caller has to say
+    # *which* file wrote the ref before a relative path means anything, and
+    # that is the `SpecDoc` overload below.
     protected def resolve_ref_json(root : JSON::Any, ref : String) : JSON::Any?
       return unless ref.starts_with?("#/")
-      node = root
-      ref[2..].split('/').each do |segment|
-        decoded = segment.gsub("~1", "/").gsub("~0", "~")
-        return unless hash = node.as_h?
-        return unless next_node = hash[decoded]?
-        node = next_node
-      end
-      node
+      resolve_pointer_json(root, ref[1..])
     end
 
     # `resolve_ref_json` for the YAML parse of the same formats. Kept
@@ -208,14 +226,225 @@ module Analyzer::Specification
     # keyed by `YAML::Any`, not by `String`.
     protected def resolve_ref_yaml(root : YAML::Any, ref : String) : YAML::Any?
       return unless ref.starts_with?("#/")
+      resolve_pointer_yaml(root, ref[1..])
+    end
+
+    # Walks a JSON Pointer (RFC 6901) from a document root — OAS2's
+    # `/definitions/Name`, OAS3's `/components/schemas/Name`, AsyncAPI's
+    # `/components/messages/Name`.
+    #
+    # `~1` and `~0` are unescaped in that order — `~0` must be decoded last
+    # or a literal `~1` in a key would be corrupted by the `~` produced from
+    # `~0`.
+    #
+    # An empty pointer is the whole document, which is what a bare
+    # `./paths/pets.yaml` ref resolves to. Returns nil at the first segment
+    # that is not a mapping or is absent, which is what lets callers treat a
+    # dangling ref as "no schema" instead of raising mid-walk.
+    protected def resolve_pointer_json(root : JSON::Any, pointer : String) : JSON::Any?
+      return root if pointer.empty?
+      return unless pointer.starts_with?('/')
       node = root
-      ref[2..].split('/').each do |segment|
+      pointer[1..].split('/').each do |segment|
+        decoded = segment.gsub("~1", "/").gsub("~0", "~")
+        return unless hash = node.as_h?
+        return unless next_node = hash[decoded]?
+        node = next_node
+      end
+      node
+    end
+
+    protected def resolve_pointer_yaml(root : YAML::Any, pointer : String) : YAML::Any?
+      return root if pointer.empty?
+      return unless pointer.starts_with?('/')
+      node = root
+      pointer[1..].split('/').each do |segment|
         decoded = segment.gsub("~1", "/").gsub("~0", "~")
         return unless hash = node.as_h?
         return unless next_node = hash[YAML::Any.new(decoded)]?
         node = next_node
       end
       node
+    end
+
+    # Follows a `$ref` written in `doc`, across a local file boundary when it
+    # names one. Three forms occur and all three land here:
+    #
+    #     $ref: '#/components/schemas/Pet'                   same document
+    #     $ref: './paths/activity/activities.yaml'           another file, whole
+    #     $ref: '../../openapi.yaml#/components/parameters/Fields'
+    #
+    # Splitting a large specification across files is the maintained shape
+    # every OpenAPI toolchain recommends, and the third form is how the parts
+    # reach back into the shared components — Directus's 70 path files write
+    # it 640 times between them. Declining the fragment would read the
+    # operations but lose every parameter they declare.
+    #
+    # Returns the node *together with the document it lives in*, because a
+    # ref nested inside that node resolves against the file it was read from,
+    # not against the caller's.
+    protected def resolve_ref_json(doc : SpecDoc(JSON::Any), ref : String) : Tuple(JSON::Any, SpecDoc(JSON::Any))?
+      file, pointer = split_ref(ref)
+
+      if file.empty?
+        node = resolve_pointer_json(doc.root, pointer)
+        return node.nil? ? nil : {node, doc}
+      end
+
+      return unless target = external_json_doc(doc.path, file)
+      node = resolve_pointer_json(target.root, pointer)
+      node.nil? ? nil : {node, target}
+    end
+
+    protected def resolve_ref_yaml(doc : SpecDoc(YAML::Any), ref : String) : Tuple(YAML::Any, SpecDoc(YAML::Any))?
+      file, pointer = split_ref(ref)
+
+      if file.empty?
+        node = resolve_pointer_yaml(doc.root, pointer)
+        return node.nil? ? nil : {node, doc}
+      end
+
+      return unless target = external_yaml_doc(doc.path, file)
+      node = resolve_pointer_yaml(target.root, pointer)
+      node.nil? ? nil : {node, target}
+    end
+
+    # Splits a `$ref` into its file part and its JSON Pointer; either may be
+    # empty.
+    protected def split_ref(ref : String) : Tuple(String, String)
+      if index = ref.index('#')
+        {ref[0, index], ref[(index + 1)..]}
+      else
+        {ref, ""}
+      end
+    end
+
+    # Cycle-breaking identity for a ref. The ref string on its own stopped
+    # being one the moment refs could cross files: `./common.yaml` names a
+    # different file in every directory, and `#/components/schemas/Pet` a
+    # different node in every document. Two files that ref each other
+    # therefore terminate on the second visit rather than recursing until the
+    # stack runs out.
+    protected def ref_key(doc : SpecDoc, ref : String) : String
+      "#{doc.path}\u0000#{ref}"
+    end
+
+    private def external_json_doc(from_path : String, file_ref : String) : SpecDoc(JSON::Any)?
+      return unless path = external_ref_path(from_path, file_ref)
+      return @external_json_docs[path] if @external_json_docs.has_key?(path)
+
+      # A JSON document's refs are parsed as JSON, even when they name a
+      # `.yaml` file: grafting a `YAML::Any` subtree onto a `JSON::Any`
+      # document is not something the two unrelated `Any` types allow, so a
+      # cross-format target is reported unresolved rather than silently
+      # dropped. The YAML side needs no such rule — YAML is a superset of
+      # JSON, so a YAML document may ref a `.json` file and get it parsed.
+      @external_json_docs[path] = begin
+        if content = read_ref_file(from_path, path, file_ref)
+          SpecDoc.new(JSON.parse(content), path)
+        end
+      rescue e
+        record_ref_gap(from_path, file_ref, e.message.presence || e.class.name)
+      end
+    end
+
+    private def external_yaml_doc(from_path : String, file_ref : String) : SpecDoc(YAML::Any)?
+      return unless path = external_ref_path(from_path, file_ref)
+      return @external_yaml_docs[path] if @external_yaml_docs.has_key?(path)
+
+      @external_yaml_docs[path] = begin
+        if content = read_ref_file(from_path, path, file_ref)
+          SpecDoc.new(parse_yaml(content), path)
+        end
+      rescue e
+        record_ref_gap(from_path, file_ref, e.message.presence || e.class.name)
+      end
+    end
+
+    # The local file a `$ref` names, or nil when it names one this scan will
+    # not read.
+    private def external_ref_path(from_path : String, file_ref : String) : String?
+      if file_ref.matches?(REMOTE_REF)
+        # noir makes no network requests during a scan. A document that hangs
+        # its operations off an `https://` ref is reported as unread rather
+        # than fetched behind the user's back.
+        return record_ref_gap(from_path, file_ref, "remote target is not fetched")
+      end
+
+      target = File.expand_path(file_ref, File.dirname(File.expand_path(from_path)))
+
+      # Containment rule: a ref target must resolve inside one of the scan
+      # bases the user passed, and must not be a path they excluded. A
+      # specification document is untrusted input — `../../../../etc/passwd`
+      # is a well-formed ref — and a scan has no business reading, still less
+      # reporting, a file outside the tree it was pointed at. The comparison
+      # runs on expanded paths, so no arrangement of `..` segments or
+      # trailing separators walks around it.
+      #
+      # `..` *within* the tree stays legal, and has to: every one of
+      # Directus's path files reaches back to `../../openapi.yaml`, so a
+      # blanket "no parent segments" rule would decline the very layout this
+      # exists to read.
+      #
+      # Expansion is textual, which leaves one way out of the tree that this
+      # check cannot see: a link inside it. `read_ref_file` closes that by
+      # refusing to follow symlinks at all, as the detector walk does.
+      unless within_scan_base?(target)
+        return record_ref_gap(from_path, file_ref, "target is outside the scan base")
+      end
+
+      if excluded_path?(target)
+        return record_ref_gap(from_path, file_ref, "target is excluded by --exclude-path")
+      end
+
+      target
+    end
+
+    # Reads a ref target, or records why it could not be read.
+    private def read_ref_file(from_path : String, target : String, file_ref : String) : String?
+      # `follow_symlinks: false`, the same stat the detector walk makes: it
+      # skips symlinked and non-regular entries outright, so following one
+      # here would diverge from the rest of the scan *and* hand a document a
+      # way around containment, since a link inside the tree can point
+      # anywhere. A FIFO is the sharper case — reading one never returns.
+      info = File.info?(target, follow_symlinks: false)
+      return record_ref_gap(from_path, file_ref, "target not found") unless info
+      unless info.file?
+        reason = info.type.symlink? ? "target is a symbolic link (not followed)" : "target is not a regular file (#{info.type})"
+        return record_ref_gap(from_path, file_ref, reason)
+      end
+
+      # The size and binary budget the detector walk applies to a document it
+      # finds itself. A ref is a second way into the file tree, not a way
+      # around that budget.
+      if reason = MediaFilter.skip_check(target, info: info)
+        return record_ref_gap(from_path, file_ref, reason)
+      end
+
+      read_file_content(target)
+    end
+
+    # Reports a ref that was declined or could not be read, once per distinct
+    # ref. A split document repeats the same ref in operation after operation,
+    # so recording per occurrence would tally one broken target hundreds of
+    # times.
+    #
+    # What gets recorded is the referring document, not the resolved target:
+    # the document is a path inside the scan, reported the way the scan
+    # reports every other path, while the resolved target is expanded and
+    # would put the scanning machine's directory layout into a report that may
+    # be shared. The ref goes into the message exactly as the document wrote
+    # it, which is also the string a reader has to go and fix.
+    #
+    # It lands in `errors` — and in `--strict`'s exit code — like every other
+    # coverage gap, because the operations behind an unread ref are endpoints
+    # the scan did not find, and a silently shorter list is exactly what
+    # `SkippedFiles` exists to prevent.
+    private def record_ref_gap(from_path : String, file_ref : String, reason : String) : Nil
+      message = "unresolved $ref '#{file_ref}': #{reason}"
+      return unless @reported_refs.add?("#{from_path}\u0000#{message}")
+      logger.debug "#{from_path}: #{message}"
+      Noir::SkippedFiles.record(tech, from_path, message, noun: "referenced file")
     end
 
     # Appends a valueless `Param` unless an equal one is already present.


### PR DESCRIPTION
## The gap

A `paths` entry may be a `$ref` to another file, and splitting a large specification that way is what Redocly, Stoplight and swagger-cli all recommend. noir only read operations written inline, so such a document produced nothing — the path strings were in the entry file and the methods were one file away.

Directus is the plain case. `packages/specs/src/openapi.yaml` is a valid 3.0.1 document listing 70 paths, every one of them `$ref`'d out to `./paths/<area>/<name>.yaml`:

```console
$ noir -b directus/packages/specs -f json    # before
{"endpoints":[],"passive_results":[],"errors":[]}

$ noir -b directus/packages/specs -f json    # after
136 endpoints over 70 paths, errors: []
```

136 is exactly the operation count in the referenced files (46 `get`, 35 `post`, 30 `patch`, 25 `delete`), and the parameters come with them — `GET /items/{collection}` carries all 15 of the query parameters that file refs, each through two hops (path file → entry document → the parameter's own file).

## Design

Resolution lives in `SpecificationEngine`, so OAS2 gets it on the same code; a split Swagger 2.0 document resolves the same way (covered in the unit spec).

The unit of resolution is now `SpecDoc` — a parsed root plus the file it came from. That pairing is the point: a ref is relative to the file that writes it, so an operation that arrived from `paths/activity/activities.yaml` resolves its `../../openapi.yaml#/components/parameters/Fields` from *that* directory, and the parameter file that lands on resolves from the entry document's. The entry root alone cannot express either hop.

Four rules bound what gets read:

- **Local files only.** A `scheme://` or protocol-relative ref is never fetched.
- **Containment.** A target must resolve inside one of the `-b` scan bases and must not be an `--exclude-path` match. The comparison runs on expanded paths, so no arrangement of `..` walks around it, while `..` inside the tree stays legal (Directus's path files all reach back to `../../openapi.yaml`). Expansion is textual, so symlinks are refused rather than followed — matching the detector walk, and keeping a FIFO from parking the scan.
- **Cycles terminate.** The `seen` sets key on document *and* ref (`./common.yaml` names a different file in every directory) and were extended to the parameter and requestBody walks, which had no guard at all — a self-referential parameter was already unbounded recursion before this change.
- **A fragment after the file name is resolved, not declined.** It is how the parts of a split document reach the shared components: Directus's path files write `../../openapi.yaml#/...` 640 times between them, and declining it would read every operation and lose every parameter.

A ref that cannot be followed costs only itself: the paths already read stay in the result and the gap is recorded through `SkippedFiles`, so it surfaces in `errors` and under `--strict` rather than as a quietly shorter list. It is recorded once per distinct ref, against the referring document rather than the resolved target (the target is expanded and would put the scanning machine's layout into a report). Parsed targets are cached per run, for the same reason those 640 repeats matter.

Path items that resolve to something other than a mapping now `next` instead of raising through the loop, which is what let one bad entry take every path after it.

## Verification

- **Detection A/B** on `spec/functional_test/fixtures`: 3191 → 3195. The four added are the new `split_document` fixture's own endpoints; nothing removed, nothing else changed. Scan time 0.670s → 0.657s.
- **Full suite**: `crystal spec` — 30101 examples, 0 failures.
- `just check` — format clean, ameba 2281 inspected, 0 failures.
- New fixture `spec/functional_test/fixtures/specification/oas3/split_document/` exercises the whole-file ref, the `file#/pointer` form, the two-hop parameter chain, and the four refs noir declines (remote, escaping the base, missing, and a two-file cycle) — the endpoint count asserts that none of them costs the paths around it.
- New unit spec `spec/unit_test/analyzer/specification/oas_external_refs_spec.cr` covers containment against a real readable file outside the base, the symlink refusal, the remote decline, cycle termination, a missing target, and the OAS2 half.
