### PR TITLE
fix(detector): stop four detectors from claiming evidence that is not theirs

### DIFF
--- a/spec/unit_test/detector/elixir/plug_spec.cr
+++ b/spec/unit_test/detector/elixir/plug_spec.cr
@@ -96,6 +96,44 @@ describe "Detect Elixir Plug" do
     instance.detect("lib/router.ex", router_content).should be_true
   end
 
+  it "detects a bare forward mount without any other Plug marker" do
+    router_content = <<-ELIXIR
+      defmodule MyApp.Router do
+        forward "/api", to: MyApp.API
+      end
+      ELIXIR
+
+    instance.detect("lib/router.ex", router_content).should be_true
+  end
+
+  it "detects a forward mount whose `to:` is not the first option" do
+    router_content = <<-ELIXIR
+      defmodule MyApp.Router do
+        forward "/", host: "api.", to: MyApp.API
+      end
+      ELIXIR
+
+    instance.detect("lib/router.ex", router_content).should be_true
+  end
+
+  it "does not detect a context module with a `forward` variable and `do:`" do
+    context_content = <<-ELIXIR
+      defmodule App.Accounts do
+        import Ecto.Query, warn: false
+        alias App.Repo
+
+        def list_users, do: Repo.all(User)
+
+        def forward_invite(user, opts \\\\ []) do
+          forward = Keyword.get(opts, :forward, true)
+          if forward, do: Mailer.deliver(user), else: :skip
+        end
+      end
+      ELIXIR
+
+    instance.detect("lib/accounts.ex", context_content).should be_false
+  end
+
   it "does not detect non-Plug files" do
     non_plug_content = <<-ELIXIR
       defmodule MyApp.Utils do

--- a/spec/unit_test/detector/javascript/socketio_spec.cr
+++ b/spec/unit_test/detector/javascript/socketio_spec.cr
@@ -30,4 +30,53 @@ describe "Detect JavaScript Socket.IO" do
   it "ignores a plain express file" do
     instance.detect("app.js", "const express = require('express'); const app = express();").should be_false
   end
+
+  it "ignores a plain `ws` server that also builds a `new Server(`" do
+    src = <<-JS
+      const { Server } = require('ws');
+
+      const wss = new Server({ port: 8080 });
+      wss.on('connection', (socket) => {
+        socket.on('message', (data) => socket.send(data));
+      });
+      JS
+    instance.detect("server.js", src).should be_false
+  end
+
+  it "ignores a gRPC server built from a `Server` import" do
+    src = <<-JS
+      import { Server, ServerCredentials } from '@grpc/grpc-js';
+
+      const server = new Server();
+      process.on('SIGTERM', () => server.tryShutdown(() => {}));
+      JS
+    instance.detect("server.ts", src).should be_false
+  end
+
+  it "detects a minimal `new Server(` server through its emitter" do
+    src = <<-JS
+      const io = new Server(httpServer);
+      io.on("connection", (socket) => {
+        socket.on("msg", (m) => io.emit("msg", m));
+      });
+      JS
+    instance.detect("server.js", src).should be_true
+  end
+
+  it "detects a `new Server(` paired with a nested room emit" do
+    src = <<-JS
+      const io = new Server(httpServer);
+      io.to(roomFor(id)).emit("update", payload);
+      JS
+    instance.detect("server.js", src).should be_true
+  end
+
+  it "detects a `new Server(` paired with a Socket.IO namespace" do
+    src = <<-JS
+      const io = new Server(httpServer);
+      const admin = io.of("/admin");
+      admin.on("connection", (socket) => socket.on("ban", () => {}));
+      JS
+    instance.detect("server.js", src).should be_true
+  end
 end

--- a/spec/unit_test/detector/python/http_server_spec.cr
+++ b/spec/unit_test/detector/python/http_server_spec.cr
@@ -28,4 +28,46 @@ describe "Detect Python http.server" do
   it "does not fire without signal" do
     instance.detect("other.py", "print('hello')").should be_false
   end
