### PR TITLE
fix(javascript/nestjs): give each app its own setGlobalPrefix

### DIFF
--- a/spec/functional_test/fixtures/javascript/nestjs_multi_app/appA/package.json
+++ b/spec/functional_test/fixtures/javascript/nestjs_multi_app/appA/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "appA",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/nestjs_multi_app/appA/src/alpha.controller.ts
+++ b/spec/functional_test/fixtures/javascript/nestjs_multi_app/appA/src/alpha.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('alpha')
+export class AlphaController {
+  @Get('ping')
+  ping() {
+    return 'ok';
+  }
+}

--- a/spec/functional_test/fixtures/javascript/nestjs_multi_app/appA/src/main.ts
+++ b/spec/functional_test/fixtures/javascript/nestjs_multi_app/appA/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('apiv1');
+  await app.listen(3000);
+}
+bootstrap();

--- a/spec/functional_test/fixtures/javascript/nestjs_multi_app/appB/package.json
+++ b/spec/functional_test/fixtures/javascript/nestjs_multi_app/appB/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "appB",
+  "dependencies": {
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/nestjs_multi_app/appB/src/beta.controller.ts
+++ b/spec/functional_test/fixtures/javascript/nestjs_multi_app/appB/src/beta.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('beta')
+export class BetaController {
+  @Get('ping')
+  ping() {
+    return 'ok';
+  }
+}

--- a/spec/functional_test/fixtures/javascript/nestjs_multi_app/appB/src/main.ts
+++ b/spec/functional_test/fixtures/javascript/nestjs_multi_app/appB/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('internal');
+  await app.listen(3000);
+}
+bootstrap();

