### PR TITLE
fix: four defects found by a differential audit of 14 real OSS applications

### DIFF
--- a/spec/functional_test/fixtures/go/mux_fork/go.mod
+++ b/spec/functional_test/fixtures/go/mux_fork/go.mod
@@ -1,0 +1,5 @@
+module example.com/muxfork
+
+go 1.21
+
+require github.com/minio/mux v1.9.2

--- a/spec/functional_test/fixtures/go/mux_fork/main.go
+++ b/spec/functional_test/fixtures/go/mux_fork/main.go
@@ -1,0 +1,27 @@
+// `github.com/minio/mux` is a maintained hard fork of gorilla/mux with the
+// same routing API. A project that imports only the fork used to detect as
+// `go_mux` (MinIO's own go.mod happens to carry gorilla/mux as an indirect
+// dependency) and then match no file, so every route went missing.
+package main
+
+import (
+	"net/http"
+
+	"github.com/minio/mux"
+)
+
+func main() {
+	router := mux.NewRouter()
+
+	router.Methods(http.MethodGet).Path("/objects/{object}").HandlerFunc(getObject)
+	router.Methods(http.MethodPut).Path("/objects/{object}").HandlerFunc(putObject)
+
+	api := router.PathPrefix("/admin").Subrouter()
+	api.Methods(http.MethodDelete).Path("/heal").HandlerFunc(heal)
+
+	http.ListenAndServe(":9000", router)
+}
+
+func getObject(w http.ResponseWriter, r *http.Request) {}
+func putObject(w http.ResponseWriter, r *http.Request) {}
+func heal(w http.ResponseWriter, r *http.Request)      {}

--- a/spec/functional_test/fixtures/kotlin/ktor/ExtensionRoutes.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor/ExtensionRoutes.kt
@@ -25,3 +25,32 @@ fun Route.extensionRoutes() {
         }
     }
 }
+
+// Ktor decorates a placeholder to say how the segment matches: `{name...}`
+// is the tailcard, `{name?}` the optional, `{...}` the anonymous tailcard.
+// The handler still reads `call.parameters["name"]`, so the decoration is
+// not part of the parameter name — and `{...}` names nothing at all.
+//
+// The tailcard route also names its own placeholder through a variable, so
+// the literal opens the brace itself. Wrapping the interpolation in another
+// pair produced the URL `/interpolated/{{tail}...}` carrying a path param
+// called `{tail`.
+fun Route.placeholderShapeRoutes() {
+    val tail = "tail"
+
+    get("/listing/{segments...}") {
+        call.respondText("Tailcard route")
+    }
+
+    get("/optional/{slug?}") {
+        call.respondText("Optional route")
+    }
+
+    get("/anonymous/{...}") {
+        call.respondText("Anonymous tailcard route")
+    }
+
+    get("/interpolated/{$tail...}") {
+        call.respondText("Interpolated tailcard route")
+    }
+}

