### PR TITLE
fix(release): re-sign macOS tarballs after install_name_tool

### DIFF
--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -2,6 +2,13 @@
 # Bundle Homebrew-linked dylibs next to a Crystal macOS binary so the
 # release tarball runs without a local OpenSSL (or other brew) install.
 #
+# Rewriting load commands with install_name_tool invalidates a Mach-O code
+# signature. The linker-signed main binary gets re-signed automatically, but
+# Homebrew's plainly ad-hoc-signed dylibs do not: they are left with a stale
+# signature, and arm64 SIGKILLs any process that maps one. So everything is
+# re-signed ad hoc after the last install_name_tool call, and the packaged
+# tarball is smoke-tested before the script reports success.
+#
 # Usage: scripts/package-macos.sh <binary-path> <output-tarball>
 #
 # Archive layout:
@@ -17,13 +24,16 @@ if [[ ! -f "$BINARY" ]]; then
   exit 1
 fi
 
-if ! command -v otool >/dev/null 2>&1 || ! command -v install_name_tool >/dev/null 2>&1; then
-  echo "error: otool and install_name_tool are required (macOS only)" >&2
-  exit 1
-fi
+for tool in otool install_name_tool codesign; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "error: $tool is required (macOS only)" >&2
+    exit 1
+  fi
+done
 
 STAGING="$(mktemp -d)"
-trap 'rm -rf "$STAGING"' EXIT
+VERIFY_DIR="$(mktemp -d)"
+trap 'rm -rf "$STAGING" "$VERIFY_DIR"' EXIT
 
 mkdir -p "$STAGING/lib"
 cp "$BINARY" "$STAGING/noir"
@@ -54,6 +64,9 @@ while true; do
       fi
       if [[ ! -f "$STAGING/lib/$base" ]]; then
         cp "$dep" "$STAGING/lib/$base"
+        # Homebrew ships dylibs read-only; install_name_tool and codesign
+        # both rewrite them in place.
+        chmod u+w "$STAGING/lib/$base"
         added=1
       fi
     done < <(homebrew_deps "$target")
