### PR TITLE
fix(js): require a handler argument before calling a verb call a route

### DIFF
--- a/spec/unit_test/miniparser/js_parser_spec.cr
+++ b/spec/unit_test/miniparser/js_parser_spec.cr
@@ -245,6 +245,108 @@ describe Noir::JSParser do
     end
   end
 
+  describe "handler-argument gate" do
+    it "drops HTTP client calls that pass only a URL" do
+      # NodeBB's test suite: `request` is an HTTP client, and the leading
+      # `${nconf.get('url')}` is the server origin, not a mount prefix.
+      code = <<-JS
+        const nconf = require('nconf');
+        const request = require('../src/request');
+
+        describe('controllers', () => {
+          it('loads config', async () => {
+            const { body } = await request.get(`${nconf.get('url')}/api/config`);
+            assert(body);
+          });
+        });
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      routes.should be_empty
+    end
+
+    it "drops HTTP client calls whose only extra argument is an options bag" do
+      code = <<-JS
+        const request = require('../src/request');
+        await request.del(`${nconf.get('url')}/api/user/revokeme/session`, { jar });
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      routes.should be_empty
+    end
+
+    it "drops the Express settings getter" do
+      code = <<-JS
+        const express = require('express');
+        const app = express();
+        const engine = app.get('view engine');
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      routes.should be_empty
+    end
+
+    it "drops Map and cache lookups that borrow the verb shape" do
+      code = <<-JS
+        const cardName = PUBLIC_CARD_ASSET_NAMES.get(`${type}/${file}`);
+        await lock.delete(machineKey);
+        await serveCache.del(`/post/${pid}`);
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      routes.should be_empty
+    end
+
+    it "keeps a route whose path is a template literal with a mount prefix" do
+      # The counterpart of the first example, from the same repository:
+      # `${relativePath}` here IS a real Express mount prefix. Only the
+      # handler argument tells the two apart.
+      code = <<-JS
+        const express = require('express');
+        const app = express();
+        app.get(`${relativePath}/ping`, pingController.ping);
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      routes.map { |r| "#{r.method} #{r.path}" }.should contain("GET /${relativePath}/ping")
+    end
+
+    it "keeps a Fastify route whose handler lives in the options object" do
+      code = <<-JS
+        const fastify = require('fastify')();
+        fastify.get('/shorthand', { schema, handler });
+        fastify.post('/opts-then-handler', { schema }, async (req, reply) => {});
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      pairs = routes.map { |r| "#{r.method} #{r.path}" }
+      pairs.should contain("GET /shorthand")
+      pairs.should contain("POST /opts-then-handler")
+    end
+
+    it "keeps a Koa named route whose handler follows the path" do
+      code = <<-JS
+        const Router = require('@koa/router');
+        const router = new Router();
+        router.get('users.show', '/users/:id', ctx => { ctx.body = {}; });
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      routes.map { |r| "#{r.method} #{r.path}" }.should contain("GET /users/:id")
+    end
+
+    it "rejects relative module specifiers as route paths" do
+      # webpack Module Federation: `container.get('./index')` (Superset).
+      code = <<-JS
+        const factory = await container.get('./index');
+        $.post('../jserror', { errorInfo });
+        JS
+      routes = Noir::JSParser.new(code).parse_routes
+
+      routes.should be_empty
+    end
+  end
+
   describe "JSRoutePattern" do
     it "stores method and path" do
       pattern = Noir::JSRoutePattern.new("GET", "/users")

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -482,6 +482,117 @@ module Noir
       [] of PathEntry
     end
 