--- a/spec/functional_test/testers/go/mux_fork_spec.cr
+++ b/spec/functional_test/testers/go/mux_fork_spec.cr
@@ -1,0 +1,20 @@
+require "../../func_spec.cr"
+
+# Regression: the analyzer gated every file on the literal import path
+# `github.com/gorilla/mux`, so a project using the API-compatible
+# `github.com/minio/mux` fork reported zero routes. MinIO's own scan lost
+# its whole S3 data plane this way.
+expected_endpoints = [
+  Endpoint.new("/objects/{object}", "GET", [
+    Param.new("object", "", "path"),
+  ]),
+  Endpoint.new("/objects/{object}", "PUT", [
+    Param.new("object", "", "path"),
+  ]),
+  Endpoint.new("/admin/heal", "DELETE"),
+]
+
+FunctionalTester.new("fixtures/go/mux_fork/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/kotlin/ktor_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_spec.cr
@@ -40,6 +40,21 @@ expected_endpoints = [
   # Documented with the OpenAPI DSL: one GET route, and no QUERY route per
   # documented query parameter.
   Endpoint.new("/stream-bytes", "GET"),
+  # Ktor's placeholder decorations describe the segment, not the parameter:
+  # the handler reads `call.parameters["segments"]`, so `segments...` was
+  # never a name anything could match. `{...}` is anonymous and names none.
+  Endpoint.new("/listing/{segments...}", "GET", [
+    Param.new("segments", "", "path"),
+  ]),
+  Endpoint.new("/optional/{slug?}", "GET", [
+    Param.new("slug", "", "path"),
+  ]),
+  Endpoint.new("/anonymous/{...}", "GET"),
+  # The literal opens the placeholder itself and interpolates only the name,
+  # so the interpolation must not add a second pair of braces.
+  Endpoint.new("/interpolated/{tail...}", "GET", [
+    Param.new("tail", "", "path"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/kotlin/ktor/", {

--- a/spec/unit_test/deliver/probe_url_spec.cr
+++ b/spec/unit_test/deliver/probe_url_spec.cr
@@ -80,6 +80,53 @@ describe "Deliver#probe_url" do
       angles = path_endpoint("http://h/u/<id>/<idx>", "id", "idx")
       probe.url_for(angles).should eq("http://h/u/1/1")
     end
+
+    # The bug: only the bare `{name}` / `<name>` spellings were filled, so
+    # every framework that types or constrains the placeholder was probed as
+    # a literal template. NetBox alone reports 165 such routes.
+    it "fills a Django/Flask converter placeholder" do
+      probe.url_for(path_endpoint("http://h/dcim/devices/<int:pk>/", "pk"))
+        .should eq("http://h/dcim/devices/1/")
+      probe.url_for(path_endpoint("http://h/media/<path:path>", "path"))
+        .should eq("http://h/media/noir")
+    end
+
+    it "fills two converter placeholders sharing one segment" do
+      endpoint = path_endpoint("http://h/extras/scripts/<str:module>.<str:name>/", "module", "name")
+      probe.url_for(endpoint).should eq("http://h/extras/scripts/noir.noir/")
+    end
+
+    # The constraint carries its own braces, so the closing delimiter cannot
+    # be found by scanning to the first `}`.
+    it "fills a chi/gorilla regex-constrained placeholder" do
+      endpoint = path_endpoint("http://h/{user}/repo/commit/{sha:[a-f0-9]{7,64}}", "user", "sha")
+      probe.url_for(endpoint).should eq("http://h/noir/repo/commit/noir")
+    end
+
+    it "fills a FastAPI typed placeholder" do
+      probe.url_for(path_endpoint("http://h/files/{file_path:path}", "file_path"))
+        .should eq("http://h/files/noir")
+    end
+
+    it "fills tail-card and catch-all decorations" do
+      probe.url_for(path_endpoint("http://h/static/{segments...}", "segments"))
+        .should eq("http://h/static/noir")
+      probe.url_for(path_endpoint("http://h/blob/{*slug}", "slug"))
+        .should eq("http://h/blob/noir")
+      probe.url_for(path_endpoint("http://h/blob/{slug*}", "slug"))
+        .should eq("http://h/blob/noir")
+    end
+
+    it "leaves a typed placeholder naming an undeclared param alone" do
+      # Only `pk` is a real param, so the neighbouring converter is not a
+      # placeholder this endpoint knows about and must survive untouched.
+      endpoint = path_endpoint("http://h/a/<int:pk>/<slug:other>/", "pk")
+      probe.url_for(endpoint).should eq("http://h/a/1/<slug:other>/")
+    end
+
+    it "leaves an unbalanced brace alone" do
+      probe.url_for(path_endpoint("http://h/u/{id", "id")).should eq("http://h/u/{id")
+    end
   end
 
   it "leaves the template alone for destructive verbs" do

--- a/spec/unit_test/detector/go/mux_spec.cr
+++ b/spec/unit_test/detector/go/mux_spec.cr
@@ -8,4 +8,12 @@ describe "Detect Go Mux" do
   it "go.mod" do
     instance.detect("go.mod", "github.com/gorilla/mux").should be_true
   end
+
+  it "go.mod declaring only the minio/mux fork" do
+    instance.detect("go.mod", "github.com/minio/mux v1.9.2").should be_true
+  end
+
+  it "go.mod without any mux dependency" do
+    instance.detect("go.mod", "github.com/go-chi/chi/v5 v5.0.0").should be_false
+  end
 end

--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -440,6 +440,24 @@ describe Noir::JSRouteExtractor do
       ).should be_false
     end
 
+    it "skips files importing fetch-mock without an HTTP server lib" do
+      # `fetchMock.get(pattern, response)` is the same shape as a route
+      # registration, so Superset's client test setup reported its glob
+      # patterns as Express routes: `GET /glob:*api/v1/security/csrf_token/*`.
+      content = <<-JS
+        import fetchMock from 'fetch-mock';
+        import { SupersetClient } from '@superset-ui/core';
+
+        export default function setupClientForTest() {
+          fetchMock.get('glob:*api/v1/security/csrf_token/*', { result: '1234' });
+        }
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/packages/core/test/query/api/setupClientForTest.ts",
+        content
+      ).should be_true
+    end
+
     it "skips strict-filename test markers unconditionally" do
       # Filenames like `foo.test.ts` / `bar.e2e-spec.ts` never
       # define real routes — even when the file imports an HTTP

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -4,7 +4,14 @@ module Analyzer::Go
   class Mux < GoEngine
     analyzer_for "go_mux"
 
-    IMPORT_MARKER = "github.com/gorilla/mux"
+    # `github.com/minio/mux` is a maintained hard fork of gorilla/mux with
+    # the same `Methods(...).Path(...).HandlerFunc(...)` / `Subrouter()`
+    # API, so the same extraction applies. MinIO itself imports only the
+    # fork: the detector still fired (gorilla/mux is an indirect entry in
+    # its go.mod) but every file failed this gate, so the whole S3 data
+    # plane — `HEAD/GET/PUT/POST/DELETE /{object}` and the `_MINIO_*`
+    # internal routes — reported zero endpoints.
+    IMPORT_MARKER = ["github.com/gorilla/mux", "github.com/minio/mux"]
 
     def analyze
       # Source Analysis

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -75,6 +75,18 @@ module Analyzer::Kotlin
       name.count('.') >= 2
     end
 
+    # The parameter name inside one Ktor placeholder. Ktor spells the
+    # tailcard as `{name...}` and the optional as `{name?}`, but the
+    # handler still reads `call.parameters["name"]` — the decoration
+    # describes the segment, not the parameter. Emitting the raw body
+    # produced params literally named `segments...` and `name?`, which
+    # no probe or spec fill could ever match. `{...}` is the anonymous
+    # tailcard and names nothing.
+    private def ktor_path_param_name(body : String) : String?
+      name = body.rchop("...").rchop("?")
+      name.empty? ? nil : name
+    end
+
     private def build_endpoint(route : Noir::TreeSitterKotlinKtorRouteExtractor::Route, path : String) : Endpoint
       details = Details.new(PathInfo.new(path, route.line + 1))
       params = [] of Param
@@ -85,8 +97,10 @@ module Analyzer::Kotlin
       # URL string, but emitting here keeps parity with the legacy
       # analyzer.
       route.path.scan(/\{([^}]+)\}/) do |match|
-        path_param_names << match[1]
-        params << Param.new(match[1], "", "path")
+        name = ktor_path_param_name(match[1])
+        next unless name
+        path_param_names << name
+        params << Param.new(name, "", "path")
       end
 
       if rt = route.receive_type

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -131,7 +131,7 @@ module Analyzer::Go
     # repos (e.g. an example monorepo where most dirs use other routers).
     # `file_contents` is still populated for every file so the per-file
     # route pass and callee pre-pass keep their read cache.
-    def collect_package_groups_ts(group_method : String = "Group", import_marker : String? = nil) : Tuple(Hash(String, Hash(String, String)), Hash(String, String))
+    def collect_package_groups_ts(group_method : String = "Group", import_marker : (String | Array(String))? = nil) : Tuple(Hash(String, Hash(String, String)), Hash(String, String))
       package_groups = Hash(String, Hash(String, String)).new
       files_by_dir = Hash(String, Array(String)).new
       file_contents = Hash(String, String).new
@@ -153,7 +153,10 @@ module Analyzer::Go
 
       files_by_dir.each do |dir, paths|
         relevant = if import_marker
-                     paths.select { |p| (c = file_contents[p]?) && c.includes?(import_marker) }
+                     markers = import_markers(import_marker)
+                     paths.select do |p|
+                       (c = file_contents[p]?) && markers.any? { |marker| c.includes?(marker) }
+                     end
                    else
                      paths
                    end
@@ -245,19 +248,29 @@ module Analyzer::Go
     # instead of rebuilding them for every candidate file.
     @extra_method_regexes = Hash(String, Regex).new
 
-    # One compiled matcher per framework import marker. Each analyzer
+    # One compiled matcher per framework import marker set. Each analyzer
     # passes a single `IMPORT_MARKER` constant, so the cardinality here is
     # one entry; the Hash just keeps the memo honest if that changes.
     @import_marker_regexes = Hash(String, Regex).new
 
-    private def import_marker_regex(import_marker : String) : Regex
-      @import_marker_regexes[import_marker] ||= Regex.union(import_marker)
+    # An analyzer may name more than one import path when a framework is
+    # shipped under several of them — a maintained hard fork exposing the
+    # same routing API, for instance. Callers keep passing a plain String.
+    private def import_markers(import_marker : String | Array(String)) : Array(String)
+      import_marker.is_a?(String) ? [import_marker] : import_marker
+    end
+
+    # Called once per candidate file, so the single-marker case reuses the
+    # constant itself as the memo key rather than allocating a joined one.
+    private def import_marker_regex(import_marker : String | Array(String)) : Regex
+      key = import_marker.is_a?(String) ? import_marker : import_marker.join('\n')
+      @import_marker_regexes[key] ||= Regex.union(import_markers(import_marker))
     end
 
     # Per-package directories that import a target framework. Some real
     # projects hide the concrete framework type behind a local interface, so
     # the file that calls `router.GET(...)` may not import Gin/Echo itself.
-    def framework_package_dirs(file_contents : Hash(String, String), import_marker : String) : Set(String)
+    def framework_package_dirs(file_contents : Hash(String, String), import_marker : String | Array(String)) : Set(String)
       dirs = Set(String).new
       marker = import_marker_regex(import_marker)
       file_contents.each do |path, content|
@@ -280,7 +293,7 @@ module Analyzer::Go
     def framework_route_source_candidate?(content : String,
                                           dir : String,
                                           framework_dirs : Set(String),
-                                          import_marker : String,
+                                          import_marker : String | Array(String),
                                           extra_methods : Array(String)) : Bool
       return false unless content_matches?(content, import_marker_regex(import_marker)) || framework_dirs.includes?(dir)
       go_route_source_candidate?(content, extra_methods)

--- a/src/detector/detectors/go/mux.cr
+++ b/src/detector/detectors/go/mux.cr
@@ -4,12 +4,14 @@ module Detector::Go
   class Mux < Detector
     detector_for "go_mux", extensions: %w[.go], path_segments: %w[go.mod]
 
+    # `github.com/minio/mux` is a maintained hard fork of gorilla/mux and
+    # exposes the same routing API, so a project that depends only on the
+    # fork is still a mux project.
+    IMPORT_PATHS = %w[github.com/gorilla/mux github.com/minio/mux]
+
     def detect(filename : String, file_contents : String) : Bool
-      if (filename.includes? "go.mod") && (file_contents.includes? "github.com/gorilla/mux")
-        true
-      else
-        false
-      end
+      return false unless filename.includes? "go.mod"
+      IMPORT_PATHS.any? { |path| file_contents.includes? path }
     end
   end
 end

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -496,6 +496,14 @@ module Noir
       "require(\"msw\")", "require('msw')",
       "from \"nock\"", "from 'nock'",
       "require(\"nock\")", "require('nock')",
+      # fetch-mock: the same job as msw/nock for the `fetch` API, and the
+      # same call shape — `fetchMock.get('glob:*/api/v1/token/*', body)`.
+      # Superset's `setupClientForTest.ts` / `setupSupersetClient.js`
+      # registered its glob patterns as Express routes, so the catalog
+      # reported `GET /glob:*api/v1/security/csrf_token/*`.
+      "from \"fetch-mock\"", "from 'fetch-mock'",
+      "from \"fetch-mock/", "from 'fetch-mock/",
+      "require(\"fetch-mock\")", "require('fetch-mock')",
       "setupApplicationTest",
       "setupRenderingTest",
       # Cypress: e2e suites use `cy.request(...)` / `cy.get(...)`

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -976,23 +976,43 @@ module Noir
       #
       # Wrap the interpolated identifier/expression in `{…}` so the
       # placeholder is preserved and the downstream path-param
-      # extractor picks it up.
+      # extractor picks it up — unless the literal already opened a
+      # Ktor placeholder around it. `get("{$name...}")` names its own
+      # path param through a variable, so the surrounding text supplies
+      # the braces; wrapping unconditionally doubled them and produced
+      # the URL `/{{name}...}` with the path param `{name`.
       buf = String.build do |io|
+        in_placeholder = false
         Noir::TreeSitter.each_named_child(node) do |child|
           case Noir::TreeSitter.node_type(child)
           when "string_content"
-            io << Noir::TreeSitter.node_text(child, source)
+            text = Noir::TreeSitter.node_text(child, source)
+            io << text
+            in_placeholder = trailing_placeholder_open?(in_placeholder, text)
           when "interpolated_identifier", "interpolated_expression"
             # node_text for these children is the identifier / inner
             # expression with the leading `$` (and `{…}` for the
             # expression form) already stripped by the grammar.
-            io << '{'
+            io << '{' unless in_placeholder
             io << Noir::TreeSitter.node_text(child, source).strip
-            io << '}'
+            io << '}' unless in_placeholder
           end
         end
       end
       buf
+    end
+
+    # Whether a `{` opened by the literal's own text is still unclosed
+    # after `text`. Ktor placeholders never nest, so the last delimiter
+    # seen decides.
+    private def trailing_placeholder_open?(open : Bool, text : String) : Bool
+      text.each_char do |char|
+        case char
+        when '{' then open = true
+        when '}' then open = false
+        end
+      end
+      open
     end
 
     # ---- handler-body scan -------------------------------------------

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -229,25 +229,27 @@ class Deliver
   protected def probe_url(endpoint : Endpoint, request_method : String) : String
     return endpoint.url unless PROBE_PATH_FILL_METHODS.includes?(request_method.upcase)
 
-    url = endpoint.url
-    # Longest name first. The `:name` form has no closing delimiter, so a
-    # param whose name merely *starts with* another's used to be eaten by the
-    # shorter substitution in declaration order: Express `/u/:id/:idx` with
-    # params [id, idx] was probed as `/u/1/1x`, a path the app does not route.
-    path_params = endpoint.params.select { |param| param.param_type == "path" }
-    path_params.sort_by! { |param| -param.name.size }
-
-    path_params.each do |param|
+    fillers = {} of String => String
+    endpoint.params.each do |param|
+      next unless param.param_type == "path"
       # A non-empty value means --set-pvalue-path already applied and the
       # optimizer substituted it; nothing left to fill.
       next unless param.value.empty?
       next if param.name.empty?
 
-      filler = NUMERIC_PATH_PARAM_RE.matches?(param.name) ? "1" : "noir"
-      escaped = Regex.escape(param.name)
-      # `{name}` and `<name>` are delimited, so a plain replace is safe.
-      url = url.gsub("{#{param.name}}", filler)
-      url = url.gsub("<#{param.name}>", filler)
+      fillers[param.name] = NUMERIC_PATH_PARAM_RE.matches?(param.name) ? "1" : "noir"
+    end
+    return endpoint.url if fillers.empty?
+
+    url = fill_delimited_path_params(endpoint.url, fillers)
+
+    # Longest name first. The `:name` form has no closing delimiter, so a
+    # param whose name merely *starts with* another's used to be eaten by the
+    # shorter substitution in declaration order: Express `/u/:id/:idx` with
+    # params [id, idx] was probed as `/u/1/1x`, a path the app does not route.
+    fillers.keys.sort_by! { |name| -name.size }.each do |name|
+      filler = fillers[name]
+      escaped = Regex.escape(name)
       # `:name` only counts at a segment boundary. Anchoring to a preceding
       # `/` keeps the scheme/port colon in `http://host:8080` and embedded
       # example text like `/profiles/celeb_:USERNAME` out of it. The trailing
@@ -258,6 +260,87 @@ class Deliver
     end
 
     url
+  end
+
+  # Replaces every `{...}` / `<...>` placeholder whose name is a fillable path
+  # param. A plain `gsub("{#{name}}")` only ever matched the bare form, so the
+  # typed and constrained spellings frameworks put *around* the name survived
+  # into the request and the probe hit a literal template:
+  #
+  #   Django / Flask  `<int:pk>`, `<str:module>`, `<path:subpath>`
+  #   chi / gorilla   `{sha:[a-f0-9]{7,64}}`
+  #   FastAPI         `{file_path:path}`
+  #   Ktor            `{segments...}`
+  #   ASP.NET / Rails `{*slug}`, `{slug*}`
+  #
+  # A brace constraint can itself contain braces (`{7,64}`), so the closing
+  # delimiter is found by depth counting rather than by a regex.
+  private def fill_delimited_path_params(url : String, fillers : Hash(String, String)) : String
+    return url unless url.includes?('{') || url.includes?('<')
+
+    chars = url.chars
+    filled = String::Builder.new(url.bytesize)
+    index = 0
+    while index < chars.size
+      open = chars[index]
+      close = case open
+              when '{' then '}'
+              when '<' then '>'
+              end
+      if close.nil?
+        filled << open
+        index += 1
+        next
+      end
+
+      depth = 1
+      cursor = index + 1
+      while cursor < chars.size
+        char = chars[cursor]
+        if char == open
+          depth += 1
+        elsif char == close
+          depth -= 1
+          break if depth.zero?
+        end
+        cursor += 1
+      end
+
+      if depth.zero?
+        body = chars[(index + 1)...cursor].join
+        # The raw body first: an analyzer that reports the decorated
+        # spelling as the param name (Ktor's `segments...`) still gets
+        # its placeholder filled, exactly as the old literal replace did.
+        name = fillers.has_key?(body) ? body : placeholder_param_name(body, open == '{')
+        if name && (filler = fillers[name]?)
+          filled << filler
+          index = cursor + 1
+          next
+        end
+      end
+
+      filled << open
+      index += 1
+    end
+
+    filled.to_s
+  end
+
+  # The param name inside one placeholder body, or nil when there is none.
+  # A colon separates the name from a type or a regex constraint, but the two
+  # families put it on opposite sides: `<int:pk>` names the converter first,
+  # `{sha:[a-f0-9]+}` names the param first.
+  private def placeholder_param_name(body : String, braces : Bool) : String?
+    return if body.empty?
+
+    name = body
+    if colon = name.index(':')
+      name = braces ? name[0, colon] : name[(colon + 1)..]
+    end
+    # Tail-card, catch-all and optional markers decorate the bare name.
+    name = name.rchop("...")
+    name = name.strip("*?")
+    name.empty? ? nil : name
   end
 
   # Headers for one probe: the analyzer-discovered `header` and `cookie`


### PR DESCRIPTION
Ran the release binary over 14 real open-source applications, then audited the **output** for defects rather than reading Noir's source first. Four bugs found and fixed, each with a fixture or unit spec that fails on `main`. One further finding is reported below without a fix.

## Corpus

Shallow clones, scanned with `noir scan <dir> -f json`.

| repo | commit | stack | endpoints before | after | wall time |
|---|---|---|---|---|---|
| go-gitea/gitea | `ee8f2b4` | Go / chi | 1313 | 1313 | 4.9s |
| minio/minio | `7aac2a2` | Go / minio-mux | 24 | **42** | 8.5s |
| netbox-community/netbox | `560da79` | Python / Django + DRF | 2074 | 2074 | 8.7s |
| apache/superset | `531587a` | Python / Flask | 544 | **542** | 13.0s |
| fastapi/full-stack-fastapi-template | `cb740b6` | Python / FastAPI | 34 | 34 | 0.1s |
| NodeBB/NodeBB | `ec5503a` | JS / Express | 762 | 762 | 4.4s |
| discourse/discourse | `e44970f2` | Ruby / Rails | 1885 | 1885 | 8.4s |
| pixelfed/pixelfed | `1a49fb5` | PHP / Laravel | 983 | 983 | 3.6s |
| jellyfin/jellyfin | `ea89b6e` | C# / ASP.NET Core | 406 | 406 | 4.0s |
| spring-projects/spring-petclinic | `818c413` | Java / Spring | 17 | 17 | 0.1s |
| ktorio/ktor-samples | `69dcff3` | Kotlin / Ktor | 103 | 103 | 0.6s |
| dani-garcia/vaultwarden | `fdc156b` | Rust / Rocket | 301 | 301 | 1.6s |
| actix/examples | `36d5d4f` | Rust / actix-web | 96 | 96 | 0.9s |
| plausible/analytics | `60e94c3` | Elixir / Phoenix | 228 | 228 | 1.3s |

No crashes, no non-zero exits, nothing over 60s. Wall times are from the baseline pass; the machine ran several agents in parallel throughout, so treat them as indicative — a repeated Discourse scan varied between 4.9s and 9.5s under identical conditions.

URL-level diff of the whole corpus, before vs after: **+18 minio, −2 superset, 1 ktor URL corrected**. Nothing else moved.

---

## Bug 1 — `--probe` sends the literal path template for every typed placeholder

**Symptom.** `probe_url` substituted only the bare `{name}` and `<name>` spellings. Every framework that types or constrains its placeholder was probed as a literal template, so the request 404'd before it reached the route — which is the entire point of `--probe` / `--probe-via` / `--status-codes`.

The path params were extracted correctly all along; only the substitution could not see past the decoration. The function's own constant documents the case it was missing:

```crystal
# A framework route constrained to an integer (`/users/{id:int}`, Django's `<int:pk>`) ...
NUMERIC_PATH_PARAM_RE = ...
```

**Root cause.** `src/models/deliver.cr` did a plain literal replace:

```crystal
url = url.gsub("{#{param.name}}", filler)
url = url.gsub("<#{param.name}>", filler)
```

`<int:pk>` is not `<pk>`, and `{sha:[a-f0-9]{7,64}}` is not `{sha}`.

**Reproduction.**

```
$ noir scan /tmp/netbox -f json | jq -r '.endpoints[] | select(.url|test("<int:pk>")) | .url' | head -3
/dcim/devices/<int:pk>/
/ipam/prefixes/<int:pk>/
/circuits/circuits/<int:pk>/
```

Feeding those through `probe_url` (unit spec `spec/unit_test/deliver/probe_url_spec.cr`):

| URL | before | after |
|---|---|---|
| `/dcim/devices/<int:pk>/` | `/dcim/devices/<int:pk>/` | `/dcim/devices/1/` |
| `/extras/scripts/<str:module>.<str:name>/` | unchanged | `/extras/scripts/noir.noir/` |
| `/{u}/repo/commit/{sha:[a-f0-9]{7,64}}` | `/noir/repo/commit/{sha:[a-f0-9]{7,64}}` | `/noir/repo/commit/noir` |
| `/files/{file_path:path}` (FastAPI) | unchanged | `/files/noir` |
| `/static/{segments...}` (Ktor) | unchanged | `/static/noir` |

**Impact on the corpus.** On read-only verbs (the only ones Noir fills), **156 NetBox endpoints and 8 Gitea endpoints** now probe a reachable URL instead of a template.

**Fix.** Placeholders are found by depth-counted delimiter scanning — a brace constraint carries braces of its own (`{7,64}`), so scanning to the first `}` is wrong — and the name is read from the body, which the two families order differently: `<int:pk>` names the converter first, `{sha:regex}` the param. The raw body is still tried first so an analyzer that reports the decorated spelling as the param name keeps the behaviour the old literal replace had. Only the outbound request changes; the reported catalog keeps the template.

---

## Bug 2 — Ktor placeholder decorations leak into the URL and the param name

Two defects, both visible in one scan of `ktor-samples`.

**2a. A route literal that names its own placeholder gets double braces.**

`filelisting/src/main/kotlin/io/ktor/samples/filelisting/FileListingApplication.kt:164`:

```kotlin
val pathParameterName = "static-content-path-parameter"
get("{$pathParameterName...}") { ... }
```

The literal already opens the brace in its own text, but the interpolation was wrapped in another pair unconditionally.

```
$ noir scan /tmp/ktor-samples -f json | jq '.endpoints[] | select(.url|test("pathParameterName"))'
# before
"url": "/{{pathParameterName}...}",
"params": [{ "name": "{pathParameterName", "param_type": "path" }]
# after
"url": "/{pathParameterName...}",
"params": [{ "name": "pathParameterName", "param_type": "path" }]
```

**2b. Tailcard and optional markers were kept as part of the param name** — a general defect, independent of interpolation:

```kotlin
get("/files/{segments...}") { call.parameters["segments"] }   // param reported as `segments...`
get("/opt/{name?}")         { call.parameters["name"] }       // param reported as `name?`
get("/anon/{...}")                                            // anonymous tailcard, names nothing
```

The decoration describes how the segment matches, not the parameter. Nothing downstream — probe fill, `--set-pvalue-path`, an OAS parameter object — could ever match `segments...`. `{...}` now emits no param at all.

Endpoint counts are unchanged; only the URL and the param names move.

---

## Bug 3 — `fetch-mock` glob patterns reported as Express routes

**Symptom.** Scanning Superset:

```
$ noir scan /tmp/superset -f json | jq -r '.endpoints[] | select(.url|test("glob:")) | "\(.method) \(.url)"'
GET /glob:*api/v1/security/csrf_token/*
GET /glob:*/api/v1/security/csrf_token/*
```

Source (`superset-frontend/packages/superset-ui-core/test/query/api/setupClientForTest.ts:26`):

```ts
import fetchMock from 'fetch-mock';
const LOGIN_GLOB = 'glob:*api/v1/security/csrf_token/*';
fetchMock.get(LOGIN_GLOB, { result: '1234' });
```

**Root cause.** `fetchMock.get(pattern, response)` is the same call shape as a route registration, and fetch-mock was simply missing from `TEST_STUB_LIBRARY_MARKERS`, which already covers msw, nock, supertest and axios.

**After.** Both endpoints gone, superset 544 → 542, nothing else moved. The HTTP-server-import exemption still applies, so a harness that stands up a real server alongside its mocks keeps its routes.

---

## Bug 4 — MinIO's entire S3 data plane missing (`minio/mux` fork)

**Symptom.** MinIO reports `go_mux` as a *detected technology* and then zero mux endpoints.

```
$ noir scan /tmp/minio --no-color | grep -A6 'Detected'
✔ Detected 5 technologies.
  ├── go_mux
$ noir scan /tmp/minio -f json | jq '[.endpoints[]|select(.details.technology=="go_mux")]|length'
0
```

**Root cause.** `github.com/minio/mux` is a maintained hard fork of gorilla/mux with the same `Methods(...).Path(...).HandlerFunc(...)` / `Subrouter()` API. Both the detector and the analyzer matched the gorilla import path literally. MinIO's own files import only the fork, so every one failed the analyzer's `IMPORT_MARKER` gate — while the detector still fired, because gorilla/mux happens to be an *indirect* entry in MinIO's `go.mod`. A project depending only on the fork was detected as nothing at all.

**Before / after.**

```
minio  before: 24 endpoints,  0 go_mux
minio  after:  42 endpoints, 18 go_mux
```

recovering the S3 data plane registered in `cmd/api-router.go`:

```
HEAD   /{object}
GET    /{object}
PUT    /{object}
POST   /{object}
DELETE /{object}
```

plus the `_MINIO_*` internal routes.

**Fix.** `GoEngine`'s import-marker helpers take either a `String` or an `Array(String)`, so an analyzer can name every import path a framework ships under. The other 18 Go analyzers keep passing a plain `String` and the single-marker path stays allocation-free.

---

## Found, not fixed

**NodeBB: 250 of 361 `js_express` endpoints come from `test/`, and they are HTTP client calls, not routes.**

```
$ noir scan /tmp/nodebb -f json | jq -r '.endpoints[] | select(.url|startswith("/{url}")) | "\(.method) \(.url)"' | head -3
DELETE /{url}/api/user/revokeme/session
GET /{url}/.well-known/webfinger?resource=acct:{handle}@{host}
GET /{url}/api/flags?quick="<script>alert('foo');</script>
```

These come from `test/controllers.js`, `test/topics.js` and friends:

```js
const { response } = await request.del(`${nconf.get('url')}/api/user/revokeme/session`, { jar });
```

`${nconf.get('url')}` becomes a `{url}` path segment, so every one of them carries a bogus leading `/{url}` and some carry test payloads verbatim (`"<script>alert('foo')</script>`).

I did not fix this. The obvious lever is adding `/test/` and `/tests/` to `TEST_STUB_PATH_MARKERS` — the list already carries the narrower `/test/helpers/`, `/test/integration/` and `/test/e2e/` — but that is a broad detection change, and I could not construct evidence that it is safe for projects whose `test/` tree holds a mock server built on a framework outside `HTTP_SERVER_LIBRARY_MARKERS`. The sharper-looking rule ("a route path whose first segment is a placeholder is a client URL") is not safe either: a leading `/{...}` is an ordinary route shape elsewhere in the corpus (251 in Gitea, 35 in Jellyfin). Worth a dedicated change with its own A/B rather than riding along here.

Two smaller items, left alone as single-endpoint noise: Superset reports `GET /./index` from a webpack Module Federation `container.get('./index')` call, and NodeBB reports an Express `RegExp` route as the URL `/\/sitemap\/topics\.(\d+)\.xml/`, JS delimiters and backslash escapes included.

**Checked and clean.** Parameter names and values across all 14 repos (no empty names, no duplicates, no source-text leakage, no keywords — every `type`/`public`/`static` hit is a genuine API parameter). Method distributions per repo. Technology attribution: no cross-analyzer theft beyond bug 3. `code_path` line numbers are never zero or negative, though Rails, Django and every spec-file analyzer omit the line entirely (Discourse points 1632 endpoints at a bare `config/routes.rb`) — that is a missing-enrichment gap, not wrong output, and threading line numbers through `logical_route_lines` is too large to bundle here.

---

## Verification

- Full fixture corpus A/B, scanned **per fixture directory** (711 dirs) before and after: **5546 → 5553**. The only two directories that changed are the two this PR adds fixtures to — `go/mux_fork` (new, +3) and `kotlin/ktor` (19 → 23, the four new placeholder routes). **Zero regressions.**
- Real-corpus URL-level diff: exactly the intended deltas listed above, nothing else.
- `just test`: 5621 unit + 24523 functional examples, 0 failures, 0 pending.
- `just check`: 2283 files inspected, 0 failures.
- `just build-release` clean.

Each fix is its own commit and reviewable independently.