+
+  it "does not fire on a `python -m http.server` mention in prose" do
+    src = <<-PY
+      """Utilities.
+
+      To preview the generated docs locally run:
+
+          python -m http.server 8000
+      """
+
+      def add(a, b):
+          return a + b
+      PY
+    instance.detect("util.py", src).should be_false
+  end
+
+  it "does not claim Tornado's HTTPServer" do
+    src = <<-PY
+      import tornado.web
+      from tornado.httpserver import HTTPServer
+
+      server = HTTPServer(tornado.web.Application([]))
+      PY
+    instance.detect("main.py", src).should be_false
+  end
+
+  it "detects a comma-list import" do
+    instance.detect("s.py", "import socketserver, http.server\n").should be_true
+  end
+
+  it "detects a first-line import in a UTF-8-BOM file" do
+    instance.detect("s.py", "\uFEFFimport http.server\n").should be_true
+  end
+
+  it "detects a mixin-first handler subclass" do
+    src = "class Handler(ThreadingMixIn, BaseHTTPRequestHandler):\n    pass"
+    instance.detect("handler.py", src).should be_true
+  end
+
+  it "detects `from http import server`" do
+    instance.detect("s.py", "from http import server\nserver.HTTPServer(('', 0), H)").should be_true
+  end
 end

--- a/spec/unit_test/detector/typescript/tanstack_router_spec.cr
+++ b/spec/unit_test/detector/typescript/tanstack_router_spec.cr
@@ -45,12 +45,55 @@ describe "Detect TypeScript TanStack Router" do
     instance.detect("root.tsx", "export const rootRoute = createRootRoute({})").should be_true
   end
 
-  it "createRoute" do
-    instance.detect("routes.ts", "const postsRoute = createRoute({ path: '/posts' })").should be_true
+  it "import_tanstack_solid_router" do
+    instance.detect("routes.ts", "import { createRoute } from '@tanstack/solid-router'").should be_true
   end
 
-  it "createRouter" do
-    instance.detect("router.ts", "const router = createRouter({ routeTree })").should be_true
+  it "ignores the devtools package on its own" do
+    instance.detect("app.ts", "import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'").should be_false
+  end
+
+  it "createRootRouteWithContext" do
+    instance.detect("root.tsx", "const rootRoute = createRootRouteWithContext<Ctx>()({})").should be_true
+  end
+
+  it "matches a formatter-wrapped multi-line import" do
+    src = <<-TS
+      import {
+        createRoute,
+        createRouter,
+      } from '@tanstack/react-router'
+
+      const postsRoute = createRoute({ path: '/posts' })
+      TS
+    instance.detect("routes.ts", src).should be_true
+  end
+
+  it "does not claim Vue Router's createRouter" do
+    src = <<-TS
+      import { createRouter, createWebHistory } from 'vue-router'
+
+      export default createRouter({
+        history: createWebHistory(),
+        routes: [{ path: '/', component: Home }],
+      })
+      TS
+    instance.detect("router.ts", src).should be_false
+  end
+
+  it "does not claim a tRPC v9 createRouter helper" do
+    src = <<-TS
+      import * as trpc from '@trpc/server'
+
+      export function createRouter() {
+        return trpc.router<Context>()
+      }
+      TS
+    instance.detect("createRouter.ts", src).should be_false
+  end
+
+  it "does not claim a bare createRoute call from another router" do
+    instance.detect("routes.ts", "const postsRoute = createRoute({ path: '/posts' })").should be_false
   end
 
   it "tsx_file" do

--- a/src/detector/detectors/elixir/plug.cr
+++ b/src/detector/detectors/elixir/plug.cr
@@ -4,6 +4,21 @@ module Detector::Elixir
   class Plug < Detector
     detector_for "elixir_plug", extensions: %w[.ex .exs], basenames: %w[mix.exs]
 
