### PR TITLE
fix: keep a second file's route, and stop treating a path '?' as the query delimiter

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_koa_foreign_mount/app.js
+++ b/spec/functional_test/fixtures/javascript/express_koa_foreign_mount/app.js
@@ -1,0 +1,7 @@
+const express = require('express');
+
+const app = express();
+
+app.get('/express-home', (req, res) => res.send('ok'));
+
+app.listen(3000);

--- a/spec/functional_test/fixtures/javascript/express_koa_foreign_mount/koa-api/routes/index.js
+++ b/spec/functional_test/fixtures/javascript/express_koa_foreign_mount/koa-api/routes/index.js
@@ -1,0 +1,13 @@
+const Router = require('koa-router');
+const router = new Router();
+const api = new Router();
+
+const users = require('./users-router');
+
+// `api` aggregates the sub-router with no prefix of its own, then the
+// whole aggregate is mounted under /api.
+api.use(users);
+
+router.use('/api', api.routes());
+
+module.exports = router;

--- a/spec/functional_test/fixtures/javascript/express_koa_foreign_mount/koa-api/routes/users-router.js
+++ b/spec/functional_test/fixtures/javascript/express_koa_foreign_mount/koa-api/routes/users-router.js
@@ -1,0 +1,7 @@
+const Router = require('koa-router');
+const router = new Router();
+
+router.get('/users', (ctx) => {});
+router.post('/users/login', (ctx) => {});
+
+module.exports = router.routes();

--- a/spec/functional_test/fixtures/javascript/express_koa_foreign_mount/koa-api/server.js
+++ b/spec/functional_test/fixtures/javascript/express_koa_foreign_mount/koa-api/server.js
@@ -1,0 +1,7 @@
+const Koa = require('koa');
+const router = require('./routes');
+
+const app = new Koa();
+app.use(router.routes());
+
+app.listen(4000);

--- a/spec/functional_test/fixtures/javascript/fastify_two_services/service-a/app.js
+++ b/spec/functional_test/fixtures/javascript/fastify_two_services/service-a/app.js
@@ -1,0 +1,11 @@
+const fastify = require('fastify')()
+
+fastify.route({
+  method: ['GET', 'POST'],
+  url: '/items/:id',
+  handler: async (request, reply) => {
+    return reply.send(itemsA.find(request.params.id))
+  }
+})
+
+fastify.listen({ port: 3000 })

--- a/spec/functional_test/fixtures/javascript/fastify_two_services/service-b/app.js
+++ b/spec/functional_test/fixtures/javascript/fastify_two_services/service-b/app.js
@@ -1,0 +1,21 @@
+const fastify = require('fastify')()
+
+// A second service in the same repo serving the same address. Its route is
+// its own endpoint declaration, not a duplicate of service-a's.
+fastify.route({
+  method: 'GET',
+  url: '/items/:id',
+  handler: async (request, reply) => {
+    return reply.send(itemsB.find(request.params.id))
+  }
+})
+
+fastify.route({
+  method: 'DELETE',
+  url: '/items/:id',
+  handler: async (request, reply) => {
+    return reply.send(itemsB.remove(request.params.id))
+  }
+})
+
+fastify.listen({ port: 3001 })

--- a/spec/functional_test/fixtures/python/django_optional_slash/api/urls.py
+++ b/spec/functional_test/fixtures/python/django_optional_slash/api/urls.py
@@ -1,0 +1,13 @@
+from django.urls import re_path
+
+from . import views
+
+urlpatterns = [
+    # Django's idiom for "the trailing slash is optional". The `?` is a
+    # regex quantifier on the preceding `/`, not a path character.
+    re_path(r'^tags/?$', views.tags),
+    re_path(r'^search/?$', views.search),
+    re_path(r'^articles/(?P<slug>[-\w]+)/comments/?$', views.comments),
+    # An optional named group: the parameter stays, the quantifier goes.
+    re_path(r'^feed/(?P<page>\d+)?$', views.feed),
+]