@@ -88,10 +101,37 @@ for candidate in "$STAGING/noir" "$STAGING"/lib/*.dylib; do
   fi
 done
 
+# Re-sign ad hoc. This must come after every install_name_tool call above,
+# and dylibs must be signed before the binary that loads them.
+for lib in "$STAGING"/lib/*.dylib; do
+  [[ -e "$lib" ]] || continue
+  codesign --force --sign - "$lib"
+done
+codesign --force --sign - "$STAGING/noir"
+
+for target in "$STAGING/noir" "$STAGING"/lib/*.dylib; do
+  [[ -e "$target" ]] || continue
+  if ! codesign --verify --strict "$target"; then
+    echo "error: invalid code signature after packaging: $target" >&2
+    exit 1
+  fi
+done
+
 mkdir -p "$(dirname "$OUTPUT")"
 tar -czf "$OUTPUT" -C "$STAGING" noir lib
 
-echo "Created $OUTPUT"
-if "$STAGING/noir" --version >/dev/null 2>&1; then
-  "$STAGING/noir" --version
+# Smoke-test the packaged artifact rather than the staged tree: this is the
+# exact layout a user unpacks, and a stale signature is fatal only at exec
+# time. Guarding this behind `if` hid exactly the breakage it existed to catch.
+tar -xzf "$OUTPUT" -C "$VERIFY_DIR"
+smoke_status=0
+VERSION_OUTPUT="$("$VERIFY_DIR/noir" --version)" || smoke_status=$?
+if [[ "$smoke_status" -ne 0 ]]; then
+  echo "error: packaged binary failed to run (exit $smoke_status): $OUTPUT" >&2
+  echo "       arm64 SIGKILLs binaries and dylibs with an invalid signature;" >&2
+  echo "       check the codesign step above." >&2
+  exit 1
 fi
+
+echo "Created $OUTPUT"
+echo "$VERSION_OUTPUT"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -64,9 +64,6 @@ while true; do
       fi
       if [[ ! -f "$STAGING/lib/$base" ]]; then
         cp "$dep" "$STAGING/lib/$base"
-        # Homebrew ships dylibs read-only; install_name_tool and codesign
-        # both rewrite them in place.
-        chmod u+w "$STAGING/lib/$base"
         added=1
       fi
     done < <(homebrew_deps "$target")
@@ -118,20 +115,35 @@ for target in "$STAGING/noir" "$STAGING"/lib/*.dylib; do
 done
 
 mkdir -p "$(dirname "$OUTPUT")"
-tar -czf "$OUTPUT" -C "$STAGING" noir lib
+
+# Archive to a scratch path first. A tarball only becomes $OUTPUT once it has
+# proven it runs, so a failed smoke test cannot leave a finished-looking but
+# unrunnable artifact for a later step to upload.
+STAGED_OUTPUT="$VERIFY_DIR/$(basename "$OUTPUT")"
+tar -czf "$STAGED_OUTPUT" -C "$STAGING" noir lib
 
 # Smoke-test the packaged artifact rather than the staged tree: this is the
 # exact layout a user unpacks, and a stale signature is fatal only at exec
 # time. Guarding this behind `if` hid exactly the breakage it existed to catch.
-tar -xzf "$OUTPUT" -C "$VERIFY_DIR"
+EXTRACT_DIR="$VERIFY_DIR/extracted"
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$STAGED_OUTPUT" -C "$EXTRACT_DIR"
 smoke_status=0
-VERSION_OUTPUT="$("$VERIFY_DIR/noir" --version)" || smoke_status=$?
+VERSION_OUTPUT="$("$EXTRACT_DIR/noir" --version)" || smoke_status=$?
 if [[ "$smoke_status" -ne 0 ]]; then
-  echo "error: packaged binary failed to run (exit $smoke_status): $OUTPUT" >&2
+  echo "error: packaged binary failed to run (exit $smoke_status)" >&2
   echo "       arm64 SIGKILLs binaries and dylibs with an invalid signature;" >&2
   echo "       check the codesign step above." >&2
   exit 1
 fi
+# Exit 0 alone is not evidence: a binary that prints nothing has not
+# demonstrated it loaded its dylibs and reached its own CLI.
+if [[ -z "${VERSION_OUTPUT//[[:space:]]/}" ]]; then
+  echo "error: packaged binary ran but printed no version" >&2
+  exit 1
+fi
+
+mv "$STAGED_OUTPUT" "$OUTPUT"
 
 echo "Created $OUTPUT"
 echo "$VERSION_OUTPUT"


### PR DESCRIPTION
## Problem

`scripts/package-macos.sh` rewrites the bundled OpenSSL load paths with `install_name_tool`, which invalidates the code signature of every Mach-O it touches. cctools re-signs the *linker-signed* main binary automatically; Homebrew's plainly ad-hoc-signed dylibs it does not — those keep a stale signature. arm64 SIGKILLs any process that maps one.

**The published `noir-v1.3.0-osx-arm64.tar.gz` does not run on Apple Silicon.** Verified by downloading the release asset on an arm64 Mac (macOS 26.6):

```
$ codesign --verify noir
noir: valid on disk                    # main binary was fine all along

$ codesign --verify lib/libssl.3.dylib
lib/libssl.3.dylib: invalid signature (code or signature have been modified)
$ codesign --verify lib/libcrypto.3.dylib
lib/libcrypto.3.dylib: invalid signature (code or signature have been modified)

$ ./noir --version; echo $?
137                                    # SIGKILL

$ codesign --force --sign - lib/*.dylib noir
$ ./noir --version                     # works
```

Clearing quarantine does not help — this is a signature check, not Gatekeeper. So the failure looks like a bare `zsh: killed noir` with no diagnostic.

## Why it shipped

The script's last lines were:

```bash
if "$STAGING/noir" --version >/dev/null 2>&1; then
  "$STAGING/noir" --version
fi
```

On the arm64 runner the staged binary was killed, the `if` went false, and the script printed `Created …` and exited 0. The smoke test that existed to catch this swallowed its own SIGKILL.

## Changes

- Re-signs dylibs, then the binary, ad hoc, after the last `install_name_tool` call.
- Hard-fails if any signature does not verify. That check is arch-independent, so it also catches the breakage on the x86_64 runner, where nothing enforces signatures at exec time.
- Extracts the finished tarball and runs *that*, replacing the failure-swallowing test. This is the exact layout a user unpacks.
- Requires `codesign` up front; makes copied dylibs writable (Homebrew ships them `0444`).

The existing all-dylibs `$BREW_PREFIX_RE` audit and the per-target `rewrite_paths` filter are untouched.

## Verification

On an arm64 Mac, against a purpose-built Homebrew-OpenSSL-linked binary run through this exact script:

| check | result |
|---|---|
| Pre-fix script | packages "successfully", extracted binary exits 137 |
| Post-fix script | binary + both dylibs `VALID`, extracted binary runs |
| Signing removed, verify gate kept | exits 1 before the tarball is written |
| Signing **and** verify gate removed | smoke test reports `exit 137`, script exits 1 |

`shellcheck` and `bash -n` clean. No Crystal sources touched, so `just build` / `just test` / `crystal tool format` are unaffected.

## Follow-ups

- Needs a patch release — the published v1.3.0 arm64 tarball stays unrunnable until one goes out.
- A CI job that packages on a `macos-latest` (arm64) runner and runs the extracted tarball would catch this before a tag is cut; packaging currently only ever runs during a release. Happy to add it here or separately.

Same root cause and fix as hahwul/hwaro#783; `gori` already carries the equivalent fix.