### PR TITLE
fix(robustness): stop a malformed file hanging the scan, report what the walk drops, and keep TOML parseable

### DIFF
--- a/spec/unit_test/analyzer/analyzers/javascript/nitro_monorepo_spec.cr
+++ b/spec/unit_test/analyzer/analyzers/javascript/nitro_monorepo_spec.cr
@@ -1,0 +1,109 @@
+require "file_utils"
+require "../../../../spec_helper"
+require "../../../../../src/models/code_locator"
+require "../../../../../src/analyzer/analyzers/javascript/nitro"
+
+# Two Nitro apps under one scan base must both be reported.
+#
+# The analyzer's own dedup used to be `result.index { |e| e.url == url &&
+# e.method == method }` — a lookup across the whole scan, with no notion of
+# which app a route belonged to. `apps/a/routes/users.post.ts` and
+# `apps/b/routes/users.post.ts` are both `POST /users`, so the second file
+# read replaced the first outright: its params, its callees and its
+# `code_path` all disappeared before the optimizer (which is where duplicate
+# endpoints are supposed to be merged) ever saw them.
+#
+# And "second file read" is decided by which worker fiber finishes first, so
+# on a large scan the surviving app flipped between runs of the identical
+# input. That is how this was found: five `noir scan` runs over one corpus,
+# diffing the JSON.
+
+# The analyzer resolves its file set through `CodeLocator`, which the
+# detection walk normally fills. These specs drive the analyzer directly, so
+# they register the tree themselves.
+private def register_tree(root : String) : Nil
+  locator = CodeLocator.instance
+  locator.clear_all
+  Dir.glob(File.join(root, "**", "*")).each do |path|
+    next unless File.file?(path)
+    locator.register_file(path, File.read(path))
+  end
+end
+
+describe "Nitro monorepo scoping" do
+  it "keeps the same route from two Nitro apps" do
+    temp_dir = File.tempname("noir_nitro_monorepo")
+
+    begin
+      ["a", "b"].each do |app|
+        routes = File.join(temp_dir, "apps", app, "routes")
+        Dir.mkdir_p(routes)
+        File.write(File.join(temp_dir, "apps", app, "nitro.config.ts"), "export default {}\n")
+        File.write(File.join(routes, "users.post.ts"), <<-TS)
+          export default defineEventHandler(async (event) => {
+            const body = await readBody(event)
+            return body.#{app}Field
+          })
+          TS
+      end
+
+      register_tree(temp_dir)
+
+      options = create_test_options
+      options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+      endpoints = Analyzer::Javascript::Nitro.new(options).analyze
+
+      users = endpoints.select { |e| e.url == "/users" && e.method == "POST" }
+      users.size.should eq(2)
+
+      paths = users.compact_map(&.details.code_paths.first?.try(&.path)).sort!
+      paths.size.should eq(2)
+      paths.first.should contain(File.join("apps", "a"))
+      paths.last.should contain(File.join("apps", "b"))
+
+      params = users.flat_map(&.params.map(&.name)).sort!
+      params.should eq(["aField", "bField"])
+    ensure
+      CodeLocator.instance.clear_all
+      FileUtils.rm_rf(temp_dir)
+    end
+  end
+
+  # The precedence rule the global lookup was really there for, kept intact:
+  # inside one app, `users.post.ts` still wins over the POST that a bare
+  # `users.ts` implies, whichever order the two files are read in.
+  it "still lets a method-specific file win inside one app" do
+    temp_dir = File.tempname("noir_nitro_specific")
+    routes = File.join(temp_dir, "routes")
+
+    begin
+      Dir.mkdir_p(routes)
+      File.write(File.join(temp_dir, "nitro.config.ts"), "export default {}\n")
+      File.write(File.join(routes, "users.ts"), <<-TS)
+        export default defineEventHandler(async (event) => {
+          const body = await readBody(event)
+          return body.genericField
+        })
+        TS
+      File.write(File.join(routes, "users.post.ts"), <<-TS)
+        export default defineEventHandler(async (event) => {
+          const body = await readBody(event)
+          return body.specificField
+        })
+        TS
+
+      register_tree(temp_dir)
+
+      options = create_test_options
+      options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+      endpoints = Analyzer::Javascript::Nitro.new(options).analyze
+
+      posts = endpoints.select { |e| e.url == "/users" && e.method == "POST" }
+      posts.size.should eq(1)
+      posts.first.params.map(&.name).should eq(["specificField"])
+    ensure
+      CodeLocator.instance.clear_all
+      FileUtils.rm_rf(temp_dir)
+    end
+  end
+end

