### PR TITLE
fix(errors): report skipped paths in a stable order, and drop two dead Express fix-ups

### DIFF
--- a/spec/unit_test/models/skipped_files_spec.cr
+++ b/spec/unit_test/models/skipped_files_spec.cr
@@ -44,6 +44,45 @@ describe Noir::SkippedFiles do
     message.should_not contain("Src#{Noir::SkippedFiles::MAX_PATHS_PER_TECH}.java")
   end
 
+  # `errors` is part of the `-f json` / `-f sarif` document, so the same skips
+  # have to produce the same line. Both halves of the message used to follow
+  # arrival order, which for the detection walk and the analysis pass is fiber
+  # completion order: three unparsable documents under one base reported
+  # `t/b, t/c, t/a`, and a rerun on a machine with a different core count had
+  # no reason to agree.
+  it "lists example paths in a stable order whatever order they arrive in" do
+    %w[src/c.rs src/a.rs src/b.rs].each do |path|
+      Noir::SkippedFiles.record("rust_axum", path, "reason for #{path}")
+    end
+
+    Noir::SkippedFiles.failures.first.message.should contain("src/a.rs, src/b.rs, src/c.rs")
+  end
+
+  # The line reads "<paths>; first error: <reason>", so the reason has to be
+  # the first path's. Keyed on arrival it named neither the first path shown
+  # nor a predictable one.
+  it "reports the reason belonging to the first path it lists" do
+    Noir::SkippedFiles.record("rust_axum", "src/z.rs", "arrived first")
+    Noir::SkippedFiles.record("rust_axum", "src/a.rs", "sorts first")
+
+    message = Noir::SkippedFiles.failures.first.message
+    message.should contain("src/a.rs, src/z.rs")
+    message.should contain("first error: sorts first")
+  end
+
+  # The cap has to bite deterministically too, or the examples a repository
+  # over the limit shows are whichever ones won the race.
+  it "keeps the smallest paths when more arrive than it can show" do
+    %w[9 8 7 6 5 4 3 2 1 0].each do |n|
+      Noir::SkippedFiles.record("java_spring", "Src#{n}.java", "reason #{n}")
+    end
+
+    message = Noir::SkippedFiles.failures.first.message
+    message.should contain("Src0.java, Src1.java, Src2.java, Src3.java, Src4.java")
+    message.should contain("(+5 more)")
+    message.should contain("first error: reason 0")
+  end
+
   it "forgets everything on clear, so a second pass starts clean" do
     Noir::SkippedFiles.record("go_gin", "main.go", "boom")
     Noir::SkippedFiles.clear

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -194,21 +194,18 @@ module Analyzer::Javascript
     private def analyze_with_regex(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)) = [] of Hash(String, String))
       # Original regex-based analysis as a fallback
       file_content = read_file_content(path)
-      # Every pass below reasons about one file, and two of them *edit* what
-      # earlier passes emitted: `scan_for_nested_router_endpoints` replaces
-      # the un-prefixed route with the router-mounted one, and
-      # `handle_v1_router_pattern` drops the un-prefixed `/status` and
-      # `/settings` before re-adding them under the router prefix. Handed the
-      # scan-wide array, those edits reach across files: the lookups match on
-      # url and method alone, so the endpoint they replace or drop is just as
-      # likely to belong to another Express app under the same scan base, and
-      # it disappears from the report along with its params and its
-      # `code_path`. Twelve one-file apps each declaring `app.post('/users')`
-      # plus twelve declaring it behind `router.use('/api', usersRouter)` came
-      # out with ten of the twelve plain apps erased. Collect into a per-file
-      # array so a fix-up can only touch this file's own endpoints, and hand
-      # the whole batch to `result` at the end; duplicates across files are
-      # the optimizer's job to merge.
+      # Every pass below reasons about one file, and `scan_for_nested_router_endpoints`
+      # *edits* what earlier passes emitted: it replaces the un-prefixed route
+      # with the router-mounted one. Handed the scan-wide array that edit
+      # reaches across files — the lookup matches on url and method alone, so
+      # the endpoint it replaces is just as likely to belong to another
+      # Express app under the same scan base, and it disappears from the
+      # report along with its params and its `code_path`. Twelve one-file apps
+      # each declaring `app.post('/users')` plus twelve declaring it behind
+      # `router.use('/api', usersRouter)` came out with ten of the twelve
+      # plain apps erased. Collect into a per-file array so a fix-up can only
+      # touch this file's own endpoints, and hand the whole batch to `result`
+      # at the end; duplicates across files are the optimizer's job to merge.
       file_endpoints = [] of Endpoint
       last_endpoint = Endpoint.new("", "")
       current_router_base = ""
