### PR TITLE
feat(analyzer): report the line each route is declared on

### DIFF
--- a/spec/unit_test/utils/spec_line_index_spec.cr
+++ b/spec/unit_test/utils/spec_line_index_spec.cr
@@ -1,0 +1,101 @@
+require "../../spec_helper"
+require "../../../src/utils/spec_line_index"
+
+YAML_DOC = <<-YAML
+  # a comment
+  openapi: 3.0.0
+  info:
+    title: t
+  paths:
+    /pets:
+      get:
+        summary: list
+      post:
+        summary: create
+    /pets/{id}:
+      delete:
+        summary: remove
+  components:
+    schemas:
+      Pet:
+        type: object
+  YAML
+
+JSON_DOC = <<-JSON
+  {
+    "openapi": "3.0.0",
+    "paths": {
+      "/pets": {
+        "get": { "summary": "list" },
+        "post": { "summary": "create" }
+      },
+      "/pets/{id}": {
+        "delete": { "summary": "remove" }
+      }
+    }
+  }
+  JSON
+
+describe Noir::SpecLineIndex do
+  describe ".yaml" do
+    it "reports the line each operation key is declared on" do
+      index = Noir::SpecLineIndex.yaml(YAML_DOC, "paths")
+      index.line("paths").should eq 5
+      index.line("paths", "/pets").should eq 6
+      index.line("paths", "/pets", "get").should eq 7
+      index.line("paths", "/pets", "post").should eq 9
+      index.line("paths", "/pets/{id}").should eq 11
+      index.line("paths", "/pets/{id}", "delete").should eq 12
+    end
+
+    it "indexes only the requested root" do
+      index = Noir::SpecLineIndex.yaml(YAML_DOC, "paths")
+      index.line("components").should be_nil
+      index.line("components", "schemas").should be_nil
+    end
+
+    it "stops at max_depth" do
+      index = Noir::SpecLineIndex.yaml(YAML_DOC, "paths", max_depth: 1)
+      index.line("paths", "/pets").should eq 6
+      index.line("paths", "/pets", "get").should be_nil
+    end
+
+    # A stray tab on an otherwise-blank line makes libyaml reject the
+    # document; `parse_yaml` recovers it by blanking such lines, and the
+    # index has to follow or every operation after the tab loses its line.
+    it "recovers the same lines from a document with a stray tab" do
+      tabbed = "paths:\n  /w:\n    get:\n      description: |-\n\t\n        text\n    post:\n      summary: c\n"
+      index = Noir::SpecLineIndex.yaml(tabbed, "paths")
+      index.line("paths", "/w", "get").should eq 3
+      index.line("paths", "/w", "post").should eq 7
+    end
+
+    it "returns an empty index for text that is not a mapping" do
+      Noir::SpecLineIndex.yaml("- 1\n- 2\n", "paths").empty?.should be_true
+    end
+  end
+
+  describe ".json" do
+    it "reports the line each operation key is declared on" do
+      index = Noir::SpecLineIndex.json(JSON_DOC, "paths")
+      index.line("paths").should eq 3
+      index.line("paths", "/pets").should eq 4
+      index.line("paths", "/pets", "get").should eq 5
+      index.line("paths", "/pets", "post").should eq 6
+      index.line("paths", "/pets/{id}", "delete").should eq 9
+    end
+
+    # The key, not whatever token the parser has reached by the time the
+    # value is in hand.
+    it "reports the key line when the value opens on a later line" do
+      doc = "{\n  \"paths\":\n  {\n    \"/a\"\n    :\n    {\n      \"get\"\n      :\n      {}\n    }\n  }\n}"
+      index = Noir::SpecLineIndex.json(doc, "paths")
+      index.line("paths", "/a").should eq 4
+      index.line("paths", "/a", "get").should eq 7
+    end
+
+    it "returns an empty index for malformed JSON" do
+      Noir::SpecLineIndex.json("{oops", "paths").empty?.should be_true
+    end
+  end
+end

--- a/spec/unit_test/utils/spec_line_index_spec.cr
+++ b/spec/unit_test/utils/spec_line_index_spec.cr
@@ -73,6 +73,16 @@ describe Noir::SpecLineIndex do
     it "returns an empty index for text that is not a mapping" do
       Noir::SpecLineIndex.yaml("- 1\n- 2\n", "paths").empty?.should be_true
     end
+
+    # A Symfony routing file is keyed directly by route name, with no
+    # wrapping root.
+    it "indexes the document mapping itself when no root is given" do
+      index = Noir::SpecLineIndex.yaml(YAML_DOC, max_depth: 1)
+      index.line("openapi").should eq 2
+      index.line("paths").should eq 5
+      index.line("components").should eq 14
+      index.line("paths", "/pets").should be_nil
+    end
   end
 
   describe ".json" do
@@ -96,6 +106,13 @@ describe Noir::SpecLineIndex do
 
     it "returns an empty index for malformed JSON" do
       Noir::SpecLineIndex.json("{oops", "paths").empty?.should be_true
+    end
+
+    it "indexes the document mapping itself when no root is given" do
+      index = Noir::SpecLineIndex.json(JSON_DOC, max_depth: 1)
+      index.line("openapi").should eq 2
+      index.line("paths").should eq 3
+      index.line("paths", "/pets").should be_nil
     end
   end
 end

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -345,7 +345,10 @@ module Analyzer::Java
           # Reactive routes declared via `router().route(...).andRoute(...)`
           # — regex-scoped because the builder-pattern shape isn't
           # worth a dedicated tree-sitter walk yet.
-          route_blocks = [] of Tuple(Array(Tuple(Int32, String, String, String)), Array(Tuple(Int32, Int32, String)))
+          # {verb calls, nest prefixes, offset of the block in `content`}.
+          # The first two hold positions relative to the block, so the block's
+          # own offset is what turns a call position into a file line.
+          route_blocks = [] of Tuple(Array(Tuple(Int32, String, String, String, Int32)), Array(Tuple(Int32, Int32, String)), Int32)
           reactive_callees = {} of String => Array(Callee)
 
           # Single tree-sitter parse for the whole reactive file: the
