### PR TITLE
fix(python): report the parameter name a client actually sends, and stop --no-log from hiding two warnings

### DIFF
--- a/spec/functional_test/fixtures/python/django_ninja/myproject/api.py
+++ b/spec/functional_test/fixtures/python/django_ninja/myproject/api.py
@@ -1,4 +1,4 @@
-from ninja import NinjaAPI, Schema, Form, File, Header, Cookie
+from ninja import NinjaAPI, Schema, Form, File, Header, Cookie, Query, Field
 from ninja.files import UploadedFile
 
 from events.api import router as events_router
@@ -12,6 +12,26 @@ class ItemIn(Schema):
     name: str
     price: float
     quantity: int = 1
+
+
+class AliasedIn(Schema):
+    user_name: str = Field(..., alias="userName")
+    age: int
+
+
+# django-ninja names a parameter `alias or <identifier>`, so an alias
+# replaces the identifier outright — `renamed` is never populated from a
+# `renamed` header. There is no underscore rule here (Django's HttpHeaders
+# resolves `x_api_key` and `x-api-key` to the same header), which is why
+# `/api/whoami` above still expects `x_api_key`.
+@api.get("/aliased")
+def aliased(request, renamed: str = Header(None, alias="X-Custom"), q_n: str = Query(None, alias="q-n")):
+    return {}
+
+
+@api.post("/aliased_body")
+def aliased_body(request, payload: AliasedIn):
+    return payload
 
 
 @api.get("/add")

--- a/spec/functional_test/fixtures/python/fastapi/api.py
+++ b/spec/functional_test/fixtures/python/fastapi/api.py
@@ -5,6 +5,7 @@ from fastapi_utils.cbv import cbv
 from typing_extensions import Annotated
 from fastapi.responses import JSONResponse
 from fastapi import FastAPI, Path, Query, status, Body, Header, Cookie, Depends, Security, Request, Response, APIRouter, WebSocket
+from pydantic import BaseModel, Field
 
 api : APIRouter = APIRouter()
 tenant_api = APIRouter(prefix="/tenants/{tenant_id}")