@@ -820,6 +817,11 @@ module Analyzer::Javascript
     end
 
     # Direct handler for the v1Router pattern in the test fixture
+    # Emits the two routes of the `vNRouter` fixture shape under their mount
+    # prefix. Runs first, on a `result` that is this file's own (empty) batch,
+    # so there is nothing here to de-duplicate against: the line loop below
+    # resolves the same routes through `nested_routers` and the optimizer
+    # merges whatever it emits with these.
     private def handle_v1_router_pattern(content : String, result : Array(Endpoint), path : String)
       # Look for the exact pattern used in the test fixture
       v1_pattern = /const\s+(v\d+Router)\s*=\s*express\.Router\(\);\s*router\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*\1\);/m
@@ -835,9 +837,6 @@ module Analyzer::Javascript
 
           # Add the status endpoint with correct prefix
           if content.match(status_route)
-            # Remove any existing /status endpoint
-            result.reject! { |e| e.url == "/status" && e.method == "GET" }
-
             # Create a new endpoint with the correct prefix
             endpoint = Endpoint.new("#{prefix}/status", "GET")
             details = Details.new(PathInfo.new(path, 1))
@@ -852,9 +851,6 @@ module Analyzer::Javascript
 
           # Add the settings endpoint with correct prefix
           if content.match(settings_route)
-            # Remove any existing /settings endpoint
-            result.reject! { |e| e.url == "/settings" && e.method == "PUT" }
-
             # Create a new endpoint with the correct prefix
             endpoint = Endpoint.new("#{prefix}/settings", "PUT")
             details = Details.new(PathInfo.new(path, 1))

--- a/src/models/skipped_files.cr
+++ b/src/models/skipped_files.cr
@@ -72,6 +72,38 @@ module Noir::SkippedFiles
     property count = 0
     property reason = ""
     getter paths = [] of String
+
+    # Remember one skip, keeping the examples sorted and the tally capped.
+    #
+    # Arrival order is not something to report on. The detection walk and the
+    # analysis pass both record from concurrent fibers, so appending until the
+    # cap was hit made both halves of the message depend on which fiber
+    # finished first: three unparsable documents under one base came out as
+    # `t/b, t/c, t/a`, and the paths a repository over the cap *shows* were
+    # whichever five happened to arrive. `errors` is part of the `-f json` /
+    # `-f sarif` document — output a consumer diffs between runs and between
+    # machines — and everything else that reaches it is ordered on purpose
+    # (`EndpointOptimizer#endpoint_order_key`, the passive rule glob's
+    # `sort!`). This is the same commitment for the one surface that was
+    # still reporting in scheduler order.
+    #
+    # Sorted insertion rather than a sort at render time, because the cap has
+    # to bite deterministically too: the five kept are the five smallest
+    # paths, not the first five to arrive. The list is `MAX_PATHS_PER_TECH`
+    # long, so the scan is cheaper than the allocation a sorted set would add.
+    def remember(path : String, reason : String) : Nil
+      index = paths.index { |seen| seen > path } || paths.size
+      # Sorts after every example already kept, and there is no room: only
+      # the count grows.
+      return if index >= MAX_PATHS_PER_TECH
+
+      paths.insert(index, path)
+      paths.pop if paths.size > MAX_PATHS_PER_TECH
+      # "first error" now names the first path listed, which is what the
+      # message has always read as. Keyed on arrival it named neither the
+      # first path shown nor a predictable one.
+      @reason = reason if index.zero?
+    end
   end
 
   # A gap with no per-item granularity — an export that never landed, a rule
