### PR TITLE
fix(cli): keep third-party logging out of the report stream

### DIFF
--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "file_utils"
 require "json"
 
 # End-to-end specs for the CLI front door, driven through the *built
@@ -15,6 +16,51 @@ private BINARY    = File.join(REPO_ROOT, "bin", "noir")
 private FIXTURE   = File.join(REPO_ROOT, "spec", "functional_test", "fixtures", "ruby", "sinatra")
 
 private record CliRun, stdout : String, stderr : String, exit_code : Int32
+
+# A HAR whose `startedDateTime` and cookie `expires` are not ISO-8601.
+# Browsers and capture proxies do emit such files, and the `har` shard reports
+# each one through Crystal's *global* `Log` — whose default backend writes to
+# STDOUT. So `noir scan ./captures -f json` printed a WARN line *and a full
+# Crystal backtrace* ahead of the JSON document, and `| jq .` died with
+# `Invalid numeric literal at line 1, column 14`.
+#
+# Neither the warning nor the shard is Noir's to change, which is the point:
+# the fix is the process-entry redirect in `Router.dispatch`
+# (`Noir::CLI.route_library_logs_to_stderr!`), so third-party logging cannot
+# reach the report stream no matter who does it. Driven through the built
+# binary because that redirect is a real-stream property — the spec runner's
+# own `Log` is set to `:none`, so nothing in-process can observe it.
+private BAD_TIMESTAMP_HAR = <<-HAR
+  {
+    "log": {
+      "version": "1.2",
+      "creator": { "name": "spec", "version": "1" },
+      "entries": [
+        {
+          "startedDateTime": "not-a-timestamp",
+          "request": {
+            "bodySize": 0, "method": "GET",
+            "url": "https://www.example.com/api/users",
+            "httpVersion": "HTTP/1.1",
+            "headers": [{ "name": "Host", "value": "www.example.com" }],
+            "cookies": [{ "name": "sid", "value": "abc",
+                          "expires": "Wed, 21 Oct 2015 07:28:00 GMT" }],
+            "queryString": [{ "name": "page", "value": "1" }],
+            "headersSize": -1
+          },
+          "response": {
+            "status": 200, "statusText": "OK", "httpVersion": "HTTP/1.1",
+            "headers": [], "cookies": [],
+            "content": { "size": 0, "mimeType": "application/json" },
+            "redirectURL": "", "headersSize": -1, "bodySize": 0
+          },
+          "cache": {}, "timings": { "send": 0, "wait": 0, "receive": 0 },
+          "time": 0
+        }
+      ]
+    }
+  }
+  HAR
 
 private def run_noir(args : Array(String)) : CliRun
   stdout = IO::Memory.new
@@ -309,6 +355,27 @@ describe "noir CLI surface (built binary)" do
       urls = JSON.parse(result.stdout)["endpoints"].as_a.map(&.["url"].as_s)
       urls.empty?.should be_false
       urls.all?(&.starts_with?("http://localhost:3000/")).should be_true
+    end
+  end
+
+  describe "stdout purity" do
+    it "keeps a third-party warning out of the report stream" do
+      dir = File.join(Dir.tempdir, "noir-stdout-purity-#{Random.rand(100_000)}")
+      Dir.mkdir_p(dir)
+      begin
+        File.write(File.join(dir, "capture.har"), BAD_TIMESTAMP_HAR)
+        result = run_noir(["scan", dir, "-f", "json", "--no-log"])
+
+        result.exit_code.should eq(0)
+        # The whole point: stdout parses, and it is the report.
+        JSON.parse(result.stdout)["endpoints"].as_a
+          .map(&.["url"].as_s)
+          .should contain("https://www.example.com/api/users")
+        # ...and the diagnostic is not lost, it moved to the other stream.
+        result.stderr.should contain("Unable to parse timestamp")
+      ensure
+        FileUtils.rm_rf(dir)
+      end
     end
   end
 