+    # True when the verb call whose `(` sits at `lparen_idx` carries an
+    # argument that could be a request handler.
+    #
+    # Every JS HTTP framework this parser covers registers a route as
+    # `verb(path, ...middleware, handler)` and the handler is mandatory —
+    # Express, Koa, Fastify, Restify, Hono and Oak all ignore (or reject) a
+    # verb call that passes nothing but a path. HTTP *client* calls have the
+    # opposite shape: the URL is the whole call, optionally followed by a
+    # plain options bag. That difference is the only structural thing
+    # separating the two in a file the extractor cannot type-check:
+    #
+    #   request.get(`${nconf.get('url')}/api/config`)        // client call
+    #   request.del(`${nconf.get('url')}/api/x`, { jar })    // client call
+    #   container.get('./index')                             // webpack MF
+    #   app.get('view engine')                               // Express getter
+    #
+    #   app.get(`${relativePath}/ping`, pingController.ping) // route
+    #   fastify.get('/x', { schema }, async (rq, rp) => {})  // route
+    #   fastify.get('/x', { schema, handler })               // route
+    #
+    # Both NodeBB shapes above live in the same repository — `app.use(
+    # `${nconf.get('relative_path')}/debug`, router)` is a real mount while
+    # `request.get(`${nconf.get('url')}/api/...`)` is a test client call — so
+    # neither the receiver name nor the leading `${...}` placeholder can tell
+    # them apart. The handler argument can.
+    #
+    # Bias is toward keeping routes: anything that is not a bare literal or a
+    # handler-less object literal counts as a handler, and an argument list
+    # this walk cannot finish (unbalanced tokens) is accepted.
+    private def route_handler_arg?(lparen_idx : Int32) : Bool
+      return true unless lparen_idx < @tokens.size && @tokens[lparen_idx].type == :lparen
+
+      idx = lparen_idx + 1
+      depth = 0
+      arg_index = 0
+      arg_start = idx
+
+      while idx < @tokens.size
+        case @tokens[idx].type
+        when :lparen, :lbracket, :lbrace
+          depth += 1
+        when :rbracket, :rbrace
+          return true if depth == 0 # unbalanced — do not drop the route
+          depth -= 1
+        when :rparen
+          if depth == 0
+            return arg_index > 0 && handler_shaped_arg?(arg_start, idx)
+          end
+          depth -= 1
+        when :comma
+          if depth == 0
+            return true if arg_index > 0 && handler_shaped_arg?(arg_start, idx)
+            arg_index += 1
+            arg_start = idx + 1
+            # A non-literal, non-object argument is handler-shaped on its
+            # first token alone, so answer here instead of walking its body:
+            # an arrow-function handler is routinely hundreds of tokens.
+            if arg_start < @tokens.size
+              case @tokens[arg_start].type
+              when :lbrace, :string, :template_literal, :number, :regex, :literal, :rparen
+                # Needs the full-argument check below.
+              else
+                return true
+              end
+            end
+          end
+        else
+          # Not a delimiter.
+        end
+        idx += 1
+      end
+
+      true
+    end
+
+    # Classify one argument (tokens `start_idx...end_idx`) as handler-shaped.
+    private def handler_shaped_arg?(start_idx : Int32, end_idx : Int32) : Bool
+      return false if start_idx >= end_idx || start_idx >= @tokens.size
+
+      case @tokens[start_idx].type
+      when :string, :template_literal, :number, :regex, :literal
+        # A bare literal is a route name (Koa's `router.get("users.show",
+        # "/users/:id", handler)`) or a client payload — never a handler.
+        # The Koa shape still registers because the handler is a later
+        # argument and every argument after the path is inspected.
+        false
+      when :lbrace
+        # Options object. Fastify's shorthand lets the handler live inside
+        # it (`fastify.get('/x', { schema, handler })`); a plain options bag
+        # (`request.del(url, { jar })`) registers nothing.
+        object_declares_handler?(start_idx, end_idx)
+      else
+        true
+      end
+    end
+
+    # True when the object literal spanning `start_idx...end_idx` names a
+    # handler property (Fastify/Restify route-options shorthand).
+    private def object_declares_handler?(start_idx : Int32, end_idx : Int32) : Bool
+      idx = start_idx
+      while idx < end_idx && idx < @tokens.size
+        token = @tokens[idx]
+        if token.type == :identifier &&
+           (token.value == "handler" || token.value == "wsHandler" || token.value == "onRequest")
+          return true
+        end
+        idx += 1
+      end
+      false
+    end
+
     private def next_top_level_arg_index(start_idx : Int32) : Int32?
       idx = start_idx
       paren_depth = 0
@@ -698,6 +809,10 @@ module Noir
            @tokens[idx + 1].type == :dot &&
            http_method?(@tokens[idx + 2]) &&
            @tokens[idx + 3].type == :lparen
+          unless route_handler_arg?(idx + 3)
+            idx += 1
+            next
+          end
           router_var = @tokens[idx].value
           method = @tokens[idx + 2].value
           paths = route_path_entries_from_args(idx + 4, allow_named_route: named_route_receiver?(router_var))
@@ -719,6 +834,10 @@ module Noir
            http_method_name?(@tokens[idx + 2].value) &&
            @tokens[idx + 3].type == :rbracket &&
            @tokens[idx + 4].type == :lparen
+          unless route_handler_arg?(idx + 4)
+            idx += 1
+            next
+          end
           router_var = @tokens[idx].value
           method = @tokens[idx + 2].value
           paths = route_path_entries_from_args(idx + 5, allow_named_route: named_route_receiver?(router_var))
@@ -816,7 +935,8 @@ module Noir
         path_idx = idx + 3
         if path_idx < @tokens.size &&
            @tokens[path_idx].type == :lparen &&
-           path_idx + 1 < @tokens.size
+           path_idx + 1 < @tokens.size &&
+           route_handler_arg?(path_idx)
           router_var = @tokens[idx].value
           path_entries = route_path_entries_from_args(path_idx + 1, allow_named_route: named_route_receiver?(router_var))
           @position = path_idx + 2 unless path_entries.empty?
@@ -969,7 +1089,8 @@ module Noir
         path_idx = idx + 2
         if path_idx < @tokens.size &&
            @tokens[path_idx].type == :lparen &&
-           path_idx + 1 < @tokens.size
+           path_idx + 1 < @tokens.size &&
+           route_handler_arg?(path_idx)
           router_var = @tokens[idx - 1].type == :identifier ? @tokens[idx - 1].value : ""
           path_entries = route_path_entries_from_args(path_idx + 1, allow_named_route: named_route_receiver?(router_var))
           @position = path_idx + 2 unless path_entries.empty?