@@ -365,21 +368,23 @@ module Analyzer::Java
               # `route().nest(path("/product"), builder ->
               # builder.GET("/name/{name}", ...))` surfaced as
               # `GET /name/{name}` instead of `GET /product/name/{name}`.
-              route_blocks << {collect_router_route_calls(method_code, constants), collect_nest_prefixes(method_code, constants)}
+              route_blocks << {collect_router_route_calls(method_code, constants),
+                               collect_nest_prefixes(method_code, constants),
+                               route_code.begin(0) || 0}
             end
 
             # Resolve same-file `this::handler` method bodies to 1-hop
             # callees so reactive endpoints carry handler context too.
             if include_callee
               wanted = Set(String).new
-              route_blocks.each { |calls, _| calls.each { |call| wanted << call[3] unless call[3].empty? } }
+              route_blocks.each { |calls, _, _| calls.each { |call| wanted << call[3] unless call[3].empty? } }
               reactive_callees = build_reactive_method_callees(root, content, path, wanted)
             end
           end
 
-          route_blocks.each do |calls, nest_prefixes|
+          route_blocks.each do |calls, nest_prefixes, block_offset|
             calls.each do |call|
-              pos, method, endpoint, handler_ref = call
+              pos, method, endpoint, handler_ref, verb_pos = call
               nest_prefix = ""
               nest_prefixes.each do |start_b, end_b, prefix|
                 if pos >= start_b && pos < end_b
@@ -387,7 +392,7 @@ module Analyzer::Java
                 end
               end
               composed = nest_prefix.empty? ? endpoint : Noir::URLPath.join_rooted(nest_prefix, endpoint)
-              details = Details.new(PathInfo.new(path))
+              details = Details.new(PathInfo.new(path, line_at_offset(content, block_offset + verb_pos)))
               reactive_endpoint = Endpoint.new(
                 resolve_endpoint_path(Noir::URLPath.join_rooted(configured_base_path, composed), spring_properties),
                 method, details
@@ -849,8 +854,8 @@ module Analyzer::Java
     # whose match position falls inside `[start, end)` should have
     # `prefix` prepended.
     private def collect_router_route_calls(code : String,
-                                           constants : Hash(String, String)) : Array(Tuple(Int32, String, String, String))
-      calls = [] of Tuple(Int32, String, String, String)
+                                           constants : Hash(String, String)) : Array(Tuple(Int32, String, String, String, Int32))
+      calls = [] of Tuple(Int32, String, String, String, Int32)
 
       code.scan(REGEX_ROUTE_CALL) do |match|
         open_idx = (match.end || 0) - 1
@@ -870,7 +875,11 @@ module Analyzer::Java
         # RouterFunction handlers carry the real behaviour worth surfacing
         # for ai-context).
         handler_ref = arg_list.size >= 2 ? handler_method_reference(arg_list[1]) : ""
-        calls << {match.begin || 0, match[2], path.gsub(/\n/, ""), handler_ref}
+        # Two positions: the match start decides which `nest(...)` range the
+        # call sits in, while the verb is where the route itself is written —
+        # `.route(\n  GET("/hello")` declares the route on the `GET` line, not
+        # on the `route(` line that opens the statement.
+        calls << {match.begin || 0, match[2], path.gsub(/\n/, ""), handler_ref, match.begin(2) || match.begin || 0}
       end
 
       calls

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -39,8 +39,13 @@ module Analyzer::Java
       getter router_name : String
       getter method : String
       getter endpoint : String
+      # 1-based line of the call that declares the route. Part of the
+      # struct's identity on purpose: the same path registered twice is
+      # two declarations, and the optimizer merges them into one endpoint
+      # carrying both lines.
+      getter line : Int32
 
-      def initialize(@router_name, @method, @endpoint)
+      def initialize(@router_name, @method, @endpoint, @line = 0)
       end
     end
 
@@ -48,8 +53,9 @@ module Analyzer::Java
       getter router_name : String
       getter route_arg : String
       getter chain : String
+      getter offset : Int32
 
-      def initialize(@router_name, @route_arg, @chain)
+      def initialize(@router_name, @route_arg, @chain, @offset = 0)
       end
     end
 
@@ -74,7 +80,6 @@ module Analyzer::Java
         next if JavaEngine.test_path?(base_relative_path(path))
         next unless File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))
 
-        details = Details.new(PathInfo.new(path))
         content = read_file_content(path)
 
         # Skip if no Vert.x related content
@@ -98,7 +103,7 @@ module Analyzer::Java
         route_candidates.each do |route|
           next if mounted_routers.includes?(route.router_name)
 
-          found = build_endpoint(route.endpoint, route.method, details)
+          found = build_endpoint(route.endpoint, route.method, Details.new(PathInfo.new(path, route.line)))
           attach_query_params(found, query_params_by_route, route.method, route.endpoint)
           attach_callees(found, callees_by_route, route.method, route.endpoint)
           @result << found
@@ -111,7 +116,9 @@ module Analyzer::Java
 
           child_routes.each do |child|
             endpoint = Noir::URLPath.join_trimmed(mount.endpoint, child.endpoint)
-            found = build_endpoint(endpoint, child.method, details)
+            # The mounted route is declared on the child router's own line;
+            # the `mountSubRouter` only says where it hangs.
+            found = build_endpoint(endpoint, child.method, Details.new(PathInfo.new(path, child.line)))
             attach_query_params(found, query_params_by_route, child.method, child.endpoint)
             attach_callees(found, callees_by_route, child.method, child.endpoint)
             @result << found
@@ -139,7 +146,7 @@ module Analyzer::Java
         next if !method.in?(HTTP_METHODS)
         next if endpoint.nil? || endpoint.empty?
 
-        candidates << RouteCandidate.new(router_name, method, endpoint)
+        candidates << RouteCandidate.new(router_name, method, endpoint, route_line(content, match))
       end
 
       # Find route().method() pattern calls
@@ -154,7 +161,7 @@ module Analyzer::Java
         next if !method.in?(HTTP_METHODS)
         next if endpoint.nil? || endpoint.empty?
 
