### PR TITLE
fix(output): close the fidelity gaps between the plain report and -f json

### DIFF
--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -1097,6 +1097,19 @@ describe "EndpointOptimizer" do
       result = optimizer.apply_pvalue("query", "unknown", "original")
       result.should eq("original")
     end
+
+    it "applies a json rule to a param the analyzer spelled `body`" do
+      options["set_pvalue_json"] = YAML::Any.new([YAML::Any.new("id=FUZZ")])
+      optimizer = EndpointOptimizer.new(logger, options)
+
+      # `body` is the alias fourteen analyzers use for a request-body field.
+      # Rules are keyed by the canonical bucket, so the lookup has to be too.
+      endpoint = Endpoint.new("/deleteUser", "POST")
+      endpoint.push_param(Param.new("id", "", "body"))
+
+      result = optimizer.optimize([endpoint])
+      result[0].params[0].value.should eq("FUZZ")
+    end
   end
 
   describe "full optimization workflow" do

--- a/spec/unit_test/output_builder/common_spec.cr
+++ b/spec/unit_test/output_builder/common_spec.cr
@@ -309,6 +309,42 @@ describe "OutputBuilderCommon" do
 
     output.should contain("/사용자/naïve/£cost")
   end
+
+  it "badges a protocol nothing else on the line shows" do
+    builder = OutputBuilderCommon.new(plain_options)
+    builder.io = IO::Memory.new
+
+    kafka = Endpoint.new("/user/signedup", "PUBLISH")
+    kafka.protocol = "kafka"
+    websocket = Endpoint.new("/chat", "SEND")
+    websocket.protocol = "ws"
+    # `http` is the default and the `cli://` URL already spells out `cli`.
+    plain = Endpoint.new("/健康", "GET")
+    cli = Endpoint.new("cli://tool/run", "CLI")
+    cli.protocol = "cli"
+
+    builder.print([kafka, websocket, plain, cli])
+    output = builder.io.to_s
+
+    output.should contain("PUBLISH /user/signedup [kafka]")
+    output.should contain("SEND /chat [websocket]")
+    output.should contain("GET /健康\n")
+    output.should contain("CLI cli://tool/run\n")
+  end
+
+  it "marks an endpoint the app calls rather than serves" do
+    builder = OutputBuilderCommon.new(plain_options)
+    builder.io = IO::Memory.new
+
+    # A Spring Feign / @HttpExchange declarative client, not attack surface.
+    client = Endpoint.new("/orders", "GET")
+    client.internal = true
+
+    builder.print([client])
+    output = builder.io.to_s
+
+    output.should contain("GET /orders [internal]")
+  end
 end
 
 # Every flag off: the plain builder reads each of these with `[]?`, but the

--- a/spec/unit_test/output_builder/common_spec.cr
+++ b/spec/unit_test/output_builder/common_spec.cr
@@ -281,6 +281,34 @@ describe "OutputBuilderCommon" do
 
     output.should contain("HomeService.build (src/handlers/home_handler.cr:7)")
   end