--- a/spec/functional_test/fixtures/python/django_optional_slash/api/views.py
+++ b/spec/functional_test/fixtures/python/django_optional_slash/api/views.py
@@ -1,0 +1,18 @@
+from django.http import HttpResponse
+
+
+def tags(request):
+    return HttpResponse()
+
+
+def search(request):
+    q = request.GET.get('q')
+    return HttpResponse(q)
+
+
+def comments(request, slug):
+    return HttpResponse(slug)
+
+
+def feed(request, page=None):
+    return HttpResponse()

--- a/spec/functional_test/testers/javascript/express_koa_foreign_mount_spec.cr
+++ b/spec/functional_test/testers/javascript/express_koa_foreign_mount_spec.cr
@@ -1,0 +1,38 @@
+require "../../func_spec.cr"
+
+# A repo holding BOTH an Express app and a koa-router app whose routes are
+# aggregated in one file and mounted under `/api` from another.
+#
+# Express and Hono each run a `RouterMountScanner` over *every* JS/TS file in
+# the tree, and both write the prefixes they resolve into the one process-wide
+# `CodeLocator` table that `Noir::JSRouteExtractor` reads back per file. The
+# koa aggregator's prefix-less `api.use(users)` reads to that scanner as a
+# mount at `/`, so `users-router.js` ended up carrying two prefixes — koa's
+# real `/api` and Express's invented `/` — and every koa route was reported a
+# second time at a bare path the application does not serve.
+#
+# Which of the two won was down to fiber scheduling between the concurrently
+# running Express and Hono scanners, so the phantom endpoints came and went
+# between runs of the same scan.
+expected_endpoints = [
+  Endpoint.new("/express-home", "GET"),
+  Endpoint.new("/api/users", "GET"),
+  Endpoint.new("/api/users/login", "POST"),
+]
+
+tester = FunctionalTester.new("fixtures/javascript/express_koa_foreign_mount/", {
+  :techs     => 2,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+tester.perform_tests
+
+it "does not report koa routes at the un-prefixed path" do
+  phantom = tester.app.endpoints.select { |endpoint| endpoint.url == "/users" || endpoint.url == "/users/login" }
+  phantom.should be_empty
+end
+
+it "keeps the koa mount prefix on the koa analyzer's endpoints" do
+  koa_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/api/users" && endpoint.method == "GET" }
+  koa_route.should_not be_nil
+  koa_route.try(&.details.technology).should eq("js_koa")
+end

--- a/spec/functional_test/testers/javascript/fastify_two_services_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_two_services_spec.cr
@@ -1,0 +1,29 @@
+require "../../func_spec.cr"
+
+# Two Fastify services in one repo, both serving `GET /items/:id`.
+#
+# The auxiliary `fastify.route({…})` pass guarded against re-emitting a route
+# with `result.any? { |e| e.url == url && e.method == method }`, and `result`
+# is the accumulator for the whole analyzer run, not the file being read. The
+# second service's declaration was therefore dropped outright — never reaching
+# the optimizer, so its file was not merged in as a second code path either.
+# Which of the two survived came down to the order the worker pool handed the
+# files over, so the same scan named a different source file between runs.
+expected_endpoints = [
+  Endpoint.new("/items/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/items/:id", "POST", [Param.new("id", "", "path")]),
+  Endpoint.new("/items/:id", "DELETE", [Param.new("id", "", "path")]),
+]
+
+tester = FunctionalTester.new("fixtures/javascript/fastify_two_services/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+tester.perform_tests
+
+it "keeps both services as code paths of the shared route" do
+  shared = tester.app.endpoints.find { |endpoint| endpoint.url == "/items/:id" && endpoint.method == "GET" }
+  shared.should_not be_nil
+  paths = shared.try(&.details.code_paths.map { |code_path| File.basename(File.dirname(code_path.path)) }) || [] of String
+  paths.sort.should eq(["service-a", "service-b"])
+end

--- a/spec/functional_test/testers/python/django_optional_slash_spec.cr
+++ b/spec/functional_test/testers/python/django_optional_slash_spec.cr
@@ -1,0 +1,33 @@
+require "../../func_spec.cr"
+
+# `re_path(r'^tags/?$')` is how a Django URLconf spells "the trailing slash
+# is optional". The `?` there is a regex quantifier on the preceding `/`,
+# not a character of the path, and the normalizer that already strips the
+# anchors and rewrites `(?P<name>…)` used to carry it into the URL. In a
+# URL a `?` is the query delimiter, so `/search/?` rendered with its query
+# params came out as `/search/??q=` — the first parameter reaching the
+# server named `?q` instead of `q`.
+extracted_endpoints = [
+  Endpoint.new("/tags/", "GET"),
+  Endpoint.new("/search/", "GET", [
+    Param.new("q", "", "query"),
+  ]),
+  Endpoint.new("/articles/{slug}/comments/", "GET", [
+    Param.new("slug", "", "path"),
+  ]),
+  # An optional *group* keeps the parameter — noir's URL shape has no way
+  # to spell an optional segment — and drops only the quantifier.
+  Endpoint.new("/feed/{page}", "GET", [
+    Param.new("page", "", "path"),
+  ]),
+]
+
+tester = FunctionalTester.new("fixtures/python/django_optional_slash/", {
+  :techs     => 1,
+  :endpoints => extracted_endpoints.size,
+}, extracted_endpoints)
+tester.perform_tests
+
+it "leaves no regex quantifier in the emitted paths" do
+  tester.app.endpoints.map(&.url).select(&.includes?('?')).should be_empty
+end

--- a/spec/unit_test/models/output_builder_spec.cr
+++ b/spec/unit_test/models/output_builder_spec.cr
@@ -243,11 +243,26 @@ describe "OutputBuilder#bake_endpoint" do
 
   it "treats route-syntax ? as part of the path, not as a query string" do
     # Express optional segments (`/geo/:ip?`) and regex routes (`(?:a|b)`)
-    # both spell a `?` that opens no query string.
+    # both spell a `?` that opens no query string. Appending the query with
+    # a second `?` said so only to noir: RFC 3986 gives the query to the
+    # *first* `?`, so `/geo/:ip??q=1` reached the server as one parameter
+    # named `?q`. Percent-encoding keeps the route's `?` in the path, which
+    # is what this case has always claimed to do.
     builder.bake_endpoint("/geo/:ip?", [Param.new("q", "1", "query")])[:url]
-      .should eq("/geo/:ip??q=1")
+      .should eq("/geo/:ip%3F?q=1")
     builder.bake_endpoint("/grp/(?:a|b)", [Param.new("q", "1", "query")])[:url]
-      .should eq("/grp/(?:a|b)?q=1")
+      .should eq("/grp/(%3F:a|b)?q=1")
+  end
+
+  it "leaves a route-syntax ? alone when there is no query to append" do
+    builder.bake_endpoint("/geo/:ip?", [] of Param)[:url].should eq("/geo/:ip?")
+    builder.bake_endpoint("/geo/:ip?", [Param.new("X-Trace", "1", "header")])[:url]
+      .should eq("/geo/:ip?")
+  end
+
+  it "encodes a route-syntax ? that precedes the route's own query string" do
+    builder.bake_endpoint("/geo/:ip?/lookup.php?action=go", [] of Param)[:url]
+      .should eq("/geo/:ip%3F/lookup.php?action=go")
   end
 
   it "keeps tags from a query param that was skipped as redundant" do

--- a/spec/unit_test/output_builder/oas3_spec.cr
+++ b/spec/unit_test/output_builder/oas3_spec.cr
@@ -412,4 +412,32 @@ describe "OutputBuilderOas3" do
     operations["SUBSCRIBE"]["requestBody"]["content"]["application/json"]["schema"]["properties"]
       .as_h.keys.should eq(["displayName"])
   end
+
+  it "declares a templated path's parameters on the Path Item when every verb is unsupported" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+      "url"     => YAML::Any.new(""),
+    }
+    builder = OutputBuilderOas3.new(options)
+    builder.io = IO::Memory.new
+
+    # A STOMP `SEND` route. Its whole operation lands under
+    # `x-noir-unsupported-operations`, an extension no validator reads
+    # parameters out of, so without the Path Item copy `{roomId}` is a
+    # template expression with nothing declaring it — an invalid document.
+    send = Endpoint.new("/app/chat/send/{roomId}", "SEND")
+    send.push_param(Param.new("roomId", "", "path"))
+    send.push_param(Param.new("text", "", "json"))
+
+    builder.print([send])
+    path_item = JSON.parse(builder.io.to_s)["paths"]["/app/chat/send/{roomId}"]
+
+    path_item["parameters"].as_a
+      .map { |p| {p["in"].as_s, p["name"].as_s, p["required"].as_bool} }
+      .should eq([{"path", "roomId", true}])
+  end
 end

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -508,7 +508,7 @@ module Analyzer::Javascript
               extract_handler_params_from_content(content, router_prefix_router_name, method, route_path, endpoint)
 
               # Add endpoint to results if it's not already there with same method and path
-              unless result.any? { |e| e.url == full_path && e.method == method_upper }
+              unless route_recorded_for_file?(result, path, full_path, method_upper)
                 result << endpoint
               end
             end
@@ -595,7 +595,7 @@ module Analyzer::Javascript
             end
 
             # Add endpoint to results if it's not already there with same method and path
-            unless result.any? { |e| e.url == full_path && e.method == method_upper }
+            unless route_recorded_for_file?(result, path, full_path, method_upper)
               result << endpoint
             end
           end
@@ -982,7 +982,7 @@ module Analyzer::Javascript
     # Scan for router mount patterns and store them in CodeLocator
     # This enables cross-file router prefix tracking
     private def scan_for_router_mounts
-      scanner = RouterMountScanner.new(all_files, @base_paths, base_path, logger)
+      scanner = RouterMountScanner.new(all_files, @base_paths, base_path, logger, :express)
       scanner.scan
     end
   end

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -5,6 +5,7 @@ require "../../../../utils/top_level_split"
 require "../../../../utils/url_path"
 require "../express_constants"
 require "../../../../utils/text_file"
+require "../../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
   # RouterMountScanner handles the two-pass scanning process for Express router mounts.
@@ -38,11 +39,20 @@ module Analyzer::Javascript
       var_to_function: Hash(String, String),
       var_prefix: Hash(String, Array(String)))
 
+    # `framework` is the analyzer that owns this scan — the same Symbol its
+    # route pass hands to `JSRouteExtractor.other_shared_extractor_framework?`.
+    # Both Express and Hono run a scanner over *every* JS/TS file in the tree,
+    # and every prefix they resolve lands in one process-wide `CodeLocator`
+    # table keyed by file. Without the symbol there is no way to tell "this
+    # file is mine" from "this file belongs to Koa", so a koa-router module
+    # picked up a `/` mount from the Express scanner and its routes were
+    # emitted a second time at the bare path.
     def initialize(
       @all_files : Array(String),
       @base_paths : Array(String),
       @base_path : String,
       @logger : NoirLogger,
+      @framework : Symbol = :express,
     )
     end
 
@@ -72,6 +82,17 @@ module Analyzer::Javascript
       global_deferred_mounts : Array(Tuple(String, String, String, String)),
     )
       content = CodeLocator.instance.content_for(main_file) || Noir::TextFile.read(main_file)