-        candidates << RouteCandidate.new(router_name, method, endpoint)
+        candidates << RouteCandidate.new(router_name, method, endpoint, route_line(content, match))
       end
 
       # Find route(HttpMethod.METHOD, "/path") pattern calls
@@ -172,7 +179,7 @@ module Analyzer::Java
         next if method.nil? || !method.in?(HTTP_METHODS)
         next if endpoint.nil? || endpoint.empty?
 
-        candidates << RouteCandidate.new(router_name, method, endpoint)
+        candidates << RouteCandidate.new(router_name, method, endpoint, route_line(content, match))
       end
 
       # A Vert.x Route without `.method(...)` or `route(HttpMethod, ...)`
@@ -191,7 +198,7 @@ module Analyzer::Java
         endpoint = resolve_route_path_arg(args[0], constants)
         next if endpoint.nil? || endpoint.empty?
 
-        candidates << RouteCandidate.new(router_name, "ANY", endpoint)
+        candidates << RouteCandidate.new(router_name, "ANY", endpoint, route_line(content, match))
       end
 
       content.scan(REGEX_ROUTE_HANDLER_OPEN) do |match|
@@ -218,7 +225,7 @@ module Analyzer::Java
         body = lambda_body_of(handler_arg)
         next unless body && terminal_handler_body?(body)
 
-        candidates << RouteCandidate.new(router_name, "ANY", endpoint)
+        candidates << RouteCandidate.new(router_name, "ANY", endpoint, route_line(content, match))
       end
 
       # `router.route("/prefix/*").subRouter(child)` exposes the child
@@ -234,7 +241,7 @@ module Analyzer::Java
         endpoint = resolve_route_path_arg(args[0], constants)
         next if endpoint.nil? || endpoint.empty?
 
-        candidates << RouteCandidate.new(router_name, "ANY", endpoint)
+        candidates << RouteCandidate.new(router_name, "ANY", endpoint, route_line(content, match))
       end
 
       # Find fluent Route API chains like
@@ -260,9 +267,10 @@ module Analyzer::Java
         endpoints.uniq!
         next if endpoints.empty?
 
+        chain_line = line_at_byte_offset(content, chain_info.offset)
         methods.each do |method|
           endpoints.each do |endpoint|
-            candidates << RouteCandidate.new(router_name, method, endpoint)
+            candidates << RouteCandidate.new(router_name, method, endpoint, chain_line)
           end
         end
       end
@@ -278,7 +286,7 @@ module Analyzer::Java
         endpoint = resolve_route_path_arg(first_top_level_arg(match[2]), constants)
         next if endpoint.nil? || endpoint.empty?
 
-        candidates << RouteCandidate.new(router_name, "GET", endpoint)
+        candidates << RouteCandidate.new(router_name, "GET", endpoint, route_line(content, match))
       end
 
       # A Vert.x Web route path is always anchored at the router root, so
@@ -679,7 +687,8 @@ module Analyzer::Java
         route_arg = match[2].strip
         start = match.byte_end(0)
         statement_end = find_statement_end(content, start)
-        chains << FluentRouteChain.new(router_name, route_arg, content.byte_slice(start, statement_end - start))
+        chains << FluentRouteChain.new(router_name, route_arg, content.byte_slice(start, statement_end - start),
+          match.byte_begin(0))
       end
       chains
     end
@@ -782,6 +791,11 @@ module Analyzer::Java
       value.size >= 2 &&
         ((value.starts_with?('"') && value.ends_with?('"')) ||
           (value.starts_with?("'") && value.ends_with?("'")))
+    end
+
+    # 1-based line of a scanned route call.
+    private def route_line(content : String, match : Regex::MatchData) : Int32
+      line_at_byte_offset(content, match.byte_begin(0) || 0)
     end
 
     private def build_endpoint(path : String, method : String, details : Details) : Endpoint

--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -1,4 +1,5 @@
 require "../../engines/php_engine"
+require "../../../utils/spec_line_index"
 
 module Analyzer::Php
   class Symfony < PhpEngine
@@ -76,9 +77,10 @@ module Analyzer::Php
           # Extract additional parameters from method body
           params.concat(extract_method_params(method_body[0])) if method_body
 
-          details = Details.new(PathInfo.new(path))
+          route_line = line_at_offset(content, route_start)
 
           methods.each do |method|
+            details = Details.new(PathInfo.new(path, route_line))
             endpoint = Endpoint.new(full_path, method.upcase, params, details)
             attach_method_callees(endpoint, method_body, path) if include_callee
             endpoints << endpoint
@@ -112,9 +114,10 @@ module Analyzer::Php
           # Extract additional parameters from method body
           params.concat(extract_method_params(method_body[0])) if method_body
 
-          details = Details.new(PathInfo.new(path))
+          route_line = line_at_offset(content, route_start)
 
           methods.each do |method|
+            details = Details.new(PathInfo.new(path, route_line))
             endpoint = Endpoint.new(full_path, method.upcase, params, details)
             attach_method_callees(endpoint, method_body, path) if include_callee
             endpoints << endpoint
@@ -231,8 +234,11 @@ module Analyzer::Php
         #   methods: [GET, POST]
 
         yaml = YAML.parse(content)
+        # A route in a Symfony YAML routing file is declared by its name key,
+        # so that key's line is where a reviewer has to look.
+        line_index = Noir::SpecLineIndex.yaml(content, max_depth: 1)
         if routes = yaml.as_h?
-          routes.each_value do |route|
+          routes.each do |route_name, route|
             route_h = route.as_h?
             next unless route_h
 
@@ -243,9 +249,10 @@ module Analyzer::Php
             methods = ["GET"] if methods.empty?
 
             params = extract_brace_path_params(route_path)
-            details = Details.new(PathInfo.new(path))
+            route_line = route_name.as_s?.try { |name| line_index.line(name) }
 
             methods.each do |method|
+              details = Details.new(PathInfo.new(path, route_line))
               endpoints << Endpoint.new(route_path, method.upcase, params, details)
             end
           end

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -107,21 +107,42 @@ module Analyzer::Ruby
     # `use_doorkeeper` block closes, so those two are reassignable.
     class RouteFileState
       getter framework_root : String