+    # `forward "/api", to: SomeRouter` — Plug.Router's mount macro, in the
+    # bare and parenthesized call forms.
+    #
+    # The marker this replaces was `"forward "` AND `"do:"`, and neither
+    # half is Plug's: `do:` is Elixir's one-line function body and appears
+    # in nearly every module, while `forward` is an ordinary identifier. Any
+    # context module with a `forward` variable and a `def …, do: …` was
+    # detected as Plug, so a plain Phoenix/Ecto project ran the Plug
+    # analyzer over its whole tree for nothing.
+    #
+    # `to:` is matched anywhere after the path rather than as the first
+    # option, because `forward/2` takes `:host`, `:init_opts`, `:private`
+    # and `:assigns` in any order (`forward "/", host: "api.", to: Api`).
+    FORWARD_RE = /(?:^|\n)[ \t]*forward[ \t(]+["'][^"'\n]*["'][^\n]*\bto:/
+
     def detect(filename : String, file_contents : String) : Bool
       # Check if this is a mix.exs file with Plug dependency
       if filename.includes?("mix.exs")
@@ -18,7 +33,7 @@ module Detector::Elixir
           file_contents.includes?("plug :dispatch") ||
           file_contents.includes?("Plug.Router") ||
           file_contents.includes?("import Plug.") ||
-          file_contents.includes?("forward ") && file_contents.includes?("do:")
+          content_matches?(file_contents, FORWARD_RE)
       end
 
       false

--- a/src/detector/detectors/javascript/socketio.cr
+++ b/src/detector/detectors/javascript/socketio.cr
@@ -3,9 +3,9 @@ require "../../../models/detector"
 module Detector::Javascript
   # Detects a Socket.IO *server*: an `import ... from "socket.io"` /
   # `require("socket.io")` (the server package; the browser client is
-  # `socket.io-client`, a different specifier) or a `new Server(` construct
-  # with `.on(` usage. Gates the Socket.IO analyzer, which emits inbound
-  # `socket.on` events as `ws://` realtime endpoints.
+  # `socket.io-client`, a different specifier), or a `new Server(` construct
+  # paired with a Socket.IO-only API call. Gates the Socket.IO analyzer,
+  # which emits inbound `socket.on` events as `ws://` realtime endpoints.
   class SocketIO < Detector
     detector_for "js_socketio"
 
@@ -16,7 +16,30 @@ module Detector::Javascript
 
     PACKAGE_MARKER = /"socket\.io"\s*:/
     NEW_SERVER     = /new Server\(/
-    ON_CALL        = /\.on\(/
+
+    # Socket.IO's own server API, required alongside the generic
+    # `new Server(` construct below.
+    #
+    # `new Server(` used to be paired with a bare `.on(`, and neither name
+    # belongs to Socket.IO: `ws`, `engine.io`, `@grpc/grpc-js`, `node:http`
+    # and `node:net` all export a `Server` class, and `.on(` is in nearly
+    # every Node file. A plain `ws` server — `const { Server } =
+    # require('ws')` … `socket.on('message', …)` — was therefore detected as
+    # Socket.IO, and the Socket.IO analyzer then reported its `socket.on`
+    # handlers as realtime `ws://` endpoints that do not exist.
+    #
+    # Namespaces (`io.of("/admin")`), room targeting (`io.to(room).emit(…)`),
+    # `socket.broadcast.emit(…)` and the `io`/`socket` emitters themselves
+    # have no counterpart in those libraries — a `ws` socket is written to
+    # with `.send(`, and a gRPC or `node:net` server has no emit surface at
+    # all. The room argument allows one level of nesting so
+    # `io.to(roomFor(id)).emit(…)` still counts.
+    SOCKET_IO_API = Regex.union(
+      /\.\s*of\s*\(\s*['"`]\//,
+      /\.\s*broadcast\s*\.\s*emit\s*\(/,
+      /\.\s*to\s*\((?:[^()]|\([^()]*\))*\)\s*\.\s*emit\s*\(/,
+      /\b(?:io|socket)\s*\.\s*emit\s*\(/,
+    )
 
     def detect(filename : String, file_contents : String) : Bool
       if File.basename(filename) == "package.json"
@@ -25,7 +48,7 @@ module Detector::Javascript
 
       return false unless source_file?(filename)
       return true if content_matches?(file_contents, SIGNAL)
-      content_matches?(file_contents, NEW_SERVER) && content_matches?(file_contents, ON_CALL)
+      content_matches?(file_contents, NEW_SERVER) && content_matches?(file_contents, SOCKET_IO_API)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/python/http_server.cr
+++ b/src/detector/detectors/python/http_server.cr
@@ -4,19 +4,48 @@ module Detector::Python
   class HttpServer < Detector
     detector_for "python_http_server", extensions: %w[.py]
 
+    # The stdlib module has to be imported before any of its handler or
+    # server classes can be named, so anchor on the import the way the
+    # other built-in-server detectors do (`java_httpserver` requires
+    # `com.sun.net.httpserver`, `dart_http` requires `import 'dart:io'`).
+    #
+    # This replaces four bare substring probes — `"http.server"`,
+    # `"HTTPServer"`, `"BaseHTTPRequestHandler"`, `"SimpleHTTPRequestHandler"`
+    # — that matched anywhere in a file, including prose. Two real cases fell
+    # out of that:
+    #
+    #   * a `python -m http.server` line in a comment or module docstring
+    #     (the standard way to say "serve these fixtures locally") flagged
+    #     the whole project as a stdlib-server app;
+    #   * `HTTPServer` alone also matched Tornado's
+    #     `from tornado.httpserver import HTTPServer`, so every Tornado
+    #     project was additionally reported as `python_http_server` and paid
+    #     for a second analyzer pass over the same tree.
+    #
+    # Covers `from http.server import ...`, `import [os, ]http.server[ as x]`
+    # and `from http import [cookies, ]server`. `\x{FEFF}` after the line
+    # start keeps a UTF-8-BOM file's first line matchable — `Noir::TextFile`
+    # deliberately strips no BOM.
+    IMPORT_RE = /(?:^|\n)[ \t\x{FEFF}]*(?:from[ \t]+http\.server[ \t]+import\b|import[ \t]+(?:[\w.]+[ \t]*,[ \t]*)*http\.server\b|from[ \t]+http[ \t]+import[ \t]+(?:[\w,][\w, \t]*[ \t,])?server\b)/
+
+    # A handler subclass still counts on its own: a module that receives the
+    # base class through a re-export (`from .compat import
+    # BaseHTTPRequestHandler`) carries no `http.server` import of its own,
+    # and it is the file the analyzer needs. Anchored to a real `class ...(`
+    # header so a bare mention of the name in prose no longer qualifies.
+    # Earlier bases are allowed: `class Handler(ThreadingMixIn,
+    # BaseHTTPRequestHandler)` is the idiomatic way to write exactly the
+    # module this branch exists for.
+    HANDLER_SUBCLASS_RE = /\bclass\s+\w+\s*\(\s*(?:[\w.]+\s*,\s*)*(?:[\w.]+\.)?(?:Base|Simple|CGI)HTTPRequestHandler\s*[,)]/
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
-      # Match stdlib http.server usage (import, from-import, or direct class/server tokens).
       # wsgiref.simple_server is related (per issue) but we intentionally do not auto-detect on it alone
       # here to avoid polluting :techs counts in framework fixtures that use wsgiref only as a test server
       # (e.g. pyramid fixture). Users can still force via similar names or future wsgi analyzer.
-      return true if file_contents.includes?("http.server")
-      return true if file_contents.includes?("BaseHTTPRequestHandler")
-      return true if file_contents.includes?("SimpleHTTPRequestHandler")
-      return true if file_contents.includes?("HTTPServer")
-
-      false
+      content_matches?(file_contents, IMPORT_RE) ||
+        content_matches?(file_contents, HANDLER_SUBCLASS_RE)
     end
   end
 end

--- a/src/detector/detectors/typescript/tanstack_router.cr
+++ b/src/detector/detectors/typescript/tanstack_router.cr
@@ -6,16 +6,37 @@ module Detector::Typescript
       extensions: %w[.ts .tsx .cts .mts .js .jsx .cjs .mjs],
       basenames: %w[package.json tsconfig.json]
 
-    # Single precompiled alternation — one PCRE2 scan instead of eight.
+    # Single precompiled alternation — one PCRE2 scan over the file.
+    #
+    # `createRouter(` and `createRoute(` used to be listed here as
+    # standalone markers, and both are ordinary names other routers own:
+    # `createRouter({ history, routes })` is *the* Vue Router 4 entry point,
+    # Solid Router exports the same name, and tRPC v9's generated
+    # `createRouter()` helper carries it too. Every Vue 3 project with a
+    # TypeScript router module was therefore reported as TanStack Router and
+    # paid for a TanStack analyzer pass that had nothing to extract.
+    #
+    # Nothing is lost by dropping them: a file that calls either factory has
+    # to import it from `@tanstack/*router` in that same file, which the
+    # import branches below match. Those branches no longer demand the
+    # `import` keyword on the same line as the specifier either, so a
+    # formatter-wrapped multi-line import (`import {\n  createRoute,\n} from
+    # '@tanstack/react-router'`) is matched rather than relying on the bare
+    # factory names to carry it.
+    #
+    # The package pattern covers every TanStack Router adapter
+    # (`@tanstack/react-router`, `/solid-router`, `/svelte-router`, the bare
+    # `/router`) without reaching `@tanstack/react-router-devtools`, which
+    # the required closing quote excludes.
+    #
+    # `createFileRoute` / `createRootRoute` stay: they are TanStack's own
+    # file-based routing API and have no other owner.
     SIGNAL = Regex.union(
-      /import.*from ['"]@tanstack\/react-router['"]/,
-      /import.*from ['"]@tanstack\/router['"]/,
-      /require\(['"]@tanstack\/react-router['"]\)/,
-      /require\(['"]@tanstack\/router['"]\)/,
-      /createFileRoute\s*\(/,
-      /createRootRoute\s*\(/,
-      /createRoute\s*\(/,
-      /createRouter\s*\(/,
+      /from\s*['"]@tanstack\/(?:[a-z]+-)?router['"]/,
+      /require\(\s*['"]@tanstack\/(?:[a-z]+-)?router['"]\s*\)/,
+      /\bcreateFileRoute\s*\(/,
+      /\bcreateLazyFileRoute\s*\(/,
+      /\bcreateRootRoute(?:WithContext)?\s*[(<]/,
     )
 
     def detect(filename : String, file_contents : String) : Bool


### PR DESCRIPTION
Four detectors keyed off markers another library owns, so the tech was reported for projects that do not use it and its analyzer ran over the whole tree for nothing. One of them produced phantom endpoints.

## `python_http_server` — unanchored substrings

It matched the bare substrings `http.server`, `HTTPServer`, `BaseHTTPRequestHandler` and `SimpleHTTPRequestHandler` anywhere in a `.py` file:

```python
"""Utilities.

To preview the generated docs locally run:

    python -m http.server 8000
"""
```
→ `python_http_server`

`HTTPServer` alone also matched Tornado's `from tornado.httpserver import HTTPServer`, so **every Tornado app** was additionally reported as a stdlib-server app and paid for a second analyzer pass.

Now anchored on a real `http.server` import (or a handler subclass header), the way `java_httpserver` anchors on `com.sun.net.httpserver` and `dart_http` on `import 'dart:io'`.

## `ts_tanstack_router` — generic route factories

`createRouter(` and `createRoute(` were listed as standalone markers. `createRouter({ history, routes })` is *the* Vue Router 4 entry point, Solid Router exports the same name, and tRPC v9's generated helper carries it too:

```ts
import { createRouter, createWebHistory } from 'vue-router'
export default createRouter({ history: createWebHistory(), routes })
```
→ `ts_tanstack_router`

So every Vue 3 project with a TypeScript router module was misreported. The import branches cover real TanStack files instead, and no longer require the `import` keyword on the same line as the specifier, so a formatter-wrapped multi-line import is matched too (previously only the bare factory names carried those). The package pattern also widened to TanStack's other adapters (`@tanstack/solid-router`, `/svelte-router`).

## `js_socketio` — `new Server(` + `.on(` → phantom endpoints

`ws`, `engine.io`, `@grpc/grpc-js`, `node:http` and `node:net` all export a `Server`, and `.on(` is in nearly every Node file. A plain `ws` server:

```js
const { Server } = require('ws');
const wss = new Server({ port: 8080 });
wss.on('connection', (socket) => {
  socket.on('message', (data) => socket.send(data));
});
```

was detected as Socket.IO, and the analyzer then reported `SEND ws://message` and `SEND ws://close` — endpoints that do not exist. The `new Server(` fallback now requires a Socket.IO-only call (namespace, room emit, broadcast, or the `io`/`socket` emitter).

## `elixir_plug` — `"forward "` AND `"do:"`

Neither half is Plug's: `do:` is Elixir's one-line function body and appears in nearly every module, and `forward` is an ordinary identifier.

```elixir
def forward_invite(user, opts \\ []) do
  forward = Keyword.get(opts, :forward, true)
  if forward, do: Mailer.deliver(user), else: :skip
end
```
→ `elixir_plug`

Now matches Plug.Router's actual `forward "/path", to: Module` macro, with `to:` accepted in any option position.

## Verification

- Detected-tech A/B across all 717 fixture directories: the only change is `typescript/trpc_v9` no longer being misreported as `ts_tanstack_router` (that tech contributed 0 endpoints there).
- `crystal spec`: 30350 examples, 0 failures.
- `just check`: format clean, 2293 files inspected by ameba, 0 failures.
- Regression specs added for every false positive above, plus for the import/subclass/adapter forms the tighter patterns must keep matching (comma-list `import socketserver, http.server`, UTF-8-BOM first line, mixin-first handler subclass, `@tanstack/solid-router`, nested-room `io.to(roomFor(id)).emit(…)`, `forward "/", host: "api.", to: Api`).