### PR TITLE
fix(cli): five scope and filter flag defects (--exclude-techs, tech-list parsing, --exclude-path validation)

### DIFF
--- a/spec/unit_test/analyzer/analyzers/llm_analyzers/agentic_spec.cr
+++ b/spec/unit_test/analyzer/analyzers/llm_analyzers/agentic_spec.cr
@@ -73,6 +73,42 @@ describe Analyzer::AI::Unified do
       end
     end
 
+    # The agent tools walk the filesystem themselves, which is why
+    # `unified_ai.cr` sits on the directory-walk allowlist in
+    # `spec/unit_test/analyzer/layering_boundary_spec.cr`. That exemption is
+    # from the walk, never from what the walk enforces: an excluded file
+    # reached the provider through read_file, showed up in list_directory
+    # and was greppable, so `--exclude-path secrets/` kept a tree out of the
+    # report and shipped it to the LLM anyway.
+    it "applies --exclude-path to every agent tool that walks the tree" do
+      temp_dir = File.tempname
+      Dir.mkdir(temp_dir)
+      begin
+        Dir.mkdir(File.join(temp_dir, "secrets"))
+        File.write(File.join(temp_dir, "secrets", "keys.py"), "AWS_SECRET = 'redacted'")
+        File.write(File.join(temp_dir, "app.py"), "AWS_SECRET = 'in-scope'")
+
+        options = build_ai_options(temp_dir)
+        options["exclude_path"] = YAML::Any.new("secrets/")
+        analyzer = Analyzer::AI::Unified.new(options)
+
+        read = analyzer.__test_run_agent_tool("read_file", %({"path":"secrets/keys.py"}))
+        read.should contain("--exclude-path")
+        read.should_not contain("redacted")
+
+        listing = analyzer.__test_run_agent_tool("list_directory", %({"path":"."}))
+        listing.should_not contain("secrets")
+        listing.should contain("app.py")
+
+        grep = analyzer.__test_run_agent_tool("grep",
+          %({"pattern":"AWS_SECRET","path":".","file_pattern":"*.py"}))
+        grep.should_not contain("secrets/keys.py")
+        grep.should contain("app.py")
+      ensure
+        FileUtils.rm_rf(temp_dir)
+      end
+    end
+
     it "truncates large files in read_file tool" do
       temp_dir = File.tempname
       Dir.mkdir(temp_dir)

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -138,11 +138,28 @@ describe "noir CLI surface (built binary)" do
     end
 
     it "rejects an --exclude-path glob that would silently match nothing" do
-      {"*.{rb", "{", "", "  "}.each do |pattern|
+      # `z[b` and `a[b` are the same malformation. The validator used to
+      # probe them with `File.match?(pattern, "noir")`, and Crystal's
+      # matcher stops at the first literal that does not match its subject:
+      # `a[b` reached the unterminated `[` and raised, `z[b` did not and
+      # sailed through to exclude nothing at all. Which one a user got
+      # depended on the first character of their pattern.
+      {"*.{rb", "{", "", "  ", "a[b", "z[b", "[", "src/[a-z"}.each do |pattern|
         result = run_noir(["scan", FIXTURE, "--exclude-path", pattern, "-f", "json", "--no-log"])
         result.stdout.should be_empty
         result.stderr.should contain("--exclude-path")
         result.exit_code.should eq(1)
+      end
+    end
+
+    # A brace group with a comma in it (`*.{rb,py}`) is not expressible
+    # here — the flag splits its value on `,` before a pattern is parsed —
+    # so the single-branch form is what these assert.
+    it "still accepts the character classes and brace groups that are valid" do
+      {"[]]", "[^a-z]*.rb", "src/[a-z]*.go", "*.{rb}", "**/vendor/**"}.each do |pattern|
+        result = run_noir(["scan", FIXTURE, "--exclude-path", pattern, "-f", "json", "--no-log"])
+        result.stderr.should_not contain("invalid glob pattern")
+        result.exit_code.should eq(0)
       end
     end
 

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -146,6 +146,30 @@ describe "noir CLI surface (built binary)" do
       end
     end
 
+    # A tech flag given nothing is stored as `""` — indistinguishable, in
+    # the options hash, from the flag never being typed. `--only-techs ""`
+    # therefore asked to restrict the scan and silently widened it back to
+    # every technology, which is what a CI job passing `--only-techs
+    # "$TECHS"` gets when `$TECHS` is unset. `--only-techs ,` went the other
+    # way: no detector ran, zero endpoints, exit 0, no word about why.
+    it "rejects a tech flag that names no technology" do
+      {
+        {"--only-techs", ""}, {"--only-techs", "  "}, {"--only-techs", ","},
+        {"--exclude-techs", ""}, {"--exclude-techs", ",,"},
+        {"-t", ""}, {"--techs", " "},
+      }.each do |(flag, value)|
+        result = run_noir(["scan", FIXTURE, flag, value, "-f", "json", "--no-log"])
+        result.stdout.should be_empty
+        result.stderr.should contain(flag == "-t" ? "--techs" : flag)
+        result.exit_code.should eq(1)
+      end
+
+      result = run_noir(["scan", FIXTURE, "--only-techs=", "-f", "json", "--no-log"])
+      result.stdout.should be_empty
+      result.stderr.should contain("--only-techs")
+      result.exit_code.should eq(1)
+    end
+
     it "still fails a CLI-typed --status-codes without a URL" do
       result = run_noir(["scan", FIXTURE, "--status-codes", "-f", "json", "--no-log"])
       result.stdout.should be_empty