--- a/spec/unit_test/analyzer/analyzers/typescript/trpc_malformed_spec.cr
+++ b/spec/unit_test/analyzer/analyzers/typescript/trpc_malformed_spec.cr
@@ -1,0 +1,89 @@
+require "file_utils"
+require "../../../../spec_helper"
+require "../../../../../src/models/code_locator"
+require "../../../../../src/analyzer/analyzers/typescript/trpc"
+
+# A malformed source file must cost the file, not the run.
+#
+# `each_top_level_kv` walks a router/procedure map body character by
+# character and, whenever it meets something it cannot parse as `key:
+# value`, hands the position to `skip_top_level_to_comma` and starts over.
+# That helper stops *on* the character that ended the value — a top-level
+# comma, or an unmatched closing bracket — so when the position it is given
+# is already such a closer it returns the position unchanged and the
+# `while` loop above it spins on that one character forever.
+#
+# Reaching it takes one brace too many, the shape a half-saved editor
+# buffer or a truncated generated file has. Found by scanning a corpus of
+# fixtures with random byte ranges cut out: a 55-byte `.ts` file hung the
+# whole scan indefinitely — no output, no timeout, no exit code.
+#
+# The assertion is "returns", and the value of the spec is that it does so
+# at all.
+private def with_ts_file(content : String, &)
+  dir = File.tempname("trpc_malformed_spec")
+  Dir.mkdir_p(dir)
+  path = File.join(dir, "router.ts")
+  File.write(path, content)
+  locator = CodeLocator.instance
+  locator.clear_all
+  locator.register_file(path, content)
+  begin
+    yield path
+  ensure
+    locator.clear_all
+    FileUtils.rm_rf(dir)
+  end
+end
+
+describe "malformed tRPC routers" do
+  options = create_test_options
+
+  it "terminates on a procedure map with an unmatched closing brace" do
+    with_ts_file("const r = createRouter().mutation('add', { input: x},});\n") do |path|
+      opts = options.dup
+      opts["base"] = YAML::Any.new([YAML::Any.new(File.dirname(path))])
+      Analyzer::Typescript::TRPC.new(opts).analyze
+    end
+  end
+
+  it "terminates on a chain whose middle procedure was truncated" do
+    source = <<-TS
+      export const todoRouter = createRouter()
+        .query('get', {
+          input: z.object({ id: z.string() }),
+        })
+        .mutation('add', {
+          input: sharedAddVali},
+        })
+        .mutation('delete', {
+          input: z.object({ id: z.string() }),
+        });
+      TS
+
+    with_ts_file(source) do |path|
+      opts = options.dup
+      opts["base"] = YAML::Any.new([YAML::Any.new(File.dirname(path))])
+      Analyzer::Typescript::TRPC.new(opts).analyze
+    end
+  end
+
+  it "still reads the routes of a well-formed router" do
+    source = <<-TS
+      import { router, publicProcedure } from './trpc';
+
+      export const appRouter = router({
+        listUsers: publicProcedure.query(() => []),
+        createUser: publicProcedure.mutation(() => null),
+      });
+      TS
+
+    with_ts_file(source) do |path|
+      opts = options.dup
+      opts["base"] = YAML::Any.new([YAML::Any.new(File.dirname(path))])
+      urls = Analyzer::Typescript::TRPC.new(opts).analyze.map(&.url).sort!
+      urls.should contain("/api/trpc/listUsers")
+      urls.should contain("/api/trpc/createUser")
+    end
+  end
+end

--- a/spec/unit_test/detector/silent_loss_reporting_spec.cr
+++ b/spec/unit_test/detector/silent_loss_reporting_spec.cr
@@ -44,6 +44,52 @@ rescue File::Error
   false
 end
 
+# One segment of the over-PATH_MAX tree below. 200 chars is under NAME_MAX
+# (255) on every filesystem the CI runs on, so 30 of them clear the 4096-byte
+# Linux limit with room to spare.
+private DEEP_SEGMENT = "d" * 200
+
+private DEEP_TREE_LEVELS = 30
+
+# Builds `levels` nested directories under `root` and writes `leaf` at the
+# bottom, stepping the working directory down as it goes: a single
+# `Dir.mkdir_p` of the full path would hit the very wall this exercises.
+private def build_deep_tree(root : String, levels : Int32, leaf : String, contents : String) : String
+  Dir.mkdir_p(root)
+  previous = Dir.current
+  begin
+    Dir.cd(root)
+    levels.times do
+      Dir.mkdir(DEEP_SEGMENT)
+      Dir.cd(DEEP_SEGMENT)
+    end
+    File.write(leaf, contents)
+    File.join(Dir.current, leaf)
+  ensure
+    Dir.cd(previous)
+  end
+end
+
+# `FileUtils.rm_rf` walks with absolute paths and so cannot reach past
+# `PATH_MAX` either; unwind the same way it was built.
+private def remove_deep_tree(root : String, levels : Int32, leaf : String) : Nil
+  return unless Dir.exists?(root)
+  previous = Dir.current
+  begin
+    Dir.cd(root)
+    levels.times { Dir.cd(DEEP_SEGMENT) }
+    File.delete?(leaf)
+    levels.times do
+      Dir.cd("..")
+      Dir.delete(DEEP_SEGMENT)
+    end
+  rescue File::Error
+    # Best effort: a partially built tree leaves the rest to the tmp reaper.
+  ensure
+    Dir.cd(previous)
+  end
+end
+
 describe "detection walk coverage reporting" do
   before_each { Noir::SkippedFiles.clear }
   after_each do
@@ -199,6 +245,97 @@ describe "detection walk coverage reporting" do
       gaps.size.should eq(1)
       gaps.first.message.should contain("skipped 2 entries")
       gaps.first.message.should contain("symbolic link (not followed)")