+
+      # A file that imports a *different* shared-extractor framework is not
+      # ours to mount. Its own analyzer resolves its prefixes (koa.cr's
+      # `resolve_koa_mount_prefixes`, oak.cr's equivalent) and writes them to
+      # the same locator table this scanner writes to, so processing it here
+      # does not merely waste work — it adds a competing prefix. The route
+      # pass already refuses these files (`other_shared_extractor_framework?`
+      # guards every `extract_routes` call); the mount pass has to refuse them
+      # for the same reason, or the prefix it invents resurfaces as a whole
+      # second copy of the other framework's routes.
+      return if Noir::JSRouteExtractor.other_shared_extractor_framework?(content, @framework)
 
       # Cheap pre-filter: every code path in this scanner is downstream
       # of a `.use(...)` or `.route(...)` call (literal mount, no-prefix

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -277,7 +277,7 @@ module Analyzer::Javascript
         url = plugin_prefix.empty? ? raw_url : Noir::URLPath.join(plugin_prefix, raw_url)
         url = Noir::URLPath.join(autoload_prefix, url) unless autoload_prefix.empty?
 
-        next if result.any? { |e| e.url == url && e.method == "QUERY" }
+        next if route_recorded_for_file?(result, path, url, "QUERY")
 
         line_no = content[0...call_start].count('\n') + 1
 
