### PR TITLE
feat(detector): detect Rails from its own source, not only from a Gemfile

### DIFF
--- a/spec/functional_test/testers/ruby/actioncable_spec.cr
+++ b/spec/functional_test/testers/ruby/actioncable_spec.cr
@@ -20,9 +20,14 @@ actioncable_endpoints = [
   build.call("ws://cable/NotificationChannel"),
 ]
 
+# The fixture is a Rails app -- `config/routes.rb` opens with
+# `Rails.application.routes.draw` -- so it detects as Rails as well as Action
+# Cable, and the Rails analyzer reads the `mount ActionCable.server =>
+# "/cable"` line the channels hang off. That mount is a real HTTP route: it is
+# the path the WebSocket handshake is made to, and `rails routes` lists it.
 actioncable_tester = FunctionalTester.new("fixtures/ruby/actioncable/", {
-  :techs     => 1,
-  :endpoints => actioncable_endpoints.size,
+  :techs     => 2,
+  :endpoints => actioncable_endpoints.size + 1,
 }, actioncable_endpoints)
 actioncable_tester.perform_tests
 

--- a/spec/unit_test/detector/ruby/rails_spec.cr
+++ b/spec/unit_test/detector/ruby/rails_spec.cr
@@ -71,4 +71,81 @@ describe "Detect Ruby Rails" do
   it "gemfile/does not match jquery-rails" do
     instance.detect("Gemfile", "gem 'jquery-rails'\ngem 'sinatra'").should be_false
   end
+
+  # The dependency declaration is the better marker, but it is only there when
+  # the scan reaches the manifest. A `config/` directory, an engine whose
+  # gemspec does not name the framework, or one service of a monorepo scanned
+  # app-by-app all detect as nothing without these — and then the analyzer
+  # never runs and every route the app declares is lost.
+  it "routes/modern draw block" do
+    contents = <<-RUBY
+      Rails.application.routes.draw do
+        get '/api/posts', to: 'posts#index'
+        resources :comments, only: [:index, :show]
+      end
+      RUBY
+    instance.detect("config/routes.rb", contents).should be_true
+  end
+
+  it "routes/pre-3.0 draw block" do
+    contents = <<-RUBY
+      Blog::Application.routes.draw do
+        root to: 'posts#index'
+      end
+      RUBY
+    instance.detect("config/routes.rb", contents).should be_true
+  end
+
+  it "config.ru/run Rails.application" do
+    contents = <<-RUBY
+      require_relative "config/environment"
+      run Rails.application
+      Rails.application.load_server
+      RUBY
+    instance.detect("config.ru", contents).should be_true
+  end
+
+  it "application.rb/Rails::Application subclass" do
+    contents = <<-RUBY
+      require_relative "boot"
+      require "rails/all"
+
+      module Blog
+        class Application < Rails::Application
+          config.load_defaults 8.0
+        end
+      end
+      RUBY
+    instance.detect("config/application.rb", contents).should be_true
+  end
+
+  it "ruby/an ordinary file is not a marker" do
+    contents = <<-RUBY
+      class PostsController < ApplicationController
+        def index
+          @posts = Post.all
+        end
+      end
+      RUBY
+    instance.detect("app/controllers/posts_controller.rb", contents).should be_false
+  end
+
+  it "ruby/another framework's routing block is not Rails" do
+    contents = <<-RUBY
+      Hanami.application.routes do
+        get "/posts", to: "posts.index"
+      end
+      RUBY
+    instance.detect("config/routes.rb", contents).should be_false
+  end
+
+  it "ruby/prose mentioning rails is not a marker" do
+    contents = <<-RUBY
+      # This gem works with Rails, Sinatra and Hanami applications.
+      # See the rails/all guide for details.
+      module Thing
+      end
+      RUBY
+    instance.detect("lib/thing.rb", contents).should be_false
+  end
 end

--- a/src/detector/detectors/ruby/rails.cr
+++ b/src/detector/detectors/ruby/rails.cr
@@ -14,6 +14,32 @@ module Detector::Ruby
     # parenthesized call form those gemspecs commonly use.
     RAILS_GEMS = ["rails", "railties"]
 