--- a/spec/unit_test/cli_validation_spec.cr
+++ b/spec/unit_test/cli_validation_spec.cr
@@ -295,6 +295,26 @@ describe Noir::CliValidation do
       options["techs"] = YAML::Any.new("")
       Noir::CliValidation.validate_tech_names!(options)
     end
+
+    # A value that is nothing but separators or whitespace names no tech,
+    # and every name in it is "valid" only because the list is empty after
+    # stripping. `--only-techs ,` then cleared the detector list and the
+    # scan reported zero endpoints with exit 0 — under --no-log, silently.
+    it "rejects a value that names no technology at all" do
+      {",", " ", ",,", " , "}.each do |value|
+        options = create_test_options
+        options["only_techs"] = YAML::Any.new(value)
+        expect_raises(Noir::CliValidation::Error, /names no technology/) do
+          Noir::CliValidation.validate_tech_names!(options)
+        end
+      end
+    end
+
+    it "still accepts a trailing comma next to a real name" do
+      options = create_test_options
+      options["only_techs"] = YAML::Any.new("flask,")
+      Noir::CliValidation.validate_tech_names!(options)
+    end
   end
 
   # `--passive-scan-severity` is validated by its flag handler in options.cr,

--- a/spec/unit_test/techs/only_exclude_techs_spec.cr
+++ b/spec/unit_test/techs/only_exclude_techs_spec.cr
@@ -2,18 +2,21 @@ require "../../spec_helper"
 require "../../../src/techs/techs"
 
 describe "--only-techs and --exclude-techs functionality" do
+  # `NoirTechs.resolve_tech_list` is the production resolution these flags
+  # share (`detector.cr` for --only-techs and -t, `cli/commands/scan.cr` for
+  # --exclude-techs). These examples used to re-type its body inline, so they
+  # asserted a copy of the logic and could not fail when the shipped code was
+  # wrong — which it was, in two ways: --exclude-techs matched on a substring
+  # of the canonical name, and neither it nor -t stripped list entries.
   describe "only_techs filtering logic" do
     # Tests for the filtering logic used by --only-techs option
     # The option filters detector_list to only include specified technologies
 
     it "filters with valid single tech" do
-      # Simulate the only_techs filtering logic from detector.cr
       only_techs_value = "rails"
       detector_names = ["ruby_rails", "ruby_sinatra", "python_flask"]
 
-      only_techs_list = only_techs_value.split(",").map do |tech|
-        NoirTechs.similar_to_tech(tech.strip)
-      end.reject(&.empty?)
+      only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
       filtered_detectors = detector_names.select do |detector_name|
         only_techs_list.includes?(detector_name)
@@ -27,9 +30,7 @@ describe "--only-techs and --exclude-techs functionality" do
       only_techs_value = "rails,flask,express"
       detector_names = ["ruby_rails", "ruby_sinatra", "python_flask", "js_express", "go_gin"]
 
-      only_techs_list = only_techs_value.split(",").map do |tech|
-        NoirTechs.similar_to_tech(tech.strip)
-      end.reject(&.empty?)
+      only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
       filtered_detectors = detector_names.select do |detector_name|
         only_techs_list.includes?(detector_name)
@@ -49,9 +50,7 @@ describe "--only-techs and --exclude-techs functionality" do
       only_techs_value = "ruby-rails,python-flask"
       detector_names = ["ruby_rails", "python_flask", "go_gin"]
 
-      only_techs_list = only_techs_value.split(",").map do |tech|
-        NoirTechs.similar_to_tech(tech.strip)
-      end.reject(&.empty?)
+      only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
       filtered_detectors = detector_names.select do |detector_name|
         only_techs_list.includes?(detector_name)
@@ -64,9 +63,7 @@ describe "--only-techs and --exclude-techs functionality" do
     it "returns empty list when all techs are invalid" do
       only_techs_value = "invalid_tech,nonexistent"
 
-      only_techs_list = only_techs_value.split(",").map do |tech|
-        NoirTechs.similar_to_tech(tech.strip)
-      end.reject(&.empty?)
+      only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
       # When all techs are invalid, only_techs_list should be empty
       only_techs_list.should be_empty
@@ -76,9 +73,7 @@ describe "--only-techs and --exclude-techs functionality" do
       only_techs_value = " rails , flask , express "
       detector_names = ["ruby_rails", "python_flask", "js_express", "go_gin"]
 