@@ -376,7 +376,7 @@ module Analyzer::Javascript
 
         methods.each do |http_method|
           method_up = http_method.upcase
-          next if result.any? { |e| e.url == url && e.method == method_up }
+          next if route_recorded_for_file?(result, path, url, method_up)
 
           endpoint = Endpoint.new(url, method_up)
           endpoint.details = Details.new(PathInfo.new(path, line_no))

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -116,7 +116,7 @@ module Analyzer::Javascript
         direct_callees = include_callee && call_start ? on_route_callees(content, path, call_start) : [] of Noir::JSCalleeExtractor::Entry
 
         methods.each do |http_method|
-          next if result.any? { |e| e.url == url && e.method == http_method.upcase }
+          next if route_recorded_for_file?(result, path, url, http_method.upcase)
 
           endpoint = Endpoint.new(url, http_method.upcase)
           details = Details.new(PathInfo.new(path, index + 1))
@@ -322,7 +322,7 @@ module Analyzer::Javascript
     end
 
     private def scan_for_router_mounts
-      scanner = RouterMountScanner.new(all_files, @base_paths, base_path, logger)
+      scanner = RouterMountScanner.new(all_files, @base_paths, base_path, logger, :hono)
       scanner.scan
     end
   end

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -292,7 +292,7 @@ module Analyzer::Javascript
         # Extract parameters from handler body
         extract_koa_params_from_content(file_content, router_var || "app", match[2], route_path, endpoint)
 