-      getter details : Details
+      getter routes_path : String
       getter parsed_route_files : Set(String)
       getter stack : Array(Frame)
       getter concern_resources : Hash(String, Array(ConcernResource))
+      # 1-based line of the `config/routes.rb` directive currently being
+      # handled, so every endpoint the handlers emit can point at the line
+      # the route is declared on rather than at the bare file.
+      property current_line : Int32?
       # `use_doorkeeper do ... end` config accumulated while the block
       # is on top of the stack: `skip_controllers :foo` drops a group,
       # `controllers foo: 'bar'` remaps the implementing controller.
       property doorkeeper_skip : Set(String)
       property doorkeeper_controllers : Hash(String, String)
 
-      def initialize(@framework_root : String, @details : Details,
+      def initialize(@framework_root : String, @routes_path : String,
                      @parsed_route_files : Set(String), @stack : Array(Frame),
                      @concern_resources : Hash(String, Array(ConcernResource)))
+        @current_line = nil
         @doorkeeper_skip = Set(String).new
         @doorkeeper_controllers = Hash(String, String).new
+      end
+
+      # A fresh `Details` for the directive being handled. Deliberately not
+      # memoized: every endpoint needs its own so the routes.rb line differs
+      # per route, and a shared `Details` would also share the `code_paths`
+      # array by reference across every endpoint of the file.
+      def details : Details
+        Details.new(PathInfo.new(@routes_path, @current_line))
+      end
+    end
+
+    # One logical routing directive: the joined text of a (possibly
+    # multi-line) statement plus the 1-based line its first token sits on.
+    record RouteLine, text : String, line : Int32 do
+      def with_text(new_text : String) : RouteLine
+        RouteLine.new(new_text, @line)
       end
     end
 
@@ -265,13 +286,14 @@ module Analyzer::Ruby
       return if parsed_route_files.includes?(parse_key)
       parsed_route_files << parse_key
 
-      scan = RouteFileState.new(framework_root, Details.new(PathInfo.new(routes_path)),
+      scan = RouteFileState.new(framework_root, routes_path,
         parsed_route_files, inherited_stack.dup, concern_resources)
       local_string_vars = Hash(String, String).new
 
-      expand_inline_route_blocks(expand_static_loops(logical_route_lines(routes_path))).each do |raw_line|
-        line = raw_line.strip
+      expand_inline_route_blocks(expand_static_loops(logical_route_lines(routes_path))).each do |route_line|
+        line = route_line.text.strip
         next if line.empty?
+        scan.current_line = route_line.line
         line = resolve_local_string_vars(line, local_string_vars)
 
         # Handle `end` (top of stack pops one).
@@ -773,29 +795,32 @@ module Analyzer::Ruby
     MAX_LOOP_VALUES =    100
     MAX_LOOP_OUTPUT = 20_000
 
-    private def expand_static_loops(lines : Array(String), depth : Int32 = 0) : Array(String)
+    # Unrolled copies keep the line of the body statement they came from:
+    # a route written once inside `%w[a b].each do |x|` really is declared
+    # on that one line, whichever value the copy carries.
+    private def expand_static_loops(lines : Array(RouteLine), depth : Int32 = 0) : Array(RouteLine)
       return lines if depth > MAX_LOOP_DEPTH
-      return lines unless lines.any?(&.matches?(LOOP_OPENER))
+      return lines unless lines.any?(&.text.matches?(LOOP_OPENER))
 
-      result = [] of String
+      result = [] of RouteLine
       index = 0
       while index < lines.size
         line = lines[index]
-        if m = line.match(LOOP_OPENER)
+        if m = line.text.match(LOOP_OPENER)
           var = m[3]
           values = m[2].split(/\s+/).reject(&.empty?)
 
           # Walk to the `end` that closes this `.each do`, mirroring the main
           # parser's one-block-open-per-line / `end`-pops-one model.
           block_depth = 1
-          body = [] of String
+          body = [] of RouteLine
           cursor = index + 1
           while cursor < lines.size && block_depth > 0
             body_line = lines[cursor]
-            if end_line?(body_line)
+            if end_line?(body_line.text)
               block_depth -= 1
               break if block_depth == 0
-            elsif opens_do_block?(body_line) || opens_keyword_block?(body_line)
+            elsif opens_do_block?(body_line.text) || opens_keyword_block?(body_line.text)
               block_depth += 1
             end
             body << body_line
@@ -813,7 +838,7 @@ module Analyzer::Ruby
             pattern = Regex.new("\\#\\{\\s*#{Regex.escape(var)}\\s*\\}")
             values.each do |value|
               break if result.size > MAX_LOOP_OUTPUT
-              expanded_body.each { |unrolled| result << unrolled.gsub(pattern, value) }
+              expanded_body.each { |unrolled| result << unrolled.with_text(unrolled.text.gsub(pattern, value)) }
             end
           end
           index = cursor + 1 # skip the closing `end`
@@ -832,13 +857,15 @@ module Analyzer::Ruby
     # structure before route extraction.
     INLINE_ROUTE_BLOCK = /^(member|collection|new)\s*\{\s*(.+?)\s*\}\s*$/
 
-    private def expand_inline_route_blocks(lines : Array(String)) : Array(String)
-      result = [] of String
+    private def expand_inline_route_blocks(lines : Array(RouteLine)) : Array(RouteLine)
+      result = [] of RouteLine
       lines.each do |line|
-        if m = line.match(INLINE_ROUTE_BLOCK)
-          result << "#{m[1]} do"
-          result << m[2].strip
-          result << "end"
+        if m = line.text.match(INLINE_ROUTE_BLOCK)
+          # All three synthesized statements come from the one source line,
+          # so they all report it.
+          result << line.with_text("#{m[1]} do")
+          result << line.with_text(m[2].strip)
+          result << line.with_text("end")
         else
           result << line
         end
@@ -883,18 +910,27 @@ module Analyzer::Ruby
       prefix.lchop('/')
     end
 
-    private def logical_route_lines(routes_path : String) : Array(String)
-      lines = [] of String
+    # Joins continuation lines into one logical directive, keeping the
+    # 1-based line the directive *starts* on — `get "/x",\n  to: "y#z"` is
+    # declared on the `get` line, not on the `to:` line that closes it.
+    private def logical_route_lines(routes_path : String) : Array(RouteLine)
+      lines = [] of RouteLine
       buffer = ""
+      buffer_line = 0
       paren_depth = 0
       bracket_depth = 0
       brace_depth = 0
 
-      read_file_content(routes_path).each_line do |raw_line|
+      read_file_content(routes_path).each_line.with_index(1) do |raw_line, line_number|
         stripped = strip_inline_comment(raw_line).strip
         next if stripped.empty?
 
-        buffer = buffer.empty? ? stripped : "#{buffer} #{stripped}"
+        if buffer.empty?
+          buffer = stripped
+          buffer_line = line_number
+        else
+          buffer = "#{buffer} #{stripped}"
+        end
         delta = delimiter_delta(stripped)
         paren_depth += delta[0]
         bracket_depth += delta[1]
@@ -903,14 +939,14 @@ module Analyzer::Ruby
         next if paren_depth > 0 || bracket_depth > 0 || brace_depth > 0
         next if stripped.ends_with?(",")
 
-        lines << buffer
+        lines << RouteLine.new(buffer, buffer_line)
         buffer = ""
         paren_depth = 0
         bracket_depth = 0
         brace_depth = 0
       end
 
-      lines << buffer unless buffer.empty?
+      lines << RouteLine.new(buffer, buffer_line) unless buffer.empty?
       lines
     end
 

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -314,6 +314,7 @@ module Analyzer::Specification
       details = Details.new(PathInfo.new(swagger_json))
       content = read_file_content(swagger_json)
       json_obj = JSON.parse(content)
+      line_index = Noir::SpecLineIndex.json(content, "paths")
       base_path = ""
       begin
         unless json_obj["basePath"].to_s.empty?
@@ -365,10 +366,11 @@ module Analyzer::Specification
             end
             apply_security_json(effective_security, schemes, params)
 
+            op_details = operation_details(details, line_index, ["paths", path, method])
             if params.size > 0
-              @result << Endpoint.new(base_path + path, method.upcase, params, details)
+              @result << Endpoint.new(base_path + path, method.upcase, params, op_details)
             else
-              @result << Endpoint.new(base_path + path, method.upcase, details)
+              @result << Endpoint.new(base_path + path, method.upcase, op_details)
             end
           rescue e
             @logger.debug "Exception of #{swagger_json}/paths/path/method"
@@ -389,6 +391,7 @@ module Analyzer::Specification
       details = Details.new(PathInfo.new(swagger_yaml))
       content = read_file_content(swagger_yaml)
       yaml_obj = parse_yaml(content)
+      line_index = Noir::SpecLineIndex.yaml(content, "paths")
       base_path = ""
       begin
         unless yaml_obj["basePath"].to_s.empty?
@@ -441,10 +444,11 @@ module Analyzer::Specification
             end
             apply_security_yaml(effective_security, schemes, params)
 
+            op_details = operation_details(details, line_index, ["paths", path.to_s, method.to_s])
             if params.size > 0
-              @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
+              @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, op_details)
             else
-              @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
+              @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, op_details)
             end
           rescue e
             @logger.debug "Exception of #{swagger_yaml}/paths/path/method"

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -390,7 +390,8 @@ module Analyzer::Specification
           @logger.debug_sub e
         end
 