-      only_techs_list = only_techs_value.split(",").map do |tech|
-        NoirTechs.similar_to_tech(tech.strip)
-      end.reject(&.empty?)
+      only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
       filtered_detectors = detector_names.select do |detector_name|
         only_techs_list.includes?(detector_name)
@@ -94,9 +89,7 @@ describe "--only-techs and --exclude-techs functionality" do
       only_techs_value = "rails,invalid_tech,flask"
       detector_names = ["ruby_rails", "python_flask", "go_gin"]
 
-      only_techs_list = only_techs_value.split(",").map do |tech|
-        NoirTechs.similar_to_tech(tech.strip)
-      end.reject(&.empty?)
+      only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
       filtered_detectors = detector_names.select do |detector_name|
         only_techs_list.includes?(detector_name)
@@ -113,9 +106,7 @@ describe "--only-techs and --exclude-techs functionality" do
       only_techs_value = "Rails,FLASK,Express"
       detector_names = ["ruby_rails", "python_flask", "js_express"]
 
-      only_techs_list = only_techs_value.split(",").map do |tech|
-        NoirTechs.similar_to_tech(tech.strip)
-      end.reject(&.empty?)
+      only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
       filtered_detectors = detector_names.select do |detector_name|
         only_techs_list.includes?(detector_name)
@@ -130,14 +121,11 @@ describe "--only-techs and --exclude-techs functionality" do
     # The option filters detected techs to exclude specified technologies
 
     it "excludes with valid single tech" do
-      # Simulate the exclude_techs filtering logic from noir.cr
       exclude_techs_value = "rails"
       detected_techs = ["ruby_rails", "python_flask", "go_gin"]
 
-      exclude_techs = exclude_techs_value.split(",")
-      filtered_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
       filtered_techs.should eq(["python_flask", "go_gin"])
       filtered_techs.should_not contain("ruby_rails")
@@ -147,10 +135,8 @@ describe "--only-techs and --exclude-techs functionality" do
       exclude_techs_value = "rails,flask"
       detected_techs = ["ruby_rails", "python_flask", "go_gin", "js_express"]
 
-      exclude_techs = exclude_techs_value.split(",")
-      filtered_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
       filtered_techs.size.should eq(2)
       filtered_techs.should eq(["go_gin", "js_express"])
@@ -163,10 +149,8 @@ describe "--only-techs and --exclude-techs functionality" do
       exclude_techs_value = "ruby-rails,python-flask"
       detected_techs = ["ruby_rails", "python_flask", "go_gin"]
 
-      exclude_techs = exclude_techs_value.split(",")
-      filtered_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
       filtered_techs.should eq(["go_gin"])
     end
@@ -175,10 +159,8 @@ describe "--only-techs and --exclude-techs functionality" do
       exclude_techs_value = "invalid_tech"
       detected_techs = ["ruby_rails", "python_flask"]
 
-      exclude_techs = exclude_techs_value.split(",")
-      filtered_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
       # Invalid techs don't match anything, so nothing is excluded
       filtered_techs.should eq(detected_techs)
@@ -188,12 +170,10 @@ describe "--only-techs and --exclude-techs functionality" do
       exclude_techs_value = ""
       detected_techs = ["ruby_rails", "python_flask"]
 
-      exclude_techs = exclude_techs_value.split(",")
-      filtered_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
-      # Empty string split results in [""], which doesn't match any valid tech
+      # An empty value resolves to no tech names, so nothing is excluded
       filtered_techs.should eq(detected_techs)
     end
 
@@ -201,10 +181,8 @@ describe "--only-techs and --exclude-techs functionality" do
       exclude_techs_value = "rails,invalid_tech,flask"
       detected_techs = ["ruby_rails", "python_flask", "go_gin"]
 
-      exclude_techs = exclude_techs_value.split(",")
-      filtered_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
       # Only valid techs in exclude list should be excluded
       filtered_techs.size.should eq(1)
@@ -215,22 +193,50 @@ describe "--only-techs and --exclude-techs functionality" do
       exclude_techs_value = "Rails,FLASK"
       detected_techs = ["ruby_rails", "python_flask", "go_gin"]
 
-      exclude_techs = exclude_techs_value.split(",")
-      filtered_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
       filtered_techs.should eq(["go_gin"])