+    ensure
+      FileUtils.rm_rf(temp_dir)
+    end
+  end
+
+  # `File.info?` answers `nil` for every `stat(2)` failure, and the walk used
+  # to `next` on that without a word — no counter, no log line, no `errors`
+  # entry. The reachable case is a path longer than `PATH_MAX`: a generated
+  # or vendored tree crosses the limit (4096 bytes on Linux, 1024 on macOS)
+  # a few dozen levels down, and from there every entry stats
+  # `ENAMETOOLONG`. A 1000-level tree therefore reported zero endpoints,
+  # `"errors": []` and exit 0 under `--strict` — the same output as a clean
+  # scan of an empty directory, for a subtree that was never looked at.
+  it "reports an entry it could not stat, and everything under it" do
+    temp_dir = File.tempname("noir_unstattable_entry")
+    Dir.mkdir_p(temp_dir)
+
+    begin
+      File.write(File.join(temp_dir, "Gemfile"), "gem 'sinatra'\n")
+      File.write(File.join(temp_dir, "app.rb"), "require 'sinatra'\nget '/root' do\nend\n")
+
+      deep_root = File.join(temp_dir, "deep")
+      leaf = build_deep_tree(deep_root, DEEP_TREE_LEVELS,
+        "buried.rb", "require 'sinatra'\nget '/buried' do\nend\n")
+      # A filesystem or platform that resolves the whole path is not the
+      # condition under test.
+      pending! "path longer than PATH_MAX is still resolvable here" unless File.info?(leaf, follow_symlinks: false).nil?
+
+      gaps = scan_gaps(temp_dir)
+
+      gaps.size.should eq(1)
+      gaps.first.tech.should eq(Noir::SkippedFiles::DETECT_SCOPE)
+      gaps.first.message.should contain("skipped 1 unreadable entry")
+    ensure
+      remove_deep_tree(File.join(temp_dir, "deep"), DEEP_TREE_LEVELS, "buried.rb")
+      FileUtils.rm_rf(temp_dir)
+    end
+  end
+
+  # A spec document the detector could not parse at all.
+  #
+  # The spec detectors wrap "parse, then check the root key" in one `rescue`
+  # and used to log both halves at `--debug` and nothing more. The shape
+  # check failing is the gate working — the file is simply not an OpenAPI
+  # document — but a `JSON::ParseException` means nothing can read the file,
+  # so it is never registered, no analyzer ever opens it, and every endpoint
+  # it declares is lost. Crystal's `JSON.parse` refuses at 512 levels of
+  # nesting, and a truncated download fails far sooner than that.
+  it "reports a specification document it could not parse" do
+    temp_dir = File.tempname("noir_unparsable_spec")
+    Dir.mkdir_p(temp_dir)
+
+    begin
+      spec_path = File.join(temp_dir, "openapi.json")
+      # Valid OpenAPI apart from one sibling key nested past the parser's
+      # ceiling, so the marker matches and the parse is what fails.
+      File.write(spec_path, String.build do |io|
+        io << %({"openapi":"3.0.3","info":{"title":"Deep","version":"1"},)
+        io << %("paths":{"/deep":{"get":{"responses":{"200":{"description":"ok"}}}}},)
+        io << %("x-deep":)
+        600.times { io << %({"a":) }
+        io << "1"
+        600.times { io << "}" }
+        io << "}"
+      end)
+
+      gaps = scan_gaps(temp_dir)
+
+      gaps.size.should eq(1)
+      gaps.first.tech.should eq("oas3")
+      gaps.first.message.should contain("skipped 1 unparsable document")
+      gaps.first.message.should contain(spec_path)
+    ensure
+      FileUtils.rm_rf(temp_dir)
+    end
+  end
+
+  # And the other half: a document that parses but is not the format must
+  # stay silent. `"openapi": "3.0.0"` nested inside a wrapper document makes
+  # the marker match and `data["openapi"]` raise `KeyError` — the gate doing
+  # its job. Reporting that would put an entry in `errors` for every file
+  # that mentions OpenAPI in passing.
+  it "stays silent on a parsable document that is not the format" do
+    temp_dir = File.tempname("noir_wrong_shape_spec")
+    Dir.mkdir_p(temp_dir)
+
+    begin
+      File.write(File.join(temp_dir, "meta.json"),
+        %({"upstream":{"openapi":"3.0.0"},"note":"not a spec document"}))
+
+      scan_gaps(temp_dir).should be_empty
     ensure
       FileUtils.rm_rf(temp_dir)
     end

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -6,6 +6,20 @@ module Analyzer::Javascript
 
     def analyze
       result = [] of Endpoint
+      # `(routes root, url, method)` -> index into `result`.
+      #
+      # The dedup this backs used to be `result.index { |e| e.url == url &&
+      # e.method == method }` — a lookup across the whole scan, with no
+      # notion of which Nitro app the route belonged to. Two Nitro projects
+      # under one scan base (a monorepo, or a repo that keeps an example app
+      # beside the real one) both define `routes/users.post.ts`, and the
+      # second one to be read overwrote the first: its params, its callees
+      # and its `code_path` all disappeared, and the survivor was whichever
+      # worker fiber finished last. Same input, different report between
+      # runs. Keying on the routes root keeps each app's route separate and
+      # lets the optimizer merge them, which is where duplicate endpoints
+      # are supposed to be resolved.
+      seen = {} of Tuple(String, String, String) => Int32
       mutex = Mutex.new
       include_callee = callees_needed?
       # `routes/` on its own is not a Nitro signal — it is the conventional
@@ -27,13 +41,15 @@ module Analyzer::Javascript
         # Focus on routes/ directory for Nitro
         next unless path.includes?("/routes/")
         next unless path_under_project_roots?(path, project_roots)
-        analyze_nitro_file(path, result, mutex, include_callee)
+        analyze_nitro_file(path, result, seen, mutex, include_callee)
       end
 
       result
     end
 
-    private def analyze_nitro_file(path : String, result : Array(Endpoint), mutex : Mutex, include_callee : Bool)
+    private def analyze_nitro_file(path : String, result : Array(Endpoint),
+                                   seen : Hash(Tuple(String, String, String), Int32),
+                                   mutex : Mutex, include_callee : Bool)
       # Extract endpoint from file path
       # routes/hello.ts -> /hello
       # routes/users/[id].ts -> /users/:id
@@ -46,6 +62,10 @@ module Analyzer::Javascript
       scoped = base_relative_path(path)
       base_path_idx = scoped.index("/routes/")
       return if base_path_idx.nil?
+
+      # Everything above `routes/` identifies the Nitro app this file
+      # belongs to — the dedup scope below.
+      routes_root = scoped[0...base_path_idx]
 
       # Get the path after /routes/
       relative_path = scoped[(base_path_idx + "/routes/".size)..-1]
@@ -147,13 +167,14 @@ module Analyzer::Javascript
           attach_js_callees(endpoint, callees) if include_callee
 
           mutex.synchronize do
-            existing_idx = result.index { |e| e.url == url && e.method == method }
-            if existing_idx
+            key = {routes_root, url, method}
+            if existing_idx = seen[key]?
               # Method-specific files take precedence over generic handlers
-              if specific_method
-                result[existing_idx] = endpoint
-              end
+              # *within the same app*: `routes/users.post.ts` wins over the
+              # POST that `routes/users.ts` implies.
+              result[existing_idx] = endpoint if specific_method
             else
+              seen[key] = result.size
               result << endpoint
             end
           end

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -656,7 +656,7 @@ module Analyzer::Typescript
                   i = close + 1
                   literal
                 else
-                  i = skip_top_level_to_comma(chars, i)
+                  i = skip_value(chars, i)
                   ""
                 end
               else
@@ -670,7 +670,7 @@ module Analyzer::Typescript
                   i = j
                   literal
                 else
-                  i = skip_top_level_to_comma(chars, i)
+                  i = skip_value(chars, i)
                   ""
                 end
               end
@@ -693,7 +693,7 @@ module Analyzer::Typescript
 
         unless chars[i] == ':'
           # Spread, method shorthand, or other construct we don't handle.
-          i = skip_top_level_to_comma(chars, i)
+          i = skip_value(chars, i)
           next
         end
 
@@ -743,6 +743,25 @@ module Analyzer::Typescript
 
     private def split_top_level(text : String, delimiter : Char) : Array(String)
       Noir::TopLevelSplit.split(text, delimiter, SPLIT_TOP_LEVEL_RULES)
+    end
+
+    # `skip_top_level_to_comma` that is guaranteed to move.
+    #
+    # The helper stops *on* the character that ended the value: a top-level
+    # comma, or an unmatched closing bracket (`depth < 0`). When `start`
+    # already sits on such a closer it returns `start`, and the
+    # `while i < n` loop in `each_top_level_kv` — which assigns the result
+    # straight back to `i` and `next`s — spins on that one character
+    # forever.
+    #
+    # Reaching it takes nothing exotic: `createRouter().mutation('add', {
+    # input: x},});` — a 55-byte file with one brace too many, the shape a
+    # half-saved editor buffer or a truncated generated file has — hung the
+    # scan indefinitely, no output, no timeout, no exit code. A malformed
+    # source file must cost the file, not the run.
+    private def skip_value(chars : Array(Char), start : Int32) : Int32
+      stop = skip_top_level_to_comma(chars, start)
+      stop > start ? stop : start + 1
     end
 
     private def skip_top_level_to_comma(chars : Array(Char), start : Int32) : Int32

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -422,6 +422,8 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
     # devices). Both used to leave no trace at any verbosity.
     unlistable_dirs = 0
     skipped_entries = 0
+    # Entries `Dir.each_child` named but `File.info?` would not stat.
+    unstattable_entries = 0
 
     # User-supplied --exclude-path patterns (comma-separated globs),
     # compiled once. `Noir::ExcludePath` owns what a pattern means; the
@@ -456,7 +458,32 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
           Dir.each_child(dir) do |entry|
             full_path = File.join(dir, entry)
             info = File.info?(full_path, follow_symlinks: false)
-            next if info.nil?
+            if info.nil?
+              # `File.info?` turns every `stat(2)` failure into `nil`, and
+              # the walk used to `next` on it without a word. The entry is
+              # not imaginary — `Dir.each_child` just handed it over — so
+              # this is a directory or file the scan drops, and when it is a
+              # directory it takes the entire subtree with it.
+              #
+              # The reachable case is a path longer than `PATH_MAX`: a deep
+              # generated tree crosses 1024 bytes around 80 levels down on
+              # macOS, and from there every entry stats `ENAMETOOLONG`. A
+              # 1000-level fixture reported zero endpoints, `"errors": []`
+              # and exit 0 under `--strict` — the same output as a clean
+              # scan of an empty directory. Re-stat once (only on this
+              # path, which is off the hot loop) to name the real errno.
+              reason = begin
+                File.info(full_path, follow_symlinks: false)
+                "stat returned no information"
+              rescue e : File::Error
+                e.message.presence || e.class.name
+              end
+              unstattable_entries += 1
+              logger.debug "Skipping #{full_path}: #{reason}"
+              Noir::SkippedFiles.record(Noir::SkippedFiles::DETECT_SCOPE, full_path, reason,
+                noun: "unreadable entry", phase: Noir::SkippedFiles::Phase::Scan)
+              next
+            end
 
             if info.directory?
               # Subtree prune happens here. Entry name (not full path)
@@ -612,10 +639,19 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
             # cache the content so analyzers can skip the re-read.
             locator.register_file(full_path, content)
           end
-        rescue e : File::NotFoundError | File::AccessDeniedError
+        rescue e : File::Error
           # `Dir.each_child` itself failed: the directory vanished between
           # being pushed on the stack and being popped, or it is not
           # listable. Treat the subtree as empty and move on.
+          #
+          # `File::Error`, not the `NotFoundError | AccessDeniedError` pair
+          # this used to name: those two cover ENOENT and EACCES, and every
+          # other errno `opendir(3)` can return — ENAMETOOLONG, ENOTDIR,
+          # EMFILE once a big scan runs out of descriptors — escaped as a
+          # bare `File::Error`, killed the reader fiber mid-walk and left
+          # every remaining base path unscanned. `File::BadPatternError` is
+          # not a `File::Error` (it descends straight from `Exception`), so
+          # the `--exclude-path` handler below still sees its own raise.
           #
           # Scope note: this is the *directory* handler. Per-file failures
           # are caught at the read above, so they no longer land here and
@@ -651,6 +687,9 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
     end
     if skipped_entries > 0
       logger.warning "Skipped #{skipped_entries} symlinked or non-regular path#{"s" if skipped_entries != 1} (symlinks are not followed)"
+    end
+    if unstattable_entries > 0
+      logger.warning "Skipped #{unstattable_entries} entr#{unstattable_entries == 1 ? "y" : "ies"} that could not be stat'd (path too long, or removed during the scan)"
     end
     if skipped_ignored_dirs > 0
       logger.debug "Pruned #{skipped_ignored_dirs} ignored directory tree(s)"

--- a/src/detector/detectors/specification/asyncapi.cr
+++ b/src/detector/detectors/specification/asyncapi.cr
@@ -27,6 +27,7 @@ module Detector::Specification
           end
         rescue e
           logger.debug "AsyncAPI JSON detection failed for #{filename}: #{e}"
+          record_unparsable_document(filename, e)
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         begin
@@ -39,6 +40,7 @@ module Detector::Specification
           end
         rescue e
           logger.debug "AsyncAPI YAML detection failed for #{filename}: #{e}"
+          record_unparsable_document(filename, e)
         end
       end
 

--- a/src/detector/detectors/specification/har.cr
+++ b/src/detector/detectors/specification/har.cr
@@ -26,6 +26,7 @@ module Detector::Specification
             end
           rescue e
             logger.debug "HAR detection failed for #{filename}: #{e}"
+            record_unparsable_document(filename, e)
           end
         end
       end

--- a/src/detector/detectors/specification/insomnia.cr
+++ b/src/detector/detectors/specification/insomnia.cr
@@ -30,6 +30,7 @@ module Detector::Specification
           end
         rescue e
           logger.debug "Insomnia JSON detection failed for #{filename}: #{e}"
+          record_unparsable_document(filename, e)
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         return false unless content_matches?(file_contents, INSOMNIA_HOST_MARKER)
@@ -49,6 +50,7 @@ module Detector::Specification
           end
         rescue e
           logger.debug "Insomnia YAML detection failed for #{filename}: #{e}"
+          record_unparsable_document(filename, e)
         end
       end
 

--- a/src/detector/detectors/specification/oas2.cr
+++ b/src/detector/detectors/specification/oas2.cr
@@ -28,6 +28,7 @@ module Detector::Specification
           end
         rescue e
           logger.debug "OAS2 JSON detection failed for #{filename}: #{e}"
+          record_unparsable_document(filename, e)
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         if content_matches?(file_contents, SWAGGER2_YAML_MARKER)

--- a/src/detector/detectors/specification/oas3.cr
+++ b/src/detector/detectors/specification/oas3.cr
@@ -41,6 +41,7 @@ module Detector::Specification
           end
         rescue e
           logger.debug "OAS3 JSON detection failed for #{filename}: #{e}"
+          record_unparsable_document(filename, e)
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         if content_matches?(file_contents, OPENAPI3_YAML_MARKER)

--- a/src/detector/detectors/specification/openrpc.cr
+++ b/src/detector/detectors/specification/openrpc.cr
@@ -23,6 +23,7 @@ module Detector::Specification
         end
       rescue e
         logger.debug "OpenRPC JSON detection failed for #{filename}: #{e}"
+        record_unparsable_document(filename, e)
       end
 
       check

--- a/src/detector/detectors/specification/postman.cr
+++ b/src/detector/detectors/specification/postman.cr
@@ -33,6 +33,7 @@ module Detector::Specification
           end
         rescue e
           logger.debug "Postman detection failed for #{filename}: #{e}"
+          record_unparsable_document(filename, e)
         end
       end
 

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -1,7 +1,9 @@
 require "./logger"
 require "./code_locator"
+require "./skipped_files"
 require "../utils/text_file"
 require "../utils/utils"
+require "json"
 require "yaml"
 
 module Noir
@@ -237,6 +239,31 @@ class Detector
       @@gemspec_dependency_res[gem_name] ||= /\badd(?:_runtime)?_dependency\s*\(?\s*['"]#{Regex.escape(gem_name)}['"]/
     end
     content_matches?(file_contents, re)
+  end
+
+  # A document that matched this format's content marker but could not be
+  # parsed at all.
+  #
+  # The spec detectors wrap "parse, then check the root key" in one
+  # `rescue`, and the two halves fail for very different reasons.
+  # `data["openapi"].as_s` raising `KeyError` / `TypeCastError` means "this
+  # JSON is simply not my format" — the gate doing its job, and reporting it
+  # would flag every document that merely mentions the word. A
+  # `JSON::ParseException` / `YAML::ParseException` is the other case: the
+  # file is not readable as JSON/YAML by anything, so it is never registered,
+  # no analyzer ever opens it, and every endpoint it declares is lost.
+  #
+  # That half used to leave a `--debug` line and nothing else. An OpenAPI
+  # document nested deeper than Crystal's 512-level `JSON.parse` ceiling —
+  # or one truncated by a failed download — reported zero endpoints,
+  # `"errors": []`, and exit 0 under `--strict`, which is indistinguishable
+  # from a repository that declares no API at all.
+  def record_unparsable_document(filename : String, error : Exception) : Nil
+    return unless error.is_a?(JSON::ParseException) || error.is_a?(YAML::ParseException)
+
+    Noir::SkippedFiles.record(@name, filename,
+      error.message.presence || error.class.name,
+      noun: "unparsable document", phase: Noir::SkippedFiles::Phase::Scan)
   end
 
   getter name, logger


### PR DESCRIPTION
Hostile-input / concurrency / failure-reporting sweep. Everything below was found by building the binary and running it — mutating the fixture corpus with random truncations, byte-range cuts and bitflips, and diffing repeated runs of the identical scan — not by reading code.

Five defects, each with a reproduction. Detection is unchanged: **3193 endpoints on `spec/functional_test/fixtures` before and after**, identical `(method, url)` sets across 11 before-runs and 5 after-runs, with the Nitro fix restoring one lost `code_path` and two lost params.

---

## 1. A tRPC router with one brace too many hangs the scan forever

**Symptom** — `noir scan` never returns. No output, no error, no exit code; the process spins at 100% CPU indefinitely. Found by cutting a random byte range out of every fixture file and scanning the result: one 900-second run produced nothing at all.

**Root cause** — `Analyzer::Typescript::TRPC#each_top_level_kv` walks a router/procedure map body character by character and, whenever it meets something it cannot read as `key: value`, hands the position to `skip_top_level_to_comma` and restarts the loop. That helper stops **on** the character that ended the value: a top-level comma, or an unmatched closing bracket (`return i if depth < 0`). When the position it is given already sits on such a closer it returns the position unchanged, `key` comes back empty, the loop `next`s, and `i` never advances.

**Reproduction** — a 55-byte file:

```console
$ printf "const r = createRouter().mutation('add', { input: x},});\n" > /tmp/min/r.ts
$ noir -b /tmp/min -t trpc -f json --no-log
```

Before — hangs; killed at 30s:

```
rc=124 secs=30
```

`sample(1)` on the hung process:

```
+  324 *Analyzer::Typescript::TRPC#analyze:Array(Endpoint)  (in noir) + 2392
+  ! 162 *Analyzer::Typescript::TRPC#skip_top_level_to_comma<Array(Char), Int32>:Int32
```

After:

```json
{"endpoints":[{"url":"/api/trpc/add","method":"POST", ...,"technology":"ts_trpc"}],"passive_results":[],"errors":[]}
rc=0 secs=0
```

The corpus that produced it (every fixture file with a random byte range removed, seed 2) went from **timing out at 900s** to finishing in **12s**. A second corpus (bitflip, seed 2) that also timed out now finishes in 6s.

**Fix** — `skip_value`, a `skip_top_level_to_comma` that is guaranteed to move. Nothing about the well-formed path changes: on valid input the helper always returns a position past `start`.

---

## 2. Two Nitro apps under one scan base: one of them silently disappears

**Symptom** — a monorepo with two Nitro apps that define the same route reports only one of them. The other app's params, callees and `code_path` are gone before the optimizer ever sees them. **And which app survives changes between runs of the identical input.**

**Root cause** — `Analyzer::Javascript::Nitro#analyze_nitro_file` deduped with `result.index { |e| e.url == url && e.method == method }` — a lookup across the whole scan, with no notion of which Nitro app a route belonged to. `apps/a/routes/users.post.ts` and `apps/b/routes/users.post.ts` are both `POST /users`, so the second file read replaced the first outright. "Second file read" is decided by which `parallel_file_scan` worker fiber finishes first.

**Reproduction** — two apps, each with a `nitro.config.ts` and a `routes/users.post.ts` reading a different body field:

```console
$ noir -b /tmp/t8 --only-techs js_nitro -f json --no-log
```

Before — `appA` is gone entirely, `alphaField` with it:

```
POST /users ['appB/routes/users.post.ts'] ['betaField']
```

After:

```
POST /users ['appA/routes/users.post.ts', 'appB/routes/users.post.ts'] ['alphaField', 'betaField']
```

**How it was found** — five identical `noir scan` runs over `spec/functional_test/fixtures`, diffing the JSON: runs 1, 2 and 5 were byte-identical to each other, runs 3 and 4 to each other, and the difference was `javascript/nitro/routes/users.post.ts` flipping places with `javascript/nitro_callees/routes/users.post.ts` — and the `username` / `password` body params appearing in one and not the other.

**Fix** — key the dedup on `(routes root, url, method)`. Duplicates now reach the optimizer, which is where duplicate endpoints are supposed to be merged. The rule the global lookup was really there for — a method-specific `users.post.ts` beating the POST that a bare `users.ts` implies — is kept, scoped to one app, and is order-independent in both directions.

---

## 3. An entry `File.info?` will not stat is deleted from the scan silently

**Symptom** — a deeply nested directory tree reports zero endpoints, `"errors": []`, and exit 0 — including under `--strict`. Indistinguishable from a clean scan of an empty directory.

**Root cause** — `File.info?` turns every `stat(2)` failure into `nil`, and the walk in `detect_techs` did `next if info.nil?` with no counter, no log line at any verbosity, and no entry in `errors`. When the entry is a directory, that silently drops the entire subtree. The reachable case is a path longer than `PATH_MAX` — 1024 bytes on macOS, 4096 on Linux — which a generated or vendored tree crosses a few dozen levels down.

**Reproduction**

```console
$ python3 -c "
import os; os.chdir('/tmp/nh/t3/deep')
for i in range(1000): os.mkdir('d%d'%i); os.chdir('d%d'%i)
open('app.py','w').write('from flask import Flask\napp=Flask(__name__)\n@app.route(\"/deep\")\ndef d(): pass\n')"
$ noir -b /tmp/nh/t3 -f json --no-log
$ noir -b /tmp/nh/t3 -f json --no-log --strict; echo "strict rc=$?"
```

Before:

```json
{"endpoints":[],"passive_results":[],"errors":[]}
strict rc=0
```

After:

```json
{"endpoints":[],"passive_results":[],"errors":[{"tech":"detect","message":"skipped 1 unreadable entry: /tmp/nh/t3/deep/d0/d1/...; first error: Error getting file info for '...': File name too long"}]}
strict rc=2
```

**Fix** — record it through `Noir::SkippedFiles`, the same route the walk's other five drop paths already use, with a single re-`stat` on the failure path only to name the real errno. The directory-listing rescue is widened from `File::NotFoundError | File::AccessDeniedError` to `File::Error` at the same time: those two cover ENOENT and EACCES, and every other errno `opendir(3)` can return (ENAMETOOLONG, ENOTDIR, EMFILE when a big scan runs out of descriptors) escaped as a bare `File::Error` and killed the reader fiber mid-walk. `File::BadPatternError` descends from `Exception`, not `File::Error`, so the `--exclude-path` handler still sees its own raise.

---

## 4. A specification document that cannot be parsed is dropped without a word

**Symptom** — an OpenAPI document nested past Crystal's 512-level `JSON.parse` ceiling (or truncated by a failed download) yields zero endpoints, `"errors": []` and exit 0 under `--strict`.

**Root cause** — the spec detectors wrap "parse, then check the root key" in one `rescue` that only logs at `--debug`. Because the detector is what registers the path in `CodeLocator`, a parse failure there means the analyzer never opens the file — so `each_spec_file`'s existing per-file reporting (which is correct) never runs either.

**Reproduction** — a valid OpenAPI 3 document with one deeply nested sibling key:

```console
$ noir -b /tmp/nh/t9d -f json --no-log
$ noir -b /tmp/nh/t9d -f json --no-log --strict; echo "strict rc=$?"
```

Before:

```json
{"endpoints":[],"passive_results":[],"errors":[]}
strict rc=0
```

After:

```json
{"endpoints":[],"passive_results":[],"errors":[{"tech":"oas3","message":"skipped 1 unparsable document: /tmp/nh/t9d/openapi.json; first error: Nesting of 513 is too deep at line 1, column 3215"}]}
strict rc=2
```

**Fix** — `Detector#record_unparsable_document`, wired into the seven detectors with this shape (oas2, oas3, asyncapi, openrpc, insomnia, postman, har). It deliberately reports **only** `JSON::ParseException` / `YAML::ParseException`. A `KeyError` / `TypeCastError` from the root-key check means "this JSON is simply not my format" — the gate doing its job — and stays silent, so a file that merely mentions `"openapi": "3.0.0"` inside a wrapper object does not land in `errors`. Both halves are pinned by specs.

Noise check: `errors` is unchanged on `spec/functional_test/fixtures` (still the one pre-existing `oas3` `$ref` entry), and empty on two real repositories (`gothinkster/realworld`, `OAI/OpenAPI-Specification`). On the truncated corpora it reports exactly the documents the mutation broke.

---

## 5. `-f toml` emits a document no TOML parser will read

**Symptom** — a control byte anywhere in an endpoint URL, a param name or a `code_path` produces invalid TOML.

**Root cause** — TOML basic strings admit no raw character in U+0000-U+0008, U+000A-U+001F or U+007F, and only `\b \t \n \f \r` have a short form. `OutputBuilderTomlSerializer` escaped exactly those five with a `gsub` chain and left every other control byte raw. One ANSI escape in a route literal is enough — and filenames may contain control characters too, which reach the document through `code_paths`.

**Reproduction**

```console
$ printf 'from flask import Flask
app = Flask(__name__)
@app.route("/ctrl\x01\x02\x1b[31m")
def a(): pass
' > /tmp/t11/app.py
$ noir -b /tmp/t11 -f toml --no-log > out.toml
$ python3 -c "import tomllib; tomllib.load(open('out.toml','rb'))"
```

Before:

```
tomllib.TOMLDecodeError: Illegal character '\x01' (at line 4, column 13)
```

After:

```
toml OK ['/ctrl\x01\x02\x1b[31m', '/del\x7f', '/nbsp\xa0zwsp\u200b', '/rtl\u202eevil']
```

**Fix** — escape the rest as `\uXXXX`. The replacement walks the string once instead of seven times, and is shared with diff mode's `print_toml`, so both outputs are fixed. `-f toml` over `spec/functional_test/fixtures` still parses and still carries all 3193 endpoints.

Also checked, and fine: `json`, `yaml`, `sarif`, `oas2`, `oas3`, `postman` all stay valid with the same input (validated with a third-party parser for each), as do all 14 formats against filenames containing newlines, quotes, emoji and 200-character names.

---

## What held up

Worth recording, because these were exercised hard and did not break:

- **Encodings** — UTF-16LE/BE with BOM, UTF-8 BOM, latin-1, and NUL-bearing binary with a `.py` extension: decoded or reported correctly, `errors` names the two skipped files.
- **Filesystem hostility** — FIFO with a source extension, symlink loop, symlink pointing outside the base, `chmod 000` file, `chmod 000` directory: all skipped and all reported, `--strict` exits 2.
- **Filenames** — newline, quote, single quote, space, tab, backslash, `$(whoami)`, `;rm -rf`, `--dashdash`, Korean, emoji, 200 chars: all 12 found, and `json` / `yaml` / `toml` output stays parseable (validated with a third-party parser for each).
- **Sizes** — a 9.4 MB single-line `.py` and a 10⁶-line `.py` both complete. The second sometimes trips the tree-sitter 10-second wall-clock ceiling, which is reported in `errors` and exits 2 under `--strict`, as designed.
- **Concurrency flags** — `--concurrency 0 / -1 / -100 / 1.5 / abc / 0x10 / 99999999999999999999` all rejected with exit 1; `999999` clamps to 256 with a warning; the config file goes through the same validation rather than around it.
- **Output failures** — writing to a read-only file or into a read-only directory prints the error and exits 1 after emitting the report to stdout.
- **Base paths** — nonexistent, a regular file, a FIFO, trailing slashes: all handled.
- **Malformed sources** — unterminated strings, unterminated heredocs and unbalanced braces across 12 languages: no crash.
- **Mutation fuzzing** — 24 whole-corpus runs (truncate / byte-range cut / bitflip / bracket corruption, seeds 5-10) against the fixed binary: no hang, no crash, no stderr output.

## Known, not fixed here

Repeated scans of the whole fixture corpus still differ occasionally in one place: `javascript/koa_nested_mount` and `javascript/oak_nested_mount` sometimes contribute their routes **without** the `/api` mount prefix as well as with it (10 `code_path` occurrences instead of 5, in roughly 2 runs out of 10). The emitter is not `js_koa`/`js_oak` — scanning the corpus with `--only-techs js_koa` or `--only-techs js_oak` is stable and correct on every run — but another JS analyzer reading those files without knowing about the koa/oak mount chain. That is the analyzer project-scoping axis rather than this one, and fixing it means deciding which analyzer should not be reading those files at all, so I have left it out rather than guess at the boundary.