-        process_paths_json(SpecDoc.new(json_obj, oas3_json), base_path, details)
+        process_paths_json(SpecDoc.new(json_obj, oas3_json), base_path, details,
+          Noir::SpecLineIndex.json(content, "paths"))
       end
 
       each_spec_file_with_details(Noir::LocatorKeys::OAS3_YAML) do |oas3_yaml, details|
@@ -405,13 +406,15 @@ module Analyzer::Specification
           @logger.debug_sub e
         end
 
-        process_paths_yaml(SpecDoc.new(yaml_obj, oas3_yaml), base_path, details)
+        process_paths_yaml(SpecDoc.new(yaml_obj, oas3_yaml), base_path, details,
+          Noir::SpecLineIndex.yaml(content, "paths"))
       end
 
       @result
     end
 
-    private def process_paths_json(doc : SpecDoc(JSON::Any), base_path : String, details : Details)
+    private def process_paths_json(doc : SpecDoc(JSON::Any), base_path : String, details : Details,
+                                   line_index : Noir::SpecLineIndex)
       schemes = security_schemes_json(doc)
       global_security = doc.root["security"]?
       paths = doc.root["paths"].as_h
@@ -457,10 +460,11 @@ module Analyzer::Specification
 
           apply_security_json(effective_security, schemes, params)
 
+          op_details = operation_details(details, line_index, ["paths", path, method])
           if params.size > 0
-            @result << Endpoint.new(base_path + path, method.upcase, params, details)
+            @result << Endpoint.new(base_path + path, method.upcase, params, op_details)
           else
-            @result << Endpoint.new(base_path + path, method.upcase, details)
+            @result << Endpoint.new(base_path + path, method.upcase, op_details)
           end
         rescue e
           @logger.debug "Exception of #{doc.path}/paths/endpoint"
@@ -472,7 +476,8 @@ module Analyzer::Specification
       @logger.debug_sub e
     end
 
-    private def process_paths_yaml(doc : SpecDoc(YAML::Any), base_path : String, details : Details)
+    private def process_paths_yaml(doc : SpecDoc(YAML::Any), base_path : String, details : Details,
+                                   line_index : Noir::SpecLineIndex)
       schemes = security_schemes_yaml(doc)
       global_security = doc.root[YAML::Any.new("security")]?
       paths = doc.root["paths"].as_h
@@ -519,10 +524,11 @@ module Analyzer::Specification
 
           apply_security_yaml(effective_security, schemes, params)
 
+          op_details = operation_details(details, line_index, ["paths", path.to_s, method.to_s])
           if params.size > 0
-            @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
+            @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, op_details)
           else
-            @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
+            @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, op_details)
           end
         rescue e
           @logger.debug "Exception of #{doc.path}/paths/endpoint"

