### PR TITLE
fix(analyzer): correct route line attribution and three endpoint-accuracy defects

### DIFF
--- a/spec/functional_test/fixtures/javascript/sails/api/controllers/admin/ReportController.js
+++ b/spec/functional_test/fixtures/javascript/sails/api/controllers/admin/ReportController.js
@@ -1,0 +1,10 @@
+/**
+ * A classic controller in a subdirectory. Sails prefixes the blueprint
+ * identity with the path below `api/controllers`, so this one is
+ * `admin/report` and serves the REST blueprints at `/admin/report`.
+ */
+module.exports = {
+  find: async function (req, res) {
+    return res.ok([]);
+  },
+};

--- a/spec/functional_test/fixtures/javascript/sails/api/controllers/user/find-one.js
+++ b/spec/functional_test/fixtures/javascript/sails/api/controllers/user/find-one.js
@@ -1,0 +1,12 @@
+/**
+ * A standalone "actions2" action, not a controller: its shadow route is the
+ * file's path below `api/controllers` (`/user/find-one`) and it answers
+ * every verb. Sits next to the nested controller above so the two
+ * conventions stay distinguishable.
+ */
+module.exports = {
+  friendlyName: 'Find one',
+  fn: async function () {
+    return;
+  },
+};

--- a/spec/functional_test/fixtures/r/plumber/plumber.R
+++ b/spec/functional_test/fixtures/r/plumber/plumber.R
@@ -44,9 +44,17 @@ r$handle("DELETE", "/resource/<resource_id>", function(resource_id) {
 
 #* The shape the official plumber template ships with: `req` and `res` are
 #* injected by plumber, not sent by the client, and `...` is R's variadic
-#* marker rather than a parameter name.
+#* marker rather than a parameter name. The apostrophe in "plumber's" below
+#* is load-bearing: it used to open a string literal that ran to the end of
+#* the file, so nothing after it was comment-stripped.
 #* @param term Search term
+#* @param ... plumber's passthrough arguments, not a parameter name
+#* @param req The request object
 #* @get /search
 function(req, res, term = "", ...) {
   list(term = term)
 }
+
+# Commented-out route. Must not be reported -- it is the assertion that the
+# roxygen block above did not swallow the rest of the file.
+# r$get("/internal-only", function() "secret")

--- a/spec/functional_test/fixtures/r/plumber/plumber.R
+++ b/spec/functional_test/fixtures/r/plumber/plumber.R
@@ -41,3 +41,12 @@ r$get("/direct", function() {
 r$handle("DELETE", "/resource/<resource_id>", function(resource_id) {
   # resource_id is path param
 })
+
+#* The shape the official plumber template ships with: `req` and `res` are
+#* injected by plumber, not sent by the client, and `...` is R's variadic
+#* marker rather than a parameter name.
+#* @param term Search term
+#* @get /search
+function(req, res, term = "", ...) {
+  list(term = term)
+}

--- a/spec/functional_test/testers/javascript/sails_spec.cr
+++ b/spec/functional_test/testers/javascript/sails_spec.cr
@@ -33,6 +33,33 @@ expected_endpoints = [
   Endpoint.new("/webhook", "OPTIONS"),
   # Note: the `r|^/\d+/(\w+)/(\w+)$|foo,bar` regex-address entry in the
   # fixture is intentionally not modeled and must not appear above.
+
+  # Blueprint routes for `api/controllers/admin/ReportController.js`. A
+  # classic controller keeps its blueprint identity in a subdirectory --
+  # `admin/report`, not the literal filename -- so these are the five REST
+  # bindings Sails generates, at `/admin/report`.
+  Endpoint.new("/admin/report", "GET"),
+  Endpoint.new("/admin/report", "POST"),
+  Endpoint.new("/admin/report/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/admin/report/:id", "PATCH", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/admin/report/:id", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
+
+  # `api/controllers/user/find-one.js` is an actions2 action, not a
+  # controller: its shadow route is the path below `api/controllers` and it
+  # answers every verb.
+  Endpoint.new("/user/find-one", "GET"),
+  Endpoint.new("/user/find-one", "POST"),
+  Endpoint.new("/user/find-one", "PUT"),
+  Endpoint.new("/user/find-one", "DELETE"),
+  Endpoint.new("/user/find-one", "PATCH"),
+  Endpoint.new("/user/find-one", "HEAD"),
+  Endpoint.new("/user/find-one", "OPTIONS"),
 ]
 
 FunctionalTester.new("fixtures/javascript/sails/", {

--- a/spec/functional_test/testers/r/plumber_spec.cr
+++ b/spec/functional_test/testers/r/plumber_spec.cr
@@ -27,6 +27,11 @@ expected_endpoints = [
   Endpoint.new("/resource/:resource_id", "DELETE", [
     Param.new("resource_id", "", "path"),
   ]),
+  # `req`/`res` are handed to the handler by plumber and `...` is R's
+  # variadic marker, so `term` is the only thing a client actually sends.
+  Endpoint.new("/search", "GET", [
+    Param.new("term", "", "query"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/r/plumber/", {

--- a/spec/unit_test/analyzer/route_line_attribution_spec.cr
+++ b/spec/unit_test/analyzer/route_line_attribution_spec.cr
@@ -1,0 +1,74 @@
+require "../../spec_helper"
+require "../../../src/models/noir"
+
+# `code_paths` is what sends a reader to the route: an endpoint whose line
+# points somewhere else is a wrong answer even when the URL and method are
+# right. The functional testers compare endpoints by URL/method/params and
+# never look at the line, so every one of the skews below passed a green
+# suite. These pin the line against the checked-in fixtures.
+private def scan_fixture(relative : String) : Array(Endpoint)
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(File.join(__DIR__, "../../functional_test/fixtures", relative))])
+  runner = NoirRunner.new(options)
+  runner.detect
+  runner.analyze
+  runner.endpoints
+ensure
+  CodeLocator.instance.reset_files
+end
+
+private def line_of(endpoints : Array(Endpoint), method : String, url : String, file_suffix : String) : Int32?
+  endpoints.each do |endpoint|
+    next unless endpoint.method == method && endpoint.url == url
+    endpoint.details.code_paths.each do |code_path|
+      return code_path.line if code_path.path.ends_with?(file_suffix)
+    end
+  end
+  nil
+end
+
+describe "route line attribution" do
+  it "points a Grails verbless mapping at its own line, not the previous one" do
+    # The verbless paren-form and closure-form patterns open with
+    # `(?:^|\n)\s*`, so match offset 0 is the newline that ENDS the previous
+    # line — and greedy `\s*` then swallows every blank and comment-blanked
+    # line after it. `/api/users` (fixture line 7) was reported at line 4 and
+    # `/api/legacy` (line 20) at line 10.
+    endpoints = scan_fixture("groovy/grails")
+    suffix = "grails-app/conf/UrlMappings.groovy"
+
+    line_of(endpoints, "POST", "/api/users", suffix).should eq(7)
+    line_of(endpoints, "GET", "/api/orders", suffix).should eq(10)
+    line_of(endpoints, "POST", "/api/legacy", suffix).should eq(20)
+    line_of(endpoints, "GET", "/api/reports", suffix).should eq(29)
+    line_of(endpoints, "GET", "/api/profile", suffix).should eq(37)
+
+    # The verb-prefixed form never had the skew and must keep its line.
+    line_of(endpoints, "GET", "/api/health", suffix).should eq(3)
+  end
+
+  it "points a Jetzig resourceful action at its `pub fn`" do
+    # `ACTION_FN_RE` opens with `(?:^|[^A-Za-z0-9_.])`, so a match at the
+    # start of a line begins on the previous line's newline: every action was
+    # reported one line high.
+    endpoints = scan_fixture("zig/jetzig")
+    suffix = "src/app/views/posts.zig"
+
+    line_of(endpoints, "GET", "/posts", suffix).should eq(4)
+    line_of(endpoints, "GET", "/posts/:id", suffix).should eq(10)
+  end
+
+  it "points an inline Yesod parseRoutes route at its file line" do
+    # The quasi-quote body is processed as a standalone document, so without
+    # a line offset every route was reported at its position *within the
+    # quote* — which for the usual `Foundation.hs` layout landed in the
+    # module header.
+    endpoints = scan_fixture("haskell/yesod")
+    suffix = "src/Foundation.hs"
+
+    line_of(endpoints, "GET", "/", suffix).should eq(11)
+    line_of(endpoints, "GET", "/blog/:text", suffix).should eq(12)
+    line_of(endpoints, "GET", "/api/health", suffix).should eq(14)
+    line_of(endpoints, "PUT", "/api/users/:user_id", suffix).should eq(15)
+  end
+end

--- a/spec/unit_test/analyzer/route_line_attribution_spec.cr
+++ b/spec/unit_test/analyzer/route_line_attribution_spec.cr
@@ -5,70 +5,87 @@ require "../../../src/models/noir"
 # points somewhere else is a wrong answer even when the URL and method are
 # right. The functional testers compare endpoints by URL/method/params and
 # never look at the line, so every one of the skews below passed a green
-# suite. These pin the line against the checked-in fixtures.
+# suite.
+#
+# Assertions name the text the line must hold rather than a line number, so
+# editing a shared fixture cannot fail this spec from a distance — the point
+# being tested is "the reported line holds the route", not "the route is on
+# line 7".
 private def scan_fixture(relative : String) : Array(Endpoint)
+  # `clear_all`, before the scan and not merely `reset_files` after it, for
+  # the reason `FunctionalTester#ensure_scanned` documents: `CodeLocator` is a
+  # process-wide singleton and under `--order random` this example can follow
+  # any other scan. `reset_files` leaves `@s_map`/`@a_map` behind.
+  CodeLocator.instance.clear_all
+
   options = create_test_options
-  options["base"] = YAML::Any.new([YAML::Any.new(File.join(__DIR__, "../../functional_test/fixtures", relative))])
+  # Spelled relative, exactly like the functional harness: skip filters and
+  # `base_relative_path` read the full path, so an absolute base would make
+  # this spec depend on where the checkout happens to sit.
+  options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/#{relative}")])
   runner = NoirRunner.new(options)
   runner.detect
   runner.analyze
   runner.endpoints
-ensure
-  CodeLocator.instance.reset_files
 end
 
-private def line_of(endpoints : Array(Endpoint), method : String, url : String, file_suffix : String) : Int32?
+# The source line an endpoint points at, in the file whose path ends with
+# `file_suffix`. Raises rather than returning nil so a missing endpoint reads
+# as "not found" instead of as a confusing comparison against nil.
+private def source_line_for(endpoints : Array(Endpoint), method : String, url : String, file_suffix : String) : String
   endpoints.each do |endpoint|
     next unless endpoint.method == method && endpoint.url == url
     endpoint.details.code_paths.each do |code_path|
-      return code_path.line if code_path.path.ends_with?(file_suffix)
+      next unless code_path.path.ends_with?(file_suffix)
+      line = code_path.line || 0
+      lines = File.read_lines(code_path.path)
+      raise "#{method} #{url}: line #{line} is outside #{code_path.path} (#{lines.size} lines)" unless 1 <= line <= lines.size
+      return lines[line - 1]
     end
   end
-  nil
+  raise "no #{method} #{url} endpoint with a code path in *#{file_suffix}"
 end
 
 describe "route line attribution" do
-  it "points a Grails verbless mapping at its own line, not the previous one" do
-    # The verbless paren-form and closure-form patterns open with
-    # `(?:^|\n)\s*`, so match offset 0 is the newline that ENDS the previous
-    # line — and greedy `\s*` then swallows every blank and comment-blanked
-    # line after it. `/api/users` (fixture line 7) was reported at line 4 and
-    # `/api/legacy` (line 20) at line 10.
+  it "points a Grails mapping at its own line" do
+    # Both verbless patterns opened with `(?:^|\n)\s*`, so match offset 0 was
+    # the newline that ENDS the previous line — and greedy `\s*` then swallowed
+    # every blank and comment-blanked line after it, putting `/api/users`
+    # three lines high. The verb-prefixed form has the same trap in its
+    # optional `name <id>:` prefix, which `\s*` lets sit on an earlier line.
     endpoints = scan_fixture("groovy/grails")
     suffix = "grails-app/conf/UrlMappings.groovy"
 
-    line_of(endpoints, "POST", "/api/users", suffix).should eq(7)
-    line_of(endpoints, "GET", "/api/orders", suffix).should eq(10)
-    line_of(endpoints, "POST", "/api/legacy", suffix).should eq(20)
-    line_of(endpoints, "GET", "/api/reports", suffix).should eq(29)
-    line_of(endpoints, "GET", "/api/profile", suffix).should eq(37)
-
-    # The verb-prefixed form never had the skew and must keep its line.
-    line_of(endpoints, "GET", "/api/health", suffix).should eq(3)
+    source_line_for(endpoints, "POST", "/api/users", suffix).should contain("\"/api/users\"")
+    source_line_for(endpoints, "GET", "/api/orders", suffix).should contain("\"/api/orders\"")
+    source_line_for(endpoints, "POST", "/api/legacy", suffix).should contain("\"/api/legacy\"")
+    source_line_for(endpoints, "GET", "/api/reports", suffix).should contain("\"/api/reports\"")
+    source_line_for(endpoints, "GET", "/api/profile", suffix).should contain("\"/api/profile\"")
+    source_line_for(endpoints, "GET", "/api/health", suffix).should contain("\"/api/health\"")
   end
 
   it "points a Jetzig resourceful action at its `pub fn`" do
-    # `ACTION_FN_RE` opens with `(?:^|[^A-Za-z0-9_.])`, so a match at the
-    # start of a line begins on the previous line's newline: every action was
-    # reported one line high.
+    # `ACTION_FN_RE` consumed a leading character, so a match at the start of a
+    # line began on the previous line's newline: every action was one line
+    # high.
     endpoints = scan_fixture("zig/jetzig")
     suffix = "src/app/views/posts.zig"
 
-    line_of(endpoints, "GET", "/posts", suffix).should eq(4)
-    line_of(endpoints, "GET", "/posts/:id", suffix).should eq(10)
+    source_line_for(endpoints, "GET", "/posts", suffix).should contain("pub fn index(")
+    source_line_for(endpoints, "GET", "/posts/:id", suffix).should contain("pub fn get(")
+    source_line_for(endpoints, "DELETE", "/posts/:id", suffix).should contain("pub fn delete(")
   end
 
   it "points an inline Yesod parseRoutes route at its file line" do
-    # The quasi-quote body is processed as a standalone document, so without
-    # a line offset every route was reported at its position *within the
-    # quote* — which for the usual `Foundation.hs` layout landed in the
-    # module header.
+    # The quasi-quote body is processed as a standalone document, so without a
+    # line offset every route was reported at its position *within the quote* —
+    # which for the usual `Foundation.hs` layout landed in the module header.
     endpoints = scan_fixture("haskell/yesod")
     suffix = "src/Foundation.hs"
 
-    line_of(endpoints, "GET", "/", suffix).should eq(11)
-    line_of(endpoints, "GET", "/blog/:text", suffix).should eq(12)
-    line_of(endpoints, "GET", "/api/health", suffix).should eq(14)
-    line_of(endpoints, "PUT", "/api/users/:user_id", suffix).should eq(15)
+    source_line_for(endpoints, "GET", "/", suffix).should contain("HomeR")
+    source_line_for(endpoints, "GET", "/blog/:text", suffix).should contain("BlogPostR")
+    source_line_for(endpoints, "GET", "/api/health", suffix).should contain("HealthR")
+    source_line_for(endpoints, "PUT", "/api/users/:user_id", suffix).should contain("UserR")
   end
 end

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -451,7 +451,12 @@ module Analyzer::Groovy
       remaining.scan(pattern) do |match|
         verb = match[1].upcase
         url_pattern = prefix + match[3]
-        line = line_for_offset(content, base_offset + (match.begin(0) || 0))
+        # Every form below takes its line from the opening quote of the URL
+        # literal, which is the one token guaranteed to sit on the mapping's
+        # own line. `match.begin(0)` does not: the optional `name <id>:` prefix
+        # is separated by `\s*`, so `name reports:` on the line above pulls the
+        # reported line up with it.
+        line = line_for_offset(content, base_offset + (match.begin(2) || 0))
         @result << Endpoint.new(translate_pattern(url_pattern), verb,
           extract_path_params(url_pattern),
           Details.new(PathInfo.new(path, line)))
@@ -461,7 +466,11 @@ module Analyzer::Groovy
       # method: 'POST')`, the `(resources: 'name')` / `(resource: 'name')`
       # REST shortcut, and `'/path'(uri: '/some/where')` redirect-style
       # mappings.
-      simple_pattern = /(?:^|\n)\s*(?:name\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?(['"])([^'"]+)\1\s*\(([^)]*?)\)/m
+      # `^` is already line-anchored (`/m`), so the `(?:^|\n)\s*` this
+      # replaces only added a consumed leading newline — which made
+      # `match.begin(0)` the END of the previous line, with greedy `\s*` then
+      # swallowing every blank and comment-blanked line after it.
+      simple_pattern = /^[ \t]*(?:name\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?(['"])([^'"]+)\1\s*\(([^)]*?)\)/m
       remaining.scan(simple_pattern) do |match|
         # Response-code mappings (`"404"(...)`, `"500"(...)`) reuse the same
         # paren-form syntax but the "path" is an HTTP status code, not a URL.
@@ -470,12 +479,7 @@ module Analyzer::Groovy
 
         url_pattern = prefix + match[2]
         body_args = match[3]
-        # `match.begin(0)` is the newline that ENDS the previous line —
-        # `(?:^|\n)\s*` consumes it, and greedy `\s*` keeps consuming every
-        # blank and comment-blanked line after it — so it named the line
-        # before the mapping, or several lines before it. The opening quote
-        # of the URL literal is on the mapping's own line.
-        line = line_for_offset(content, base_offset + (match.begin(1) || match.begin(0) || 0))
+        line = line_for_offset(content, base_offset + (match.begin(1) || 0))
 
         if body_args.match(/\bresources:\s*['"]/)
           RESOURCES_ENDPOINTS.each do |ep|
@@ -520,14 +524,13 @@ module Analyzer::Groovy
       end
 
       # Closure-form mapping: `'/path' { controller = 'foo'; method = 'POST' }`.
-      closure_pattern = /(?:^|\n)\s*(['"])([^'"]+)\1\s*\{([^}]*)\}/m
+      closure_pattern = /^[ \t]*(['"])([^'"]+)\1\s*\{([^}]*)\}/m
       remaining.scan(closure_pattern) do |match|
         next if status_code_mapping?(match[2])
         url_pattern = prefix + match[2]
         body_block = match[3]
         next unless body_block.match(/\b(controller|action|method|view)\s*=/)
-        # Same leading-`(?:^|\n)\s*` offset skew as the paren form above.
-        line = line_for_offset(content, base_offset + (match.begin(1) || match.begin(0) || 0))
+        line = line_for_offset(content, base_offset + (match.begin(1) || 0))
         verb = extract_method_assignment(body_block) || "GET"
         @result << Endpoint.new(translate_pattern(url_pattern), verb,
           extract_path_params(url_pattern),

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -470,7 +470,12 @@ module Analyzer::Groovy
 
         url_pattern = prefix + match[2]
         body_args = match[3]
-        line = line_for_offset(content, base_offset + (match.begin(0) || 0))
+        # `match.begin(0)` is the newline that ENDS the previous line —
+        # `(?:^|\n)\s*` consumes it, and greedy `\s*` keeps consuming every
+        # blank and comment-blanked line after it — so it named the line
+        # before the mapping, or several lines before it. The opening quote
+        # of the URL literal is on the mapping's own line.
+        line = line_for_offset(content, base_offset + (match.begin(1) || match.begin(0) || 0))
 
         if body_args.match(/\bresources:\s*['"]/)
           RESOURCES_ENDPOINTS.each do |ep|
@@ -521,7 +526,8 @@ module Analyzer::Groovy
         url_pattern = prefix + match[2]
         body_block = match[3]
         next unless body_block.match(/\b(controller|action|method|view)\s*=/)
-        line = line_for_offset(content, base_offset + (match.begin(0) || 0))
+        # Same leading-`(?:^|\n)\s*` offset skew as the paren form above.
+        line = line_for_offset(content, base_offset + (match.begin(1) || match.begin(0) || 0))
         verb = extract_method_assignment(body_block) || "GET"
         @result << Endpoint.new(translate_pattern(url_pattern), verb,
           extract_path_params(url_pattern),

--- a/src/analyzer/analyzers/haskell/yesod.cr
+++ b/src/analyzer/analyzers/haskell/yesod.cr
@@ -99,7 +99,9 @@ module Analyzer::Haskell
       content.scan(/\[(?:parseRoutes|parseRoutesNoCheck)\|([\s\S]*?)\|\]/) do |match|
         next if match.size < 2
         body_start = match.begin(1) || 0
-        blocks << {text: match[1], line_offset: content[0...body_start].count('\n')}
+        # `line_number_for_index` walks the byte buffer; `content[0...i]` would
+        # copy the whole prefix per block.
+        blocks << {text: match[1], line_offset: line_number_for_index(content, body_start) - 1}
       end
 
       blocks

--- a/src/analyzer/analyzers/haskell/yesod.cr
+++ b/src/analyzer/analyzers/haskell/yesod.cr
@@ -37,7 +37,7 @@ module Analyzer::Haskell
 
         content = read_file_content(path)
         extract_inline_route_blocks(content).each do |block|
-          process_route_content(path, block, include_callee, handler_bodies)
+          process_route_content(path, block[:text], include_callee, handler_bodies, block[:line_offset])
         end
 
         extract_external_route_paths(content).each do |relative_path|
@@ -85,12 +85,21 @@ module Analyzer::Haskell
       {base_path, name}
     end
 
-    private def extract_inline_route_blocks(content : String) : Array(String)
-      blocks = [] of String
+    # The quasi-quoted route table plus the count of lines that precede it in
+    # the file. The block is processed as a standalone document, so its own
+    # line numbering starts at 1 — without the offset every route declared in
+    # an inline `[parseRoutes| ... |]` was reported at its position *within
+    # the quote*, which for the usual `Foundation.hs` layout pointed at the
+    # module header instead of the route.
+    private alias InlineRouteBlock = NamedTuple(text: String, line_offset: Int32)
+
+    private def extract_inline_route_blocks(content : String) : Array(InlineRouteBlock)
+      blocks = [] of InlineRouteBlock
 
       content.scan(/\[(?:parseRoutes|parseRoutesNoCheck)\|([\s\S]*?)\|\]/) do |match|
         next if match.size < 2
-        blocks << match[1]
+        body_start = match.begin(1) || 0
+        blocks << {text: match[1], line_offset: content[0...body_start].count('\n')}
       end
 
       blocks
@@ -110,7 +119,8 @@ module Analyzer::Haskell
     private def process_route_content(source_path : String,
                                       content : String,
                                       include_callee : Bool,
-                                      handler_bodies : HandlerBodies)
+                                      handler_bodies : HandlerBodies,
+                                      line_offset : Int32 = 0)
       scope_stack = [{indent: -1, raw_segments: [] of String}]
 
       logical_route_lines(content).each do |entry|
@@ -140,7 +150,7 @@ module Analyzer::Haskell
         methodless_route = methodless_route?(tokens)
 
         url, params = build_url_and_params(scope_stack.last[:raw_segments] + raw_segments)
-        details = Details.new(PathInfo.new(source_path, entry[:line]))
+        details = Details.new(PathInfo.new(source_path, entry[:line] + line_offset))
 
         methods.each do |method|
           endpoint_params = params.map { |param| Param.new(param.name, param.value, param.param_type) }

--- a/src/analyzer/analyzers/javascript/sails.cr
+++ b/src/analyzer/analyzers/javascript/sails.cr
@@ -254,6 +254,13 @@ module Analyzer::Javascript
         next unless js_source_file?(file)
         next unless file.starts_with?("#{models_prefix}/")
         rel = file[(models_prefix.size + 1)..]
+        # Top-level only, deliberately — unlike the controllers above. A
+        # controller announces itself with the `*Controller.js` suffix, so
+        # descending is safe; a model is any capitalised filename, and
+        # `MODEL_FILE_RE` would claim every nested helper under `api/models/`
+        # and publish five blueprint routes for each. Nested models are a real
+        # (rarer) Sails layout, so this trades a known false negative for a
+        # much noisier false positive; revisit with a stronger model signal.
         next if rel.empty? || rel.includes?("/")
         base = File.basename(rel)
         next unless md = base.match(MODEL_FILE_RE)

--- a/src/analyzer/analyzers/javascript/sails.cr
+++ b/src/analyzer/analyzers/javascript/sails.cr
@@ -232,8 +232,17 @@ module Analyzer::Javascript
         base = File.basename(rel)
         next if base.starts_with?(".")
 
-        if !rel.includes?("/") && (md = base.match(CONTROLLER_FILE_RE))
+        # A classic controller keeps its blueprint identity wherever it sits:
+        # Sails prefixes the identity with the path below `api/controllers`,
+        # so `api/controllers/admin/ReportController.js` is `admin/report` and
+        # serves `/admin/report`. Requiring a top-level file sent every nested
+        # controller down the actions2 branch instead, which published seven
+        # verbs on the literal filename (`/admin/ReportController`) and lost
+        # the five REST routes the app really exposes.
+        if md = base.match(CONTROLLER_FILE_RE)
+          dir = File.dirname(rel)
           identity = md[1].downcase
+          identity = "#{dir.downcase}/#{identity}" unless dir == "."
           identities[identity] ||= file
           next
         end

--- a/src/analyzer/analyzers/r/plumber.cr
+++ b/src/analyzer/analyzers/r/plumber.cr
@@ -16,6 +16,20 @@ module Analyzer::R
     # Matches R function declaration: function(...)
     FUNCTION_DECLARATION = /\bfunction\s*\(([^)]*)\)/
 
+    # Arguments plumber injects into a handler rather than reading off the
+    # request. `function(req, res, msg = "")` is the shape the official
+    # plumber template ships with, so reporting `req`/`res` as client-supplied
+    # parameters put two phantom entries on almost every real endpoint — and,
+    # for a POST, two phantom JSON body fields in the rendered request.
+    INJECTED_ARGS = Set{"req", "res"}
+
+    # An R formal that names something a client can actually send. Rules out
+    # the variadic `...` (and `..1`, `..2`), which the previous
+    # `[A-Za-z0-9_.-]+` check accepted and emitted verbatim as a parameter
+    # named `...`, and leading-digit/dash tokens that are not identifiers at
+    # all — what those really signal is that the argument list did not parse.
+    R_ARGUMENT_NAME_RE = /\A(?:[A-Za-z][A-Za-z0-9._]*|\.(?![0-9.])[A-Za-z0-9._]*)\z/
+
     # Programmatic routes:
     # pr_get("/path", handler)
     PROGRAMMATIC_PIPELINE = /\bpr_(get|post|put|delete|patch|head|options)\s*\(\s*["']([^"']+)["']/i
@@ -167,7 +181,8 @@ module Analyzer::R
         end
 
         # 2. Function/annotation parameters next
-        all_other_param_names = (func_params + param_descriptions.keys).uniq
+        all_other_param_names = (func_params.reject { |name| INJECTED_ARGS.includes?(name) } +
+                                 param_descriptions.keys).uniq
         all_other_param_names.each do |p_name|
           next if seen_params.includes?(p_name)
           seen_params.add(p_name)
@@ -224,7 +239,7 @@ module Analyzer::R
           if !arg.empty?
             # Extract param name (before '=')
             name = arg.split('=').first.strip
-            if name.matches?(/\A[A-Za-z0-9_.-]+\z/)
+            if name.matches?(R_ARGUMENT_NAME_RE)
               names << name
             end
           end
@@ -239,7 +254,7 @@ module Analyzer::R
       arg = current.to_s.strip
       if !arg.empty?
         name = arg.split('=').first.strip
-        if name.matches?(/\A[A-Za-z0-9_.-]+\z/)
+        if name.matches?(R_ARGUMENT_NAME_RE)
           names << name
         end
       end

--- a/src/analyzer/analyzers/r/plumber.cr
+++ b/src/analyzer/analyzers/r/plumber.cr
@@ -23,12 +23,13 @@ module Analyzer::R
     # for a POST, two phantom JSON body fields in the rendered request.
     INJECTED_ARGS = Set{"req", "res"}
 
-    # An R formal that names something a client can actually send. Rules out
-    # the variadic `...` (and `..1`, `..2`), which the previous
-    # `[A-Za-z0-9_.-]+` check accepted and emitted verbatim as a parameter
-    # named `...`, and leading-digit/dash tokens that are not identifiers at
-    # all — what those really signal is that the argument list did not parse.
-    R_ARGUMENT_NAME_RE = /\A(?:[A-Za-z][A-Za-z0-9._]*|\.(?![0-9.])[A-Za-z0-9._]*)\z/
+    # A name that can stand for something a client actually sends. Rules out
+    # the variadic `...` (and `..1`, `..2`), which both the formals parser and
+    # `PARAM_ANNOTATION` accept and which used to be emitted verbatim as a
+    # parameter named `...`, plus leading-digit/dash tokens that are not
+    # identifiers at all — what those really signal is that the argument list
+    # did not parse.
+    CLIENT_PARAM_NAME_RE = /\A(?:[A-Za-z][A-Za-z0-9._]*|\.(?![0-9.])[A-Za-z0-9._]*)\z/
 
     # Programmatic routes:
     # pr_get("/path", handler)
@@ -86,16 +87,25 @@ module Analyzer::R
 
         if c == '#'
           if i + 1 < size && chars[i + 1] == '*'
-            result << '#'
-            result << '*'
-            i += 2
-            next
-          else
+            # A roxygen block is kept verbatim — it carries the `@get`/`@param`
+            # annotations `process_file` reads — but it is PROSE, not code, so
+            # the scan must not fall back into the literal branch inside it. It
+            # used to: `#* Returns the user's profile` opened a string at the
+            # apostrophe that ran to the next quote or to EOF, and everything it
+            # swallowed stopped being comment-stripped, so a commented-out
+            # `# r$get("/internal-only", ...)` below it was reported as a real
+            # endpoint.
             while i < size && chars[i] != '\n'
+              result << chars[i]
               i += 1
             end
             next
           end
+
+          while i < size && chars[i] != '\n'
+            i += 1
+          end
+          next
         end
 
         result << c
@@ -180,10 +190,15 @@ module Analyzer::R
           params << Param.new(p_name, "", "path")
         end
 
-        # 2. Function/annotation parameters next
-        all_other_param_names = (func_params.reject { |name| INJECTED_ARGS.includes?(name) } +
-                                 param_descriptions.keys).uniq
+        # 2. Function/annotation parameters next. Both guards run over the
+        # merged list rather than over the formals alone: `#* @param req The
+        # request object` and `#* @param ... passed through` are documentation
+        # authors do write, and they name exactly the two things a client
+        # cannot send.
+        all_other_param_names = (func_params + param_descriptions.keys).uniq
         all_other_param_names.each do |p_name|
+          next if INJECTED_ARGS.includes?(p_name)
+          next unless p_name.matches?(CLIENT_PARAM_NAME_RE)
           next if seen_params.includes?(p_name)
           seen_params.add(p_name)
 
@@ -239,7 +254,7 @@ module Analyzer::R
           if !arg.empty?
             # Extract param name (before '=')
             name = arg.split('=').first.strip
-            if name.matches?(R_ARGUMENT_NAME_RE)
+            if name.matches?(CLIENT_PARAM_NAME_RE)
               names << name
             end
           end
@@ -254,7 +269,7 @@ module Analyzer::R
       arg = current.to_s.strip
       if !arg.empty?
         name = arg.split('=').first.strip
-        if name.matches?(R_ARGUMENT_NAME_RE)
+        if name.matches?(CLIENT_PARAM_NAME_RE)
           names << name
         end
       end

--- a/src/analyzer/analyzers/zig/jetzig.cr
+++ b/src/analyzer/analyzers/zig/jetzig.cr
@@ -92,7 +92,11 @@ module Analyzer::Zig
         method, suffix, has_id = spec
 
         url = build_url(resource, suffix)
-        line = Noir::ZigCalleeExtractor.line_at(stripped, match.begin(0) || 0)
+        # The action name, not `match.begin(0)`: the regex opens with
+        # `(?:^|[^A-Za-z0-9_.])`, so offset 0 of a match at the start of a line
+        # is the newline that ended the PREVIOUS line — every resourceful
+        # route was reported one line above its `pub fn`.
+        line = Noir::ZigCalleeExtractor.line_at(stripped, match.begin(1) || match.begin(0) || 0)
         details = Details.new(PathInfo.new(path, line))
 
         params = [] of Param

--- a/src/analyzer/analyzers/zig/jetzig.cr
+++ b/src/analyzer/analyzers/zig/jetzig.cr
@@ -36,7 +36,11 @@ module Analyzer::Zig
       "delete" => {"DELETE", "/:id", true},
     }
 
-    ACTION_FN_RE = /(?:^|[^A-Za-z0-9_.])pub\s+fn\s+(index|get|new|edit|post|put|patch|delete)\s*\(/
+    # Zero-width lookbehind rather than `(?:^|[^A-Za-z0-9_.])`: the consuming
+    # form made `match.begin(0)` the previous line's newline for every action
+    # written at the start of a line, so each route was reported one line above
+    # its `pub fn`. A lookbehind is the same predicate with the offset intact.
+    ACTION_FN_RE = /(?<![A-Za-z0-9_.])pub\s+fn\s+(index|get|new|edit|post|put|patch|delete)\s*\(/
     PARAM_GET_RE = /\b(?:params|query)\s*\.\s*get\s*\(\s*"([^"]+)"/
 
     # Explicit custom route registered in the app's startup hook, e.g.
@@ -92,11 +96,7 @@ module Analyzer::Zig
         method, suffix, has_id = spec
 
         url = build_url(resource, suffix)
-        # The action name, not `match.begin(0)`: the regex opens with
-        # `(?:^|[^A-Za-z0-9_.])`, so offset 0 of a match at the start of a line
-        # is the newline that ended the PREVIOUS line — every resourceful
-        # route was reported one line above its `pub fn`.
-        line = Noir::ZigCalleeExtractor.line_at(stripped, match.begin(1) || match.begin(0) || 0)
+        line = Noir::ZigCalleeExtractor.line_at(stripped, match.begin(0) || 0)
         details = Details.new(PathInfo.new(path, line))
 
         params = [] of Param


### PR DESCRIPTION
Six analyzer defects, found by sweeping every functional fixture for endpoints whose reported source line does not hold the route, and by running the analyzers against framework shapes the fixtures never covered.

## Line attribution

`code_paths` is what sends a reader to the route. The functional testers compare endpoints by URL/method/params and never look at the line, so all three of these passed a green suite.

| Analyzer | Symptom | Cause |
| --- | --- | --- |
| Grails `UrlMappings` | `/api/users` (line 7) reported at line 4, `/api/legacy` (line 20) at line 10 | The verbless paren and closure patterns opened with `(?:^\|\n)\s*`. Their `^` was already line-anchored by `/m`, so the prefix only added a consumed newline — making match offset 0 the *end of the previous line*, with greedy `\s*` then swallowing every blank and comment-blanked line after it. |
| Zig Jetzig | every resourceful action one line above its `pub fn` | Same class: `ACTION_FN_RE` opened with `(?:^\|[^A-Za-z0-9_.])`. |
| Haskell Yesod | routes at lines 2–6 instead of 11–15 | An inline `[parseRoutes\| … \|]` block was processed as a standalone document, so line numbers were relative to the quote — for the usual `Foundation.hs` layout, that lands in the module header. |

The two regexes are now anchored (`^[ \t]*`, and a zero-width lookbehind for Jetzig) rather than compensated at the call site, so `begin(0)` is correct by construction instead of by every future caller remembering to skip a character. Grails' verb-prefixed form keeps the same trap through its optional `name <id>:` prefix, which `\s*` lets sit on an earlier line, so all three forms read their line from the URL literal. Yesod's block carries its file line offset.

## Endpoint accuracy

**R plumber — phantom parameters on nearly every endpoint.** `function(req, res, msg = "")` is the shape the official plumber template ships with. `req` and `res` are injected by plumber, not sent by a client, so almost every real endpoint carried two phantom parameters — and two phantom JSON body fields in the rendered request on a POST. R's variadic `...` was emitted as a parameter literally named `...`. Both guards run over the merged formals + `@param` list, since `#* @param req The request object` is documentation authors do write.

**R plumber — a doc-comment apostrophe disabled comment stripping.** `strip_r_comments` preserved a `#*` block by emitting the marker and then scanning the rest as *code*, so the apostrophe in `#* Returns the user's profile` opened a string literal running to the next quote or to EOF. Everything it swallowed stopped being comment-stripped:

```r
#* Returns the user's profile
#* @get /profile
function() { list() }

# TODO: r$get("/internal-only", handler)
```

reported `GET /internal-only`. Remove the apostrophe and it does not. The block is now copied verbatim to end of line.

**Sails — nested controllers.** A classic controller keeps its blueprint identity in a subdirectory, so `api/controllers/admin/ReportController.js` is `admin/report`. Requiring a top-level file sent every nested controller down the actions2 branch instead: seven verbs published on the literal filename (`/admin/ReportController`) and the five REST routes the app really exposes lost. The blueprint path had no fixture coverage at all; this adds a nested controller and a nested actions2 action so the two conventions stay distinguishable.

## Verification

- A/B scan of all **717 functional fixtures**: the only outputs that move are the three line-number fixes (endpoint sets byte-identical) plus the two fixtures extended here. The second commit's regex rewrites are byte-identical to the first commit's output.
- Full suite green: 5709 unit + 24659 functional examples, 0 failures. `crystal tool format --check` clean, ameba clean (2294 files).
- New `spec/unit_test/analyzer/route_line_attribution_spec.cr` asserts the *text* on the reported line rather than a hardcoded number, so editing a shared fixture cannot fail it from a distance.

## Known limitation left in place

The Sails models loop stays top-level-only, now with the reasoning written down: a controller announces itself with the `*Controller.js` suffix, but a model is any capitalised filename, so descending there would publish five blueprint routes for every nested helper under `api/models/`. Nested models are a real (rarer) Sails layout — a known false negative traded against a much noisier false positive, revisit with a stronger model signal.