+    end
+
+    # `--exclude-techs go_httprouter` used to drop `go_http` too: the filter
+    # asked `similar_to_tech(entry).includes?(tech)`, a substring test on the
+    # canonical name. Every key that is a prefix of another was affected —
+    # go_http/go_httprouter, zig_http/zig_httpz,
+    # elixir_phoenix/elixir_phoenix_channel and, the one a user is most
+    # likely to hit, python_django/python_django_ninja.
+    it "excludes only the named tech, not techs whose name it starts with" do
+      [
+        {"go_httprouter", "go_http"},
+        {"zig_httpz", "zig_http"},
+        {"python_django_ninja", "python_django"},
+        {"elixir_phoenix_channel", "elixir_phoenix"},
+      ].each do |(excluded, kept)|
+        exclude_techs = NoirTechs.resolve_tech_list(excluded).to_set
+        [excluded, kept].reject { |tech| exclude_techs.includes?(tech) }.should eq([kept])
+      end
+    end
+
+    # The list is comma-separated, and people put a space after a comma.
+    # `--exclude-techs` and `-t` split without stripping, so every entry
+    # after the first resolved to "" and was silently ignored — while the
+    # CLI validator, which does strip, reported the value as perfectly good.
+    it "ignores whitespace around comma-separated entries" do
+      exclude_techs_value = "js_express, python_flask ,\tgo_gin"
+      detected_techs = ["js_express", "python_flask", "go_gin", "ruby_rails"]
+
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
+
+      filtered_techs.should eq(["ruby_rails"])
     end
 
     it "excludes all techs when all are in exclude list" do
       exclude_techs_value = "rails,flask,gin"
       detected_techs = ["ruby_rails", "python_flask", "go_gin"]
 
-      exclude_techs = exclude_techs_value.split(",")
-      filtered_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      filtered_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
       filtered_techs.should be_empty
     end
@@ -242,13 +248,11 @@ describe "--only-techs and --exclude-techs functionality" do
       # exclude_techs filters the results after detection
       # They work at different stages, so both can be used together
 
-      # Simulate only_techs filtering first (during detection)
+      # only_techs filtering first (during detection)
       only_techs_value = "rails,flask,gin"
       all_detectors = ["ruby_rails", "python_flask", "go_gin", "js_express"]
 
-      only_techs_list = only_techs_value.split(",").map do |tech|
-        NoirTechs.similar_to_tech(tech.strip)
-      end.reject(&.empty?)
+      only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
       detected_techs = all_detectors.select do |detector_name|
         only_techs_list.includes?(detector_name)
@@ -256,10 +260,8 @@ describe "--only-techs and --exclude-techs functionality" do
 
       # After detection, apply exclude_techs
       exclude_techs_value = "flask"
-      exclude_techs = exclude_techs_value.split(",")
-      final_techs = detected_techs.reject do |tech|
-        exclude_techs.any? { |exclude_tech| NoirTechs.similar_to_tech(exclude_tech).includes?(tech) }
-      end
+      exclude_techs = NoirTechs.resolve_tech_list(exclude_techs_value).to_set
+      final_techs = detected_techs.reject { |tech| exclude_techs.includes?(tech) }
 
       # Only rails and gin should remain (flask excluded)
       final_techs.size.should eq(2)

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -673,6 +673,10 @@ module Analyzer::AI
 
         begin
           next if File.symlink?(full_path)
+          # A directory is tested too, so `--exclude-path secrets/` hides the
+          # subtree rather than listing it and then filtering each file out
+          # of it one by one.
+          next if excluded_path?(full_path)
 
           if File.directory?(full_path)
             lines << "#{indent}[D] #{agent_relative_path(full_path)}/"
@@ -693,6 +697,7 @@ module Analyzer::AI
 
       resolved = resolve_agent_single_path(path)
       return "ERROR: file '#{path}' is outside base paths or does not exist." if resolved.nil?
+      return "ERROR: file '#{path}' is excluded by --exclude-path." if excluded_path?(resolved)
       return "ERROR: '#{path}' is a directory. Use list_directory instead." if File.directory?(resolved)
 
       content = Noir::TextFile.read(resolved)
@@ -759,6 +764,7 @@ module Analyzer::AI
           next if File.directory?(file_path) || File.symlink?(file_path)
           next if ignore_extensions.includes?(File.extname(file_path))
           next unless path_within_base?(file_path)
+          next if excluded_path?(file_path)
 
           begin
             line_number = 0

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -72,6 +72,7 @@ module Noir::CLI::ScanCommand
     normalize_probe_via!(noir_options)
     validate_url_dependent_flags(noir_options, cli_flags)
     validate_exclude_path!(noir_options, argv)
+    validate_blank_tech_flags!(argv)
     validate_options!(noir_options)
 
     if noir_options["nolog"] == false
@@ -337,7 +338,7 @@ module Noir::CLI::ScanCommand
   # list at parse time instead, before a single file is read.
   private def self.validate_exclude_path!(noir_options : Hash(String, YAML::Any),
                                           argv : Array(String))
-    if blank_exclude_path_arg?(argv)
+    if blank_flag_value?(argv, ["--exclude-path"])
       Noir::CLI.die("--exclude-path needs a glob pattern; the value given is empty.")
     end
 
@@ -358,21 +359,50 @@ module Noir::CLI::ScanCommand
     end
   end
 