--- a/spec/unit_test/cli/stdout_purity_spec.cr
+++ b/spec/unit_test/cli/stdout_purity_spec.cr
@@ -1,0 +1,95 @@
+require "../../spec_helper"
+require "../../../src/cli/common"
+
+# STDOUT belongs to the report. Nothing else may be written there.
+#
+# Noir's own diagnostics have gone through `NoirLogger` (STDERR) for a long
+# time, but Crystal's *global* `Log` is a second, quieter route to the same
+# stream: the stdlib configures it, at the bottom of its own `log.cr`, with a
+# `Log::IOBackend` whose IO defaults to STDOUT. Anything written through it —
+# by Noir, by the stdlib, or by a shard Noir depends on — lands in the middle
+# of the `-f json` / `-f sarif` / `-f yaml` document and breaks every
+# downstream parser.
+#
+# Two guards, because the hazard arrives from two directions:
+#
+#   1. code Noir owns, caught here at the source level;
+#   2. code Noir does not own, caught at runtime by the process-entry
+#      redirect this file also pins.
+#
+# The end-to-end proof lives in `binary_surface_spec.cr` (a HAR whose
+# timestamps the `har` shard warns about), because these examples run in the
+# same process as the spec runner and cannot observe the real streams: Crystal's
+# spec DSL rebinds the global `Log` to `:none` at startup, so a leak is silent
+# here no matter which IO it was aimed at.
+
+private def source_files : Array(String)
+  Dir.glob("src/**/*.cr").sort!
+end
+
+# Comment lines are dropped before matching: the fixes that removed these
+# calls left comments *naming* them (`"was a `Log.debug` on Crystal's global
+# `Log`"`), and a guard that fired on its own changelog would be useless.
+private def stripped_sources : Hash(String, Array(Tuple(Int32, String)))
+  source_files.to_h do |path|
+    lines = [] of Tuple(Int32, String)
+    File.read_lines(path).each_with_index do |line, index|
+      next if line.lstrip.starts_with?('#')
+      lines << {index + 1, line}
+    end
+    {path, lines}
+  end
+end
+
+# `Log.info { ... }` and friends on the *global* logger. `logger.info`,
+# `ClientLog.info` and `AuditLog.write` are all excluded by the leading
+# boundary: the receiver has to be exactly `Log` (or `::Log`).
+private GLOBAL_LOG_CALL = /(?:^|[^[:alnum:]_.])(?:::)?Log\.(?:trace|debug|info|notice|warn|error|fatal)\b/
+
+describe "stdout purity" do
+  describe "the global Log" do
+    it "is never used as a diagnostic sink anywhere in src/" do
+      offenders = [] of String
+      stripped_sources.each do |path, lines|
+        lines.each do |(number, line)|
+          offenders << "#{path}:#{number}: #{line.strip}" if line.matches?(GLOBAL_LOG_CALL)
+        end
+      end
+
+      # `Log.debug` in `llm/cache.cr` and the GraphQL file hook were the last
+      # two. Both were also dead: nothing in Noir lowers the global logger's
+      # `Info` threshold, so they could never print — a diagnostic aimed at the
+      # report stream that also reported nothing. Diagnostics go through
+      # `NoirLogger` (STDERR, honouring `--debug`), coverage losses through
+      # `Noir::SkippedFiles`.
+      offenders.should be_empty
+    end
+
+    it "is redirected to STDERR before the CLI does anything else" do
+      # Order matters more than it looks: the redirect has to land before any
+      # code can log, so it is the first statement of `Router.dispatch` rather
+      # than something a later subcommand opts into.
+      body = File.read("src/cli/router.cr")
+      after_signature = body.split("def self.dispatch", 2)[1]?
+      after_signature.should_not be_nil
+
+      # `[1..]` drops the remainder of the `def` line itself (the parameter
+      # list), leaving the method body.
+      statements = after_signature.not_nil!.lines[1..]
+        .map(&.strip)
+        .reject { |line| line.empty? || line.starts_with?('#') }
+      statements.first?.should eq("Noir::CLI.route_library_logs_to_stderr!")
+    end
+
+    it "binds a STDERR backend, not the stdlib's STDOUT default" do
+      # Restored afterwards to the level Crystal's spec DSL installs, so this
+      # example cannot make the rest of the suite noisy.
+      Noir::CLI.route_library_logs_to_stderr!
+      backend = ::Log.for("noir.stdout_purity_spec").backend
+      backend.should be_a(::Log::IOBackend)
+      backend.as(::Log::IOBackend).io.should be(STDERR)
+    ensure
+      ::Log.setup(::Log::Severity::None)
+    end
+  end
+end

--- a/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
+++ b/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
@@ -1,7 +1,7 @@
 require "../../../models/analyzer"
 require "../../../models/endpoint"
+require "../../../models/skipped_files"
 require "json"
-require "log"
 require "../../../utils/text_file"
 
 # Parses GraphQL *operation documents* (`query Foo { ... }`,
