### PR TITLE
fix: two scan-wide endpoint edits that delete another file's work

### DIFF
--- a/spec/functional_test/fixtures/csharp/httplistener_multi_service/svcA/Program.cs
+++ b/spec/functional_test/fixtures/csharp/httplistener_multi_service/svcA/Program.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+public static class ProgramA
+{
+    public static async Task Main()
+    {
+        var listener = new HttpListener();
+        listener.Prefixes.Add("http://localhost:8080/");
+        listener.Start();
+        while (true)
+        {
+            var context = await listener.GetContextAsync();
+            await Handle(context);
+        }
+    }
+
+    private static async Task Handle(HttpListenerContext context)
+    {
+        var request = context.Request;
+        var method = request.HttpMethod;
+        var path = request.Url?.AbsolutePath ?? "/";
+
+        if (method == "GET" && path == "/health")
+        {
+            var alpha = request.Headers["X-Alpha"];
+            Console.WriteLine(alpha);
+        }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/httplistener_multi_service/svcB/Program.cs
+++ b/spec/functional_test/fixtures/csharp/httplistener_multi_service/svcB/Program.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+public static class ProgramB
+{
+    public static async Task Main()
+    {
+        var listener = new HttpListener();
+        listener.Prefixes.Add("http://localhost:9090/");
+        listener.Start();
+        while (true)
+        {
+            var context = await listener.GetContextAsync();
+            await Handle(context);
+        }
+    }
+
+    private static async Task Handle(HttpListenerContext context)
+    {
+        var request = context.Request;
+        var method = request.HttpMethod;
+        var path = request.Url?.AbsolutePath ?? "/";
+
+        if (method == "GET" && path == "/health")
+        {
+            var beta = request.Headers["X-Beta"];
+            Console.WriteLine(beta);
+        }
+    }
+}

--- a/spec/functional_test/testers/csharp/httplistener_multi_service_spec.cr
+++ b/spec/functional_test/testers/csharp/httplistener_multi_service_spec.cr
@@ -1,0 +1,28 @@
+require "../../func_spec.cr"
+
+# Two HttpListener services under one scan base that answer the same route.
+# `merge_endpoint` folds them into a single endpoint, and both services'
+# params and both source files have to survive that fold.
+expected_endpoints = [
+  Endpoint.new("/health", "GET", [
+    Param.new("X-Alpha", "", "header"),
+    Param.new("X-Beta", "", "header"),
+  ]),
+]
+
+tester = FunctionalTester.new("fixtures/csharp/httplistener_multi_service/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+
+tester.perform_tests
+
+describe "C# HttpListener analyzer across two services" do
+  it "keeps a code path for every file that serves the route" do
+    health = tester.app.endpoints.find { |e| e.url == "/health" && e.method == "GET" }
+    health.should_not be_nil
+    paths = health.as(Endpoint).details.code_paths.map(&.path)
+    paths.any?(&.includes?("svcA/Program.cs")).should be_true
+    paths.any?(&.includes?("svcB/Program.cs")).should be_true
+  end
+end

--- a/src/analyzer/analyzers/csharp/httplistener.cr
+++ b/src/analyzer/analyzers/csharp/httplistener.cr
@@ -399,11 +399,29 @@ module Analyzer::CSharp
       merge_endpoint(endpoint)
     end
 
+    # `@result` spans the whole scan, so the endpoint this folds into may
+    # well have been emitted by a different file: two services under one
+    # scan base that both answer `GET /health` land on the same entry.
+    # Folding their params and callees together is fine — the optimizer
+    # would union those anyway — but the second file's `code_path` used to
+    # be dropped on the floor, and because the fold happens here the
+    # optimizer never saw it either. The report then named one of the two
+    # files that serve the route and silently omitted the other. Carry the
+    # code paths across too.
+    #
+    # `Endpoint` and `Details` are structs, so `existing` is a copy; the
+    # merge lands because `params`, `callees` and `code_paths` are all
+    # Arrays, and an Array is a reference the copy shares with the entry in
+    # `@result`.
     private def merge_endpoint(endpoint : Endpoint)
       existing = @result.find { |candidate| candidate.url == endpoint.url && candidate.method == endpoint.method }
       if existing
         endpoint.params.each { |param| existing.push_param(param) }
         endpoint.callees.each { |callee| existing.push_callee(callee) }
+        endpoint.details.code_paths.each do |code_path|
+          next if existing.details.code_paths.any? { |seen| seen == code_path }
+          existing.details.add_path(code_path)
+        end
       else
         @result << endpoint
       end

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -194,16 +194,32 @@ module Analyzer::Javascript
     private def analyze_with_regex(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)) = [] of Hash(String, String))
       # Original regex-based analysis as a fallback
       file_content = read_file_content(path)
+      # Every pass below reasons about one file, and two of them *edit* what
+      # earlier passes emitted: `scan_for_nested_router_endpoints` replaces
+      # the un-prefixed route with the router-mounted one, and
+      # `handle_v1_router_pattern` drops the un-prefixed `/status` and
+      # `/settings` before re-adding them under the router prefix. Handed the
+      # scan-wide array, those edits reach across files: the lookups match on
+      # url and method alone, so the endpoint they replace or drop is just as
+      # likely to belong to another Express app under the same scan base, and
+      # it disappears from the report along with its params and its
+      # `code_path`. Twelve one-file apps each declaring `app.post('/users')`
+      # plus twelve declaring it behind `router.use('/api', usersRouter)` came
+      # out with ten of the twelve plain apps erased. Collect into a per-file
+      # array so a fix-up can only touch this file's own endpoints, and hand
+      # the whole batch to `result` at the end; duplicates across files are
+      # the optimizer's job to merge.
+      file_endpoints = [] of Endpoint
       last_endpoint = Endpoint.new("", "")
       current_router_base = ""
       router_detected = false
       nested_routers = {} of String => String
 
       # First, handle the specific v1Router pattern directly
-      handle_v1_router_pattern(file_content, result, path)
+      handle_v1_router_pattern(file_content, file_endpoints, path)
 
       # Handle app.route('/path').method1().method2() patterns
-      handle_app_route_chaining(file_content, result, path)
+      handle_app_route_chaining(file_content, file_endpoints, path)
 
       collect_express_static_paths(path, file_content, static_dirs)
 
@@ -277,7 +293,7 @@ module Analyzer::Javascript
 
               details = Details.new(PathInfo.new(path, index + 1))
               expanded_endpoint.details = details
-              result << expanded_endpoint
+              file_endpoints << expanded_endpoint
             end
           else
             # Apply nested router prefix if applicable
@@ -293,7 +309,7 @@ module Analyzer::Javascript
 
             details = Details.new(PathInfo.new(path, index + 1))
             endpoint.details = details
-            result << endpoint
+            file_endpoints << endpoint
             last_endpoint = endpoint
           end
         end
@@ -308,7 +324,9 @@ module Analyzer::Javascript
       end
 
       # After processing all lines, look for any nested router patterns we might have missed
-      scan_for_nested_router_endpoints(file_content, result, path)
+      scan_for_nested_router_endpoints(file_content, file_endpoints, path)
+
+      result.concat(file_endpoints)
     end
 
     # Enhanced method to detect nested router patterns that might be missed in the regular line-by-line analysis


### PR DESCRIPTION
Follow-up to #2678, which fixed the same shape in the Nitro analyzer. The
question was whether `src/analyzer/analyzers/javascript/express.cr:378` is
reachable, and whether it loses anything when it is.

## Verdict on the Express line

**Reachable, and lossy — but only through the miniparser's `rescue`.**

`scan_for_nested_router_endpoints` is called from exactly one place:
`analyze_with_regex`, which `analyze` only calls in its `rescue` when
`Noir::JSRouteExtractor.extract_routes` (or one of the two calls after it)
raises. Nothing else reaches it.

How hard that rescue is to reach:

- 712 fixture directories, scanned separately, with a trace printed on
  every entry into `analyze_with_regex` and every hit on line 378:
  **0 hits**.
- ~9,000 fuzzed JS/TS inputs (three seeds x 3,009 files: mutated copies of
  every `express*` fixture source, plus targeted pathological shapes —
  unbalanced braces, unterminated template literals and comments, NUL
  bytes, 400-deep nesting, a 500 KB single line — one round with callee
  extraction on): **0 parser failures**.

So this is a latent bug on a defensive path, not something a user sees
today. That is why nothing in the corpus moves.

## What it does when it does run

Reproduced with an env-gated `raise` in the try block (instrumentation
only, not in this diff), against 24 one-file Express apps under one scan
base — twelve declaring `app.post('/users', ...)` directly, twelve
declaring the same route behind `router.use('/api', usersRouter)`.

Before:

```
POST /api/users params=[]                    apps=[nested00..nested11]
POST /users     params=[p10,p11]             apps=[plain10,plain11]
```

Ten of the twelve plain apps are simply gone — params, callees and
`code_path` — with nothing in the report to say they were ever read. After:

```
POST /users     params=[p00..p11]            apps=[plain00..plain11]
```

Stable across five runs before and after; scheduling did not change which
app survived on this machine, but the append order the lookup walks is
produced by the worker fibers, so there is no ordering guarantee to lean
on either.

The lookup is worse than Nitro's was in one respect: it matches on
`route_path` (the un-prefixed path) while it stores `full_path` (the
prefixed one), so it can never dedup its own output — the only endpoint it
can ever find is somebody else's.

`handle_v1_router_pattern`'s two `result.reject!` calls have the same
problem, and their intent — drop the un-prefixed `/status` and `/settings`
this file just emitted — is a no-op against a per-file array, because that
pass runs before anything has been emitted. Scoping makes them harmless
instead of destructive.

## Fix

Give `analyze_with_regex` its own array and `concat` it into the scan-wide
one at the end. Every pass it drives reasons about a single file's
content, so a fix-up can now only touch that file's own endpoints.
Duplicates across files go to the optimizer, which is where they belong.

## Second finding: C# HttpListener

The sweep for the same antipattern turned up one more provable loss.
`Analyzer::Csharp::HttpListener#merge_endpoint` folds a route into an
entry another file produced and carries the params and callees across —
but not the code paths, and because it folds them itself the optimizer
never gets the chance to. Two services under one scan base that both
answer `GET /health`:

```
before: GET /health ['X-Alpha','X-Beta'] ['svcA']
after:  GET /health ['X-Alpha','X-Beta'] ['svcA','svcB']
```

Fixed and covered by `spec/functional_test/fixtures/csharp/httplistener_multi_service/`;
the new spec fails on the unfixed analyzer.

## Swept and clean

- `javascript/nuxtjs.cr:293` — same `result[existing_idx] = merged` shape,
  but the key is already scoped by app root and it merges params, callees
  and code paths. Correct.
- `csharp/fastendpoints.cr:119` — `defs.index { |d| d.file == file }` on a
  per-file map of request-type declarations, and it unions. Correct.
- `csharp/aspnet_core_mvc.cr:478`, `specification/insomnia.cr:405`,
  `java/struts2.cr:618`, `csharp/minimal_api_support.cr:626` — all
  `index` into local arrays, not the endpoint result.

## Reported, not fixed

Two things found nearby that are out of this PR's scope:

1. `line_to_endpoint` reads `path = $1` **after** running a second
   `line.match(...)`, so `$1` is the method name, not the path. Every
   endpoint the regex fallback produces is named after its verb —
   `app.post('/users', ...)` comes out as `POST /post`. Dead alongside
   everything else in that branch.
2. `javascript/nestjs.cr:89` applies `global_prefix_holder.first?` — the
   first `setGlobalPrefix` found *anywhere in the scan* — to every endpoint
   in the result. Two NestJS apps under one base with different prefixes
   would have one app's prefix stamped on both. URL corruption rather than
   data loss, so a different axis.

Worth a separate decision: the whole `analyze_with_regex` fallback is
~500 lines that nothing reaches, that emit verb-named URLs when they do
run, and that carry hardcoded `/status` and `/settings` endpoints matched
against a fixture-shaped regex. Deleting it is probably better than
maintaining it, but that is a bigger call than this PR.

## Verification

- `just test` — 5648 unit + 24532 functional examples, 0 failures.
- `just check` — 2286 inspected, 0 failures.
- `just build-release`.
- Full corpus A/B, 712 fixture directories scanned separately, digest over
  `(method, url, params, code_paths)`: **identical**, 5553 rows. Re-run
  with the release binary over 713 directories: the only delta is the new
  regression fixture's own row.

https://claude.ai/code/session_01HdzEFevZ91ibHArJ1eKEf7