--- a/src/analyzer/engines/specification_engine.cr
+++ b/src/analyzer/engines/specification_engine.cr
@@ -6,6 +6,7 @@ require "json"
 require "yaml"
 require "../../models/locator_keys"
 require "../../utils/media_filter"
+require "../../utils/spec_line_index"
 require "../../utils/yaml"
 
 module Analyzer::Specification
@@ -128,6 +129,26 @@ module Analyzer::Specification
       each_spec_file(key) do |path|
         block.call(path, Details.new(PathInfo.new(path)))
       end
+    end
+
+    # `Details` for one operation of a specification document: the same
+    # document `details` names, plus the line the operation is declared on.
+    #
+    # Falls back to `details` untouched when the index has no line for the
+    # key path — an operation reached through a `$ref` is declared in the
+    # file the ref points at, not at `paths/<path>/<method>` of this one, and
+    # a wrong line a reviewer would trust is worse than no line at all.
+    #
+    # A fresh `Details` per operation also stops every endpoint of a document
+    # sharing one `code_paths` array by reference.
+    protected def operation_details(details : Details,
+                                    index : Noir::SpecLineIndex,
+                                    keys : Array(String)) : Details
+      path_info = details.code_paths.first?
+      return details unless path_info
+      line = index.line(keys)
+      return details unless line
+      Details.new(PathInfo.new(path_info.path, line))
     end
 
     # `scheme://` prefix of an absolute URL. `//host/path` is deliberately not

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -133,6 +133,17 @@ class Analyzer
     content[0...offset].count('\n') + 1
   end
 
+  # `line_at_offset` for a *byte* offset — what `Regex::MatchData#byte_begin`
+  # and the byte-wise scanners hand back. Counting newline bytes over a slice
+  # is both correct for multibyte content (a UTF-8 continuation byte never
+  # collides with an ASCII value) and free of the per-call string allocation
+  # the char form pays.
+  def line_at_byte_offset(content : String, byte_offset : Int32) : Int32
+    return 1 if byte_offset <= 0
+    byte_offset = content.bytesize if byte_offset > content.bytesize
+    content.to_slice[0, byte_offset].count(0x0a_u8) + 1
+  end
+
   # Whether the user's `--exclude-path` covers `path`.
   #
   # `CodeLocator` lookups need no such check: the exclusion is applied once,

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -120,6 +120,19 @@ class Analyzer
     Noir::TextFile.read(path)
   end
 
+  # 1-based line the character at `offset` sits on.
+  #
+  # The `content[0...offset].count('\n') + 1` this names is open-coded in a
+  # couple of dozen analyzers; naming it keeps the off-by-one in one place
+  # (a 0 offset is line 1, not line 0 — `PathInfo` drops a 0 as "no line").
+  # Callers that need a line for many offsets in the same file should build
+  # their own newline table instead: this is linear in `offset`.
+  def line_at_offset(content : String, offset : Int32) : Int32
+    return 1 if offset <= 0
+    offset = content.size if offset > content.size
+    content[0...offset].count('\n') + 1
+  end
+
   # Whether the user's `--exclude-path` covers `path`.
   #
   # `CodeLocator` lookups need no such check: the exclusion is applied once,