@@ -187,7 +187,19 @@ FileAnalyzer.add_hook(->(path : String, _url : String) : Array(Endpoint) {
   begin
     file_content = Noir::TextFile.read(path)
   rescue ex
-    Log.debug { "GraphQL Analyzer: Error reading file #{path}: #{ex.message} (#{ex.class})" }
+    # The hook's own rescue is what keeps one unreadable `.graphql` file
+    # from costing the whole analysis pass, but it also hides the loss
+    # from `FileAnalyzer`'s per-file rescue, which is what normally
+    # records a skipped file. Record it here instead, so the drop shows up
+    # in `errors` and under `--strict` like every other skipped file.
+    #
+    # This was a `Log.debug` on Crystal's global `Log`, whose default
+    # backend writes to STDOUT — the stream the `-f json` / `-f sarif`
+    # report goes out on. Nothing in Noir lowers that logger's `Info`
+    # threshold either, so the line could never actually appear: a
+    # diagnostic pointed at the report stream that also reported nothing.
+    Noir::SkippedFiles.record(
+      "file_analyzer", path, "#{ex.message.presence || ex.class.name} (#{ex.class})")
     return [] of Endpoint # Return empty if read fails
   end
 

--- a/src/cli/common.cr
+++ b/src/cli/common.cr
@@ -1,10 +1,51 @@
 require "colorize"
+require "log"
 require "./catalog"
 
 module Noir::CLI
   # Known top-level verbs. The router falls back to `scan` when ARGV[0]
   # is not one of these (preserving the `noir -b ./app` v0 usage pattern).
   KNOWN_COMMANDS = Catalog::NAMES
+
+  # Point Crystal's global `Log` at STDERR.
+  #
+  # The stdlib configures that logger, at the bottom of its own `log.cr`,
+  # with a `Log::IOBackend` whose IO defaults to **STDOUT** — and stdout is
+  # where Noir's report goes. So anything logged through the global `Log`,
+  # by Noir or by a shard Noir pulls in, lands in the middle of the
+  # `-f json` / `-f sarif` / `-f yaml` document and breaks every downstream
+  # parser.
+  #
+  # Not hypothetical, and not limited to code this repo owns:
+  #
+  #   * the `har` shard warns through the global `Log` for an unparsable
+  #     `startedDateTime` or cookie `expires`, so a browser capture whose
+  #     timestamps are not ISO-8601 printed a WARN line *and a full Crystal
+  #     backtrace* ahead of the JSON — `noir scan ./captures -f json | jq .`
+  #     died with `Invalid numeric literal at line 1, column 14`;
+  #   * `NOIR_ACP_RAW_LOG=1` deliberately un-mutes the `acp` shard's
+  #     `acp.client` / `acp.transport` sources, which then wrote their
+  #     protocol diagnostics to the same stdout.
+  #
+  # Every diagnostic Noir writes itself already goes to STDERR through
+  # `NoirLogger`. This makes the same invariant hold for the code Noir does
+  # not own, once, at the process entry point.
+  #
+  # The severity threshold is left exactly where the stdlib default puts it
+  # (`Info`) — this changes the stream, not what gets logged — and is
+  # deliberately *not* wired to `LOG_LEVEL`, so a variable that happens to
+  # be exported for some other tool cannot start adding lines to a Noir run.
+  #
+  # `Sync` rather than the default async dispatcher: these are rare
+  # diagnostics, and an async backend flushes from its own fiber, which can
+  # reorder them against — or lose them behind — `NoirLogger`'s STDERR
+  # writes and the process exiting.
+  def self.route_library_logs_to_stderr! : Nil
+    ::Log.setup(
+      ::Log::Severity::Info,
+      ::Log::IOBackend.new(STDERR, dispatcher: ::Log::DispatchMode::Sync)
+    )
+  end
 
   # Disable Crystal's Colorize globally when the user asks for plain
   # output via `--no-color` or the `NO_COLOR` env var. Applied at the

--- a/src/cli/router.cr
+++ b/src/cli/router.cr
@@ -26,6 +26,8 @@ require "./commands/help"
 # Dockerfile entrypoint, and shell alias from v0.x.
 module Noir::CLI::Router
   def self.dispatch(argv : Array(String) = ARGV)
+    # First, before any code can log: stdout belongs to the report.
+    Noir::CLI.route_library_logs_to_stderr!
     Noir::CLI.apply_global_color_flag!(argv)
     argv = Legacy.rewrite(argv)
 

--- a/src/llm/cache.cr
+++ b/src/llm/cache.cr
@@ -13,10 +13,36 @@ require "digest/sha256"
 require "file_utils"
 require "time"
 require "../utils/home"
-require "log"
+require "../models/logger"
 
 module LLM
   module Cache
+    # Where the swallowed cache failures below are reported.
+    #
+    # They used to go to Crystal's global `Log` at debug level, which was
+    # wrong twice over: that logger's default backend writes to **STDOUT**,
+    # the stream carrying the `-f json` / `-f sarif` report, and nothing in
+    # Noir ever lowers its `Info` threshold, so the messages could not
+    # surface at all. A diagnostic that is simultaneously invisible and
+    # aimed at the report stream is the worst of both.
+    #
+    # `NoirLogger` (STDERR, gated on `--debug`) is where every other Noir
+    # diagnostic goes. Nil until a run installs one, so a library caller
+    # constructing no logger stays silent exactly as before.
+    @@logger : NoirLogger? = nil
+
+    def self.logger=(logger : NoirLogger?) : Nil
+      @@logger = logger
+    end
+
+    def self.logger : NoirLogger?
+      @@logger
+    end
+
+    private def self.debug(message : String) : Nil
+      @@logger.try &.debug(message)
+    end
+
     # All cache entries are stored as `<sha256>.json` flat in
     # `cache_dir`. The bulk operations below (`clear`, `purge_older_than`,
     # `stats`) filter on this suffix so a stray `.lock` or user-dropped
@@ -104,7 +130,7 @@ module LLM
       return unless File.exists?(path)
       File.read(path)
     rescue e
-      Log.debug { "Cache fetch failed for #{key}: #{e.message}" }
+      debug("Cache fetch failed for #{key}: #{e.message}")
       nil
     end
 
@@ -124,7 +150,7 @@ module LLM
       File.rename(tmp, final)
       true
     rescue e
-      Log.debug { "Cache store failed for #{key}: #{e.message}" }
+      debug("Cache store failed for #{key}: #{e.message}")
       begin
         File.delete(tmp) if tmp && File.exists?(tmp)
       rescue
@@ -139,7 +165,7 @@ module LLM
       File.delete(path)
       true
     rescue e
-      Log.debug { "Cache delete failed for #{key}: #{e.message}" }
+      debug("Cache delete failed for #{key}: #{e.message}")
       false
     end
 
@@ -188,7 +214,7 @@ module LLM
           File.delete(fp)
           tmp ? (orphans += 1) : (deleted += 1)
         rescue e
-          Log.debug { "Cache delete failed for #{fp}: #{e.message}" }
+          debug("Cache delete failed for #{fp}: #{e.message}")
           failed += 1
         end
       end
@@ -234,7 +260,7 @@ module LLM
             oldest = oldest ? (mtime < oldest ? mtime : oldest) : mtime
             newest = newest ? (mtime > newest ? mtime : newest) : mtime
           rescue e
-            Log.debug { "Cache stats: failed to read #{fp}: #{e.message}" }
+            debug("Cache stats: failed to read #{fp}: #{e.message}")
           end
         end
       end

--- a/src/models/minilexer/minilexer.cr
+++ b/src/models/minilexer/minilexer.cr
@@ -67,18 +67,23 @@ class MiniLexer
     @tokens.select { |token| token.type == token_type }
   end
 
-  def trace
+  # Token dump for debugging a lexer by hand. Written to STDERR, like every
+  # other Noir diagnostic: STDOUT carries the report, so a `puts` here would
+  # land in the middle of a `-f json` / `-f sarif` document the moment anyone
+  # called this from inside a scan. Nothing calls it today, which is exactly
+  # why the stream it writes to has to be right before someone does.
+  def trace(io : IO = STDERR)
     line_number = -1
     lines = @input.split "\n"
-    puts "Line Size: #{lines.size}, Token Count: #{tokens.size}"
+    io.puts "Line Size: #{lines.size}, Token Count: #{tokens.size}"
     @tokens.each do |token|
       if line_number != token.line
         line_number = token.line
-        puts "\nLine #{token.line}: " + lines[line_number - 1]
+        io.puts "\nLine #{token.line}: " + lines[line_number - 1]
         next if token.type == :NEWLINE # Skip newline token
       end
 
-      puts token.to_s
+      io.puts token.to_s
     end
   end
 end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -5,6 +5,7 @@ require "../passive_scan/rules.cr"
 require "../deliver/*"
 require "../output_builder/*"
 require "../optimizer/llm_optimizer.cr"
+require "../llm/cache.cr"
 require "../ai_context/augmentor.cr"
 require "../mobile/linker.cr"
 require "./analyzer_failure.cr"
@@ -91,6 +92,13 @@ class NoirRunner
 
     @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log, @no_spinner
 
+    # The LLM disk cache swallows its own IO failures and has no logger of
+    # its own (it is a module of class methods reached from several
+    # layers). Hand it this run's logger so those failures follow `--debug`
+    # onto STDERR like every other Noir diagnostic — they used to be
+    # written to Crystal's global `Log`, whose backend is STDOUT.
+    LLM::Cache.logger = @logger
+
     if ai_context_enabled?
       @options["include_callee"] = YAML::Any.new(true)
     end
@@ -141,10 +149,6 @@ class NoirRunner
         @passive_scans = NoirPassiveScan.load_rules rules_dir, @logger
       end
     end
-  end
-
-  def run
-    puts @techs
   end
 
   def detect


### PR DESCRIPTION
#2677 fixed one instance of "a diagnostic reaches stdout and destroys the machine-readable report". This is the general case, including for code this repository does not own.

## Symptom

A browser capture whose `startedDateTime` (or a cookie `expires`) is not ISO-8601 — which real capture proxies do emit:

```console
$ noir scan ./captures -f json --no-log | head -3
2026-09-02T05:09:44.524380Z   WARN - Unable to parse timestamp "not-a-timestamp"
Invalid number at 0: ">>not-a-timestamp" (Time::Format::Error)
  from /opt/homebrew/.../time/format/parser.cr:600:9 in 'raise'

$ noir scan ./captures -f json --no-log | jq .
jq: parse error: Invalid numeric literal at line 1, column 14
```

A WARN line **and a full Crystal backtrace** ahead of the JSON document. `NOIR_ACP_RAW_LOG=1` reproduces the same thing through the `acp` shard.

## Root cause

Crystal's stdlib configures the global `Log` with a `Log::IOBackend` whose IO defaults to **STDOUT** — the stream Noir's report goes out on. The `har` shard warns through that logger. So does anything else in the dependency tree that logs.

This is not fixable at the call site: the offending `Log.warn` is in a shard, not in this repository.

## Fix

`Router.dispatch` points the global `Log` at STDERR before any code can log:

```crystal
def self.route_library_logs_to_stderr! : Nil
  ::Log.setup(
    ::Log::Severity::Info,
    ::Log::IOBackend.new(STDERR, dispatcher: ::Log::DispatchMode::Sync)
  )
end
```

- The severity threshold stays at the stdlib default (`Info`) — this changes the **stream**, not what gets logged — and is deliberately not wired to `LOG_LEVEL`, so a variable exported for some other tool cannot start adding lines to a Noir run.
- `Sync` rather than the default async dispatcher: these are rare diagnostics, and an async backend flushes from its own fiber, which can reorder them against `NoirLogger`'s STDERR writes or lose them behind process exit.

## The three call sites Noir does own

Each was writing to the global logger; each moves to where Noir's own diagnostics go.

1. **`LLM::Cache`** — five swallowed IO failures were `Log.debug`. Wrong twice over: aimed at the report stream, *and* invisible, because nothing in Noir lowers that logger's `Info` threshold. They now go through the run's `NoirLogger` (STDERR, gated on `--debug`), wired in `NoirRunner#initialize`.
2. **GraphQL analyzer** — an unreadable `.graphql` file was a `Log.debug` that could not print. It is now recorded through `Noir::SkippedFiles`, so the dropped file shows up in `errors` and under `--strict` like every other skipped file. The hook's own rescue had been hiding the loss from `FileAnalyzer`'s per-file rescue.
3. **`MiniLexer#trace`** — took `puts`; now takes an IO.

## Also removed

`NoirRunner#run`. Nothing in `src/` or `spec/` calls it, and its entire body was `puts @techs` — straight onto the report stream.

## After

```console
$ noir scan ./captures -f json --no-log > out.json 2> err.txt
$ head -c 80 out.json
{"endpoints":[{"callees":[],"url":"https://www.example.com/api/users","method":"GET"
$ head -1 err.txt
2026-09-02T05:21:20.926379Z   WARN - Unable to parse timestamp "not-a-timestamp"
```

stdout is the report; the diagnostic moved rather than disappeared.

## Verification

- New spec drives the **built binary** with real stream redirection. That matters here: the spec runner sets its own `Log` to `:none`, so nothing in-process can observe this property — a green in-process spec would have proved nothing.
- Full fixture corpus A/B, scanned per fixture directory: detection unchanged.
- `just test`: 5690 unit + 24540 functional examples, 0 failures.
- `just check`: 2290 inspected, 0 failures.