### PR TITLE
docs(ko): keep Korean pages linking to Korean pages

### DIFF
--- a/docs/content/development/analyzer_architecture/index.ko.md
+++ b/docs/content/development/analyzer_architecture/index.ko.md
@@ -109,7 +109,7 @@ Detector 는 프로젝트의 후보 파일별로 한 번씩 실행됩니다. `tr
 
 ### 1. Detector
 
-`src/detector/detectors/{언어}/{프레임워크}.cr` 생성:
+`src/detector/detectors/{lang}/{framework}.cr` 생성:
 
 ```crystal
 require "../../../models/detector"
@@ -127,7 +127,7 @@ end
 
 ### 2. Analyzer
 
-`src/analyzer/analyzers/{언어}/{프레임워크}.cr` 생성. 언어 엔진을 상속:
+`src/analyzer/analyzers/{lang}/{framework}.cr` 생성. 언어 엔진을 상속:
 
 ```crystal
 require "../../engines/go_engine"
@@ -204,7 +204,7 @@ end
 
 ### 4. Fixture
 
-`spec/functional_test/fixtures/{언어}/{프레임워크}/` 에 최소 앱 생성:
+`spec/functional_test/fixtures/{lang}/{framework}/` 에 최소 앱 생성:
 
 ```
 spec/functional_test/fixtures/go/hertz/
