### PR TITLE
fix(output): escape every control character in TOML output

### DIFF
--- a/spec/unit_test/output_builder/toml_spec.cr
+++ b/spec/unit_test/output_builder/toml_spec.cr
@@ -80,4 +80,34 @@ describe "OutputBuilderToml" do
     output.should contain("file_path = \"test.cr\"")
     output.should contain("line_number = 10")
   end
+
+  # TOML basic strings admit no raw control character. Only `\b \t \n \f \r`
+  # have a short form; everything else in U+0000-U+001F, plus U+007F, needs
+  # `\uXXXX`. The escaper covered exactly those five, so one ANSI escape in a
+  # route literal — or a control byte in a filename, which reaches the
+  # document through `code_paths` — emitted a document no TOML parser will
+  # read.
+  it "escapes control characters so the document stays parseable" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderToml.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/ctrl\u0001\u0002\e[31m", "GET",
+      Details.new(PathInfo.new("src/we\u007Fird.py", 3)))
+    endpoint.push_param(Param.new("na\u0001me", "va\u001Flue", "query"))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should_not match(/[\x00-\x08\x0B\x0E-\x1F\x7F]/)
+    output.should contain(%(url = "/ctrl\\u0001\\u0002\\u001B[31m"))
+    output.should contain(%("na\\u0001me"))
+    output.should contain(%(path = "src/we\\u007Fird.py"))
+  end
 end

--- a/src/output_builder/toml_serializer.cr
+++ b/src/output_builder/toml_serializer.cr
@@ -36,7 +36,39 @@ module OutputBuilderTomlSerializer
   # [config].file) and corrupt the document, so quote anything non-bare.
   private def toml_key(key : String) : String
     return key if key.matches?(/\A[A-Za-z0-9_-]+\z/)
-    %("#{key.gsub("\\", "\\\\").gsub("\"", "\\\"")}")
+    %("#{toml_escape(key)}")
+  end
+
+  # TOML basic strings admit no raw control character: U+0000-U+0008,
+  # U+000A-U+001F and U+007F all have to be escaped, and only `\b \t \n \f
+  # \r` have a short form — everything else needs `\uXXXX`.
+  #
+  # The `gsub` chain this replaces covered exactly those five and left every
+  # other control byte raw, so a single ANSI escape in a route literal
+  # (`@app.route("/ctrl\e[31m")`), a NUL, or a DEL in a filename — which
+  # reaches the document through `code_paths` — emitted a TOML document no
+  # parser will read: `Illegal character '\x01'`. Chained `gsub` also walked
+  # the string seven times; this walks it once.
+  private def toml_escape(raw : String) : String
+    String.build do |io|
+      raw.each_char do |char|
+        case char
+        when '\\' then io << "\\\\"
+        when '"'  then io << "\\\""
+        when '\b' then io << "\\b"
+        when '\t' then io << "\\t"
+        when '\n' then io << "\\n"
+        when '\f' then io << "\\f"
+        when '\r' then io << "\\r"
+        else
+          if char.ord < 0x20 || char.ord == 0x7F
+            io << "\\u" << char.ord.to_s(16, upcase: true).rjust(4, '0')
+          else
+            io << char
+          end
+        end
+      end
+    end
   end
 
   private def toml_value(value : JSON::Any) : String
@@ -44,7 +76,7 @@ module OutputBuilderTomlSerializer
     when String
       # TOML basic strings can't contain raw newlines/control chars — escape
       # them so a multi-line snippet/description doesn't break the document.
-      %("#{raw.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("\b", "\\b").gsub("\t", "\\t").gsub("\n", "\\n").gsub("\f", "\\f").gsub("\r", "\\r")}")
+      %("#{toml_escape(raw)}")
     when Int64, Float64
       raw.to_s
     when Bool


### PR DESCRIPTION
Follow-up to #2678 — this was found in the same hostile-input sweep but landed on the branch after that PR was merged, so it needs its own.

## Symptom

`-f toml` emits a document no TOML parser will read whenever an endpoint URL, a param name or a `code_path` carries a control byte.

## Root cause

TOML basic strings admit no raw character in U+0000-U+0008, U+000A-U+001F or U+007F, and only `\b \t \n \f \r` have a short form — everything else needs `\uXXXX`. `OutputBuilderTomlSerializer` escaped exactly those five with a chained `gsub` and left every other control byte raw.

One ANSI escape in a route literal is enough to trip it. Filenames may contain control characters too, and those reach the document through `code_paths`.

## Reproduction

```console
$ printf 'from flask import Flask\napp = Flask(__name__)\n@app.route("/ctrl\x01\x02\x1b[31m")\ndef a(): pass\n' > /tmp/t11/app.py
$ noir -b /tmp/t11 -f toml --no-log > out.toml
$ python3 -c "import tomllib; tomllib.load(open('out.toml','rb'))"
```

Before:

```
tomllib.TOMLDecodeError: Illegal character '\x01' (at line 4, column 13)
```

After:

```
toml OK ['/ctrl\x01\x02\x1b[31m', '/del\x7f', '/nbsp\xa0zwsp​', '/rtl‮evil']
```

The values round-trip: the escaped document parses back to exactly the URLs noir found.

## Fix

Escape the remaining control characters as `\uXXXX`. The replacement walks the string once instead of seven times, and lives in the serializer shared with diff mode's `print_toml`, so both outputs are fixed. `toml_key` goes through the same escaper — a key with a control character was equally unquotable.

## Checks

- `-f toml` over `spec/functional_test/fixtures` still parses and still carries all **3193** endpoints — unchanged from before.
- The same input through `json`, `yaml`, `sarif`, `oas2`, `oas3` and `postman` was already valid and still is (validated with a third-party parser for each).
- New spec asserts the emitted document contains no raw control byte, and pins the three escaped forms (URL, param name, `code_path`).
- `crystal spec spec/unit_test/output_builder`: 236 examples, 0 failures. `crystal tool format --check` and `ameba` clean.