--- a/src/utils/spec_line_index.cr
+++ b/src/utils/spec_line_index.cr
@@ -1,0 +1,184 @@
+require "json"
+require "yaml"
+require "./yaml"
+
+module Noir
+  # Where each key of a structured specification document is declared.
+  #
+  # The specification analyzers read their documents through `JSON.parse` /
+  # `YAML.parse`, and `JSON::Any` / `YAML::Any` keep no source positions at
+  # all. That is why an OpenAPI scan could say an operation came from
+  # `openapi.yaml` but never which of its 8000 lines — the parser threw the
+  # position away before the analyzer saw the node.
+  #
+  # This walks the same text a second time with the position-aware pull
+  # parsers and records the 1-based line of every mapping key under `root`,
+  # down to `max_depth` levels. For OpenAPI that is `paths` -> path ->
+  # method, i.e. `root: "paths", max_depth: 2`, which is exactly the line an
+  # operation is declared on.
+  #
+  # Only the subtree under `root` is walked; everything else is skipped
+  # without being materialized, so indexing a large document costs a scan of
+  # its `paths` section rather than a second full parse tree.
+  #
+  # Mapping keys only. A sequence value is skipped whole, so a document that
+  # addresses operations by array position (Postman's nested `item`) is not
+  # served by this and gets no line rather than a guessed one.
+  class SpecLineIndex
+    # Key paths are flattened into one string so lookups don't allocate an
+    # array per query. NUL cannot appear in a JSON/YAML key that the parsers
+    # hand back as a scalar, so it is an unambiguous separator.
+    SEPARATOR = '\u0000'
+
+    # A document bigger than this is not indexed. Both walks are streaming,
+    # but the index itself is proportional to the number of keys under
+    # `root`, and noir scans untrusted repositories.
+    MAX_CONTENT_BYTES = 64 * 1024 * 1024
+
+    getter entries : Hash(String, Int32)
+
+    def initialize(@entries : Hash(String, Int32) = Hash(String, Int32).new)
+    end
+
+    def self.empty : SpecLineIndex
+      new
+    end
+
+    # Index a JSON document.
+    def self.json(content : String, root : String, max_depth : Int32 = 2) : SpecLineIndex
+      return empty if content.bytesize > MAX_CONTENT_BYTES
+      entries = Hash(String, Int32).new
+      begin
+        pull = JSON::PullParser.new(content)
+        if pull.kind.begin_object?
+          pull.read_begin_object
+          until pull.kind.end_object?
+            key_line = pull.line_number
+            key = pull.read_object_key
+            if key == root
+              entries[key] = key_line
+              walk_json(pull, key, entries, 1, max_depth)
+            else
+              pull.skip
+            end
+          end
+        end
+      rescue
+        # A malformed document simply has no index; the analyzer's own parse
+        # is what decides whether it yields endpoints.
+      end
+      new(entries)
+    end
+
+    # Index a YAML document (first document of the stream).
+    def self.yaml(content : String, root : String, max_depth : Int32 = 2) : SpecLineIndex
+      return empty if content.bytesize > MAX_CONTENT_BYTES
+
+      entries, complete = build_yaml(content, root, max_depth)
+      return new(entries) if complete
+
+      # `parse_yaml` recovers a document libyaml rejects for a stray tab on an
+      # otherwise-blank line by blanking those lines; the analyzer therefore
+      # has endpoints from text this walk choked on. Retry on the same
+      # recovered text — it is line-for-line identical — so the operations
+      # after the tab get their lines too.
+      recovered, recovered_complete = build_yaml(blank_whitespace_only_lines(content), root, max_depth)
+      return new(recovered) if recovered_complete || recovered.size > entries.size
+      new(entries)
+    end
+
+    # `{entries, no exception was raised}`. Entries recorded before a failure
+    # are still correct, just incomplete, so the caller decides whether to
+    # keep them or prefer a recovered pass.
+    private def self.build_yaml(content : String, root : String,
+                                max_depth : Int32) : Tuple(Hash(String, Int32), Bool)
+      entries = Hash(String, Int32).new
+      begin
+        parser = YAML::PullParser.new(content)
+        parser.read_stream_start
+        parser.read_document_start
+        if parser.kind.mapping_start?
+          parser.read_mapping_start
+          until parser.kind.mapping_end?
+            key_line = parser.start_line
+            break unless parser.kind.scalar?
+            key = parser.read_scalar
+            if key == root
+              entries[key] = key_line
+              walk_yaml(parser, key, entries, 1, max_depth)
+            else
+              parser.skip
+            end
+          end
+        end
+      rescue
+        # See `json`.
+        return {entries, false}
+      end
+      {entries, true}
+    end
+
+    private def self.walk_json(pull : JSON::PullParser, prefix : String,
+                               entries : Hash(String, Int32),
+                               depth : Int32, max_depth : Int32) : Nil
+      unless pull.kind.begin_object?
+        pull.skip
+        return
+      end
+
+      pull.read_begin_object
+      until pull.kind.end_object?
+        key_line = pull.line_number
+        key = pull.read_object_key
+        child = "#{prefix}#{SEPARATOR}#{key}"
+        entries[child] = key_line
+        if depth >= max_depth
+          pull.skip
+        else
+          walk_json(pull, child, entries, depth + 1, max_depth)
+        end
+      end
+      pull.read_end_object
+    end
+
+    private def self.walk_yaml(parser : YAML::PullParser, prefix : String,
+                               entries : Hash(String, Int32),
+                               depth : Int32, max_depth : Int32) : Nil
+      # An alias (`*shared`) or a scalar here is not a mapping to descend
+      # into; skipping keeps the parser in step with the document.
+      unless parser.kind.mapping_start?
+        parser.skip
+        return
+      end
+
+      parser.read_mapping_start
+      until parser.kind.mapping_end?
+        key_line = parser.start_line
+        break unless parser.kind.scalar?
+        key = parser.read_scalar
+        child = "#{prefix}#{SEPARATOR}#{key}"
+        entries[child] = key_line
+        if depth >= max_depth
+          parser.skip
+        else
+          walk_yaml(parser, child, entries, depth + 1, max_depth)
+        end
+      end
+      parser.read_mapping_end
+    end
+
+    def empty? : Bool
+      @entries.empty?
+    end
+
+    # 1-based line the given key path is declared on, or nil when the
+    # document has no such key at an indexed depth.
+    def line(*keys : String) : Int32?
+      @entries[keys.join(SEPARATOR)]?
+    end
+
+    def line(keys : Array(String)) : Int32?
+      @entries[keys.join(SEPARATOR)]?
+    end
+  end
+end

--- a/src/utils/spec_line_index.cr
+++ b/src/utils/spec_line_index.cr
@@ -44,22 +44,28 @@ module Noir
       new
     end
 
-    # Index a JSON document.
-    def self.json(content : String, root : String, max_depth : Int32 = 2) : SpecLineIndex
+    # Index a JSON document. `root` names the single top-level key whose
+    # subtree is indexed; `nil` indexes the document mapping itself, which is
+    # what a document keyed directly by route name needs.
+    def self.json(content : String, root : String? = nil, max_depth : Int32 = 2) : SpecLineIndex
       return empty if content.bytesize > MAX_CONTENT_BYTES
       entries = Hash(String, Int32).new
       begin
         pull = JSON::PullParser.new(content)
         if pull.kind.begin_object?
-          pull.read_begin_object
-          until pull.kind.end_object?
-            key_line = pull.line_number
-            key = pull.read_object_key
-            if key == root
-              entries[key] = key_line
-              walk_json(pull, key, entries, 1, max_depth)
-            else
-              pull.skip
+          if root.nil?
+            walk_json(pull, "", entries, 1, max_depth)
+          else
+            pull.read_begin_object
+            until pull.kind.end_object?
+              key_line = pull.line_number
+              key = pull.read_object_key
+              if key == root
+                entries[key] = key_line
+                walk_json(pull, key, entries, 1, max_depth)
+              else
+                pull.skip
+              end
             end
           end
         end
@@ -70,8 +76,9 @@ module Noir
       new(entries)
     end
 
-    # Index a YAML document (first document of the stream).
-    def self.yaml(content : String, root : String, max_depth : Int32 = 2) : SpecLineIndex
+    # Index a YAML document (first document of the stream). See `json` for
+    # what `root` means.
+    def self.yaml(content : String, root : String? = nil, max_depth : Int32 = 2) : SpecLineIndex
       return empty if content.bytesize > MAX_CONTENT_BYTES
 
       entries, complete = build_yaml(content, root, max_depth)
@@ -90,7 +97,7 @@ module Noir
     # `{entries, no exception was raised}`. Entries recorded before a failure
     # are still correct, just incomplete, so the caller decides whether to
     # keep them or prefer a recovered pass.