@@ -39,6 +40,29 @@ async def hidden_header(
     return {"hidden_header": hidden_header}
 
 
+# The name a client sends is not always the Python identifier: `alias=`
+# overrides it outright, and `Header` maps `_` to `-` unless it is told
+# `convert_underscores=False`.
+@api.get("/wire_names")
+async def wire_names(
+    x_token: Optional[str] = Header(default=None),
+    renamed: Optional[str] = Header(default=None, alias="X-Custom-Auth"),
+    keep_underscores: Optional[str] = Header(default=None, convert_underscores=False),
+    q_name: Optional[str] = Query(default=None, alias="q-name"),
+    sess_id: Optional[str] = Cookie(default=None, alias="sess-id"),
+):
+    return {}
+
+
+@api.get("/wire_names/annotated")
+async def wire_names_annotated(
+    x_api_key: Annotated[Optional[str], Header()] = None,
+    tok: Annotated[Optional[str], Header(alias="X-Tok")] = None,
+    q_x: Annotated[Optional[str], Query(alias="q-x")] = None,
+):
+    return {}
+
+
 @api.get("/cookie_examples/")
 def cookie_examples(
     data: Union[str, None] = Cookie(
@@ -57,6 +81,22 @@ def cookie_examples(
     ),
 ):
     return data
+
+# A Pydantic model describes the body, and `Field(alias=...)` /
+# `validation_alias=...` rename the key the client has to send. `note`
+# guards the other direction: a default that merely contains the text
+# `alias=` is not a rename.
+class AliasedPayload(BaseModel):
+    user_name: str = Field(..., alias="userName")
+    v2_name: str = Field(..., validation_alias="v2Name")
+    age: int
+    note: str = "plain"
+
+
+@api.post("/aliased_body")
+async def aliased_body(payload: AliasedPayload):
+    return payload
+
 
 @api.post("/dummypath")
 async def get_body(request: Request):

--- a/spec/functional_test/testers/python/django_ninja_spec.cr
+++ b/spec/functional_test/testers/python/django_ninja_spec.cr
@@ -17,6 +17,14 @@ expected_endpoints = [
     Param.new("price", "", "json"),
     Param.new("quantity", "1", "json"),
   ]),
+  Endpoint.new("/api/aliased", "GET", [
+    Param.new("X-Custom", "", "header"),
+    Param.new("q-n", "", "query"),
+  ]),
+  Endpoint.new("/api/aliased_body", "POST", [
+    Param.new("userName", "", "json"),
+    Param.new("age", "", "json"),
+  ]),
   Endpoint.new("/api/search", "GET", [Param.new("q", "", "query"), Param.new("limit", "10", "query")]),
   Endpoint.new("/api/upload", "POST", [Param.new("note", "", "form"), Param.new("attachment", "", "form")]),
   Endpoint.new("/api/whoami", "GET", [Param.new("x_api_key", "", "header"), Param.new("session", "", "cookie")]),

--- a/spec/functional_test/testers/python/fastapi_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_spec.cr
@@ -3,7 +3,27 @@ require "../../func_spec.cr"
 expected_endpoints = [
   Endpoint.new("/api/query/param-required/int", "GET", [Param.new("query", "", "query")]),
   Endpoint.new("/api/items/{item_id}", "PUT", [Param.new("item_id", "", "path"), Param.new("name", "", "form"), Param.new("size", "", "form")]),
-  Endpoint.new("/api/hidden_header", "GET", [Param.new("hidden_header", "", "header")]),
+  # `Header` maps `_` to `-` unless `convert_underscores=False`, so the name
+  # a client actually sends is `hidden-header`, not the Python identifier.
+  Endpoint.new("/api/hidden_header", "GET", [Param.new("hidden-header", "", "header")]),
+  Endpoint.new("/api/wire_names", "GET", [
+    Param.new("x-token", "", "header"),
+    Param.new("X-Custom-Auth", "", "header"),
+    Param.new("keep_underscores", "", "header"),
+    Param.new("q-name", "", "query"),
+    Param.new("sess-id", "", "cookie"),
+  ]),
+  Endpoint.new("/api/aliased_body", "POST", [
+    Param.new("userName", "", "form"),
+    Param.new("v2Name", "", "form"),
+    Param.new("age", "", "form"),
+    Param.new("note", "plain", "form"),
+  ]),
+  Endpoint.new("/api/wire_names/annotated", "GET", [
+    Param.new("x-api-key", "", "header"),
+    Param.new("X-Tok", "", "header"),
+    Param.new("q-x", "", "query"),
+  ]),
   Endpoint.new("/api/cookie_examples/", "GET", [Param.new("data", "", "cookie")]),
   Endpoint.new("/api/dummypath", "POST", [Param.new("dummy", "", "json")]),
   Endpoint.new("/api/constant/concat", "GET"),

--- a/spec/unit_test/cli/binary_surface_spec.cr
+++ b/spec/unit_test/cli/binary_surface_spec.cr
@@ -14,6 +14,9 @@ require "json"
 private REPO_ROOT = File.expand_path(File.join(__DIR__, "..", "..", ".."))
 private BINARY    = File.join(REPO_ROOT, "bin", "noir")
 private FIXTURE   = File.join(REPO_ROOT, "spec", "functional_test", "fixtures", "ruby", "sinatra")
+# A second, deliberately different codebase, so `--diff-path` has something
+# to report as added/removed rather than an empty diff.
+private DIFF_FIXTURE = File.join(REPO_ROOT, "spec", "functional_test", "fixtures", "ruby", "rails")
 
 private record CliRun, stdout : String, stderr : String, exit_code : Int32
 
@@ -376,6 +379,29 @@ describe "noir CLI surface (built binary)" do
       ensure
         FileUtils.rm_rf(dir)
       end
+    end
+  end
+
+  describe "diff mode with a format it cannot render" do
+    # Diff mode only implements plain/json/yaml/toml. Any other `-f` falls
+    # back to the decorated text diff, and the notice saying so used to go
+    # through the progress logger — which `--no-log` silences wholesale.
+    # That is exactly backwards: `--no-log -f sarif -o report.sarif` in CI
+    # is the run that most needs to hear it, and it was the one run that
+    # could not. The warning now takes the same always-visible STDERR path
+    # as the other "your flag was ignored" notices.
+    it "warns on stderr even under --no-log" do
+      result = run_noir(["scan", FIXTURE, "--diff-path", DIFF_FIXTURE,
+                         "--no-color", "--no-log", "-f", "sarif"])
+      result.stderr.should contain("diff mode does not support -f sarif")
+      result.stdout.should_not contain("\"$schema\"")
+    end
+
+    it "stays quiet for a format diff mode does implement" do
+      result = run_noir(["scan", FIXTURE, "--diff-path", DIFF_FIXTURE,
+                         "--no-color", "--no-log", "-f", "json"])
+      result.stderr.should_not contain("does not support")
+      JSON.parse(result.stdout)["added"].as_a.should_not be_nil
     end
   end
 

--- a/src/analyzer/analyzers/python/django_ninja.cr
+++ b/src/analyzer/analyzers/python/django_ninja.cr
@@ -1,5 +1,6 @@
 require "../../engines/python_engine"
 require "../../../utils/top_level_split"
+require "./python_helper"
 
 module Analyzer::Python
   # Django Ninja is a FastAPI-inspired REST framework that plugs into
@@ -271,7 +272,7 @@ module Analyzer::Python
 
         if param_type = infer_ninja_param_type(param)
           default_value = return_literal_value(param.default)
-          params << Param.new(param.name, default_value, param_type)
+          params << Param.new(ninja_wire_name(param), default_value, param_type)
           next
         end
 
@@ -287,6 +288,30 @@ module Analyzer::Python
       end
 
       dedupe_params(params)
+    end
+
+    # django-ninja builds its parameter name as `Header(alias=...) or
+    # <identifier>` (`ninja/signature/details.py`), so an alias replaces the
+    # identifier outright — `renamed: str = Header(None, alias="X-Custom")`
+    # is only ever populated from an `X-Custom` header, never from
+    # `renamed`. Unlike FastAPI there is no underscore-to-hyphen rule here:
+    # the lookup goes through Django's `HttpHeaders`, which resolves
+    # `x_token` and `x-token` to the same header, so the identifier stays as
+    # written when no alias is given.
+    NINJA_PARAM_CLASS_RE = /\b(?:Header|Query|Cookie|Path|Body|Form|File)\s*\(/
+
+    # A `ninja.Schema` is a Pydantic model, so a body field renames the same
+    # way a FastAPI one does.
+    NINJA_FIELD_CALL_RE = /\bField\s*\(/
+
+    private def ninja_wire_name(param : FunctionParameter) : ::String
+      {param.default, param.type}.each do |declaration|
+        next unless declaration.matches?(NINJA_PARAM_CLASS_RE)
+        if explicit = Helper.declared_alias(declaration)
+          return explicit
+        end
+      end
+      param.name
     end
 
     private def infer_ninja_param_type(param : FunctionParameter) : ::String?
@@ -364,7 +389,8 @@ module Analyzer::Python
           default = assignment[1].strip if assignment.size == 2
         end
 
-        params << Param.new(field_name, return_literal_value(default), "json")
+        wire_name = default.matches?(NINJA_FIELD_CALL_RE) ? (Helper.declared_alias(default) || field_name) : field_name
+        params << Param.new(wire_name, return_literal_value(default), "json")
       end
 
       params.empty? ? nil : params

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -1,5 +1,6 @@
 require "../../engines/python_engine"
 require "../../../utils/top_level_split"
+require "./python_helper"
 
 module Analyzer::Python
   class FastAPI < PythonEngine
@@ -250,7 +251,7 @@ module Analyzer::Python
                           end
                         else
                           # Add endpoint param
-                          params << Param.new(param.name, default_value, param_type)
+                          params << Param.new(fastapi_wire_name(param, param_type), default_value, param_type)
                         end
                       end
                     end
@@ -1113,7 +1114,7 @@ module Analyzer::Python
             new_params.each { |model_param| params << model_param }
           end
         else
-          params << Param.new(param.name, default_value, param_type)
+          params << Param.new(fastapi_wire_name(param, param_type), default_value, param_type)
         end
       end
 
@@ -1185,6 +1186,64 @@ module Analyzer::Python
       normalized == "/" ? "/*" : "#{normalized}/*"
     end
 
+    # The Python identifier a FastAPI handler declares is not always the name
+    # the client sends. Two rules rewrite it, and Noir honored neither:
+    #
+    #   * `alias=` overrides the name outright, for every parameter class
+    #     (`Header`, `Query`, `Cookie`, `Form`, `File`, `Body`, `Path`).
+    #   * `Header` — and only `Header` — additionally maps `_` to `-`, because
+    #     an HTTP header name can't carry an underscore in most stacks. That
+    #     is `convert_underscores`, and it defaults to **True**; passing
+    #     `convert_underscores=False` is what opts back out.
+    #
+    # Reporting the identifier verbatim is not a cosmetic mismatch: it is the
+    # name Noir hands to the next stage. `-f curl` emitted `-H 'x_token: '`
+    # for `x_token: str = Header(None)`, a header the app reads as nothing,
+    # and a DAST tool importing the OpenAPI doc probed `?q_name=` for a
+    # parameter the app only accepts as `q-name`.
+    FASTAPI_PARAM_CLASS_RE    = /\b(?:Header|Query|Cookie|Path|Body|Form|File)\s*\(/
+    NO_CONVERT_UNDERSCORES_RE = /\bconvert_underscores\s*=\s*False\b/
+
+    # The same rename, one layer down. A request body is described by a
+    # Pydantic model, and `Field(alias=...)` renames the key there too —
+    # with `populate_by_name` off (the default) the alias is the *only* key
+    # the model accepts, so the attribute name is a body field the app
+    # rejects outright.
+    MODEL_FIELD_CALL_RE = /\bField\s*\(/
+
+    # `param_type` is Noir's resolved slot ("header", "query", ...), which is
+    # what decides whether the underscore rule applies; the declaration text
+    # is whichever of the default value or the annotation actually carries the
+    # `Header(...)` / `Query(...)` call, since `Annotated[str, Header()]` puts
+    # it in the annotation and `= Header()` puts it in the default.
+    private def fastapi_wire_name(param : FunctionParameter, param_type : ::String) : ::String
+      declaration = fastapi_param_declaration(param)
+      return param.name if declaration.empty?
+
+      if explicit = Helper.declared_alias(declaration)
+        return explicit
+      end
+
+      return param.name unless param_type == "header"
+      return param.name if declaration.matches?(NO_CONVERT_UNDERSCORES_RE)
+      param.name.tr("_", "-")
+    end
+
+    # Gated on an actual parameter-class call so a plain default that merely
+    # contains the text `alias=` (`mode: str = "alias=1"`) is left alone.
+    private def fastapi_param_declaration(param : FunctionParameter) : ::String
+      return param.default if param.default.matches?(FASTAPI_PARAM_CLASS_RE)
+      return param.type if param.type.matches?(FASTAPI_PARAM_CLASS_RE)
+      ""
+    end
+
+    # Same gate as `fastapi_param_declaration`: only a real `Field(...)`
+    # call renames anything, so `note: str = "alias=x"` keeps its name.
+    private def model_field_wire_name(attribute : ::String, default : ::String) : ::String
+      return attribute unless default.matches?(MODEL_FIELD_CALL_RE)
+      Helper.declared_alias(default) || attribute
+    end
+
     # Infers the type of the parameter based on its default value or type annotation
     def infer_parameter_type(data : ::String, is_param_type = false) : ::String?
       if data.matches?(/Cookie/)
@@ -1234,7 +1293,7 @@ module Analyzer::Python
 
           if !param_name.empty? && !param_type.empty?
             default_value = return_literal_value(param_default.strip)
-            params << Param.new(param_name.strip, default_value, "form")
+            params << Param.new(model_field_wire_name(param_name.strip, param_default), default_value, "form")
           end
         end
       end

--- a/src/analyzer/analyzers/python/python_helper.cr
+++ b/src/analyzer/analyzers/python/python_helper.cr
@@ -23,5 +23,31 @@ module Analyzer::Python
       string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
       string_match ? string_match[1] : nil
     end
+
+    # `alias=` renames a parameter on the wire. Every Pydantic-backed Python
+    # framework Noir supports spells it the same way — FastAPI's
+    # `Header(alias=...)` / `Query(alias=...)`, django-ninja's identical
+    # forms, and a `Field(alias=...)` on the body model behind either. With
+    # the alias in force the identifier is no longer a name the app answers
+    # to, so reporting it hands the next stage (cURL, OpenAPI, a DAST
+    # import) a header or field the target rejects.
+    #
+    # Pydantic v2 splits the input side out as `validation_alias`, which
+    # wins over a plain `alias` when both are present, so it is tried first.
+    # `\b` keeps `\balias` from matching the tail of `validation_alias`.
+    VALIDATION_ALIAS_RE = /\bvalidation_alias\s*=\s*(?:"([^"]*)"|'([^']*)')/
+    ALIAS_RE            = /\balias\s*=\s*(?:"([^"]*)"|'([^']*)')/
+
+    # Callers gate on having seen a real parameter-class call first, so a
+    # default that merely contains the text `alias=` (`mode: str =
+    # "alias=1"`) never reaches here.
+    def declared_alias(declaration : ::String) : ::String?
+      {VALIDATION_ALIAS_RE, ALIAS_RE}.each do |pattern|
+        next unless match = declaration.match(pattern)
+        name = match[1]? || match[2]?
+        return name if name && !name.empty?
+      end
+      nil
+    end
   end
 end

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -65,7 +65,15 @@ class NoirLogger
   end
 
   def log(level : LogLevel, message : String)
-    return if @no_log
+    # `--no-log` suppresses the *message*, never the termination. The early
+    # return used to cover the whole method, so `fatal` under `--no-log`
+    # printed nothing AND skipped the `exit(1)` below — the one log level
+    # whose entire contract is that the process stops. The caller then ran
+    # on past an unrecoverable state with no trace of it.
+    if @no_log
+      exit(1) if level == LogLevel::FATAL
+      return
+    end
 
     prefix = case level
              when LogLevel::DEBUG

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -307,10 +307,19 @@ class NoirRunner
       # Diff mode only implements plain/json/yaml/toml. Any other explicit
       # format (only-url, curl, sarif, oas3, …) was silently rendered as the
       # decorated text diff, corrupting automation pipelines that expected the
-      # requested format. Warn (to STDERR) so the mismatch is visible.
+      # requested format.
       fmt = options["format"].to_s
       unless fmt.empty? || fmt == "plain"
-        @logger.warning "Diff mode does not support -f #{fmt}; showing the text diff instead. Supported diff formats: plain, json, yaml, toml."
+        # Straight to STDERR rather than through `@logger.warning`, which
+        # `--no-log` silences wholesale — and `--no-log` is exactly the run
+        # that needs to hear this. `noir scan new --diff-path old -f sarif
+        # --no-log -o report.sarif` in CI otherwise writes the text diff
+        # into a `.sarif` file with nothing on either stream saying the
+        # format request was dropped. A "your flag was ignored" notice about
+        # the result stream itself belongs with the `--concurrency` clamp
+        # and the other always-visible CliValidation warnings, not with the
+        # progress log.
+        STDERR.puts "WARNING: diff mode does not support -f #{fmt}; showing the text diff instead. Supported diff formats: plain, json, yaml, toml.".colorize(:yellow)
       end
       builder.print @endpoints, diff_app
     end


### PR DESCRIPTION
Found while building the tool and exercising it against real framework code. Four fixes, two of them verified against the frameworks themselves.

## FastAPI / django-ninja report the wrong parameter name

FastAPI and django-ninja name a parameter after the Python identifier only until something renames it, and Noir was reporting the identifier either way. That name is not decoration — it is what `-f curl` puts after `-H`, what the generated OpenAPI document declares, and what a DAST tool importing that document probes. Getting it wrong means the request Noir hands to the next stage reaches a parameter the app never reads.

Three renames were unhandled:

- **`alias=`** replaces the name outright, for every parameter class (Header, Query, Cookie, Path, Body, Form, File) in both frameworks.
- **FastAPI's `Header`** — and only `Header` — maps `_` to `-`, because an HTTP header name cannot carry an underscore in most stacks. That is `convert_underscores`, and it defaults to `True`; `convert_underscores=False` opts back out.
- **A Pydantic body model** renames its keys the same way with `Field(alias=...)`. With `populate_by_name` off (the default) the alias is the *only* key the model accepts, so the attribute name is a body field the app rejects with a 422.

| declaration | before | after |
|---|---|---|
| `x_token: str = Header(None)` | `x_token` ✗ | `x-token` ✓ |
| `Header(None, alias="X-Custom-Auth")` | `token` ✗ | `X-Custom-Auth` ✓ |
| `Header(None, convert_underscores=False)` | `x_token` ✓ | `x_token` ✓ |
| `Query(None, alias="q-name")` | `q_name` ✗ | `q-name` ✓ |
| `Annotated[str, Header()]` | `x_api_key` ✗ | `x-api-key` ✓ |
| `Field(..., alias="userName")` | `user_name` ✗ | `userName` ✓ |

What it looked like from the outside — every one of these headers is read as nothing by the app:

```
$ noir -b ./app -f curl -u http://t.example      # before
curl -i -X 'GET' 'http://t.example/h1' -H 'x_token: '
curl -i -X 'GET' 'http://t.example/h2' -H 'token: '
curl -i -X 'GET' 'http://t.example/h4?q_name=' -H 'user_agent: '
```

**Verified against the frameworks, not against my reading of them.** Driving FastAPI 0.141 and django-ninja on Django 5 directly: every name this PR now reports reaches the handler, and every name it reported before does not — the body case failing hard, with FastAPI itself naming the key it wanted.

```
== the name Noir now reports ==            == the name Noir reported before ==
h1  header 'x-token'       -> {'v':'HIT'}  h1  header 'x_token'    -> {'v': None}
h2  header 'X-Custom-Auth' -> {'v':'HIT'}  h2  header 'renamed'    -> {'v': None}
h4  query  'q-name'        -> {'v':'HIT'}  h4  query  'q_name'     -> {'v': None}
a1  header 'x-api-key'     -> {'v':'HIT'}  a1  header 'x_api_key'  -> {'v': None}
a4  cookie 'sess-id'       -> {'v':'HIT'}  a4  cookie 'sess_id'    -> {'v': None}
p   body   'userName'      -> {'v':'HIT'}  p   body   'user_name'  -> 422 missing 'userName'
```

django-ninja deliberately gets the alias rule but **not** the underscore one. Its parameter name is `alias or <identifier>` (`ninja/signature/details.py`), and the lookup goes through Django's `HttpHeaders`, which resolves `x_token` and `x-token` to the same header — so there the identifier as written is correct, and `/api/whoami` in the fixture still expects `x_api_key`.

`declared_alias` lives in the shared `Analyzer::Python::Helper` rather than in either adapter: `alias=` / `validation_alias=` is a Pydantic-level spelling, identical in both frameworks, and the next Pydantic-backed analyzer shouldn't carry a third copy of the regex.

## `--no-log` was hiding two things it shouldn't

**Diff mode's unsupported-format warning.** Diff mode only renders plain/json/yaml/toml; any other `-f` falls back to the decorated text diff. The notice saying so went through `@logger.warning`, which `--no-log` silences wholesale — and `--no-log` is exactly the run that needs to hear it. `noir scan new --diff-path old -f sarif --no-log -o report.sarif` in CI wrote the text diff into a `.sarif` file with nothing on either stream saying the format request had been dropped. It now takes the same always-visible STDERR path as the `--concurrency` clamp and the other CliValidation notices, because it is the same kind of message: your flag was ignored.

**`LogLevel::FATAL` not exiting.** `NoirLogger#log` returned early on `@no_log` before reaching `exit(1) if level == LogLevel::FATAL`, so under `--no-log` the one level whose entire contract is that the process stops printed nothing *and* kept going. No caller reaches `fatal` today, which is why this never surfaced — but `write_stderr_line`'s own comment already reasons about that `exit(1)` running, so the next caller would have inherited the trap. `--no-log` now suppresses the message and nothing else.

## Testing

- New fixture cases and expectations: 8 for FastAPI (both the `= Header(...)` and `Annotated[str, Header(...)]` forms, plus the negative case where a default merely *contains* the text `alias=`), 4 for django-ninja.
- The diff-format warning is covered end-to-end through the built binary in `binary_surface_spec`, where argv, exit codes and the stdout/stderr split are observable. **Reverting the fix fails that example** — checked, then restored.
- `just check`: 2293 inspected, 0 failures. `just test`: 5706 unit + 24625 functional, 0 failures.
- Re-scanned all 33 fixture languages with `-T --include path,techs,callee --ai-context`: clean, no exceptions, no exit-code changes.

## Not fixed here, but worth a look

`--probe` and `--status-codes` send an **absolute-form request target** to origin servers:

```
GET http://127.0.0.1:18333/a/b?q= HTTP/1.1     <- noir
GET /a/b?q= HTTP/1.1                            <- curl
```

RFC 9112 §3.2.1 makes origin-form a MUST when talking to an origin server directly; absolute-form is the proxy shape. Servers MUST accept it, so it usually interoperates, but a WAF or API gateway can read it as a proxy request and answer 400 or route it differently. It originates in the `crest` shard (`HTTP::Request.new(method, @url)` with the full URL), and fixing it in Noir would mean re-implementing TLS, timeouts and redirect handling across the three deliver classes — and absolute-form is the *correct* shape for the `--probe-via` path that shares the code. Left alone deliberately; flagging it rather than fixing it blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyU8rhorsKuu1tkejKYvE3