+
+  it "escapes control characters that came out of the scanned source" do
+    builder = OutputBuilderCommon.new(plain_options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/x\e]8;;http://evil.example\aclick\e]8;;\a", "GET")
+    endpoint.push_param(Param.new("head\ner", "v", "header"))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should_not contain("\e")
+    output.should_not contain("\a")
+    output.should contain("\\x1b]8;;http://evil.example\\x07click")
+    output.should contain("head\\x0aer: v")
+  end
+
+  it "leaves non-ASCII text alone" do
+    builder = OutputBuilderCommon.new(plain_options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/사용자/naïve/£cost", "GET")
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("/사용자/naïve/£cost")
+  end
 end
 
 # Every flag off: the plain builder reads each of these with `[]?`, but the

--- a/spec/unit_test/output_builder/common_spec.cr
+++ b/spec/unit_test/output_builder/common_spec.cr
@@ -266,6 +266,21 @@ describe "OutputBuilderCommon" do
     output.should contain("○ tags: graphql-return")
     output.scan(/graphql-return/).size.should eq(1)
   end
+
+  it "shows the file a callee lives in, not a bare line number" do
+    options = plain_options
+    options["include_callee"] = YAML::Any.new(true)
+    builder = OutputBuilderCommon.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/", "GET")
+    endpoint.push_callee(Callee.new("HomeService.build", "src/handlers/home_handler.cr", 7))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("HomeService.build (src/handlers/home_handler.cr:7)")
+  end
 end
 
 # Every flag off: the plain builder reads each of these with `[]?`, but the

--- a/spec/unit_test/output_builder/common_spec.cr
+++ b/spec/unit_test/output_builder/common_spec.cr
@@ -214,4 +214,42 @@ describe "OutputBuilderCommon" do
     # "body" request_type is mapped to json, so it should not render a redundant `○ body: content` line
     output.scan(/○ body:/).size.should eq(1)
   end
+
+  it "keeps form params when the same endpoint also carries a JSON body" do
+    builder = OutputBuilderCommon.new(plain_options)
+    builder.io = IO::Memory.new
+
+    # A handler that reads both (`c.Request.PostFormValue` next to
+    # `c.BindJSON`). `bake_endpoint` has one body slot and JSON takes it, so
+    # the form fields have to be rendered on their own row or they vanish.
+    endpoint = Endpoint.new("/api/submit", "POST")
+    endpoint.push_param(Param.new("username", "", "form"))
+    endpoint.push_param(Param.new("password", "", "json"))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("○ body: {\"password\":\"\"}")
+    output.should contain("○ form:")
+    output.should contain("username")
+  end
+end
+
+# Every flag off: the plain builder reads each of these with `[]?`, but the
+# specs above spell the full hash out so a new option defaulting to "on"
+# cannot silently change what a case is asserting.
+private def plain_options
+  {
+    "debug"          => YAML::Any.new(false),
+    "verbose"        => YAML::Any.new(false),
+    "color"          => YAML::Any.new(false),
+    "nolog"          => YAML::Any.new(false),
+    "output"         => YAML::Any.new(""),
+    "include_path"   => YAML::Any.new(false),
+    "include_callee" => YAML::Any.new(false),
+    "include_techs"  => YAML::Any.new(false),
+    "ai_context"     => YAML::Any.new(false),
+    "status_codes"   => YAML::Any.new(false),
+    "exclude_codes"  => YAML::Any.new(""),
+  }
 end

--- a/spec/unit_test/output_builder/common_spec.cr
+++ b/spec/unit_test/output_builder/common_spec.cr
@@ -233,6 +233,22 @@ describe "OutputBuilderCommon" do
     output.should contain("○ form:")
     output.should contain("username")
   end
+
+  it "renders the value of a path param" do
+    builder = OutputBuilderCommon.new(plain_options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/v1/users/:userId", "GET")
+    endpoint.push_param(Param.new("userId", "Integer", "path"))
+    endpoint.push_param(Param.new("bare", "", "path"))
+    # Giraffe's `%i` names a segment after its own type; "int=int" adds nothing.
+    endpoint.push_param(Param.new("int", "int", "path"))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("○ path: userId=Integer, bare, int")
+  end
 end
 
 # Every flag off: the plain builder reads each of these with `[]?`, but the

--- a/spec/unit_test/output_builder/common_spec.cr
+++ b/spec/unit_test/output_builder/common_spec.cr
@@ -249,6 +249,23 @@ describe "OutputBuilderCommon" do
 
     output.should contain("○ path: userId=Integer, bare, int")
   end
+
+  it "prints one row per distinct tag name" do
+    builder = OutputBuilderCommon.new(plain_options)
+    builder.io = IO::Memory.new
+
+    # Same name, different tagger: `add_tag` keeps both, and this row shows
+    # names only, so without a dedup it reads "graphql-return graphql-return".
+    endpoint = Endpoint.new("/graphql", "POST")
+    endpoint.add_tag(Tag.new("graphql-return", "User", "js_apollo_analyzer"))
+    endpoint.add_tag(Tag.new("graphql-return", "User", "graphql_sdl_analyzer"))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("○ tags: graphql-return")
+    output.scan(/graphql-return/).size.should eq(1)
+  end
 end
 
 # Every flag off: the plain builder reads each of these with `[]?`, but the

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -190,11 +190,12 @@ class OutputBuilder
   # saved report is plain text whether the color came from `Colorize` or
   # from the scanned repo.
   #
-  # Scope note: this covers the file only. The stdout copy is written raw,
-  # because the color codes there are the point and stripping them would
-  # have to happen before each builder colorizes rather than after. Escapes
-  # that originate in scanned source therefore still reach a terminal —
-  # unchanged from before, and true of `NoirLogger`'s output as well.
+  # Scope note: this covers the file only, and only as a backstop. The
+  # stdout copy is written raw, because the color codes there are the point
+  # and stripping them would have to happen before each builder colorizes
+  # rather than after — which is exactly what `escape_control_chars` does
+  # for the plain report, so scanned source no longer reaches a terminal
+  # (or this function) carrying live escapes.
   private def strip_ansi(message : String) : String
     return message unless message.includes?('\e')
 
@@ -520,6 +521,52 @@ class OutputBuilder
     return "(line #{line})" if line
 
     nil
+  end
+
+  # Renders C0/C1 control characters — the escape sequences a terminal
+  # acts on — as visible `\xNN` text.
+  #
+  # Everything a report prints comes out of the repo being scanned, which is
+  # the one thing Noir never trusts: a route literal
+  # `"/x\e]8;;http://evil.example\aclick\e]8;;\a"` was replayed verbatim into
+  # the terminal, where it rendered as a clickable link to the attacker's
+  # host instead of as the string the source actually contains. `\e[2J`,
+  # `\ec` and a bare newline in a param name are the same problem with a
+  # different payload: the report stops describing the code and starts
+  # obeying it.
+  #
+  # Escaped rather than stripped so the report still says what is there —
+  # `-f json` shows the byte as `\u001b`, and this is that fact in plain
+  # text. Only the control blocks are touched, so a CJK route or a `£` in a
+  # param value passes through unchanged.
+  protected def escape_control_chars(text : String) : String
+    return text unless may_contain_control_char?(text)
+
+    String.build do |io|
+      text.each_char do |char|
+        if control_char?(char)
+          io << "\\x" << char.ord.to_s(16).rjust(2, '0')
+        else
+          io << char
+        end
+      end
+    end
+  end
+
+  # Byte-level prefilter so the common (clean) string never pays for a
+  # char-by-char walk. C1 controls are two bytes in UTF-8 and always start
+  # with 0xC2, which also introduces `\u00a0`-`\u00bf`; those fall through to
+  # `control_char?` and are left alone.
+  private def may_contain_control_char?(text : String) : Bool
+    text.each_byte do |byte|
+      return true if byte < 0x20 || byte == 0x7f || byte == 0xc2
+    end
+    false
+  end
+
+  private def control_char?(char : Char) : Bool
+    ord = char.ord
+    ord < 0x20 || ord == 0x7f || (0x80 <= ord <= 0x9f)
   end
 
   private def format_noir_callee(callee : Callee) : String

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -289,7 +289,17 @@ class OutputBuilder
         end
 
         if param.request_type == "path"
-          final_path_params << "#{param.name}"
+          # `name=value`, like the cookie row and the form body below. The
+          # value was dropped here, so the plain report printed a bare
+          # `path: userId` while `-f json` carried `"value": "Integer"` —
+          # 42 path params across the fixture tree lost the only thing the
+          # analyzer knew about them beyond the name.
+          #
+          # A value equal to the name is skipped: Giraffe's `%i`/`%s` route
+          # format names a segment after its own type, and `path: int=int`
+          # says nothing the name did not.
+          redundant_value = param.value.empty? || param.value == param.name
+          final_path_params << (redundant_value ? param.name : "#{param.name}=#{param.value}")
         end
 
         if param.request_type == "header"

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -138,7 +138,12 @@ class EndpointOptimizer
         endpoint.params.each do |param|
           next if param.name.includes?(" ") || param.name.blank?
           next unless seen_params.add?({param.name, param.param_type})
-          param.value = apply_pvalue(param.param_type, param.name, param.value).to_s
+          # `request_type`, not `param_type`: the fourteen analyzers that
+          # spell a request body `body` rather than `json` produce params no
+          # `--pvalue json=` (or `--pvalue any=`) rule ever matched, so their
+          # fields stayed empty in every output and in the probe payload.
+          # Every other consumer already dispatches on the canonical bucket.
+          param.value = apply_pvalue(param.request_type, param.name, param.value).to_s
           tiny_tmp.params << param
         end
       end

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -265,9 +265,13 @@ class OutputBuilderCommon < OutputBuilder
           end
         end
       elsif any_to_bool(@options["include_callee"]?) && !endpoint.callees.empty?
-        callee_entries = endpoint.callees.map do |callee|
-          callee.line ? "#{callee.name} (line #{callee.line})" : callee.name
-        end
+        # `format_noir_callee`, the same renderer the OpenAPI/Postman
+        # descriptions use, so the location is spelled one way everywhere.
+        # This row used to build its own `name (line N)` and drop
+        # `callee.path` — and a callee almost always lives in the handler
+        # file, not the route file printed on the `file:` row just above, so
+        # a bare line number pointed the reader at the wrong file.
+        callee_entries = endpoint.callees.map { |callee| format_noir_callee(callee) }
         append_tree_field r_buffer, "callees", callee_entries, :light_cyan
       end
 

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -212,6 +212,14 @@ class OutputBuilderCommon < OutputBuilder
         tags << tag.name.to_s
       end
 
+      # Deduped by name, the way `-f only-tag` already does it. `add_tag`
+      # dedupes by (name, tagger), so one endpoint legitimately carries three
+      # distinct `graphql-return` tags from three analyzers — and this row,
+      # which prints names only, rendered them as "graphql-return
+      # graphql-return graphql-return". 45 rows in the fixture tree repeated a
+      # name they had nothing left to tell apart by.
+      tags = tags.uniq
+
       # Space-joined, unlike every other multi-value row above, which uses ", ".
       append_field r_buffer, "tags", tags.join(" "), :light_magenta unless tags.empty?
 

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -172,15 +172,24 @@ class OutputBuilderCommon < OutputBuilder
         append_field r_buffer, label, selected.map(&.name).join(", "), :cyan unless selected.empty?
       end
 
+      # Same tree shape as headers/cookies but cyan, and with no
+      # "[unresolved]" marker even on params carrying that tag.
+      form_entries = endpoint.params.select { |p| p.request_type == "form" }.map do |param|
+        param.value.empty? ? param.name : "#{param.name}=#{param.value}"
+      end
+
       if baked[:body_type] == "form"
-        # Same tree shape as headers/cookies but cyan, and with no
-        # "[unresolved]" marker even on params carrying that tag.
-        form_entries = endpoint.params.select { |p| p.request_type == "form" }.map do |param|
-          param.value.empty? ? param.name : "#{param.name}=#{param.value}"
-        end
         append_tree_field r_buffer, "body", form_entries, :cyan
-      elsif !baked[:body].empty?
-        append_field r_buffer, "body", baked[:body], :cyan
+      else
+        append_field r_buffer, "body", baked[:body], :cyan unless baked[:body].empty?
+        # An endpoint whose handler reads both a JSON body and form fields
+        # (`c.Request.PostFormValue` next to `c.BindJSON`, say) has params of
+        # both kinds, but `bake_endpoint` has one `body` slot and JSON wins
+        # it — so every form param on such an endpoint was dropped from this
+        # report while `-f json` and `-f markdown-table` still listed it.
+        # Render them under their own type name, the same convention the
+        # leftover-bucket rows below use, rather than a second "body" row.
+        append_tree_field r_buffer, "form", form_entries, :cyan
       end
 
       # Anything left is still a named input the endpoint reads (multipart

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -57,6 +57,12 @@ class OutputBuilderCommon < OutputBuilder
     "form", "json",
   }
 
+  # Protocols the rest of the line already tells the reader about, so a badge
+  # would only repeat it: `http` is the default and says nothing, the mobile
+  # protocols drive the SCHEME/INTENT/UNIVERSAL/PROVIDER prefix, and `cli` is
+  # spelled out by the `cli://` URL.
+  SILENT_PROTOCOLS = Endpoint::MOBILE_PROTOCOLS | Endpoint::CLI_PROTOCOLS | Set{"http"}
+
   @ai_context_features : Set(String)? = nil
 
   # The plain report is the only format that frames itself — a heading over
@@ -145,9 +151,22 @@ class OutputBuilderCommon < OutputBuilder
         r_buffer << " [#{status_code}]".to_s.colorize(status_color).toggle(@is_color).to_s
       end
 
-      if endpoint.protocol == "ws"
-        r_ws = "[websocket]".colorize(:light_red).toggle(@is_color)
-        r_buffer << " #{r_ws}"
+      # The protocol was visible for websockets only, so an AsyncAPI Kafka
+      # topic, an MQTT channel, an AMQP queue, a gRPC/Connect method and an
+      # nginx `listen 443 ssl` route all printed as if they were plain HTTP —
+      # a distinction `-f json` and `-f markdown-table` both carry.
+      if badge = protocol_badge(endpoint)
+        r_protocol = "[#{escape_control_chars(badge)}]".colorize(:light_red).toggle(@is_color)
+        r_buffer << " #{r_protocol}"
+      end
+
+      # `internal` marks an endpoint the application *calls* — a Spring Feign
+      # or `@HttpExchange` declarative client — rather than one it serves.
+      # Only the structured formats said so, so a client stub read here as
+      # attack surface.
+      if endpoint.internal
+        r_internal = "[internal]".colorize(:dark_gray).toggle(@is_color)
+        r_buffer << " #{r_internal}"
       end
 
       PARAM_TREE_FIELDS.each do |param_type, label, separator|
@@ -283,6 +302,15 @@ class OutputBuilderCommon < OutputBuilder
 
       ob_puts r_buffer.to_s
     end
+  end
+
+  # The badge to print after the endpoint line, or nil when the protocol adds
+  # nothing. `ws` keeps the spelled-out "websocket" it has always had.
+  private def protocol_badge(endpoint : Endpoint) : String?
+    protocol = endpoint.protocol
+    return if SILENT_PROTOCOLS.includes?(protocol)
+
+    protocol == "ws" ? "websocket" : protocol
   end
 
   # One `○ <label>: <value>` row under the endpoint line. `color` is nil for

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -97,22 +97,28 @@ class OutputBuilderCommon < OutputBuilder
                        else               :default
                        end
 
-      r_method = endpoint.method.colorize(r_method_color).toggle(@is_color)
+      # Every string below is repo-derived and passes through
+      # `escape_control_chars` before it is colorized, so an escape sequence
+      # embedded in a route or a param name is shown rather than executed by
+      # the reader's terminal. Colorize's own codes are added afterwards and
+      # so are never touched.
+      r_method = escape_control_chars(endpoint.method).colorize(r_method_color).toggle(@is_color)
+      safe_url = escape_control_chars(baked[:url])
 
       r_buffer = String::Builder.new
       if mobile_label = MOBILE_PROTOCOL_LABELS[endpoint.protocol]?
         # intent:// is a synthetic scheme used so the optimizer treats
         # component names as absolute URLs; hide it in the text output.
-        display_url = baked[:url].lchop("intent://")
+        display_url = safe_url.lchop("intent://")
         r_label = mobile_label.colorize(:light_blue).toggle(@is_color)
         r_url = display_url.colorize(:light_yellow).toggle(@is_color)
         r_buffer << "\n#{r_label} #{r_url}"
       elsif endpoint.kind.empty?
-        r_url = baked[:url].colorize(:light_yellow).toggle(@is_color)
+        r_url = safe_url.colorize(:light_yellow).toggle(@is_color)
         r_buffer << "\n#{r_method} #{r_url}"
       else
-        r_kind = "[#{endpoint.kind}]".colorize(:light_magenta).toggle(@is_color)
-        r_name = baked[:url].lstrip('/').colorize(:light_yellow).toggle(@is_color)
+        r_kind = "[#{escape_control_chars(endpoint.kind)}]".colorize(:light_magenta).toggle(@is_color)
+        r_name = safe_url.lstrip('/').colorize(:light_yellow).toggle(@is_color)
         r_buffer << "\n#{r_method} #{r_kind} #{r_name}"
       end
 
@@ -282,7 +288,8 @@ class OutputBuilderCommon < OutputBuilder
   # One `○ <label>: <value>` row under the endpoint line. `color` is nil for
   # the one row that is printed uncolorized.
   private def append_field(r_buffer : String::Builder, label : String, value : String, color : Symbol?)
-    r_buffer << "\n  ○ " << label << ": "
+    value = escape_control_chars(value)
+    r_buffer << "\n  ○ " << escape_control_chars(label) << ": "
     if color
       r_buffer << value.colorize(color).toggle(@is_color)
     else
@@ -296,10 +303,10 @@ class OutputBuilderCommon < OutputBuilder
   private def append_tree_field(r_buffer : String::Builder, label : String, entries : Array(String), color : Symbol)
     return if entries.empty?
 
-    r_buffer << "\n  ○ " << label << ": "
+    r_buffer << "\n  ○ " << escape_control_chars(label) << ": "
     entries.each_with_index do |entry, index|
       prefix = index == entries.size - 1 ? "└── " : "├── "
-      r_buffer << "\n    " << "#{prefix}#{entry}".colorize(color).toggle(@is_color)
+      r_buffer << "\n    " << "#{prefix}#{escape_control_chars(entry)}".colorize(color).toggle(@is_color)
     end
   end
 
@@ -318,7 +325,7 @@ class OutputBuilderCommon < OutputBuilder
 
     r_buffer << "\n    - #{label}:"
     entries.each do |entry|
-      r_entry = format_ai_context_entry(entry).colorize(:light_cyan).toggle(@is_color)
+      r_entry = escape_control_chars(format_ai_context_entry(entry)).colorize(:light_cyan).toggle(@is_color)
       r_buffer << "\n      * #{r_entry}"
     end
   end


### PR DESCRIPTION
Fixes #1795

The plain (default) report is the only format Noir renders by hand, and it had
drifted from what `-f json` carries. This is a sweep of that gap: every
`param_type` the model can hold, plus tags, callee locations, protocol and the
`internal` flag, compared against the JSON for the *same* scan across all 274
fixture directories.

Detection is unchanged: `-f json` is **byte-identical** for all 274 fixture
directories before and after (5546 endpoints on both sides).

---

## 1. Form params were dropped when the endpoint also had a JSON body

**Symptom** — an endpoint whose handler reads both a JSON body and form fields
lost every form field from the console report.

**Root cause** — `bake_endpoint` has a single `body` slot. Form params fill it
first, then `is_json` overwrites it with the JSON hash. The plain builder only
drew its form tree when `body_type == "form"`, so once JSON won the slot the
form params were rendered nowhere — and `HANDLED_PARAM_TYPES` includes `form`,
so the leftover-bucket catch-all did not pick them up either.

**Repro**

```console
$ noir -b spec/functional_test/fixtures/go/gf -f json | jq '.endpoints[]|select(.url=="/api/submit").params[]|"\(.name) (\(.param_type))"'
"username (form)"
"password (json)"
"User-Agent (header)"
```

Before:

```
POST /api/submit
  ○ headers:
    └── User-Agent
  ○ body: {"password":""}          <- username is gone
```

After:

```
POST /api/submit
  ○ headers:
    └── User-Agent
  ○ body: {"password":""}
  ○ form:
    └── username
```

9 endpoints in the fixture tree get their form fields back. `-f markdown-table`,
`-f yaml`, `-f toml`, `-f jsonl` and `-f only-param` listed both all along.

*Scope note:* `-f curl` / `-f httpie` / `-f powershell` still emit only the JSON
body for such an endpoint. That is correct for those formats — one HTTP request
carries one body encoding — and is left as is.

## 2. Path param values were never printed

**Symptom** — `○ path: userId` where `-f json` says `"value": "Integer"`.

**Root cause** — `bake_endpoint` recorded path params as `param.name` only,
while every sibling kind renders its value (query bakes into the URL, a header
renders `Name: value`, cookies and form fields `name=value`).

**Repro**

```console
$ noir -b spec/functional_test/fixtures/haskell/servant -f json | jq -c '..|objects|select(.param_type?=="path")' | head -1
{"name":"userId","value":"Integer","param_type":"path","tags":[]}
```

Before / after:

```
DELETE /v1/users/:userId            DELETE /v1/users/:userId
  ○ path: userId                      ○ path: userId=Integer
```

25 path params across the fixture tree now show what the analyzer resolved. A
value identical to the name is still printed bare: Giraffe's `%i`/`%s` route
format names a segment after its own type, and `path: int=int` is noise.

## 3. The `tags:` row repeated names it could not tell apart

**Symptom** — `○ tags: graphql graphql-return graphql-return graphql-return graphql`.

**Root cause** — `Endpoint#add_tag` dedupes by `(name, tagger)`, so an endpoint
that three analyzers tag `graphql-return` legitimately holds three `Tag` objects.
This row prints names only and printed all three. `-f only-tag` already dedupes
by name for exactly this reason; the plain builder did not.

**Repro**

```console
$ noir -b spec/functional_test/fixtures -T | grep '○ tags:' | \
    awk -F'tags: ' '{n=split($2,a," "); for(i=1;i<=n;i++) for(j=i+1;j<=n;j++) if(a[i]==a[j]) {print; next}}' | wc -l
      45      # before
       0      # after
```

## 4. A callee's line number named the wrong file

**Symptom** — `○ callees: HomeService.build (line 7)` printed directly under
`○ file: .../src/routes.cr (line 2)`. Line 7 is in `home_handler.cr`, not
`routes.cr`, and the file was dropped entirely.

**Root cause** — `format_location` / `format_noir_callee` exist so callees and
AI-context entries cannot drift apart (the comment on `format_location` says so),
and `-f oas3` / `-f postman` use them. The plain builder kept a private copy that
built `name (line N)` and threw `callee.path` away.

**Repro**

```console
$ noir -b spec/functional_test/fixtures/crystal/marten_callees --include callee,path
```

Before:

```
GET /
  ○ file: .../src/routes.cr (line 2)
  ○ callees:
    ├── HomeService.build (line 7)
```

After:

```
GET /
  ○ file: .../src/routes.cr (line 2)
  ○ callees:
    ├── HomeService.build (.../src/handlers/home_handler.cr:7)
```

## 5. Escape sequences from scanned source were executed, not shown

**Symptom** — a route or param name containing a terminal escape drove the
reader's terminal. Reading untrusted repositories is Noir's whole job.

**Root cause** — `strip_ansi` sanitizes only the `-o` file copy; the stdout copy
is written raw, because stripping after `Colorize` would eat Noir's own codes.
The existing comment documented this as a known limitation.

**Repro** — `app.js` containing a route whose query key is an OSC-8 hyperlink
(`ESC ] 8 ; ; http://evil.example BEL click ESC ] 8 ; ; BEL`):

Before (`noir -b . | cat -v`):

```
GET /tail?^[]8;;http://evil.example^Gclick^[]8;;^G=
```

— which the terminal renders as a clickable link to the attacker's host.
`ESC [ 2J`, `ESC c` and a newline inside a param name are the same hole with
different payloads.

After:

```
GET /tail?\x1b]8;;http://evil.example\x07click\x1b]8;;\x07=
```

Fixed by escaping the repo-derived strings *before* they are colorized, so
Colorize's own codes are untouched. Escaped rather than stripped, so the report
still says what is there — `-f json` reports the same byte as `\u001b`. Only
C0/C1 and DEL are touched; CJK and Latin-1 pass through unchanged:

```
GET /사용자/검색?검색어=
GET /naïve/£cost?café=
```

## 6. Protocol and `internal` were structured-format-only

**Symptom** — an AsyncAPI Kafka topic, an MQTT channel, an AMQP queue, a
gRPC/Connect method and an nginx `listen 443 ssl` route all printed as if they
were plain HTTP. Only `ws` had a badge, though `-f json`, `-f markdown-table`
and the HTML report all carry the protocol.

Before -> after:

```
PUBLISH /user/signedup         ->  PUBLISH /user/signedup [kafka]
SEND /order/created            ->  SEND /order/created [mqtt]
SEND /notifications/inbox      ->  SEND /notifications/inbox [amqp]
POST /user.v1.UserService/Get  ->  POST /user.v1.UserService/Get [grpc]
```

`http` stays silent (it is the default), and so do the mobile protocols and
`cli`, which the `SCHEME`/`INTENT`/... prefix and the `cli://` URL already spell
out. 33 endpoints in the fixture tree gain a badge.

Same shape of gap: `internal` marks an endpoint the app *calls* — a Spring Feign
or `@HttpExchange` declarative client — rather than one it serves. Only the
structured formats said so, so a client stub read here as attack surface. It now
gets an `[internal]` badge.

## 7. `--pvalue` never reached request-body params spelled `body`

Found while sweeping param kinds; this one affects every format, not just the
console.

**Symptom** — `--pvalue json=X` (and `--pvalue any=X`) left `body`-typed params
empty everywhere, including the probe payload.

**Root cause** — `EndpointOptimizer` looked the rule up by raw `param_type`,
while the rule table is keyed by the canonical bucket. The fourteen analyzers
that spell a request body `body` rather than `json` (Next.js server actions,
NestJS, Rocket, tRPC, Servant, Play, Nuxt, Nitro, ...) matched nothing.

**Repro**

```console
$ noir -b spec/functional_test/fixtures/javascript/nextjs --pvalue json=XX -f curl | grep auth/login
```

Before:

```
curl -i -X 'POST' '/api/auth/login' --data-raw '{"username":"","password":""}' -H 'Content-Type: application/json'
```

After:

```
curl -i -X 'POST' '/api/auth/login' --data-raw '{"username":"XX","password":"XX"}' -H 'Content-Type: application/json'
```

---

## About #1795

The reported symptom — direct server-action arguments such as
`banUser(userId: string, reason: string)` visible in `-f json` but not in the
console — no longer reproduces on `main`: the `BODY_TYPE_ALIASES` work routed
`body` params into the plain report's body row.

```console
$ cat app/actions/admin.ts
"use server"
export async function banUser(userId: string, reason: string) { return { userId, reason } }
export async function updateProfile(formData: FormData) { return { nickname: formData.get("nickname") } }

$ noir -b .
POST [server-action] banUser
  ○ body: {"userId":"","reason":""}

POST [server-action] updateProfile
  ○ body:
    └── nickname
```

What the issue points at *is* still real, though, and this PR closes it as a
class rather than as one route: the console formatter had five more places where
it silently held less than `-f json` (sections 1-5 above), and section 7 is the
same `body`-vs-`json` alias hole one layer down, where `--pvalue` still could not
fill a server action's arguments.

---

## Verification

| check | result |
| --- | --- |
| `-f json` A/B over all 274 fixture dirs | 0 files differ, 5546 endpoints on both sides |
| param names in `-f json` missing from console | 6 -> 0 |
| param values in `-f json` missing from console | 14 -> 0 (the 8 that remain are JSON-escaped quotes, a harness artifact) |
| tags / callees / code paths / technology | already clean, still clean |
| `just test` | 5620 unit + 24497 functional, 0 failures |
| `just check` | 2282 inspected, 0 failures |
| `just build-release` | ok; every repro above re-run on the release binary |

Also verified that `-f yaml`, `-f toml`, `-f jsonl`, `-f markdown-table` and
`-f only-param` carry everything `-f json` does for the mixed-body case.