-    private def self.build_yaml(content : String, root : String,
+    private def self.build_yaml(content : String, root : String?,
                                 max_depth : Int32) : Tuple(Hash(String, Int32), Bool)
       entries = Hash(String, Int32).new
       begin
@@ -98,16 +105,20 @@ module Noir
         parser.read_stream_start
         parser.read_document_start
         if parser.kind.mapping_start?
-          parser.read_mapping_start
-          until parser.kind.mapping_end?
-            key_line = parser.start_line
-            break unless parser.kind.scalar?
-            key = parser.read_scalar
-            if key == root
-              entries[key] = key_line
-              walk_yaml(parser, key, entries, 1, max_depth)
-            else
-              parser.skip
+          if root.nil?
+            walk_yaml(parser, "", entries, 1, max_depth)
+          else
+            parser.read_mapping_start
+            until parser.kind.mapping_end?
+              key_line = parser.start_line
+              break unless parser.kind.scalar?
+              key = parser.read_scalar
+              if key == root
+                entries[key] = key_line
+                walk_yaml(parser, key, entries, 1, max_depth)
+              else
+                parser.skip
+              end
             end
           end
         end
@@ -130,7 +141,7 @@ module Noir
       until pull.kind.end_object?
         key_line = pull.line_number
         key = pull.read_object_key
-        child = "#{prefix}#{SEPARATOR}#{key}"
+        child = prefix.empty? ? key : "#{prefix}#{SEPARATOR}#{key}"
         entries[child] = key_line
         if depth >= max_depth
           pull.skip
@@ -156,7 +167,7 @@ module Noir
         key_line = parser.start_line
         break unless parser.kind.scalar?
         key = parser.read_scalar
-        child = "#{prefix}#{SEPARATOR}#{key}"
+        child = prefix.empty? ? key : "#{prefix}#{SEPARATOR}#{key}"
         entries[child] = key_line
         if depth >= max_depth
           parser.skip

--- a/src/utils/yaml.cr
+++ b/src/utils/yaml.cr
@@ -37,7 +37,11 @@ end
 # the original newline characters. A blank line is legal anywhere in YAML
 # (including inside a block scalar) regardless of indentation, so this is a
 # structurally safe normalization.
-private def blank_whitespace_only_lines(content : String) : String
+#
+# Line *count* is preserved exactly — only the characters before each newline
+# are dropped — so a position-aware second pass over the recovered text
+# (`Noir::SpecLineIndex`) reports the same line numbers as the original.
+def blank_whitespace_only_lines(content : String) : String
   String.build do |io|
     content.each_line(chomp: false) do |line|
       stripped = line.rstrip("\r\n")


### PR DESCRIPTION
Follow-up to the gap #2681 reported and left unfixed:

> `code_path` line numbers are never zero or negative, though Rails, Django and every spec-file analyzer omit the line entirely (Discourse points **1632 endpoints** at a bare `config/routes.rb`) — that is a missing-enrichment gap, not wrong output.

"1632 endpoints, all at `config/routes.rb`" is close to useless for the two audiences Noir exists to serve: a reviewer cannot jump to the route, and an LLM auditor gets no anchor to read around.

## Result

Across the fixture corpus (scanned one directory at a time), endpoints carrying a `code_path` line go from **4642/5556 (83.5%)** to **4840/5556 (87.1%)**. Per technology:

| technology | endpoints | with line, before | after |
|---|---|---|---|
| `ruby_rails` | 137 | 55 | **135** (+80) |
| `java_vertx` | 36 | 0 | **36** (+36) |
| `oas3` | 34 | 0 | **28** (+28) |
| `php_symfony` | 25 | 0 | **25** (+25) |
| `java_spring` | 90 | 73 | **90** (+17) |
| `oas2` | 14 | 0 | **12** (+12) |

**No technology loses a line.** The set of endpoints is unchanged.

## What each commit does

- **`ruby/rails`** — resolve `resources`/`match`/verb routes to the controller action that serves them and point at that `def`, instead of at `config/routes.rb` with no line.
- **`specification` (oas2/oas3)** — a shared `Noir::SpecLineIndex` maps a JSON-pointer-ish path (`paths./pets.get`) back to the line in the source document, so an operation points at its own `get:` / `post:` key. Built once per document.
- **`php/symfony`** — point at the route entry in `config/routes.yaml` that declares the path.
- **`java/vertx`** — point at the `router.get("/x").handler(...)` registration line.
- **`java/spring`** — cover the reactive `RouterFunction` DSL, which had no line where annotated controllers already did.

## Correctness

A wrong line is worse than no line, because a reviewer will trust it. Every analyzer here was sampled by emitting the line and reading the source at that position:

```
=== java/vertx ===
  GET     /                      L24  | router.get("/").handler(this::indexHandler);
  GET     /health                L25  | router.get("/health").handler(this::healthCheck);
  POST    /api/users             L26  | router.post("/api/users").handler(this::createUser);
  PUT     /api/users/:id         L27  | router.put("/api/users/:id").handler(this::updateUser);

=== ruby/rails ===   (-> app/controllers/posts_controller.rb)
  GET     /posts                 L6   | def index
  GET     /posts/1               L15  | def show
  POST    /posts                 L29  | def create
  DELETE  /posts/1               L57  | def destroy

=== php/symfony ===  (-> config/routes.yaml)
  GET     /api/categories        L9   | api_categories:          # methods: [GET, POST]
  POST    /api/categories        L9   | api_categories:
  DELETE  /api/categories/{id}   L13  | api_category_show:       # methods: [GET, PUT, DELETE]

=== specification/oas2 ===
  GET     /v1/pets               L15  | get:
  POST    /v1/pets               L24  | post:
```

Where the position genuinely cannot be recovered the line stays `nil` rather than being guessed — a few `oas2_edge_cases` operations are exactly that, and they are reported with no line, as before.

## Verification

- Full fixture corpus A/B, scanned **per fixture directory**: the endpoint set is byte-identical, only the enrichment moves.
- `just test`: 5686 unit + 24532 functional examples, 0 failures.
- `just check`: 2288 inspected, 0 failures.

## Not covered

Django, and the remaining spec-file analyzers (Postman, HAR, AsyncAPI, RAML, WSDL, OpenRPC), still omit the line. They are left for a follow-up rather than guessed at.