-  # `--exclude-path ''` and `--exclude-path=` both collapse to the same
-  # empty string the option carries when it was never passed at all (and
-  # `exclude_path: ""` is in the generated config template), so the fully
-  # blank case can only be read off argv.
-  private def self.blank_exclude_path_arg?(argv : Array(String)) : Bool
+  # Every spelling of each tech-selection flag. They all store a
+  # comma-separated string whose "never passed" value is `""` — the same
+  # string `--flag ''` produces, and the same one the generated config
+  # template ships — so the blank case can only be read off argv.
+  #
+  # `--only-techs ''` was the sharpest of these: it asked to *restrict* the
+  # scan and silently widened it back to everything, which is what a CI job
+  # doing `--only-techs "$TECHS"` gets when `$TECHS` is unset.
+  TECH_FLAG_SPELLINGS = {
+    "-t/--techs"      => ["-t", "--techs"],
+    "--only-techs"    => ["--only-techs"],
+    "--exclude-techs" => ["--exclude-techs"],
+  }
+
+  # True when any spelling in `names` appears on the command line carrying a
+  # value that is empty or whitespace only. The `--flag=value` form is only
+  # recognised for long spellings: `-t=x` is a value of `"=x"` to
+  # OptionParser, not an empty one.
+  private def self.blank_flag_value?(argv : Array(String), names : Array(String)) : Bool
     argv.each_with_index do |arg, i|
-      if arg == "--exclude-path"
+      if names.includes?(arg)
         value = argv[i + 1]?
         # A missing value is OptionParser's error to report, not ours.
         return true if value && value.strip.empty?
-      elsif arg.starts_with?("--exclude-path=")
-        return true if arg.split("=", 2)[1].strip.empty?
+      else
+        names.each do |name|
+          next unless name.starts_with?("--") && arg.starts_with?("#{name}=")
+          return true if arg.split("=", 2)[1].strip.empty?
+        end
       end
     end
     false
+  end
+
+  # `-t`, `--only-techs` and `--exclude-techs` given a value that names no
+  # tech at all. `CliValidation.validate_tech_names!` rejects a *wrong*
+  # name; this rejects no name, which the options hash cannot tell apart
+  # from the flag never being typed.
+  private def self.validate_blank_tech_flags!(argv : Array(String))
+    TECH_FLAG_SPELLINGS.each do |flag, names|
+      next unless blank_flag_value?(argv, names)
+      Noir::CLI.die("#{flag} needs at least one tech name; the value given is empty. " \
+                    "List supported names with `noir list techs`.")
+    end
   end
 
   # Returns nil for a usable glob, otherwise the reason it is broken.

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -407,19 +407,39 @@ module Noir::CLI::ScanCommand
 
   # Returns nil for a usable glob, otherwise the reason it is broken.
   #
-  # `File.match?` parses the pattern itself, so character-class errors
-  # come back from Crystal with its own wording. Brace groups it accepts
-  # and then never matches (`*.{rb` matches nothing at all), so the
-  # `{`/`}` balance is checked here — skipping over character classes,
-  # inside which a brace is an ordinary character.
+  # Both malformations are found by walking the pattern rather than by
+  # asking `File.match?`. Crystal's matcher is lazy: it only raises
+  # `BadPatternError` for an unterminated `[` once it actually *reaches*
+  # that `[`, and it stops at the first literal that does not match the
+  # subject. Probing with one fixed string therefore reported an
+  # unterminated character set for `a[b` (whose `a` happens to be a prefix
+  # of nothing in particular) and passed `z[b` — the identical
+  # malformation — straight through, where it then excluded nothing and
+  # matched no file loudly enough to raise either. Which of the two a user
+  # got depended on the first character of their pattern.
+  #
+  # Brace groups have the same problem in the other direction: `*.{rb` is
+  # accepted by the matcher and then never matches anything.
+  #
+  # Inside a character class a brace is an ordinary character, and the
+  # first character of a class is a literal member — `[]]` is the class
+  # containing `]`, exactly as Crystal's matcher reads it.
   def self.glob_error(pattern : String) : String?
     depth = 0
     in_class = false
+    class_first = false
     pattern.each_char do |char|
       if in_class
+        if class_first
+          # `^` marks the class negated and does not consume the
+          # literal-member slot, so `[^]]` is still a valid class.
+          class_first = false unless char == '^'
+          next
+        end
         in_class = false if char == ']'
       elsif char == '['
         in_class = true
+        class_first = true
       elsif char == '{'
         depth += 1
       elsif char == '}'
@@ -428,7 +448,10 @@ module Noir::CLI::ScanCommand
       end
     end
     return "unterminated `{` group" if depth > 0
+    return "unterminated character set" if in_class
 
+    # Backstop for anything the walk above does not model (brace nesting
+    # deeper than Crystal's ten levels, say).
     begin
       File.match?(pattern, "noir")
       nil

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -573,17 +573,20 @@ module Noir::CLI::ScanCommand
     else
       app.logger.success "Detected #{app.techs.size} technologies."
 
-      exclude_techs = app.options["exclude_techs"].to_s.split(",")
+      # Alias-resolved once, then matched by identity. `--exclude-techs`
+      # used to ask `similar_to_tech(entry).includes?(tech)`, a substring
+      # test that also dropped every tech whose name is a prefix of the
+      # excluded one — `--exclude-techs python_django_ninja` took
+      # `python_django` with it. See `NoirTechs.resolve_tech_list`.
+      exclude_techs = NoirTechs.resolve_tech_list(app.options["exclude_techs"].to_s).to_set
       app.techs.each_with_index do |tech, index|