-        unless result.any? { |e| e.url == full_path && e.method == http_method }
+        unless route_recorded_for_file?(result, path, full_path, http_method)
           result << endpoint
         end
       end

--- a/src/analyzer/analyzers/javascript/oak.cr
+++ b/src/analyzer/analyzers/javascript/oak.cr
@@ -246,7 +246,7 @@ module Analyzer::Javascript
 
         extract_oak_params_from_content(file_content, router_var || "app", match[2], route_path, endpoint)
 
-        unless result.any? { |e| e.url == full_path && e.method == http_method }
+        unless route_recorded_for_file?(result, path, full_path, http_method)
           result << endpoint
         end
       end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -773,7 +773,44 @@ module Analyzer::Python
 
     private def normalize_django_route(route : ::String) : ::String
       normalized = route.gsub(/^\^/, "").gsub(/\$$/, "")
-      normalize_django_named_regex_groups(normalized)
+      normalized = normalize_django_named_regex_groups(normalized)
+      strip_django_optional_quantifiers(normalized)
+    end
+
+    # `re_path(r'^tags/?$')` is the Django idiom for "trailing slash
+    # optional", and `?` there is a regex quantifier on the preceding `/`,
+    # not a character of the path. Carried through, it lands in the URL as
+    # the query delimiter: `/tags/?` rendered with query params came out as
+    # `/tags/??q=&page=`, so the first parameter reached the server named
+    # `?q`. The anchors, the named groups and the `\.` escapes of a
+    # `re_path` pattern are already translated out; this finishes the job
+    # for the one quantifier that changes what the URL means.
+    #
+    # Only quantifiers whose target is a path token this method can keep
+    # are dropped: `/?` keeps the slash (one of the two paths the pattern
+    # matches), and `{name}?` keeps the parameter, since noir's URL shape
+    # has no way to spell an optional segment. A `?` anywhere else belongs
+    # to regex syntax the normalizer does not claim to translate (`(?:`,
+    # `(?P<`, a lazy `+?`) and is left alone.
+    private def strip_django_optional_quantifiers(route : ::String) : ::String
+      return route unless route.includes?('?')
+
+      String.build do |io|
+        index = 0
+        while index < route.size
+          ch = route[index]
+          if ch == '?' && index > 0 && optional_quantifier_target?(route[index - 1])
+            index += 1
+            next
+          end
+          io << ch
+          index += 1
+        end
+      end
+    end
+
+    private def optional_quantifier_target?(previous : Char) : Bool
+      previous == '/' || previous == '}'
     end
 
     private def normalize_django_named_regex_groups(route : ::String) : ::String

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -99,6 +99,31 @@ module Analyzer::Javascript
       end
     end
 