--- a/spec/functional_test/testers/javascript/nestjs_multi_app_spec.cr
+++ b/spec/functional_test/testers/javascript/nestjs_multi_app_spec.cr
@@ -1,0 +1,29 @@
+require "../../func_spec.cr"
+
+# Two NestJS applications under one scan base, each with its own
+# `setGlobalPrefix`. The prefix belongs to the app whose bootstrap declared
+# it; stamping one app's prefix onto the other reports a URL that does not
+# exist and loses the one that does.
+expected_endpoints = [
+  Endpoint.new("/apiv1/alpha/ping", "GET"),
+  Endpoint.new("/internal/beta/ping", "GET"),
+]
+
+tester = FunctionalTester.new("fixtures/javascript/nestjs_multi_app/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+
+tester.perform_tests
+
+describe "NestJS analyzer across two applications" do
+  it "gives each application its own global prefix" do
+    urls = tester.app.endpoints.map(&.url).sort!
+    urls.should eq ["/apiv1/alpha/ping", "/internal/beta/ping"]
+  end
+
+  it "does not stamp one application's prefix onto the other" do
+    tester.app.endpoints.count(&.url.starts_with?("/apiv1/")).should eq 1
+    tester.app.endpoints.count(&.url.starts_with?("/internal/")).should eq 1
+  end
+end

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -66,7 +66,11 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
       include_callee = callees_needed?
-      global_prefix_holder = [] of GlobalPrefixConfig
+      # `(bootstrap file, config)` for every `setGlobalPrefix` in the scan,
+      # not just the first one seen. Two NestJS apps under one scan base each
+      # set their own prefix, and only the file they live beside tells them
+      # apart.
+      global_prefix_holder = [] of Tuple(String, GlobalPrefixConfig)
       global_prefix_mutex = Mutex.new
 
       # Resolve enum/object constants used cross-file as `@Controller(...)`
@@ -84,9 +88,9 @@ module Analyzer::Javascript
       # Process static directories to create endpoints for static files
       process_static_dirs(static_dirs, result)
 
-      # Apply discovered global prefix (`app.setGlobalPrefix('api')`)
+      # Apply discovered global prefixes (`app.setGlobalPrefix('api')`)
       # — the bootstrap call mounts every controller under that prefix.
-      apply_global_prefix(result, global_prefix_holder.first?)
+      apply_global_prefixes(result, global_prefix_holder)
 
       result
     end
@@ -100,6 +104,70 @@ module Analyzer::Javascript
         relative.includes?("/test/fixtures/") || relative.includes?("/tests/fixtures/")
     end
 
+    # Markers that identify a NestJS application root, so a prefix set in
+    # one app's bootstrap is not stamped onto another app's controllers.
+    NEST_PACKAGE_MARKERS  = ["@nestjs/core", "@nestjs/common"]
+    NEST_CONFIG_BASENAMES = ["nest-cli.json"]
+
+    # Route each discovered `setGlobalPrefix` to the endpoints it actually
+    # governs.
+    #
+    # This used to be `apply_global_prefix(result, holder.first?)` over a
+    # holder that kept only the first prefix found anywhere in the scan. Two
+    # NestJS apps under one scan base — an ordinary monorepo — therefore had
+    # one app's prefix stamped on both: `appB` with `setGlobalPrefix('internal')`
+    # was reported at `/apiv1/appB/ping` because `appA` happened to be read
+    # first. The URL reported did not exist and the real one was missing, so
+    # anything consuming the output (a DAST target list, an OAS export,
+    # `--probe`) was aimed at a 404. Worse, "first" was decided by which
+    # `parallel_file_scan` fiber finished first, so the same input could
+    # report different URLs between runs.
+    private def apply_global_prefixes(result : Array(Endpoint),
+                                      entries : Array(Tuple(String, GlobalPrefixConfig)))
+      return if entries.empty?
+
+      # Sort before anything picks a winner: the collection order is fiber
+      # completion order, which is not stable across runs.
+      sorted = entries.sort_by { |(path, _)| path }
+      roots = discover_js_project_roots(NEST_PACKAGE_MARKERS, NEST_CONFIG_BASENAMES)
+
+      by_root = {} of String => GlobalPrefixConfig
+      sorted.each do |(path, config)|
+        root = nest_app_root_for(path, roots)
+        by_root[root] = config unless by_root.has_key?(root)
+      end
+
+      # One app (the overwhelmingly common case, and every project without a
+      # discoverable root) keeps the original whole-scan behaviour, including
+      # for endpoints that carry no source file such as static-directory ones.
+      if by_root.size <= 1
+        apply_global_prefix(result, sorted.first[1])
+        return
+      end
+
+      result.each_with_index do |endpoint, idx|
+        file = endpoint.details.code_paths.first?.try(&.path)
+        next if file.nil?
+        config = by_root[nest_app_root_for(file, roots)]?
+        next if config.nil?
+        prefixed = prefix_endpoint(endpoint, config)
+        result[idx] = prefixed if prefixed
+      end
+    end
+
+    # The deepest discovered project root containing `path`, or `""` when the
+    # scan found no root for it. Deepest, not first: a nested app inside a
+    # workspace root must win over the workspace.
+    private def nest_app_root_for(path : String, roots : Array(String)) : String
+      expanded = File.expand_path(path)
+      best = ""
+      roots.each do |root|
+        next unless Noir::PathScope.under_normalized_root?(expanded, root)
+        best = root if root.size > best.size
+      end
+      best
+    end
+
     # Prepend the discovered `app.setGlobalPrefix('api')` value to
     # every endpoint URL. Endpoints whose URL already starts with the
     # normalized prefix (e.g. controllers that hard-coded `/api/...`)
@@ -107,22 +175,36 @@ module Analyzer::Javascript
     private def apply_global_prefix(result : Array(Endpoint), config : GlobalPrefixConfig?)
       return unless config
 
+      # `Endpoint` is a struct (value type), so the block-local
+      # binding is a copy — write back through the index to make the
+      # URL change visible to callers.
+      result.each_with_index do |endpoint, idx|
+        prefixed = prefix_endpoint(endpoint, config)
+        result[idx] = prefixed if prefixed
+      end
+    end
+
+    # The prefixed endpoint, or `nil` when this config leaves it alone.
+    # Shared by the single-app and per-app paths so the two cannot drift.
+    private def prefix_endpoint(endpoint : Endpoint, config : GlobalPrefixConfig) : Endpoint?
+      normalized = normalized_global_prefix(config)
+      return if normalized.nil?
+      return if global_prefix_excluded?(endpoint, config.excludes)
+      # Controllers that hard-coded `/api/...` are already where the prefix
+      # would put them; prefixing again would double it.
+      return if endpoint.url.starts_with?(normalized + "/") || endpoint.url == normalized
+
+      endpoint.url = endpoint.url.starts_with?("/") ? "#{normalized}#{endpoint.url}" : "#{normalized}/#{endpoint.url}"
+      endpoint
+    end
+
+    private def normalized_global_prefix(config : GlobalPrefixConfig) : String?
       prefix = config.prefix
       return if prefix.empty?
 
       normalized = prefix.starts_with?("/") ? prefix : "/#{prefix}"
       normalized = normalized.chomp("/")
-      return if normalized.empty?
-
-      # `Endpoint` is a struct (value type), so the block-local
-      # binding is a copy — write back through the index to make the
-      # URL change visible to callers.
-      result.each_with_index do |endpoint, idx|
-        next if global_prefix_excluded?(endpoint, config.excludes)
-        next if endpoint.url.starts_with?(normalized + "/") || endpoint.url == normalized
-        endpoint.url = endpoint.url.starts_with?("/") ? "#{normalized}#{endpoint.url}" : "#{normalized}/#{endpoint.url}"
-        result[idx] = endpoint
-      end
+      normalized.empty? ? nil : normalized
     end
 
     private def global_prefix_excluded?(endpoint : Endpoint, excludes : Array(GlobalPrefixExclude)) : Bool
@@ -156,7 +238,7 @@ module Analyzer::Javascript
       process_js_static_dirs(static_dirs, result)
     end
 
-    private def analyze_nestjs_file(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)), include_callee : Bool, global_prefix_holder : Array(GlobalPrefixConfig), global_prefix_mutex : Mutex)
+    private def analyze_nestjs_file(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)), include_callee : Bool, global_prefix_holder : Array(Tuple(String, GlobalPrefixConfig)), global_prefix_mutex : Mutex)
       content = read_file_content(path)
 
       collect_static_paths(path, content, static_dirs, :nestjs)
