### PR TITLE
fix(cli): flag placement, broken pipes, and three crash paths on the CLI surface

### DIFF
--- a/docs/content/usage/cli_commands/_index.ko.md
+++ b/docs/content/usage/cli_commands/_index.ko.md
@@ -209,6 +209,9 @@ Crystal, LLVM, 타깃 트리플 등 빌드 세부 정보를 추가합니다(v0
 | `-v, --version`| Noir 버전 출력 후 종료                                                |
 | `-h, --help`   | 현재 명령의 도움말 표시                                              |
 
+동사 앞뒤 어디에 놓아도 동일합니다 — `noir --no-color list techs` 와
+`noir list techs --no-color` 는 같은 명령입니다.
+
 명령어별 플래그(출력 형식, 동시성, passive scan, AI provider 등)는
 `noir scan` 아래에 있습니다. `noir help scan` 으로 전체 목록을 볼 수
 있습니다.
@@ -224,9 +227,9 @@ noir scan ./app              # v1 형식
 noir scan -b ./app           # v1 동사 + v0 스타일 플래그
 ```
 
-`ARGV[0]` 가 알려진 동사가 아니면 라우터가 `scan` 으로 폴백합니다. CI
-파이프라인, GitHub Action, Dockerfile entrypoint, 쉘 alias 가 수정
-없이 그대로 동작합니다.
+글로벌 플래그를 지나친 첫 인자가 알려진 동사가 아니면 라우터가 `scan`
+으로 폴백합니다. CI 파이프라인, GitHub Action, Dockerfile entrypoint,
+쉘 alias 가 수정 없이 그대로 동작합니다.
 
 deprecation 경고는 추후 v1.x 시리즈에서 추가됩니다. 동사 형식이
 의무가 되는 시점은 v2.x 입니다.

--- a/docs/content/usage/cli_commands/_index.md
+++ b/docs/content/usage/cli_commands/_index.md
@@ -206,6 +206,9 @@ A small set of flags work on every subcommand, not just `scan`:
 | `-v, --version`| Print the noir version and exit                                       |
 | `-h, --help`   | Show help for the current command                                     |
 
+These may sit on either side of the verb — `noir --no-color list techs`
+and `noir list techs --no-color` are the same command.
+
 Per-command flags (output format, concurrency, passive scan, AI
 provider, and so on) live under `noir scan`. See `noir help scan` for
 the full list.
@@ -221,7 +224,8 @@ noir scan ./app              # v1 form
 noir scan -b ./app           # v1 verb with v0-style flags
 ```
 
-When `ARGV[0]` is not a known verb, the router falls back to `scan`.
+When the first argument (past any global flag) is not a known verb, the
+router falls back to `scan`.
 CI pipelines, GitHub Actions, Dockerfile entrypoints, and shell aliases
 all keep working without edits.
 

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -244,6 +244,17 @@ describe "noir CLI surface (built binary)" do
       end
     end
 
+    it "reports a --config-file that is a directory instead of crashing" do
+      # `File.exists?` is true for a directory and the `File.read` that
+      # followed it sat outside ConfigInitializer's YAML rescue, so this
+      # printed a raw Crystal backtrace before CliValidation's one-liner.
+      result = run_noir(["scan", FIXTURE, "--config-file", Dir.tempdir, "-f", "json", "--no-log"])
+      result.stdout.should be_empty
+      result.stderr.should_not contain("Unhandled exception")
+      result.stderr.should contain("--config-file is not a file")
+      result.exit_code.should eq(1)
+    end
+
     it "leaves a well-formed scan untouched" do
       result = run_noir(["scan", FIXTURE, "-u", "http://localhost:3000", "-f", "json", "--no-log"])
       result.stderr.should be_empty

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -230,4 +230,28 @@ describe "noir CLI surface (built binary)" do
       urls.all?(&.starts_with?("http://localhost:3000/")).should be_true
     end
   end
+
+  describe "broken pipe" do
+    # `noir list techs` writes far more than a pipe buffer holds, so a
+    # reader that stops early (`| head`) closes the pipe mid-write. Scan's
+    # own stdout writes have been guarded for a while, but the thin
+    # subcommands write straight to STDOUT — this painted a full Crystal
+    # backtrace over the terminal and exited non-zero.
+    it "exits quietly when the reader closes the pipe" do
+      log = File.tempname("noir-epipe-", ".log")
+      begin
+        # The brace group sends both noir's stderr and its exit status to
+        # `log`, because `$?` after a pipeline in `sh` belongs to `head`.
+        Process.run("/bin/sh", args: [
+          "-c", "{ \"$0\" list techs; echo \"rc=$?\" >&2; } 2>\"$1\" | head -1 >/dev/null",
+          BINARY, log,
+        ])
+        captured = File.read(log)
+        captured.should_not contain("Unhandled exception")
+        captured.should contain("rc=0")
+      ensure
+        File.delete?(log)
+      end
+    end
+  end
 end

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -221,6 +221,29 @@ describe "noir CLI surface (built binary)" do
       end
     end
 
+    it "treats everything after `--` as a path, flag-shaped or not" do
+      # Crystal's OptionParser drops the `--` and leaves the tail in place,
+      # which erased the boundary: the positional loop skipped every
+      # leftover starting with `-`, so a flag typed after `--` vanished and
+      # its value was promoted to a base path.
+      result = run_noir(["scan", "--", FIXTURE, "-f", "json"])
+      result.stdout.should be_empty
+      result.stderr.should contain("Base path does not exist: -f")
+      result.exit_code.should eq(1)
+    end
+
+    it "scans a directory whose name starts with a dash when given after `--`" do
+      dir = File.join(Dir.tempdir, "-noir-dash-#{Random.rand(100_000)}")
+      Dir.mkdir_p(dir)
+      begin
+        result = run_noir(["scan", "-f", "json", "--no-log", "--", dir])
+        result.exit_code.should eq(0)
+        JSON.parse(result.stdout)["endpoints"].as_a.empty?.should be_true
+      ensure
+        Dir.delete(dir) if Dir.exists?(dir)
+      end
+    end
+
     it "leaves a well-formed scan untouched" do
       result = run_noir(["scan", FIXTURE, "-u", "http://localhost:3000", "-f", "json", "--no-log"])
       result.stderr.should be_empty

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -77,6 +77,55 @@ describe "noir CLI surface (built binary)" do
     end
   end
 
+  describe "global flags before the verb" do
+    # `noir help` documents `--no-color` / `--no-spinner` as working on
+    # "every command's output", but the router only ever tested `argv[0]`
+    # for a verb — so a global flag typed first pushed the whole invocation
+    # down the v0 bare-flag path and every one of these died with
+    # `Base path does not exist: <verb>`.
+    it "dispatches a verb that follows a leading global flag" do
+      result = run_noir(["--no-color", "version"])
+      result.stdout.strip.should match(/\A\d+\.\d+\.\d+/)
+      result.exit_code.should eq(0)
+    end
+
+    it "accepts several leading global flags at once" do
+      result = run_noir(["--no-color", "--no-spinner", "list", "formats"])
+      result.stdout.should contain("json")
+      result.exit_code.should eq(0)
+    end
+
+    it "still reaches scan, with the flag applied" do
+      result = run_noir(["--no-color", "scan", FIXTURE, "-f", "json", "--no-log"])
+      result.exit_code.should eq(0)
+      result.stdout.should_not contain("\e[")
+      JSON.parse(result.stdout)["endpoints"].as_a.empty?.should be_false
+    end
+
+    it "shows the top-level overview for `--no-color -h`, not scan's flag dump" do
+      result = run_noir(["--no-color", "-h"])
+      result.stdout.should contain("COMMANDS:")
+      result.stdout.should_not contain("--passive-scan-severity")
+      result.exit_code.should eq(0)
+    end
+
+    it "does not let the v0 rewrite hijack a subcommand's own -v" do
+      # Same exposure as `noir rules path -v` above, reached through the
+      # leading-global-flag path: `subcommand_invocation?` looked at
+      # `argv[0]`, saw `--no-color`, and let `-v => version` win.
+      result = run_noir(["--no-color", "rules", "path", "-v"])
+      result.stdout.should contain("passive_rules")
+      result.stdout.strip.should_not match(/\A\d+\.\d+\.\d+\z/)
+      result.exit_code.should eq(0)
+    end
+
+    it "keeps a globals-only argv on the v0 scan path" do
+      result = run_noir(["--no-color"])
+      result.stderr.should contain("No path to scan was given")
+      result.exit_code.should eq(1)
+    end
+  end
+
   describe "config" do
     it "rejects --config-file with no value instead of using the default file" do
       result = run_noir(["config", "path", "--config-file"])

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -244,6 +244,12 @@ describe "noir CLI surface (built binary)" do
       end
     end
 
+    it "names an empty base path instead of reporting a blank one as missing" do
+      result = run_noir(["scan", ""])
+      result.stderr.should contain("Base path is empty")
+      result.exit_code.should eq(1)
+    end
+
     it "reports a --config-file that is a directory instead of crashing" do
       # `File.exists?` is true for a directory and the `File.read` that
       # followed it sat outside ConfigInitializer's YAML rescue, so this

--- a/spec/unit_test/cli/router_spec.cr
+++ b/spec/unit_test/cli/router_spec.cr
@@ -97,6 +97,22 @@ describe "Noir::CLI::Legacy.rewrite" do
     Noir::CLI::Legacy.subcommand_invocation?(["-b", "scan"]).should be_false
   end
 
+  it "looks past leading global flags for the verb" do
+    # The router dispatches `noir --no-color rules update`, so the rewrite
+    # layer has to agree that it is a subcommand invocation — otherwise
+    # `-v => version` hijacks `rules update`'s own `-v` again, this time
+    # only when a global flag leads.
+    Noir::CLI::Legacy.subcommand_invocation?(["--no-color", "rules", "update"]).should be_true
+    Noir::CLI::Legacy.subcommand_invocation?(["--no-color", "--no-spinner", "list"]).should be_true
+    Noir::CLI::Legacy.subcommand_invocation?(["--no-color"]).should be_false
+    Noir::CLI::Legacy.subcommand_invocation?(["--no-color", "-b", "./app"]).should be_false
+  end
+
+  it "leaves a global-flag-led subcommand's own flags alone" do
+    argv = ["--no-color", "rules", "update", "-v"]
+    Noir::CLI::Legacy.rewrite(argv).should eq(argv)
+  end
+
   it "is idempotent on already-rewritten input" do
     # `rewrite` consumes the original v0 form and emits the v1 form,
     # which contains no terminal flags by construction — passing it
@@ -196,6 +212,32 @@ describe "Noir::CLI::Router.strip_global_flags" do
   it "leaves argv without global flags untouched" do
     argv = ["purge", "7"]
     Noir::CLI::Router.strip_global_flags(argv).should eq(argv)
+  end
+end
+
+describe "Noir::CLI.verb_index" do
+  # The router only inspected `argv[0]`, so `noir --no-color scan ./app`
+  # fell through to the v0 bare-flag path and died with
+  # `Base path does not exist: scan` — for a flag `noir help` documents as
+  # applying to "every command's output".
+  it "returns 0 when no global flag leads" do
+    Noir::CLI.verb_index(["scan", "./app"]).should eq(0)
+    Noir::CLI.verb_index(["-b", "./app"]).should eq(0)
+    Noir::CLI.verb_index([] of String).should eq(0)
+  end
+
+  it "skips the leading run of global flags" do
+    Noir::CLI.verb_index(["--no-color", "scan"]).should eq(1)
+    Noir::CLI.verb_index(["--no-color", "--no-spinner", "list", "techs"]).should eq(2)
+  end
+
+  it "stops at the first non-global token" do
+    # A `--no-color` further along belongs to the subcommand's own argv.
+    Noir::CLI.verb_index(["cache", "--no-color", "info"]).should eq(0)
+  end
+
+  it "returns argv.size when argv is nothing but global flags" do
+    Noir::CLI.verb_index(["--no-color", "--no-spinner"]).should eq(2)
   end
 end
 

--- a/spec/unit_test/cli_validation_spec.cr
+++ b/spec/unit_test/cli_validation_spec.cr
@@ -19,6 +19,19 @@ describe Noir::CliValidation do
     end
   end
 
+  it "names an empty base path rather than reporting a blank one as missing" do
+    # `noir scan "$TARGET"` with `TARGET` unset. The entry is present, so
+    # the "No path to scan was given" branch above doesn't fire, and the
+    # existence check printed `Base path does not exist: ` — a message with
+    # nothing after the colon.
+    options = create_test_options
+    options["base"] = YAML::Any.new([YAML::Any.new("")])
+
+    expect_raises(Noir::CliValidation::Error, /Base path is empty/) do
+      Noir::CliValidation.validate_base_paths!(options)
+    end
+  end
+
   it "rejects invalid output formats" do
     options = create_test_options
     options["format"] = YAML::Any.new("madeup")

--- a/spec/unit_test/config_initializer_spec.cr
+++ b/spec/unit_test/config_initializer_spec.cr
@@ -396,6 +396,35 @@ describe ConfigInitializer do
       end
     end
 
+    it "falls back to defaults when the override path is a directory" do
+      # `File.exists?` is true for a directory, and the `File.read` that
+      # followed it sat *outside* the YAML rescue below — so
+      # `noir scan ./app --config-file /some/dir` died with a raw Crystal
+      # backtrace (`read (...): Is a directory`) before CliValidation could
+      # print its one-line "--config-file is not a file".
+      dir = File.tempname("noir-config-dir-")
+      Dir.mkdir(dir)
+      begin
+        options = ConfigInitializer.new(dir).read_config
+        options["format"].to_s.should eq("plain")
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "falls back to defaults when the override path cannot be read" do
+      path = File.tempname("noir-config-noperm-", ".yaml")
+      File.write(path, "format: json\n")
+      File.chmod(path, 0o000)
+      begin
+        options = ConfigInitializer.new(path).read_config
+        options["format"].to_s.should eq("plain")
+      ensure
+        File.chmod(path, 0o600)
+        File.delete?(path)
+      end
+    end
+
     it "does NOT auto-create the file when the override path is missing" do
       # Default config path auto-creates a template on first run, but
       # a missing user-supplied --config-file path is a typo — should

--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -67,6 +67,46 @@ describe "default_options" do
 end
 
 describe "run_options_parser" do
+  # POSIX `--`: everything after it is a positional, never a flag. Crystal's
+  # OptionParser drops the marker and leaves the tail in place, which erased
+  # the boundary — the positional loop then skipped every leftover starting
+  # with `-`, so `noir scan -- -old-api` scanned nothing at all and
+  # `noir scan -- ./app -f json` promoted `json` to a base path.
+  it "treats every token after -- as a base path, flag-shaped included" do
+    original_argv = ARGV.dup
+
+    ARGV.clear
+    ARGV.concat(["--", "./app", "-f", "json"])
+
+    begin
+      noir_options = run_options_parser()
+      # `normalize_base` drops the leading `./`, as it does for any positional.
+      noir_options["base"].as_a.map(&.to_s).should eq(["app", "-f", "json"])
+      # `-f` after the marker is a path, so the format stays at its default.
+      noir_options["format"].to_s.should eq("plain")
+    ensure
+      ARGV.clear
+      ARGV.concat(original_argv)
+    end
+  end
+
+  it "still parses the flags typed before --" do
+    original_argv = ARGV.dup
+
+    ARGV.clear
+    ARGV.concat(["-f", "json", "--no-log", "--", "-dash-dir"])
+
+    begin
+      noir_options = run_options_parser()
+      noir_options["format"].to_s.should eq("json")
+      noir_options["nolog"].should be_true
+      noir_options["base"].as_a.map(&.to_s).should eq(["-dash-dir"])
+    ensure
+      ARGV.clear
+      ARGV.concat(original_argv)
+    end
+  end
+
   it "supports --no-spinner" do
     original_argv = ARGV.dup
 

--- a/src/cli/common.cr
+++ b/src/cli/common.cr
@@ -26,6 +26,25 @@ module Noir::CLI
     value != "0"
   end
 
+  # Flags the router itself owns, valid anywhere on the command line —
+  # including *before* the verb, which is where `noir help` documents them
+  # ("Strip ANSI color from every command's output"). `verb_index` is what
+  # lets that placement work: without it the router only ever looked at
+  # `argv.first`, so `noir --no-color scan ./app` fell through to the v0
+  # bare-flag path and died with `Base path does not exist: scan`.
+  GLOBAL_FLAGS = ["--no-color", "--no-spinner"]
+
+  # Index of the first token that is not one of the leading global flags,
+  # i.e. where the subcommand verb would be. Returns `argv.size` when argv
+  # holds nothing but global flags.
+  def self.verb_index(argv : Array(String)) : Int32
+    index = 0
+    while index < argv.size && GLOBAL_FLAGS.includes?(argv[index])
+      index += 1
+    end
+    index
+  end
+
   def self.die(message : String, code : Int32 = 1) : NoReturn
     STDERR.puts "ERROR: #{message}".colorize(:red)
     exit(code)

--- a/src/cli/legacy.cr
+++ b/src/cli/legacy.cr
@@ -48,8 +48,14 @@ module Noir::CLI::Legacy
   # router dispatches to a subcommand (`head` must be in
   # `KNOWN_COMMANDS`). Everything after that verb is that subcommand's
   # own argv and must reach its own parser untouched.
+  #
+  # Leading global flags are skipped for the same reason the router skips
+  # them: `noir --no-color rules update -v` is a v1 subcommand invocation,
+  # and testing `argv.first` alone let the `-v => version` rewrite hijack
+  # `rules update`'s own `-v` — printing the version and exiting 0 while
+  # the rules were never updated.
   def self.subcommand_invocation?(argv : Array(String)) : Bool
-    head = argv.first?
+    head = argv[Noir::CLI.verb_index(argv)]?
     return false if head.nil?
     Noir::CLI::KNOWN_COMMANDS.includes?(head)
   end

--- a/src/cli/router.cr
+++ b/src/cli/router.cr
@@ -1,5 +1,6 @@
 require "./common"
 require "./legacy"
+require "../models/logger"
 require "./commands/scan"
 require "./commands/list"
 require "./commands/cache"
@@ -70,6 +71,17 @@ module Noir::CLI::Router
       # v0 compat: bare flags or an existing positional path → default to scan.
       ScanCommand.run(argv)
     end
+  rescue ex : IO::Error
+    # A downstream reader closed the pipe (`noir list techs | head`, `noir
+    # completion zsh | grep -m1 ...`). The scan path has guarded its own
+    # stdout writes for a while (`NoirLogger#puts`, `OutputBuilder#ob_puts`),
+    # but the thin subcommands write straight to STDOUT, so `noir list techs
+    # | head` printed a full Crystal backtrace over the user's terminal and
+    # exited non-zero. Exit quietly, the same way the logger does — and only
+    # for a broken pipe: a real write failure (disk full, bad fd) must still
+    # surface rather than be laundered into a lying exit(0).
+    raise ex unless NoirLogger.broken_pipe?(ex)
+    exit(0)
   end
 
   # True for a first token that looks like a mistyped subcommand: not a flag,

--- a/src/cli/router.cr
+++ b/src/cli/router.cr
@@ -33,19 +33,33 @@ module Noir::CLI::Router
       return
     end
 
-    head = argv.first
+    # Global flags may lead the command line — `noir help` documents them
+    # that way — so the verb is the first token past them, not `argv[0]`.
+    # Everything before it is carried along and re-attached below rather
+    # than dropped: `scan` re-reads both flags through its own parser.
+    lead = Noir::CLI.verb_index(argv)
+    globals = argv[0...lead]
+    rest = argv[lead..]
+
+    # argv was nothing but global flags. Keep the v0 shape (bare flags mean
+    # a scan) so the error names the real problem — the missing path.
+    if rest.empty?
+      ScanCommand.run(argv)
+      return
+    end
+
+    head = rest.first
 
     # `noir -h` / `noir --help` with no other args show the top-level
     # subcommand overview, not scan's full flag dump. (Per-command help
     # is reachable via `noir scan -h`, `noir list -h`, etc.)
-    if argv.size == 1 && (head == "-h" || head == "--help")
+    if rest.size == 1 && (head == "-h" || head == "--help")
       HelpCommand.run([] of String)
       return
     end
 
     if !head.starts_with?("-") && KNOWN_COMMANDS.includes?(head)
-      rest = argv[1..]
-      route(head, rest)
+      route(head, globals + rest[1..])
     elsif likely_mistyped_command?(head)
       # A bare word that is neither a known command nor an existing path is
       # almost certainly a mistyped subcommand. Pre-fix this fell through to
@@ -70,16 +84,16 @@ module Noir::CLI::Router
     true
   end
 
-  # Router-consumed global flags. `apply_global_color_flag!` already
-  # acted on `--no-color`, and `--no-spinner` only means anything to a
-  # scan's loading spinner. Neither is meaningful to the thin
-  # subcommands, whose "first positional = action/subject" parsers would
-  # otherwise misread a leading `--no-color` as the action itself
-  # (`Unknown cache action: --no-color`). They're stripped before those
-  # commands parse. `scan` is deliberately excluded: its own OptionParser
-  # re-reads both flags to thread color/spinner state through
-  # NoirRunner, so scan keeps the full argv.
-  GLOBAL_FLAGS = ["--no-color", "--no-spinner"]
+  # Router-consumed global flags, re-exported from `Noir::CLI` so the
+  # router and the legacy layer test the same list. `apply_global_color_flag!`
+  # already acted on `--no-color`, and `--no-spinner` only means anything to
+  # a scan's loading spinner. Neither is meaningful to the thin subcommands,
+  # whose "first positional = action/subject" parsers would otherwise misread
+  # a leading `--no-color` as the action itself (`Unknown cache action:
+  # --no-color`). They're stripped before those commands parse. `scan` is
+  # deliberately excluded: its own OptionParser re-reads both flags to thread
+  # color/spinner state through NoirRunner, so scan keeps the full argv.
+  GLOBAL_FLAGS = Noir::CLI::GLOBAL_FLAGS
 
   # Pure helper (no exit/die) so the strip rule stays unit-testable.
   def self.strip_global_flags(args : Array(String)) : Array(String)

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -277,6 +277,17 @@ module Noir::CliValidation
     end
 
     base_paths.each do |base_path|
+      # An empty entry is `noir scan "$TARGET"` with `TARGET` unset, or
+      # `-b ""`. It reached the check below and produced `Base path does not
+      # exist: ` — a message with nothing after the colon, which names
+      # neither the flag nor the fact that the value was blank. Dropping it
+      # silently would be worse: the scan would then run against whatever
+      # other paths were given, or report "No path to scan was given" for a
+      # command line that plainly had one.
+      if base_path.empty?
+        raise Error.new("Base path is empty. Check the value passed to a positional path or -b/--base-path — an unset shell variable expands to nothing.")
+      end
+
       unless File.exists?(base_path)
         raise Error.new("Base path does not exist: #{base_path}")
       end

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -175,6 +175,30 @@ class ConfigInitializer
     STDERR.puts "WARNING: could not initialize noir config at #{@config_file} (#{e.message}); continuing with defaults.".colorize(:yellow)
   end
 
+  # The config file's bytes, or "" when there is nothing readable there.
+  #
+  # `File.exists?` is true for a directory and for a file the process can't
+  # open, and the `File.read` that followed it sat *outside* the YAML
+  # `begin/rescue` below — so `noir scan ./app --config-file /some/dir` (and
+  # a config file with no read permission) killed the process with a raw
+  # Crystal backtrace before `CliValidation` could print either of the
+  # one-line messages it already has for both cases. Read defensively and let
+  # that validator do the reporting.
+  private def read_raw_config : String
+    return "" unless File.file?(@config_file)
+    File.read(@config_file)
+  rescue e : IO::Error
+    # Stay quiet for an explicit `--config-file`: `CliValidation` reports
+    # that one as a hard error moments later, and printing both turns one
+    # problem into two paragraphs. The default config has no such follow-up,
+    # so an unreadable one has to say so here or it silently reverts to
+    # defaults.
+    unless @is_override
+      STDERR.puts "WARNING: could not read config #{@config_file} (#{e.message}); using defaults.".colorize(:yellow)
+    end
+    ""
+  end
+
   def read_config
     # Ensure the config file is set up
     setup
@@ -183,7 +207,7 @@ class ConfigInitializer
     # didn't scaffold) or an empty one is a legitimate "no overrides"
     # state — fall back to defaults quietly. Only a file with real but
     # unparsable content is worth warning about below.
-    raw = File.exists?(@config_file) ? File.read(@config_file) : ""
+    raw = read_raw_config
     return default_options if raw.strip.empty?
 
     # Read the config file, or use the default config if reading fails

--- a/src/options.cr
+++ b/src/options.cr
@@ -58,6 +58,28 @@ private def scan_config_file_override(args : Array(String)) : String?
   found
 end
 
+# POSIX end-of-options marker. Removes the first `--` and everything after
+# it from `args`, returning the tail — the tokens the user declared to be
+# positionals no matter what they look like.
+#
+# Crystal's OptionParser handles `--` by dropping the marker and leaving the
+# tail in place, which erases the boundary: scan's positional loop then skips
+# every leftover starting with `-`, so `noir scan -- -old-api` silently
+# scanned nothing ("No path to scan was given") and `noir scan -- ./app -f
+# json` reported "Base path does not exist: json" — the `-f` had been thrown
+# away and its value promoted to a path. Splitting the tail off before any
+# parsing keeps the marker's meaning: a directory whose name starts with `-`
+# has a way in, and a flag typed after `--` is reported as the path it now is
+# instead of vanishing.
+private def split_end_of_options!(args : Array(String)) : Array(String)
+  index = args.index("--")
+  return [] of String if index.nil?
+
+  tail = args[(index + 1)..]
+  args.delete_at(index, args.size - index)
+  tail
+end
+
 # Validate a CLI flag value that needs to be a positive (>=1)
 # integer. `String#to_i` raises ArgumentError on non-numeric input
 # and silently produces 0 for "" — both surface as Crystal stack
@@ -356,6 +378,11 @@ module Noir::OptionsParsing
 end
 
 def run_options_parser
+  # Split off a POSIX `--` tail before anything reads ARGV: those tokens are
+  # positionals by the user's explicit declaration, so neither the
+  # `--config-file` pre-scan nor the flag rewrites below may interpret them.
+  end_of_options = split_end_of_options!(ARGV)
+
   # Resolve `--config-file PATH` (if present in ARGV) before
   # ConfigInitializer reads the file, so the user-supplied path
   # becomes the source ConfigInitializer parses. Defaults < file <
@@ -690,8 +717,10 @@ def run_options_parser
   # Anything left in `extracted_args` after OptionParser ran is a
   # positional argument. In v1 scan, those are treated as additional
   # base paths so `noir scan ./a ./b` mirrors `-b ./a -b ./b`.
-  extracted_args.each do |positional|
-    next if positional.starts_with?("-")
+  #
+  # Everything after `--` joins them verbatim — no `starts_with?("-")` skip,
+  # because that is exactly what the marker exists to switch off.
+  (extracted_args.reject(&.starts_with?("-")) + end_of_options).each do |positional|
     append_to_yaml_array(noir_options, "base", Noir::PathScope.normalize_base(positional))
   end
 


### PR DESCRIPTION
Hands-on bug hunt on the **CLI surface** (`src/cli/`, every subcommand, the
option parser and the config/validation layer behind them), driven by running
the built binary rather than reading code. Five defects found and fixed.

Every reproduction below was run against `bin/noir` at `de73eec4` (v1.3.0).

---

### 1. Global flags typed before the verb break every subcommand

**Symptom** — `noir help` and `docs/usage/cli_commands` both present
`--no-color` / `--no-spinner` as global flags that work "on every command's
output". Typed before the verb, they broke the command instead:

```
$ noir --no-color scan ./app
ERROR: Base path does not exist: scan
$ noir --no-color help
ERROR: Base path does not exist: help
$ noir --no-spinner list formats
ERROR: Base path does not exist: list
```

All eight verbs were affected. `noir --no-color -h` also printed scan's full
flag dump instead of the top-level overview. This is the router flag-placement
report deferred out of #2311.

A second, quieter symptom: because `Legacy.subcommand_invocation?` also tested
only `argv.first`, a leading global flag re-opened the v0 rewrite table over a
subcommand's own flags — the exact hazard that method exists to prevent:

```
$ noir --no-color rules path -v
1.3.0                      # `-v` matched the `-v => version` rewrite
```

`noir rules update -v` on that path reports success while the rules are never
updated, so the documented `noir rules update && noir scan . -P` precondition
becomes a silent no-op.

**Root cause** — `Router.dispatch` and `Legacy.subcommand_invocation?` both
looked at `argv[0]` alone. Anything else fell through to the v0 bare-flag path,
where `scan`'s parser read the verb as a positional base path.

**Fix** — `Noir::CLI.verb_index` names the first token past the leading run of
global flags; the router dispatches on that and re-attaches the flags to the
argv it hands the command (so `scan`'s own parser still threads color/spinner
state through `NoirRunner`, while `strip_global_flags` keeps them away from the
thin subcommands' "first positional = action" parsers). `subcommand_invocation?`
skips the same prefix. An argv of nothing but global flags stays on the v0 scan
path, so it still reports the missing path rather than silently showing help.

**After**

```
$ noir --no-color scan ./app -f json --no-log
{"endpoints":[{"callees":[],"url":"/hello", ...
$ noir --no-color help
USAGE:
  noir <command> [arguments] [flags]
$ noir --no-color rules path -v
/Users/…/.config/noir/passive_rules
$ noir --no-color                      # unchanged: globals-only is still a scan
ERROR: No path to scan was given.
```

---

### 2. `noir list techs | head` dies with a Crystal backtrace

**Symptom**

```
$ noir list techs | head -1
Unhandled exception: write (#<IO::FileDescriptor:0x1042d7e00>): Broken pipe (IO::Error)
  from …/polling.cr:228:9 in 'write'
  … 14 more frames
                                        # noir's own exit status: 1
```

**Root cause** — the scan path has guarded its stdout writes for a while
(`NoirLogger#puts`, `OutputBuilder#ob_puts`), but the thin subcommands write
straight to `STDOUT` with nothing catching `EPIPE`. `list techs` is where it
always reproduces: it emits far more than a pipe buffer holds, so `head` closes
the read end mid-write.

**Fix** — guard `Router.dispatch` the way the logger already does. A broken pipe
exits 0; every other `IO::Error` (disk full, a bad fd) still surfaces rather
than being laundered into a lying success.

**After** — no output on stderr, noir's own exit status `0`.

---

### 3. `--` (POSIX end-of-options) is accepted but not honored

**Symptom** — a flag typed after `--` vanished and its value was promoted to a
base path:

```
$ noir scan -- ./app -f json
ERROR: Base path does not exist: json     # `-f` was silently dropped
```

And the reason `--` exists at all did not work — a directory whose name starts
with a dash had no way in:

```
$ noir scan -- -old-api
ERROR: No path to scan was given.
```

**Root cause** — Crystal's `OptionParser` drops the marker and leaves the tail
in place, erasing the boundary. Scan's positional loop then skipped every
leftover starting with `-`.

**Fix** — split the tail off before anything reads `ARGV` (ahead of the
`--config-file` pre-scan and the flag rewrites, so neither can interpret a token
the user already declared positional) and append it to the base list verbatim.

**After**

```
$ noir scan -f json --no-log -- -old-api
{"endpoints":[ …                          # the dash-named directory is scanned
$ noir scan -- ./app -f json
ERROR: Base path does not exist: -f       # reported as the path it now is
```

---

### 4. `--config-file` pointing at a directory (or an unreadable file) crashes

**Symptom**

```
$ noir scan ./app --config-file /some/dir
Unhandled exception: read (/some/dir): Is a directory (IO::Error)
  … 12 more frames

$ chmod 000 noir.yaml && noir scan ./app --config-file noir.yaml
Unhandled exception: Error opening file with mode 'r': … (File::AccessDeniedError)
```

**Root cause** — `File.exists?` is true for a directory and for a file the
process cannot open, and the `File.read` that followed it in
`ConfigInitializer#read_config` sat *outside* the YAML `begin/rescue` below. The
process died before `CliValidation.validate_config_file!` — which already
carries a one-line message for each case — ever ran. `noir config show
--config-file <dir>` was fixed for this in #2311; the scan path reaches
`ConfigInitializer` directly and was left behind.

**Fix** — read defensively (`File.file?` plus an `IO::Error` rescue) and let the
validator report. The warning is suppressed for an explicit `--config-file`,
whose hard error follows a moment later; an unreadable *default* config still
warns, or it would silently revert every setting to defaults.

**After**

```
$ noir scan ./app --config-file /some/dir
ERROR: --config-file is not a file: /some/dir
$ noir scan ./app --config-file noir.yaml       # chmod 000
ERROR: --config-file could not be read: noir.yaml
  Error opening file with mode 'r': 'noir.yaml': Permission denied
```

---

### 5. An empty base path reports a message with nothing in it

**Symptom** — `noir scan "$TARGET"` with `TARGET` unset (the classic CI slip):

```
$ noir scan ""
ERROR: Base path does not exist:
```

The list is non-empty, so the "No path to scan was given" branch never fires and
the existence check has nothing to name.

**Fix** — report the blank value itself. Dropping the entry silently would be
worse: the scan would then run against whatever other paths were given, or claim
no path was passed for a command line that plainly had one.

**After**

```
$ noir scan ""
ERROR: Base path is empty. Check the value passed to a positional path or
-b/--base-path — an unset shell variable expands to nothing.
```

---

## Verification

- `just test` — unit **5633 examples, 0 failures**; functional **24497 examples, 0 failures**.
- `just check` — `crystal tool format --check` clean, ameba **2282 inspected, 0 failures**.
- `just build-release` — succeeds.
- **Detection A/B**: every leaf directory under `spec/functional_test/fixtures`
  (711 projects) scanned with `-f json --no-log --no-color`, before vs. after —
  **0 differing files, 5546 endpoints on both sides** (re-confirmed with the
  `--release` binary).

New specs: `Noir::CLI.verb_index` and the global-flag-led `subcommand_invocation?`
/ `rewrite` cases (`router_spec`), the `--` tail (`options_spec`), the
directory/unreadable config (`config_initializer_spec`), the empty base path
(`cli_validation_spec`), and eleven binary-driven examples in
`cli/binary_surface_spec` covering all five fixes end to end (argv, exit code,
and the stdout/stderr split).

## What else was exercised and held up

Checked by hand and found correct, so untouched: exit codes across every
subcommand (help/no-args 0, bad flag/action 1, `--strict` degraded 2); unknown
flags and surplus positionals on all eight verbs; `--help` fidelity per
subcommand versus the real parsers; stdout/stderr discipline (`-f json|sarif`
stayed byte-parseable under `--debug`, `--verbose`, `-P`, `-T`, `--ai-context`);
`--no-color` / `NO_COLOR` / `NO_COLOR=0` under a pty; config-file values going
through the same validation as CLI flags (format, concurrency, url, probe-via,
exclude-path, exclude-codes, taggers, techs, ai_context_features, base paths all
rejected identically from either source); repeated flags accumulating rather
than clobbering; `--flag=value` forms; missing and empty flag values;
`noir list -f json|yaml` document shape; and `noir version` output. `--no-log`
does **not** suppress `-f json` — that trap is the `--nolog` spelling, which the
parser correctly rejects as an unknown flag.