@@ -218,7 +218,7 @@ Fixture 는 현실적 패턴(path param, query/form/header/cookie, 라우트 그
 
 ### 5. Spec
 
-`spec/functional_test/testers/{언어}/{프레임워크}_spec.cr` 생성:
+`spec/functional_test/testers/{lang}/{framework}_spec.cr` 생성:
 
 ```crystal
 require "../../func_spec.cr"
@@ -257,7 +257,7 @@ just test                  # unit + functional spec 통과
 just check                 # crystal tool format --check + ameba
 
 # 수동 확인
-./bin/noir -b spec/functional_test/fixtures/{언어}/{프레임워크}
+./bin/noir -b spec/functional_test/fixtures/{lang}/{framework}
 ```
 
 ## 새 언어 엔진 추가하기

--- a/docs/content/get_started/ai_power/index.ko.md
+++ b/docs/content/get_started/ai_power/index.ko.md
@@ -82,7 +82,7 @@ Noir는 다음 AI 제공업체 프리셋을 지원합니다:
 
 사용자 정의 제공업체는 전체 API URL을 사용합니다: `--ai-provider=http://my-custom-api:9000`.
 
-`azure` 프리셋이 쓰던 공용 호스트는 상위에서 종료되었습니다. 대신 사용할 리소스별 URL은 [Azure AI](@/usage/ai_providers/azure/index.md) 문서를 참고하세요.
+`azure` 프리셋이 쓰던 공용 호스트는 상위에서 종료되었습니다. 대신 사용할 리소스별 URL은 [Azure AI](@/usage/ai_providers/azure/index.ko.md) 문서를 참고하세요.
 
 원본 ACP/에이전트 stderr 로그가 필요하면 `NOIR_ACP_RAW_LOG=1`을 설정합니다.
 

--- a/docs/content/get_started/installation/index.ko.md
+++ b/docs/content/get_started/installation/index.ko.md
@@ -303,4 +303,4 @@ noir --version
 
 ---
 
-**다음**: [첫 번째 스캔](@/get_started/running/index.md)
+**다음**: [첫 번째 스캔](@/get_started/running/index.ko.md)

--- a/docs/content/get_started/overview/index.ko.md
+++ b/docs/content/get_started/overview/index.ko.md
@@ -34,7 +34,7 @@ Noir는 오픈 소스 SAST 도구입니다. 소스 코드를 읽어 애플리케
 
 **AI SAST에 쓸 만한 컨텍스트 제공.** Noir가 추출한 엔드포인트 인벤토리는 진입점, 소스 파일, 파라미터, 태그로 구성되며, `--include callee`를 쓰면 각 핸들러가 호출하는 1-hop 함수까지 담깁니다. LLM 기반 SAST, 코드 감사자, 보안 에이전트가 공격자 도달 가능한 버그를 찾는 데 필요한 바로 그 컨텍스트입니다. `--ai-context`를 켜면 한 단계 더 나아가, 엔드포인트별로 집약된 리뷰 컨텍스트(guards, callees, sources, sinks, validators, signals)까지 함께 붙어서 모델이 다시 찾아낼 필요가 없습니다. 모델에게 저장소 전체를 훑게 하는 대신, Noir가 매핑해 둔 표면을 그대로 넘기세요.
 
-**다음 도구가 읽을 형식으로 출력.** JSON, YAML, OpenAPI 명세, CI/CD용 SARIF, cURL, HTTPie, HTML 보고서, Postman 컬렉션 등 파이프라인의 다음 도구가 기대하는 형식으로 결과가 나옵니다.
+**다음 도구가 읽을 형식으로 출력.** JSON, YAML, OpenAPI 명세, CI/CD용 SARIF, cURL, HTTPie, HTML 리포트, Postman 컬렉션 등 파이프라인의 다음 도구가 기대하는 형식으로 결과가 나옵니다.
 
 ## 어떻게 작동하나요?
 
@@ -100,4 +100,4 @@ Noir는 오픈 소스이며 모든 기여를 환영합니다. [기여 가이드]
 
 ---
 
-**다음**: [Noir 설치](@/get_started/installation/index.md)
+**다음**: [Noir 설치](@/get_started/installation/index.ko.md)

--- a/docs/content/get_started/running/index.ko.md
+++ b/docs/content/get_started/running/index.ko.md
@@ -50,7 +50,7 @@ Noir가 분석할 수 있는 모든 기술을 보려면:
 noir list techs
 ```
 
-목록에 없는 프레임워크라면 [AI 기반 분석](@/get_started/ai_power/index.md)으로 엔드포인트를 탐지할 수 있습니다.
+목록에 없는 프레임워크라면 [AI 기반 분석](@/get_started/ai_power/index.ko.md)으로 엔드포인트를 탐지할 수 있습니다.
 
 ## 다양한 출력 형식 사용
 
@@ -70,7 +70,7 @@ noir scan . -f oas3
 noir scan . -f curl -u https://your-target.com
 ```
 
-사용 가능한 모든 형식은 `noir list formats` 또는 [출력 형식](@/usage/output_formats/_index.md) 섹션을 참조하세요.
+사용 가능한 모든 형식은 `noir list formats` 또는 [출력 형식](@/usage/output_formats/_index.ko.md) 섹션을 참조하세요.
 
 ## 결과를 파일로 저장
 
@@ -135,7 +135,7 @@ noir scan . --ai-context
 noir scan . --ai-context guards,sinks
 ```
 
-데이터 모양과 프레임워크별 지원은 [Callee 커버리지](@/usage/supported/callee_coverage/index.md)와 [AI 컨텍스트](@/usage/supported/ai_context_coverage/index.md)를 참고하세요.
+데이터 모양과 프레임워크별 지원은 [Callee 커버리지](@/usage/supported/callee_coverage/index.ko.md)와 [AI 컨텍스트](@/usage/supported/ai_context_coverage/index.ko.md)를 참고하세요.
 
 ## 주요 플래그 정리
 
@@ -170,8 +170,8 @@ noir scan . --ai-context guards,sinks
 
 시작하기 가이드를 완료했습니다! 다음으로 살펴볼 내용:
 
-- **[CLI 명령어](@/usage/cli_commands/_index.md)**: v1 서브커맨드(scan, list, cache, config, rules 등) 전체 레퍼런스
-- **[설정](@/usage/configurations/configuration_file/index.md)**: 매번 플래그를 반복하지 않도록 기본 옵션 설정
-- **[출력 형식](@/usage/output_formats/_index.md)**: 모든 출력 형식 자세히 알아보기
-- **[패시브 스캔](@/usage/passive_scan/_index.md)**: 하드코딩된 비밀키, 잘못된 설정 등 보안 이슈 스캔
-- **[AI 기반 분석](@/get_started/ai_power/index.md)**: AI로 미지원 프레임워크의 엔드포인트 탐지
+- **[CLI 명령어](@/usage/cli_commands/_index.ko.md)**: v1 서브커맨드(scan, list, cache, config, rules 등) 전체 레퍼런스
+- **[설정](@/usage/configurations/configuration_file/index.ko.md)**: 매번 플래그를 반복하지 않도록 기본 옵션 설정
+- **[출력 형식](@/usage/output_formats/_index.ko.md)**: 모든 출력 형식 자세히 알아보기
+- **[패시브 스캔](@/usage/passive_scan/_index.ko.md)**: 하드코딩된 비밀키, 잘못된 설정 등 보안 이슈 스캔
+- **[AI 기반 분석](@/get_started/ai_power/index.ko.md)**: AI로 미지원 프레임워크의 엔드포인트 탐지

--- a/docs/content/resources/faq/index.ko.md
+++ b/docs/content/resources/faq/index.ko.md
@@ -16,11 +16,11 @@ sort_by = "weight"
 
 ### Noir를 어떻게 설치하나요?
 
-Homebrew, Snapcraft, Docker 등을 통해 설치할 수 있습니다. [설치](@/get_started/installation/index.md) 페이지를 참조하세요.
+Homebrew, Snapcraft, Docker 등을 통해 설치할 수 있습니다. [설치](@/get_started/installation/index.ko.md) 페이지를 참조하세요.
 
 ### Noir는 어떤 언어와 프레임워크를 지원하나요?
 
-[지원되는 언어 및 프레임워크](@/usage/supported/language_and_frameworks/index.md) 페이지에서 전체 목록을 확인하세요.
+[지원되는 언어 및 프레임워크](@/usage/supported/language_and_frameworks/index.ko.md) 페이지에서 전체 목록을 확인하세요.
 
 ### Noir에 어떻게 기여할 수 있나요?
 
@@ -32,11 +32,11 @@ Homebrew, Snapcraft, Docker 등을 통해 설치할 수 있습니다. [설치](@
 
 ### 다른 보안 도구와 어떻게 통합하나요?
 
-ZAP, Burp Suite, Caido 등과 통합할 수 있습니다. [DAST 파이프라인](@/usage/more_features/pipeline-for-dast/index.md) 가이드를 참조하세요.
+ZAP, Burp Suite, Caido 등과 통합할 수 있습니다. [DAST 파이프라인](@/usage/more_features/pipeline-for-dast/index.ko.md) 가이드를 참조하세요.
 
 ### 결과를 어떻게 내보내나요?
 
-JSON, YAML, OpenAPI 명세, cURL 등 다양한 형식을 지원합니다. [출력 형식](@/usage/output_formats/_index.md) 섹션을 참조하세요.
+JSON, YAML, OpenAPI 명세, cURL 등 다양한 형식을 지원합니다. [출력 형식](@/usage/output_formats/_index.ko.md) 섹션을 참조하세요.
 
 ### 버그 보고나 기능 요청은 어떻게 하나요?
 

--- a/docs/content/resources/troubleshooting/index.ko.md
+++ b/docs/content/resources/troubleshooting/index.ko.md
@@ -17,7 +17,7 @@ sort_by = "weight"
 - 올바른 디렉토리를 지정했는지 확인하세요: `noir scan ./your-app`
 - 프레임워크가 지원되는지 확인하세요: `noir list techs`
 - `--verbose`를 사용하여 어떤 기술이 감지되었는지 확인하세요
-- 프레임워크가 지원되지 않는 경우 [AI 기반 분석](@/get_started/ai_power/index.md)을 사용하세요
+- 프레임워크가 지원되지 않는 경우 [AI 기반 분석](@/get_started/ai_power/index.ko.md)을 사용하세요
 
 ## 스캔이 너무 오래 걸림
 
@@ -35,7 +35,7 @@ sort_by = "weight"
 
 - API 키가 올바른지 확인하세요: `--ai-key <KEY>` 또는 `NOIR_AI_KEY` 환경 변수 설정
 - 로컬 제공업체(Ollama, vLLM, LM Studio)의 경우 서버가 실행 중인지 확인하세요
-- [AI 제공업체](@/usage/ai_providers/_index.md) 비교표에서 기본 호스트를 확인하세요
+- [AI 제공업체](@/usage/ai_providers/_index.ko.md) 비교표에서 기본 호스트를 확인하세요
 - 사용자 정의 엔드포인트의 경우 전체 URL을 사용하세요: `--ai-provider=http://your-server:port`
 - ACP 제공업체의 경우 `NOIR_ACP_RAW_LOG=1`로 디버그 로그를 활성화하세요
 
@@ -57,10 +57,10 @@ sort_by = "weight"
 **증상:** 설치 후 탭 자동완성이 작동하지 않습니다.
 
 - Homebrew로 설치한 경우 자동완성이 자동으로 설치됩니다
-- 수동 설정은 [셸 자동완성](@/usage/configurations/shell-completion/index.md)을 참조하세요
+- 수동 설정은 [셸 자동완성](@/usage/configurations/shell-completion/index.ko.md)을 참조하세요
 - 설정 후 셸을 재시작하거나 `source ~/.zshrc` (또는 해당 셸의 동등한 명령)를 실행하세요
 
 ## 추가 도움이 필요하신가요?
 
 - [GitHub 이슈](https://github.com/owasp-noir/noir/issues)를 열어주세요
-- [연락처](@/resources/contact/index.md) 페이지에서 팀에 연락하는 다른 방법을 확인하세요
+- [연락처](@/resources/contact/index.ko.md) 페이지에서 팀에 연락하는 다른 방법을 확인하세요

--- a/docs/content/usage/output_formats/_index.ko.md
+++ b/docs/content/usage/output_formats/_index.ko.md
@@ -20,7 +20,7 @@ sort_by = "weight"
 | 사람이 읽기 쉬운 검토 | [YAML](yaml/) | `-f yaml` |
 | 설정 스타일 출력 | [기타](more/) (TOML) | `-f toml` |
 | Postman으로 가져오기 | [기타](more/) (Postman Collection) | `-f postman` |
-| 시각적 보고서 공유 | [HTML](html/) | `-f html` |
+| 시각적 리포트 공유 | [HTML](html/) | `-f html` |
 | API 구조 시각화 | [Mermaid](mermaid/) | `-f mermaid` |
 | URL이나 파라미터만 추출 | [기타](more/) (필터) | `-f only-url` |
 
@@ -31,6 +31,6 @@ sort_by = "weight"
 *   **[YAML](yaml/)**: 사람이 직접 훑어볼 때 JSON보다 읽기 편한 형식.
 *   **[OpenAPI 명세(OAS)](openapi/)**: 코드에서 생성한 OpenAPI 문서. API 문서화나 보안 도구 임포트에 사용.
 *   **[SARIF](sarif/)**: CI/CD 보안 대시보드가 받아들이는 표준 형식.
-*   **[HTML 보고서](html/)**: 단일 파일로 완결되는 인터랙티브 HTML 리포트.
+*   **[HTML 리포트](html/)**: 단일 파일로 완결되는 인터랙티브 HTML 리포트.
 *   **[Mermaid 차트](mermaid/)**: API 구조 다이어그램.
 *   **[추가 형식](more/)**: TOML, JSONL, Postman 컬렉션, 마크다운 테이블, 출력 필터.

--- a/docs/content/usage/supported/ai_context_coverage/index.ko.md
+++ b/docs/content/usage/supported/ai_context_coverage/index.ko.md
@@ -74,4 +74,4 @@ noir scan . --ai-context -f oas3 -o spec.json
 - AI 컨텍스트는 **부가적**입니다. 휴리스틱에 걸리지 않는 엔드포인트는 플래그 없이 돌렸을 때와 동일하게 나옵니다 (직렬화된 모델에 `ai_context` 키가 추가되지 않음).
 - 휴리스틱은 보수적으로 튜닝되어 있지만 거짓 양성/음성 모두 존재합니다. 항목은 확정된 결론이 아니라 검토를 시작할 단서로 다루세요.
 - guard/sink/validator 패턴은 점진적으로 개선됩니다. Noir가 이미 지원하는 프레임워크 매트릭스에 걸쳐 단일 컨텍스트 스키마가 통하도록 의도적으로 cross-language로 설계됐습니다.
-- AI 컨텍스트의 많은 부분이 callee 커버리지에서 비롯됩니다. 어떤 프레임워크가 오늘날 핸들러 callee를 노출하는지는 [Callee 커버리지](@/usage/supported/callee_coverage/index.md)를 참고하세요.
+- AI 컨텍스트의 많은 부분이 callee 커버리지에서 비롯됩니다. 어떤 프레임워크가 오늘날 핸들러 callee를 노출하는지는 [Callee 커버리지](@/usage/supported/callee_coverage/index.ko.md)를 참고하세요.


### PR DESCRIPTION
## What

Every internal `@/...` link on a Korean page pointed at the **English** target, so a reader on `/ko/` clicking a Korean-labelled link landed on the English site.

The Korean [실행하기](https://owasp-noir.github.io/noir/ko/get_started/running/) page was the worst case — all seven of its body links left the Korean docs, including the entire "다음 단계" list:

```
$ grep -rho 'href="/noir/[a-z_/]*"' public/ko/get_started/running/index.html | sort -u
href="/noir/get_started/ai_power/"
href="/noir/usage/cli_commands/"
href="/noir/usage/configurations/configuration_file/"
href="/noir/usage/output_formats/"
href="/noir/usage/passive_scan/"
href="/noir/usage/supported/ai_context_coverage/"
href="/noir/usage/supported/callee_coverage/"
```

Not one `/noir/ko/` link. Three links in the repo already used the `@/….ko.md` form and resolved correctly, so the idiom was already settled — the other 21 just never followed it.

**No existing gate catches this.** `check_doc_parity.sh` checks that both locales exist, `check_edit_links.sh` checks edit targets, and `hwaro tool check-links` sees a valid URL either way — only the wrong language.

## Two smaller fixes found along the way

- **`analyzer_architecture.ko.md` wrote the same path placeholder two ways** — `{언어}/{프레임워크}` in the five step-by-step sections, `{lang}/{framework}` in the layer table and the extractor note. These are literal path templates under `src/`, so the Latin form wins.
- **Finished the `보고서` → `리포트` unification from #2694.** The HTML page is titled "HTML 리포트", but three sites elsewhere still said 보고서 — one of them mixing both spellings in a single sentence.

## Verification

Checked against the **built HTML**, asserting absence rather than presence:

```
# no page under public/ko/ emits a body link outside /noir/ko/
$ grep -rho 'href="/noir/[a-z0-9_/.-]*"' public/ko/ | grep -v '/noir/ko/'
(empty)

# and no English page gained a /ko/ link
$ find public -name '*.html' -not -path 'public/ko/*' | xargs grep -l 'href="/noir/ko/'
(empty)
```

Also: `check_doc_parity.sh` OK, `check_edit_links.sh` OK (122 targets), `hwaro tool validate` clean, `hwaro build` clean. Dead links reported by `check-links` drop **19 → 15**; the remaining 15 are the `../images/` paths the Korean landing page is [documented to use](https://github.com/owasp-noir/noir/blob/main/docs/AGENTS.md).

## Prose is deliberately left alone

#2694 swept it one commit ago. A re-read found no em-dashes outside the two quoted CLI output lines, no AI-slop vocabulary, and no leftovers of that commit's declared terminology targets (`구성`→`설정`, `매개변수`→`파라미터`, `룰`→`규칙`, `상황별 분석`) — the remaining `구성` hits are all the verb 구성되다/구성 요소, which is correct.

## One open question for a maintainer

Particle spacing after code spans and Latin words is split across the Korean docs: **132 spaced** (`` `--verbose` 는 ``, `v0 의`) vs **218 unspaced** (`` `--verbose`는 ``). The split is *between* files, not within them — `analyzer_architecture` (35) and `cli_commands` (31) are spaced, `deliver` (19) and `mobile` (15) are not.

I left these alone: #2694 rewrote `migrate_v0_to_v1.ko.md` at exactly this seam and kept every space, so it reads as a deliberate style rather than an oversight. Happy to normalize in a follow-up if you'd like one form site-wide.