+    # True when this file has already contributed `method url` to `result`.
+    #
+    # The auxiliary passes each analyzer runs after the shared extractor
+    # (Fastify's `route({…})` config objects, Hono's `app.on(…)`, the
+    # regex fallbacks) re-read routes the extractor may have emitted for the
+    # same file, so they need a "did I already record this?" guard. Written
+    # as a bare `result.any? { |e| e.url == url && e.method == method }` that
+    # guard reaches across the *whole run*: `result` accumulates every file's
+    # endpoints, so a route was dropped because a different file happened to
+    # declare the same address first. Two services in one repo both serving
+    # `GET /items/:id` reported a single endpoint carrying one of the two
+    # source locations, and which one survived depended on the order the
+    # worker pool handed the files over — the same scan named a different
+    # file between runs.
+    #
+    # Matching the file as well keeps the intra-file de-duplication the
+    # guard exists for and lets a genuine second declaration through, where
+    # the optimizer merges the two into one endpoint with both code paths.
+    protected def route_recorded_for_file?(result : Array(Endpoint), path : String, url : String, method : String) : Bool
+      result.any? do |endpoint|
+        endpoint.url == url && endpoint.method == method &&
+          endpoint.details.code_paths.any? { |code_path| code_path.path == path }
+      end
+    end
+
     protected def discover_js_project_roots(package_markers : Array(String), config_basenames : Array(String)) : Array(String)
       roots = [] of String
 

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -214,6 +214,25 @@ class OutputBuilder
     print(endpoints)
   end
 
+  # `?` is a reserved delimiter: whatever parser reads the baked URL takes the
+  # first one as the start of the query string. A route that spells a `?` as
+  # syntax — Express's optional `/posts/:id?`, Ktor's `{slug?}`, a regex route
+  # `/grp/(?:a|b)` — therefore cannot also carry query params: `/posts/:id?`
+  # plus a `filter` param baked to `/posts/:id??filter=`, and the server read
+  # the first parameter's name as `?filter`. Percent-encode the route's own
+  # `?` (everything before `before`) so it stays in the path and the query
+  # begins where `INLINE_QUERY` says it does.
+  #
+  # Only called on a URL that has, or is about to gain, a query string. A
+  # route with no params to append is unambiguous as written and keeps its
+  # literal spelling.
+  private def escape_route_question_marks(url : String, before : Int32) : String
+    head = url[0, before]
+    return url unless head.includes?('?')
+
+    "#{head.gsub('?', "%3F")}#{url[before..]}"
+  end
+
   # The block form of `NoirLogger#debug`, not the String one: `bake_endpoint`
   # runs once per endpoint for most builders, and the String overload would
   # build all seven of these messages on every call only for the logger to
@@ -248,10 +267,19 @@ class OutputBuilder
     # `?` here does not always open a query string — it is also route syntax
     # (Express `/geo/:ip?`, regex routes `/grp/(?:a|b)`). Only a `?` that
     # introduces a `key=value` pair before the next path separator does.