@@ -108,8 +140,7 @@ module Noir::SkippedFiles
         fresh
       end
       tally.count += 1
-      tally.reason = reason if tally.reason.empty?
-      tally.paths << path if tally.paths.size < MAX_PATHS_PER_TECH
+      tally.remember(path, reason)
     end
   end
 
@@ -170,6 +201,9 @@ module Noir::SkippedFiles
     "#{tech}/#{noun}"
   end
 
+  # `Tally#remember` keeps `paths` sorted and `reason` pinned to `paths`
+  # first, so the same skips produce the same line whatever order the fibers
+  # recorded them in.
   private def message_for(tally : Tally) : String
     noun = pluralize(tally.noun, tally.count)
     examples = tally.paths.join(", ")


### PR DESCRIPTION
Two follow-ups to yesterday's merges.

## 1. `errors` reported in fiber order

`errors` is part of the `-f json` / `-f sarif` / `-f yaml` document — output a consumer diffs between runs and between machines. `SkippedFiles` appended example paths as they arrived and pinned `first error:` to whichever reason landed first, and both the detection walk and the analysis pass record from concurrent fibers. So both halves of the message followed scheduler order:

```
$ noir scan ./t6 -f json --no-log     # three unparsable openapi.json under one base
skipped 3 unparsable documents: t6/b/openapi.json, t6/c/openapi.json, t6/a/openapi.json;
  first error: unexpected token '<EOF>' at line 2, column 1
```

Neither walk order nor alphabetical, and nothing about the input said which it would be. Over `MAX_PATHS_PER_TECH` the cap made it worse: the paths a broken checkout *shows* were whichever five won the race, so two runs of the same scan could name five different files.

Everything else reaching this document is ordered on purpose — `EndpointOptimizer#endpoint_order_key` sorts for exactly this reason, and #2677 sorted the passive-rule glob so a duplicate id resolves the same way every time. This was the one output surface still reporting in scheduler order, and #2678 made it a lot more reachable by routing unparsable specification documents and unstattable entries through it.

`Tally#remember` now inserts into a sorted, capped list, so the examples are the five smallest paths rather than the first five to arrive, and `first error:` names the first path listed — which is how the line has always read. Sorted insertion rather than a sort at render time, because the cap has to bite deterministically too; the list is five entries long, so the scan costs less than the allocation a sorted set would add.

## 2. Two Express fix-ups that can no longer find anything

#2684 gave `analyze_with_regex` a per-file endpoint array so its fix-up passes could not reach across files. That made `handle_v1_router_pattern`'s two `reject!` calls dead: it runs first, on a batch that is still empty, so "remove any existing `/status` endpoint" has nothing to remove and has not had since the array stopped being scan-wide.

Dead is the right outcome — those calls only ever deleted another file's work, which is what #2684 was fixing — but leaving them in states a guard the code does not have, and the comment above the batch still describes the drop as something that happens. Both removed, and the pass now says what it actually relies on: the line loop below resolves the same two routes through `nested_routers`, and the optimizer merges whatever it emits with these.

## Verification

- `just test-unit`: 5675 examples, 0 failures (3 new in `skipped_files_spec.cr`, covering stable order, the reason following the first path, and the cap keeping the smallest paths).
- A/B over all 712 fixture directories, scanned one at a time, digest over (method, url, technology, code paths, params) plus `errors`: **identical, 5567 rows.**
- `spec/functional_test/fixtures/javascript/express` still reports `GET /v1/status` and `PUT /v1/settings` and no un-prefixed copies.
- `crystal tool format --check` and ameba clean on the changed files.