+    # Rails APIs that cannot appear in a project that is not Rails, so a
+    # single `.rb` or `.ru` file is enough to place the whole tree.
+    #
+    # The dependency declaration is the better marker when it is there, but
+    # it is only there when the scan reaches the manifest. Point noir at a
+    # Rails app's `config/` directory, at an engine whose gemspec does not
+    # name the framework, or at a service inside a monorepo scanned
+    # app-by-app, and there is no Gemfile in the walk — the app detects as
+    # nothing, the Rails analyzer never runs, and every route the app
+    # declares is lost. That is the same gap the Django detector closes for
+    # DRF-only apps, and it is worth closing here because the file the
+    # analyzer actually reads, `config/routes.rb`, is itself proof:
+    # `.routes.draw` is the Rails routing DSL and belongs to no other
+    # framework.
+    RAILS_CODE_MARKERS = [
+      # config/routes.rb, in both the modern and the pre-3.0 spelling
+      # (`AppName::Application.routes.draw do`).
+      /(^|\W)[A-Za-z_:][\w:]*\.routes\.draw\b/,
+      # config.ru and initializers: `run Rails.application`.
+      /(^|\W)Rails\.application\b/,
+      # config/application.rb: `class Application < Rails::Application`.
+      /(^|\W)Rails::Application\b/,
+      # config/application.rb, top of file.
+      /(^|\s)require\s+["']rails\/all["']/,
+    ]
+
     def detect(filename : String, file_contents : String) : Bool
       if filename.includes?("Gemfile")
         return RAILS_GEMS.any? { |gem_name| gemfile_dependency?(file_contents, gem_name) }
@@ -21,6 +47,10 @@ module Detector::Ruby
 
       if filename.ends_with?(".gemspec")
         return RAILS_GEMS.any? { |gem_name| gemspec_dependency?(file_contents, gem_name) }
+      end
+
+      if filename.ends_with?(".rb") || filename.ends_with?(".ru")
+        return RAILS_CODE_MARKERS.any? { |marker| file_contents.matches?(marker) }
       end
 
       false


### PR DESCRIPTION
## The gap

The Rails detector looks at `Gemfile`, `Gemfile.lock` and `.gemspec`, and
nothing else. When the manifest is not in the walk, a Rails app detects as
nothing at all — the analyzer never runs, and every route the app declares is
lost.

```console
$ ls -R myapp
config/routes.rb  app/controllers/comments_controller.rb

$ noir -b myapp -f json | jq '.endpoints | length'
0
```

`config/routes.rb` there is an ordinary Rails routes file. Three shapes hit
this:

- scanning the directory the routes live in (`noir -b myapp/config`)
- an engine whose gemspec does not name the framework
- one service of a monorepo scanned app-by-app

## Why source markers are safe here

This is the gap the Django detector already closes for DRF-only apps, where a
`urls.py` importing only `rest_framework` has no `django.` import to find. The
Ruby case is more clear-cut, because the file the analyzer actually reads is
itself the proof: `.routes.draw` is the Rails routing DSL and belongs to no
other framework.

`.rb` and `.ru` are already in the detector's extension list and already being
read, so this adds a content test rather than a new walk. Four markers, none of
which can occur outside Rails:

| Marker | Where it lives |
| --- | --- |
| `X.routes.draw` | `config/routes.rb`, modern and pre-3.0 spellings |
| `Rails.application` | `config.ru`, initializers |
| `Rails::Application` | `config/application.rb` |
| `require "rails/all"` | `config/application.rb` |

A controller, another framework's routing block (`Hanami.application.routes`),
and prose mentioning Rails are all still nothing — covered by specs.

## After

```console
$ noir -b myapp -f json | jq -r '.endpoints[] | "\(.method) \(.url)"'
GET /api/posts
POST /api/posts
GET /api/posts/1
GET /comments
GET /comments/1
```

## One fixture moved

`fixtures/ruby/actioncable/` is a Rails app — its `config/routes.rb` opens with
`Rails.application.routes.draw` — so it now detects as Rails as well, and the
Rails analyzer reads the `mount ActionCable.server => "/cable"` line the
channels hang off. That mount is a real HTTP route: it is where the WebSocket
handshake is made, and `rails routes` lists it. Counts updated from 1 tech / 3
endpoints to 2 / 4; the three `ws://` endpoints are unchanged.

## Checks

- `crystal spec` — 30108 examples, 0 failures
- `crystal run lib/ameba/bin/ameba.cr` — 2282 inspected, 0 failures
- `crystal tool format --check` on the changed files

Found while cross-checking [alibi](https://github.com/owasp-noir/alibi)
against real repositories: a Rails source tree scanned without its Gemfile
produced an empty code view, which reads downstream as "this project
implements nothing".