-        is_excluded = exclude_techs.any? { |t| NoirTechs.similar_to_tech(t).includes?(tech) }
+        is_excluded = exclude_techs.includes?(tech)
         prefix = index < app.techs.size - 1 ? "├──" : "└──"
         status = is_excluded ? " (skip)" : ""
         app.logger.sub "#{prefix} #{tech}#{status}"
       end
 
-      app.techs = app.techs.reject do |tech|
-        exclude_techs.any? { |t| NoirTechs.similar_to_tech(t).includes?(tech) }
-      end
+      app.techs = app.techs.reject { |tech| exclude_techs.includes?(tech) }
       analysis_message = "Starting code analysis based on the detected technologies."
     end
 

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -216,16 +216,24 @@ module Noir::CliValidation
     {"techs", "only_techs", "exclude_techs"}.each do |key|
       raw = options[key]?.try(&.to_s) || ""
       next if raw.empty?
-      unknown = raw.split(",").map(&.strip).reject(&.empty?).reject do |tech|
-        !NoirTechs.similar_to_tech(tech).empty?
-      end
-      next if unknown.empty?
       cli_flag = case key
                  when "techs"         then "-t/--techs"
                  when "only_techs"    then "--only-techs"
                  when "exclude_techs" then "--exclude-techs"
                  else                      key
                  end
+      names = raw.split(",").map(&.strip).reject(&.empty?)
+      # A value made only of separators or whitespace (`--only-techs ,`,
+      # `--only-techs " "`) names nothing. `--only-techs` then cleared its
+      # detector list and the scan reported zero endpoints with exit 0 and,
+      # under `--no-log`, not one word about why.
+      if names.empty?
+        raise Error.new("#{cli_flag}: #{raw.inspect} names no technology. List supported names with `noir list techs`.")
+      end
+      unknown = names.reject do |tech|
+        !NoirTechs.similar_to_tech(tech).empty?
+      end
+      next if unknown.empty?
       raise Error.new("#{cli_flag}: unknown tech#{"es" if unknown.size > 1} #{unknown.map(&.inspect).join(", ")}. List supported names with `noir list techs`.")
     end
   end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -317,9 +317,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   # Handle --only-techs: filter detector_list to only specified techs
   only_techs_value = options["only_techs"]?.to_s
   if only_techs_value.size > 0
-    only_techs_list = only_techs_value.split(",").map do |tech|
-      NoirTechs.similar_to_tech(tech.strip)
-    end.reject(&.empty?)
+    only_techs_list = NoirTechs.resolve_tech_list(only_techs_value)
 
     if only_techs_list.empty?
       logger.error "No valid technologies specified in --only-techs. No detectors will be run."
@@ -335,7 +333,11 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
 
   # Handle -t/--techs: add techs directly (without detection validation)
   if options["techs"].to_s.size > 0
-    techs_tmp = options["techs"].to_s.split(",")
+    # Stripped, like `--only-techs` and like the CLI validator: without it
+    # `-t "js_express, python_flask"` resolved `" python_flask"` against the
+    # alias table, found nothing, and added only the first tech — while the
+    # count printed here still claimed two.
+    techs_tmp = options["techs"].to_s.split(",").map(&.strip).reject(&.empty?)
     logger.success "Setting #{techs_tmp.size} techs from command line."
     techs_tmp.each do |tech|
       similar_tech = NoirTechs.similar_to_tech(tech)

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -238,6 +238,34 @@ module NoirTechs
     ""
   end
 
+  # The canonical tech keys named by a comma-separated flag value
+  # (`-t/--techs`, `--only-techs`, `--exclude-techs`). Entries are stripped
+  # before resolution and unresolvable ones drop out.
+  #
+  # Both halves of that used to be re-typed at each call site, and two of
+  # the three got them wrong:
+  #
+  #   * `--exclude-techs` and `-t` split on `,` without stripping, so
+  #     `--exclude-techs "js_express, python_flask"` resolved `" python_flask"`
+  #     — with the leading space — against the alias table, found nothing,
+  #     and silently excluded only the first entry. `--only-techs` stripped,
+  #     and so did the validator, so the typo passed validation and then did
+  #     nothing.
+  #   * `--exclude-techs` compared with
+  #     `similar_to_tech(entry).includes?(tech)` — a *substring* test on the
+  #     canonical name. `--exclude-techs python_django_ninja` therefore also
+  #     dropped `python_django`, `--exclude-techs go_httprouter` dropped
+  #     `go_http`, and so on for every key that is a prefix of another.
+  #
+  # Returning resolved keys lets callers compare with `==` / a Set, which is
+  # what "exclude this tech" has always meant.
+  def self.resolve_tech_list(raw : String) : Array(String)
+    raw.split(',').compact_map do |entry|
+      resolved = similar_to_tech(entry.strip)
+      resolved.empty? ? nil : resolved
+    end
+  end
+
   def self.context_supported?(tech : String, feature : String) : Bool
     case feature
     when "callee"