@@ -1325,6 +1446,13 @@ module Noir
       return false if path.empty?
       return false if path.includes?("://")
       return false if path.each_char.any?(&.whitespace?)
+      # Relative module specifiers. An HTTP route path is always rooted;
+      # `./x` / `../x` is a filesystem-or-bundler path, and the shape reaches
+      # this parser through calls that merely look like a verb-DSL — webpack
+      # Module Federation's `container.get('./index')` (Superset's
+      # `ExtensionsLoader.ts`) is the canonical case. `/.well-known/...` is
+      # unaffected: it starts at the root.
+      return false if path.starts_with?("./") || path.starts_with?("../")
       # Filter bare identifiers that leak in via `resolve_dynamic_path`
       # when an unresolved variable name is used as a `.get`/`.all`
       # argument — e.g. `Promise.all(Object.values(...).map(...))` would


### PR DESCRIPTION
Fixes the defect #2681 reported and deliberately left unfixed.

> **NodeBB: 250 of 361 `js_express` endpoints come from `test/`, and they are HTTP client calls, not routes.**
> I did not fix this. The obvious lever is adding `/test/` and `/tests/` to `TEST_STUB_PATH_MARKERS` … but that is a broad detection change, and I could not construct evidence that it is safe for projects whose `test/` tree holds a mock server. The sharper-looking rule ("a route path whose first segment is a placeholder is a client URL") is not safe either: a leading `/{...}` is an ordinary route shape elsewhere in the corpus (251 in Gitea, 35 in Jellyfin).

Both objections are about **where the call is** and **what the path looks like**. This uses neither.

## The rule

Every JS HTTP framework this parser covers registers a route as `verb(path, ...middleware, handler)`, and the handler is **mandatory** — Express, Koa, Fastify, Restify, Hono and Oak all ignore or reject a verb call carrying nothing but a path. A client call is the opposite shape: the URL is the whole call, optionally followed by a plain options bag.

```js
request.get(`${nconf.get('url')}/api/config`)         // client call
request.del(`${nconf.get('url')}/api/x`, { jar })     // client call
container.get('./index')                              // webpack Module Federation
app.get('view engine')                                // Express getter

app.get(`${relativePath}/ping`, controller.ping)      // route
fastify.get('/x', { schema }, async (rq, rp) => {})   // route
fastify.get('/x', { schema, handler })                // route
```

The test is on the **call**, not the path and not the file — so it holds for a test tree that really does stand up a server, which is exactly the case the path-marker rule could not be shown safe for.

Bias is deliberately toward keeping routes: only a bare literal or a handler-less object literal counts as "no handler"; anything else counts as a handler; an argument list the token walk cannot finish (unbalanced tokens) is accepted.

## Result — NodeBB @ `ec5503a`

| | before | after |
|---|---|---|
| `js_express` endpoints | 361 | **121** |
| leading `/{url}` phantoms | 248 | **11** |
| real routes under `src/` | 110 | **110** |
| endpoints gained | — | **0** |

**All 240 removed endpoints were verified false positives**, one by one:

- 237 test-tree HTTP client calls (`request.get/del/put(...)` against `${nconf.get('url')}`), several carrying test payloads verbatim (`?quick="<script>alert('foo');</script>`).
- `GET /{baseUrl}/{url}` — `test/controllers.js:241`.
- `DELETE /{upload_path}/files/private-ext-{now}.pdf` — `test/uploads.js:26`.
- `DELETE /post/{pid}` — `src/activitypub/index.js:77`, which is

  ```js
  pubsub.on('post:delete', pid => ActivityPub.serveCache.del(`/post/${pid}`));
  ```

  a cache eviction read as an HTTP route. The only removal outside `test/`, and it is a false positive too.

## What it does not catch

The 11 surviving `/{url}` endpoints pass an **identifier** as the second argument (`requestOpts`, `adminApiOpts`) rather than an object literal:

```js
let { response: res } = await request.get(`${nconf.get('url')}/api/admin/${route}`, requestOpts);
```

The walk cannot prove `requestOpts` is not a handler, so it keeps them. Resolving that needs local binding resolution, which is a bigger change with its own risk; a 96% reduction without a single lost route is the safe part of the win.

The two smaller items #2681 also listed — Superset's `GET /./index` and NodeBB's `RegExp` route URL — are **not** addressed here. `container.get('./index')` is now dropped by this rule (no handler argument), but the RegExp-route URL is a separate formatting question.

## Verification

- Full fixture corpus A/B, scanned **per fixture directory** (as one project it is nondeterministic): **byte-identical**. No route lost in any express / koa / fastify / hono / oak / restify fixture, including the callee variants.
- NodeBB before/after diffed endpoint by endpoint (above): 240 lost, 0 gained, every loss inspected at its source line.
- `just test`: 5694 unit + 24540 functional examples, 0 failures.
- `just check`: 2289 inspected, 0 failures.