-    existing_query = final_url.match(INLINE_QUERY).try(&.[1])
+    existing_match = final_url.match(INLINE_QUERY)
+    existing_query = existing_match.try(&.[1])
     existing_pairs = existing_query.try(&.split('&')) || [] of String
     existing_names = existing_pairs.map { |pair| pair.split('=', 2)[0] }
     first_query = existing_query.nil?
+
+    # Knowing which `?` opens the query is only half the job: the reader of
+    # the baked URL does not get this regex, it gets RFC 3986, where the
+    # *first* `?` wins. A route `?` standing ahead of the real query has to
+    # be encoded or the two disagree.
+    if query_start = existing_match.try(&.begin(0))
+      final_url = escape_route_question_marks(final_url, query_start)
+    end
 
     unless params.nil?
       params.each do |param|
@@ -272,6 +300,10 @@ class OutputBuilder
                       (param.value.empty? && existing_names.includes?(param.name))
           unless redundant
             if first_query
+              # No inline query, so every `?` left in the URL is route
+              # syntax and all of it has to be encoded before this pair
+              # opens the real one.
+              final_url = escape_route_question_marks(final_url, final_url.size)
               final_url += "?#{pair}"
               first_query = false
             else

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -281,6 +281,7 @@ module OutputBuilderOasCommon
   # data. Keyed by the verb as the analyzer spelled it, merged the same way
   # a real operation is when two endpoints collapse onto one.
   private def add_unsupported_operation(path_item : Hash(String, JSON::Any), method : String, operation : Hash(String, JSON::Any))
+    promote_path_parameters_to_item(path_item, operation)
     operations = path_item["x-noir-unsupported-operations"]?.try(&.as_h?).try(&.dup) || {} of String => JSON::Any
 
     if existing = operations[method]?
@@ -290,6 +291,37 @@ module OutputBuilderOasCommon
     end
 
     path_item["x-noir-unsupported-operations"] = JSON::Any.new(operations)
+  end
+
+  # Path templating requires every `{name}` in the path to be declared "in the
+  # Path Item Object itself and/or in each Operation's parameters". An
+  # operation parked under `x-noir-unsupported-operations` is an extension —
+  # no validator reads parameters out of it — so a path whose only verbs are
+  # unsupported ones declared none at all: `/app/chat/send/{roomId}`, a STOMP
+  # `SEND` route, left `{roomId}` dangling and the document invalid. The Path
+  # Item is where a parameter shared by every operation belongs, and putting
+  # it there satisfies the rule without inventing an operation the verb
+  # cannot have.
+  private def promote_path_parameters_to_item(path_item : Hash(String, JSON::Any), operation : Hash(String, JSON::Any))
+    operation_parameters = operation["parameters"]?.try(&.as_a?)
+    return unless operation_parameters
+
+    parameters = path_item["parameters"]?.try(&.as_a?).try(&.compact_map(&.as_h?)) || [] of Hash(String, JSON::Any)
+    added = false
+
+    operation_parameters.each do |raw|
+      parameter = raw.as_h?
+      next unless parameter
+      next unless parameter["in"]?.try(&.as_s?) == "path"
+      next if parameters.any? { |existing| parameter_key(existing) == parameter_key(parameter) }
+
+      parameters << parameter
+      added = true
+    end
+
+    return unless added
+
+    path_item["parameters"] = JSON::Any.new(parameters.map { |parameter| JSON::Any.new(parameter) })
   end
 
   private def parameter_key(parameter : Hash(String, JSON::Any)) : String


### PR DESCRIPTION
Five defects, two families. One family is a scan-wide lookup that cannot tell "this file already emitted this route" from "a different file did". The other is a `?` that is route syntax, not a query delimiter, being baked into the URL as one.

## 1. A second file's `GET /items/:id` is dropped

The auxiliary passes each JS analyzer runs after the shared extractor (Fastify's `route({...})` config objects, Hono's `app.on(...)`, the Express / Koa / Oak regex fallbacks) guarded re-emission with:

```crystal
result.any? { |e| e.url == url && e.method == method }
```

`result` is the accumulator for the **whole analyzer run**, not the file being read. Two Fastify services under one scan base, both serving `GET /items/:id`, reported a single endpoint carrying one of the two source locations — and which one survived depended on the order the worker pool handed the files over.

The optimizer would have merged the two into one endpoint with both code paths, but the second declaration never reached it.

**Fix:** `JavascriptEngine#route_recorded_for_file?` matches the declaring file as well. Intra-file de-duplication (what the guard exists for) is unchanged; a genuine second declaration now gets through.

```console
# after — one endpoint, both services as code paths
GET /items/:id    service-a/app.js, service-b/app.js
```

## 2. Express invents a `/` mount for a Koa router

Express and Hono each run a `RouterMountScanner` over **every** JS/TS file in the tree, and both write the prefixes they resolve into one process-wide `CodeLocator` table keyed by file. A koa-router aggregator:

```js
api.use(users);                 // no prefix of its own
router.use('/api', api.routes());
```

reads to that scanner as a mount at `/`. `users-router.js` then carried two prefixes — Koa's real `/api` and Express's invented `/` — and every Koa route was reported a second time at a bare path the application does not serve. Which of the two won was fiber scheduling between the concurrently running Express and Hono scanners, so the phantom endpoints came and went between runs of the same scan.

The route pass already refuses another framework's files (`JSRouteExtractor.other_shared_extractor_framework?` guards every `extract_routes` call). The mount pass now takes the same gate, and the scanner is told which framework owns it (`:express` / `:hono`).

## 3. Django `re_path(r'^tags/?$')` keeps the quantifier

`/?` is how a Django URLconf spells "the trailing slash is optional". The `?` is a regex quantifier on the preceding `/`, not a character of the path. The normalizer already strips the anchors and rewrites `(?P<name>…)`; it used to carry the `?` through. In a URL a `?` is the query delimiter, so `/search/?` rendered with its query params came out as `/search/??q=` — the first parameter reaching the server named `?q` instead of `q`.

**Fix:** drop a `?` whose target is a path token we keep (`/` or `}`). `/?` keeps the slash (one of the two paths the pattern matches); `{name}?` keeps the parameter, since noir's URL shape has no way to spell an optional segment. A `?` anywhere else belongs to regex syntax the normalizer does not claim to translate (`(?:`, `(?P<`, a lazy `+?`) and is left alone.

## 4. `bake_endpoint` opens the query on the *first* `?`

The same collision, one layer later. Express `/geo/:ip?` and regex `/grp/(?:a|b)` both spell a `?` that opens no query string. Appending a query with a second `?` said so only to noir: RFC 3986 gives the query to the first `?`, so `/geo/:ip??q=1` reached the server as one parameter named `?q`.

**Fix:** percent-encode every route-syntax `?` in the path before a real query is appended (`/geo/:ip%3F?q=1`). A route with no query to append is unambiguous as written and keeps its literal spelling.

## 5. A STOMP `SEND` leaves `{roomId}` undeclared

Path templating requires every `{name}` in the path to be declared in the Path Item Object and/or in each Operation's parameters. An operation parked under `x-noir-unsupported-operations` is an extension — no validator reads parameters out of it — so a path whose only verbs are unsupported ones declared none at all. `/app/chat/send/{roomId}`, a STOMP `SEND` route, left `{roomId}` dangling and the document invalid.

**Fix:** promote those path parameters onto the Path Item, which is where a parameter shared by every operation belongs, without inventing an operation the verb cannot have.

## Verification

- New fixtures: `javascript/fastify_two_services`, `javascript/express_koa_foreign_mount`, `python/django_optional_slash`.
- New unit coverage for `bake_endpoint`'s route-syntax `?` and for OAS3 Path Item parameters on an unsupported-only path.
- `just test`: 5701 unit + 24582 functional examples, 0 failures.
- `just check`: 2293 inspected, 0 failures.