### PR DESCRIPTION
Hands-on bug hunt on the **scope and filter flags** — everything that decides which files and which technologies a scan looks at: `-b/--base-path`, `--exclude-path`, `-t/--techs`, `--only-techs`, `--exclude-techs`, `-u/--url`, and the media/size/binary filters. Every flag was exercised against the built binary on real projects, not read.

Five defects, four commits. Detection is unchanged: an A/B over all **711 fixture directories** in `spec/functional_test/fixtures` (scanned one directory at a time, comparing the sorted `(method, url, technology)` digest, not just a count) is byte-identical before and after — 5546 endpoints both ways.

---

## 1. `--exclude-techs X` also dropped every tech whose name is a prefix of X

**Symptom.** Excluding one framework silently removed a second, unrelated one.

**Root cause.** `src/cli/commands/scan.cr` decided exclusion with `NoirTechs.similar_to_tech(entry).includes?(tech)` — a **substring** test on the canonical tech name. Four real key pairs are affected: `go_http`/`go_httprouter`, `zig_http`/`zig_httpz`, `elixir_phoenix`/`elixir_phoenix_channel`, and `python_django`/`python_django_ninja`.

**Reproduction.** A project with an httprouter router and a plain `net/http` handler alongside an Express app and a Flask app:

```
$ noir scan ./mix --exclude-techs go_httprouter -f json --no-log
```

| | endpoints | technologies |
|---|---|---|
| before | 2 | `js_express`, `python_flask` |
| after | 9 | `go_http`, `js_express`, `python_flask` |

The scan log made it explicit — `go_http (skip)` on a run that never asked for it.

## 2. `--exclude-techs` and `-t/--techs` ignored every list entry with whitespace

**Symptom.** `--exclude-techs "a, b"` excluded only `a`. `-t "a, b"` printed *"Setting 2 techs from command line"* and added one.

**Root cause.** Both split on `,` without stripping, so `" python_flask"` (leading space) was resolved against the alias table, matched nothing, and was dropped. `--only-techs` *did* strip, and so does `CliValidation.validate_tech_names!` — which is why the value passed validation and then quietly did nothing.

**Reproduction.**

```
$ noir scan ./mix --exclude-techs 'js_express, python_flask' -f json --no-log
before: 9 endpoints [go_http, go_httprouter, python_flask]   # python_flask not excluded
after:  8 endpoints [go_http, go_httprouter]

$ noir scan ./mix --only-techs go_gin -t 'js_express, python_flask' -f json --no-log
before: 1 endpoint  [js_express]
after:  2 endpoints [js_express, python_flask]
```

**Fix for 1 and 2.** `NoirTechs.resolve_tech_list` is now the single place a comma-separated tech value becomes canonical keys (stripped, alias-resolved, unresolvable entries dropped), and the exclusion compares against a `Set`. `spec/unit_test/techs/only_exclude_techs_spec.cr` used to re-type the production logic inline — which is exactly why it stayed green while the shipped code was wrong — and now calls the helper, with new cases for the prefix pairs and for whitespace.

## 3. A tech flag given an empty value was accepted and meant the opposite

**Symptom.** `--only-techs ''` asked to *restrict* the scan and silently widened it back to every technology. This is what a CI job spelling `--only-techs "$TECHS"` gets when `$TECHS` is unset.

**Root cause.** All three flags store a comma-separated string whose "never passed" value is `""` — indistinguishable, in the options hash, from `--flag ''`. `--exclude-path` already had an argv-level blank check for exactly this; the tech flags did not. Separator-only values fail the other way: `--only-techs ,` cleared the detector list, and the `"No valid technologies specified"` line goes to the logger, which `--no-log` suppresses.

**Reproduction.**

```
$ noir scan ./mix --only-techs '' -f json --no-log
before: exit 0, all four technologies scanned
after:  exit 1, "--only-techs needs at least one tech name; the value given is empty."

$ noir scan ./mix --only-techs ',' -f json --no-log
before: exit 0, {"endpoints":[],"passive_results":[],"errors":[]}, nothing on stderr
after:  exit 1, "--only-techs: \",\" names no technology."
```

**Fix.** The empty case is checked on argv (generalizing the existing `--exclude-path` check to any flag spelling, `-t` and `--flag=` forms included); the separator-only case is visible in the options hash and is rejected in `validate_tech_names!` next to the unknown-name check. `--only-techs flask,` (trailing comma next to a real name) stays valid.

## 4. `--exclude-path` glob validation depended on a probe string

**Symptom.** Two identically malformed globs got opposite treatment: `a[b` was rejected, `z[b` was accepted and then excluded nothing, with no warning.

**Root cause.** `glob_error` probed with `File.match?(pattern, "noir")`. Crystal's matcher is lazy — it stops at the first literal that does not match the subject, and only raises `BadPatternError` for an unterminated `[` once it actually reaches that `[`. Whether a user got an error depended on the first character of their pattern. That silent "excluded exactly zero files" outcome is the one this validator exists to prevent.