@@ -171,7 +253,7 @@ module Analyzer::Javascript
       # all files have been parsed.
       if prefix = extract_global_prefix_config(sanitized)
         global_prefix_mutex.synchronize do
-          global_prefix_holder << prefix if global_prefix_holder.empty?
+          global_prefix_holder << {path, prefix}
         end
       end
 


### PR DESCRIPTION
Found while reviewing #2684 — reported there as "not fixed", reproduced here and fixed.

## Symptom

Two NestJS applications under one scan base, each with its own `app.setGlobalPrefix`. Scanned separately both are right; scanned together the second one is reported under the first one's prefix.

```console
$ cat appA/src/main.ts | grep setGlobalPrefix
  app.setGlobalPrefix('apiv1');
$ cat appB/src/main.ts | grep setGlobalPrefix
  app.setGlobalPrefix('internal');

$ noir -b appA -f json --no-log | jq -c '[.endpoints[].url]'
["/apiv1/alpha/ping"]
$ noir -b appB -f json --no-log | jq -c '[.endpoints[].url]'
["/internal/beta/ping"]

$ noir -b . -f json --no-log | jq -c '[.endpoints[].url]|sort'
["/apiv1/alpha/ping","/apiv1/beta/ping"]
                      ^^^^^ appB, stamped with appA's prefix
```

`/apiv1/beta/ping` does not exist and `/internal/beta/ping` is gone. Anything built from that report — a DAST target list, an OAS export, `--probe` — is aimed at a URL that 404s while the real route goes unscanned.

Worse, "first" was decided by which `parallel_file_scan` fiber finished first, so the same input could report different URLs between runs.

## Root cause

`src/analyzer/analyzers/javascript/nestjs.cr`:

```crystal
global_prefix_holder << prefix if global_prefix_holder.empty?   # keep only the first
...
apply_global_prefix(result, global_prefix_holder.first?)        # apply it to everything
```

The holder kept one prefix for the whole scan and `apply_global_prefix` walked every endpoint in `result`, with nothing tying a prefix to the application that declared it.

## Fix

Collect every `setGlobalPrefix` together with the file that declared it, group them by NestJS application root (`@nestjs/core` / `@nestjs/common` in a `package.json`, or a `nest-cli.json`, via the shared `discover_js_project_roots`), and prefix each endpoint using the root its source file sits under — deepest root wins, so a nested app beats the workspace it lives in. Entries are sorted by path before any winner is chosen, so two bootstrap files in one app resolve identically on every run.

**Deliberately conservative:** when the scan yields at most one prefixed app root — every single-app repository, and any project with no discoverable root — the original whole-scan path runs unchanged, including for endpoints that carry no source file (the static-directory ones). Only a scan holding two or more prefixed roots takes the new path.

The prefixing itself moved into one `prefix_endpoint` helper shared by both paths so they cannot drift.

## After

```console
$ noir -b . -f json --no-log | jq -c '[.endpoints[].url]|sort'
["/apiv1/alpha/ping","/internal/beta/ping"]
```

Stable across 5 identical runs.

## Verification

- New fixture `javascript/nestjs_multi_app` + tester. Against the pre-change binary it produces `["/apiv1/alpha/ping","/apiv1/beta/ping"]`, so the guard genuinely fails without the fix.
- Existing NestJS fixtures (10 of them, single-app) are unchanged.
- Full fixture corpus A/B, scanned **per fixture directory** (nondeterministic as one project): **byte-identical, 5554 endpoints** before and after.
- `just test`: 5676 unit + 24540 functional examples, 0 failures.
- `just check`: 2287 inspected, 0 failures.