**Reproduction.**

```
$ noir scan ./mix --exclude-path 'z[b' -f json --no-log
before: exit 0, full result, nothing excluded, nothing on stderr
after:  exit 1, "--exclude-path contains an invalid glob pattern (unterminated character set): \"z[b\"."

$ noir scan ./mix --exclude-path 'a[b' -f json --no-log
before: exit 1, but raised mid-scan from the detector's walk
after:  exit 1 at parse time, before a file is read
```

**Fix.** The unterminated `[` is found by the same character walk that already checks `{`/`}` balance, following Crystal's own rule that the first character inside a class is a literal member (`[]]` is the class containing `]`, `[^]]` its negation). The `File.match?` probe stays as a backstop for what the walk does not model. Valid patterns (`[]]`, `[^a-z]*.rb`, `src/[a-z]*.go`, `*.{rb}`, `**/vendor/**`) are asserted to still pass.

## 5. `--exclude-path` was ignored by the AI agent's filesystem tools

**Symptom.** With `--ai-agent`, a subtree the user excluded was readable, listable and greppable by the agent — and its contents were sent to the AI provider.

**Root cause.** `spec/unit_test/analyzer/layering_boundary_spec.cr` spells out the contract for adapters on its directory-walk allowlist: *"Being on this list is an exemption from the walk, never from what the walk exists to enforce: every entry here applies `--exclude-path` itself via `Analyzer#excluded_path?`, because a file the user excluded must not reach a report through a side door."* `unified_ai.cr` is on that list and applied nothing. It checks containment (`path_within_base?`) but never exclusion.

**Reproduction** (through the existing `__test_run_agent_tool` harness; base holds `secrets/keys.py`, options carry `exclude_path: "secrets/"`):

```
before  READ  => FILE secrets/keys.py
                 AWS_SECRET = 'hunter2'
        LIST  => [D] secrets/  /  [F] secrets/keys.py
        GREP  => secrets/keys.py:1: AWS_SECRET = 'hunter2'

after   READ  => ERROR: file 'secrets/keys.py' is excluded by --exclude-path.
        LIST  => app.py only
        GREP  => app.py only
```

**Fix.** `read_file` and the grep collector (which `semantic_search` also drives) consult `excluded_path?`; the walk behind `list_directory` tests directories as well as files, so `--exclude-path secrets/` hides the subtree rather than listing it and filtering it out one file at a time.

---

## What was exercised and held up

No defect found on these; recording them so the axis is not re-walked:

- **`-b/--base-path`**: single base, multiple bases, relative (`./x`, `.`), redundant separators (`././real//`), trailing slash, a path with a space, a path with Hangul, a path with glob metacharacters (`gl[1]`, `gl{a,b}`), a symlinked base (followed), a symlink *inside* a base (skipped and reported in `errors`), a file as base (rejected), a missing base (rejected), an empty base (rejected). Positional paths and `-b` mix correctly.
- **Multi-base**: sibling bases with a shared prefix (`app` / `app2`) do not leak into each other; nested bases (`sub`, `sub/nested`) resolve to the innermost; `--exclude-path` applies relative to the base that owns each file, in both single- and multi-base scans.
- **Checkout-location independence**: a project scanned from inside a directory literally named `alpha` with `--exclude-path 'alpha/'` excludes only the project's own `alpha/`. The class of bug where analyzers matched absolute paths is gone from the exclude/scope layer.
- **`--exclude-path`**: basename globs, `dir/`, `dir/*`, `**/dir/**`, repeated flags, comma lists, spaces around commas, a pattern that matches nothing, a pattern outside the base, case folding on macOS. Repeat-flag accumulation and the config-file-vs-CLI precedence both behave as documented. Applied correctly by the Go static-directory resolver (`r.Static("/assets", "./public")` — `--exclude-path 'public/'`, `'*.css'` and `'public/img/'` each removed the right static endpoints).
- **`--only-techs` / `--exclude-techs` / `-t`**: unknown names rejected with a useful message (CLI *and* config-file sourced), alias names, case-insensitive aliases, canonical keys, comma lists and repeated flags both accumulate, `--only-techs` restricts detectors and analyzers, specification techs (`oas2`/`oas3`) filter correctly. All 253 detector names map 1:1 to `TECHS` keys, so no valid tech name is unreachable through `--only-techs`.
- **`-u/--url`**: bare host, trailing slash, base path with and without a trailing slash, an inline query (dropped), no scheme (defaults to https), explicit port, and a malformed value (rejected).
- **Size / media / binary filters**: `NOIR_MAX_FILE_SIZE` honoured in bytes and with unit suffixes, oversize files reported through `errors` rather than dropped silently, and junk / zero / negative values falling back to the default.

## Verification

- `just check` — clean
- `crystal spec spec/unit_test` — 5618 examples, 0 failures
- `crystal spec spec/functional_test` — 24497 examples, 0 failures
- `just build-release` — clean
- Fixture A/B — 711 directories, identical endpoint sets before and after
