### PR TITLE
test: compile the spec suite once and run it in parallel

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,10 +1,14 @@
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-# Disable spec filename check for fixture files (they represent real code)
+# Disable spec filename check for fixture files (they represent real code).
+# spec/suite.cr is also exempt, and its name is load-bearing: it is the entry
+# point that requires both suites into one binary, so it must NOT match the
+# `*_spec.cr` glob that `crystal spec` picks up on its own.
 Lint/SpecFilename:
   Excluded:
     - "spec/functional_test/fixtures/**/*"
+    - "spec/suite.cr"
 
 # Disable useless assign warnings for fixture files
 Lint/UselessAssign:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,8 +322,25 @@ jobs:
           key: crystal-${{ runner.os }}-1.21.0-lint-${{ hashFiles('shard.lock') }}
           restore-keys: |
             crystal-${{ runner.os }}-1.21.0-lint-
+      - name: Cache the compiled Ameba binary
+        id: ameba-cache
+        uses: actions/cache@v6
+        with:
+          # 126s of this job's 155s was compiling Ameba, and it recompiled the
+          # same source on every run. The shard ships only
+          # lib/ameba/bin/ameba.cr, no prebuilt binary, so something has to
+          # compile it once. `shard.lock` pins the Ameba version, and the
+          # Crystal version is in the key too, so a hit means the binary was
+          # built from exactly this source by exactly this compiler.
+          path: bin/ameba
+          key: ameba-${{ runner.os }}-1.21.0-${{ hashFiles('shard.lock') }}
       - name: Install dependencies
         run: shards install
+      - name: Build Ameba
+        if: steps.ameba-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p bin
+          crystal build lib/ameba/bin/ameba.cr -o bin/ameba
       - name: Run Ameba linter
         # Run the Ameba pinned in shard.lock rather than
         # crystal-ameba/github-action@master, whose image tracks an
@@ -331,7 +348,7 @@ jobs:
         # (and tightened Lint/UselessAssign), failing CI on unrelated,
         # already-merged code. shard.lock keeps the rule set stable and
         # reproducible with local `ameba` runs.
-        run: crystal run lib/ameba/bin/ameba.cr
+        run: ./bin/ameba
   tests:
     needs: changes
     if: needs.changes.outputs.spec == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,18 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/crystal
-          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-${{ hashFiles('shard.lock', 'src/**/*.cr', 'spec/**/*.cr') }}
+          # `spec/**/*.cr` is deliberately not in the key. Nearly every pull
+          # request that reaches this job touches a spec file, so including it
+          # meant the primary key essentially never hit and every run came in
+          # through the restore-keys ladder below. Crystal fingerprints its own
+          # cache entries by content, so restoring an entry set that is partly
+          # stale for the spec half is safe: it only ever means those entries
+          # recompile, which they were going to do anyway. Keying on
+          # `shard.lock` plus `src/**/*.cr` lets a run whose src/ is unchanged
+          # hit the primary key instead. Note that a primary-key hit also means
+          # actions/cache does not re-save, so the entry ages until src/ moves.
+          # Watch the `--stats` lines on the build step for the effect.
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
           restore-keys: |
             crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-
             crystal-${{ runner.os }}-${{ matrix.crystal-version }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,10 +396,20 @@ jobs:
       # `--stats` prints the per-phase compile times, which costs nothing and
       # is what makes a regression in the Crystal cache below visible in the
       # log rather than only in the job's total.
+      #
+      # `--no-debug` is CI-only. Measured locally on this program: a cold build
+      # goes from 23.2s to 19.9s and 6.84GB to 6.59GB, and a warm one from 10.1s
+      # to 8.4s. It also takes the ~/.cache/crystal payload from 236MB to 195MB,
+      # though only on the runs where the step above re-saves it, which after
+      # the src-only key means the runs that changed src/. What it costs is
+      # file:line in the backtrace when an analyzer raises during a scan, so a
+      # raise here names the exception but not where it came from. Spec assertion failures are unaffected, because
+      # the spec DSL passes its own file and line. Reproduce such a failure with
+      # `just spec-build`, which keeps debug info on purpose.
       - name: Build the spec binary
         run: |
           mkdir -p bin
-          crystal build spec/suite.cr -o bin/noir_spec --stats
+          crystal build spec/suite.cr -o bin/noir_spec --stats --no-debug
       # Spec files load in directory order, which differs between macOS and
       # Linux, so an example that depends on state another example left behind
       # passes locally and fails here, on an unrelated PR. Four such couplings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,27 +374,53 @@ jobs:
             crystal-${{ runner.os }}-${{ matrix.crystal-version }}-
       - name: Install dependencies
         run: shards install
-      - name: Run unit tests
-        run: crystal spec spec/unit_test
-      - name: Run functional tests
-        run: crystal spec spec/functional_test
+      # This job used to run four `crystal spec` steps (unit, functional, and
+      # both again in randomized order) and so compiled the same program four
+      # times: measured at 92s, 87s, 91s and 86s, of which only 17.7s, 21.0s,
+      # 17.8s and 20.4s was actually running examples. Compiling both suites
+      # into one binary costs no more than compiling the unit suite alone, so
+      # build once here and re-run the binary below as many times as the
+      # ordering fences need.
+      #
+      # `--stats` prints the per-phase compile times, which costs nothing and
+      # is what makes a regression in the Crystal cache below visible in the
+      # log rather than only in the job's total.
+      - name: Build the spec binary
+        run: |
+          mkdir -p bin
+          crystal build spec/suite.cr -o bin/noir_spec --stats
       # Spec files load in directory order, which differs between macOS and
-      # Linux — so an example that depends on state another example left
-      # behind passes locally and fails here, on an unrelated PR. Four such
-      # couplings had accumulated. Randomizing on purpose turns "flaky CI"
-      # into a named failure: crystal prints the seed, and
-      # `crystal spec spec/unit_test --order <seed>` reproduces it exactly.
-      - name: Run unit tests in randomized order
-        run: crystal spec spec/unit_test --order random
-      # The functional suite passes randomized today, which is worth fencing
-      # even though the property is currently cheap to hold: `FunctionalTester`
-      # runs each scan at *collection* time and the examples only assert over
-      # already-materialized structs, so shuffling examples shuffles no work.
-      # The fence matters for what comes next — moving those scans inside the
-      # examples is what makes ordering load-bearing, and this step is what
-      # will catch it if that change introduces an order dependency.
-      - name: Run functional tests in randomized order
-        run: crystal spec spec/functional_test --order random
+      # Linux, so an example that depends on state another example left behind
+      # passes locally and fails here, on an unrelated PR. Four such couplings
+      # had accumulated. Randomizing on purpose turns "flaky CI" into a named
+      # failure: the runner prints the seed, and `bin/noir_spec --order <seed>`
+      # reproduces it exactly.
+      #
+      # The randomized run is a real fence rather than a formality now that
+      # `FunctionalTester` scans lazily from inside the first example that
+      # needs it: which example runs first decides which tester pays for the
+      # scan, so ordering is load-bearing and this step is what catches a new
+      # order dependency.
+      #
+      # Both runs are the same binary and take ~0.3GB each, so they go in
+      # parallel: measured locally at 19s wall against 36s sequential.
+      #
+      # Each run's output goes to its own file and is replayed in a collapsed
+      # group afterwards, because two runners writing to the same stdout
+      # interleave their progress dots and their failure reports.
+      - name: Run the suite in default and randomized order
+        run: |
+          ./bin/noir_spec > /tmp/spec-default.log 2>&1 & default_pid=$!
+          ./bin/noir_spec --order random > /tmp/spec-random.log 2>&1 & random_pid=$!
+          failed=0
+          wait $default_pid || failed=1
+          wait $random_pid || failed=1
+          for order in default random; do
+            echo "::group::bin/noir_spec ($order order)"
+            cat "/tmp/spec-$order.log"
+            echo "::endgroup::"
+          done
+          exit $failed
   nix:
     # Nix is one of the documented install paths (`nix profile add
     # github:owasp-noir/noir`), and nothing in CI ever looked at it — so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,22 +402,36 @@ jobs:
       # scan, so ordering is load-bearing and this step is what catches a new
       # order dependency.
       #
-      # Both runs are the same binary and take ~0.3GB each, so they go in
-      # parallel: measured locally at 19s wall against 36s sequential.
+      # The randomized run stays over the *whole* suite rather than the tagged
+      # halves below. Before both suites shared a binary they were separate
+      # processes, so a unit example could not possibly depend on state a
+      # functional one left behind; now it can, and this is the only run that
+      # would notice.
       #
-      # Each run's output goes to its own file and is replayed in a collapsed
-      # group afterwards, because two runners writing to the same stdout
-      # interleave their progress dots and their failure reports.
-      - name: Run the suite in default and randomized order
+      # The two tagged halves fence what the tags claim: that each half stands
+      # alone. `just test` runs them as its two parallel processes, so a
+      # cross-half dependency has to fail here rather than only on a
+      # contributor's machine.
+      #
+      # Every run is single-threaded and takes ~0.3GB, so all four go at once
+      # and the full randomized run (~18s) sets the wall time. Each writes to
+      # its own file, replayed in a collapsed group afterwards, because runners
+      # sharing a stdout interleave their progress dots and their failure
+      # reports.
+      - name: Run the suite
         run: |
-          ./bin/noir_spec > /tmp/spec-default.log 2>&1 & default_pid=$!
-          ./bin/noir_spec --order random > /tmp/spec-random.log 2>&1 & random_pid=$!
+          ./bin/noir_spec > /tmp/spec-default.log 2>&1 & pid_default=$!
+          ./bin/noir_spec --order random > /tmp/spec-random.log 2>&1 & pid_random=$!
+          ./bin/noir_spec --tag functional > /tmp/spec-functional.log 2>&1 & pid_functional=$!
+          ./bin/noir_spec --tag '~functional' > /tmp/spec-unit.log 2>&1 & pid_unit=$!
           failed=0
-          wait $default_pid || failed=1
-          wait $random_pid || failed=1
-          for order in default random; do
-            echo "::group::bin/noir_spec ($order order)"
-            cat "/tmp/spec-$order.log"
+          for name in default random functional unit; do
+            pid_var="pid_$name"
+            wait "${!pid_var}" || failed=1
+          done
+          for name in default random functional unit; do
+            echo "::group::bin/noir_spec ($name)"
+            cat "/tmp/spec-$name.log"
             echo "::endgroup::"
           done
           exit $failed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Crystal-based attack surface detector that identifies endpoints by static analys
 | Command | Alternative | Timeout |
 |---------|-------------|---------|
 | `just build` | `shards build` | 120s (~30s typical) |
-| `just test` | `crystal spec` | 60s (~10s typical) |
+| `just test` | `crystal build spec/suite.cr -o bin/noir_spec && ./bin/noir_spec` | 120s (~40s typical) |
 | `just check` | format check + lint | 60s |
 | `just fix` | auto-format + fix lint | 60s |
 
@@ -68,6 +68,7 @@ src/
 └── banner.cr               # Banner display
 
 spec/
+├── suite.cr                # Entry point: requires both suites into one binary
 ├── functional_test/
 │   ├── fixtures/           # Sample code for testing (by language/framework)
 │   └── testers/            # Functional test implementations

--- a/justfile
+++ b/justfile
@@ -80,17 +80,32 @@ docs-i18n-check:
 docs-dependencies:
     brew install hahwul/hwaro/hwaro
 
+# The Ameba shard ships source only, so running it means compiling it: about
+# two minutes here and 126s of CI's 155s lint job. Build it once and the
+# recipes below use the binary instead. CI caches the same binary keyed on
+# shard.lock.
+#
+# Build the pinned Ameba linter into bin/ameba.
+[group('development')]
+ameba-build:
+    mkdir -p bin
+    crystal build lib/ameba/bin/ameba.cr -o bin/ameba
+
 # Auto-format code and fix lint issues.
 [group('development')]
 fix:
+    #!/usr/bin/env bash
+    set -euo pipefail
     crystal tool format
-    lib/ameba/bin/ameba.cr --fix
+    if [ -x bin/ameba ]; then ./bin/ameba --fix; else lib/ameba/bin/ameba.cr --fix; fi
 
 # Check code format and lint without changes.
 [group('development')]
 check:
+    #!/usr/bin/env bash
+    set -euo pipefail
     crystal tool format --check
-    lib/ameba/bin/ameba.cr
+    if [ -x bin/ameba ]; then ./bin/ameba; else lib/ameba/bin/ameba.cr; fi
 
 # Compiling src/ is nearly the whole cost of a spec run, and that cost does not
 # grow when both suites go into one program: unit alone compiles in ~20s and
@@ -104,10 +119,13 @@ spec-build:
     mkdir -p bin
     crystal build spec/suite.cr -o bin/noir_spec
 
-# Run all tests, as two processes split on the `functional` tag. The run is
-# single-threaded and takes only ~0.3GB, so the halves are ~18s together and
-# ~10s in parallel (the unit half is the slower of the two, at 9.7s). Each writes to its own log because two spec runners sharing
-# a terminal interleave their progress dots and their failure reports.
+# The run is single-threaded and takes only ~0.3GB, so splitting it on the
+# `functional` tag turns ~18s of examples into ~10s of wall time (the unit half
+# is the slower of the two, at 9.7s). Each half writes to its own log, because
+# two spec runners sharing a terminal interleave their progress dots and their
+# failure reports.
+#
+# Run all tests, as two parallel processes.
 [group('development')]
 test: spec-build
     #!/usr/bin/env bash
@@ -125,11 +143,13 @@ test: spec-build
     done
     exit $failed
 
-# Re-run the already-built suite in a randomized example order, which is how an
-# accidental order dependency between examples surfaces. Deliberately one
-# process over the whole suite rather than the tagged halves, so it can also
-# catch a unit example that depends on a functional one, or the reverse. The
-# seed is printed at the end; reproduce it with `just test-seed <seed>`.
+# A randomized example order is how an accidental order dependency between
+# examples surfaces. Deliberately one process over the whole suite rather than
+# the tagged halves, so it can also catch a unit example that depends on a
+# functional one, or the reverse. The seed is printed at the end; reproduce it
+# with `just test-seed <seed>`.
+#
+# Re-run the built suite in a randomized example order.
 [group('development')]
 test-random: spec-build
     ./bin/noir_spec --order random

--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ check:
 # Compiling src/ is nearly the whole cost of a spec run, and that cost does not
 # grow when both suites go into one program: unit alone compiles in ~20s and
 # unit+functional together compiles in the same ~20s. Building once gives a
-# binary that runs all 30,357 examples in 18s on 0.3GB, so re-running in
+# binary that runs all 20,807 examples in 17.5s on 0.3GB, so re-running in
 # randomized order or under a filter costs nothing more.
 #
 # Build the whole suite as one binary at bin/noir_spec.
@@ -106,7 +106,7 @@ spec-build:
 
 # Run all tests, as two processes split on the `functional` tag. The run is
 # single-threaded and takes only ~0.3GB, so the halves are ~18s together and
-# ~10s in parallel. Each writes to its own log because two spec runners sharing
+# ~10s in parallel (the unit half is the slower of the two, at 9.7s). Each writes to its own log because two spec runners sharing
 # a terminal interleave their progress dots and their failure reports.
 [group('development')]
 test: spec-build

--- a/justfile
+++ b/justfile
@@ -92,11 +92,34 @@ check:
     crystal tool format --check
     lib/ameba/bin/ameba.cr
 
+# Compiling src/ is nearly the whole cost of a spec run, and that cost does not
+# grow when both suites go into one program: unit alone compiles in ~20s and
+# unit+functional together compiles in the same ~20s. Building once gives a
+# binary that runs all 30,356 examples in 18s on 0.3GB, so re-running in
+# randomized order or under a filter costs nothing more.
+#
+# Build the whole suite as one binary at bin/noir_spec.
+[group('development')]
+spec-build:
+    mkdir -p bin
+    crystal build spec/suite.cr -o bin/noir_spec
+
 # Run all tests.
 [group('development')]
-test:
-    crystal spec spec/unit_test
-    crystal spec spec/functional_test
+test: spec-build
+    ./bin/noir_spec
+
+# Re-run the already-built suite in a randomized example order, which is how an
+# accidental order dependency between examples surfaces. The seed is printed on
+# failure; reproduce it with `just test-seed <seed>`.
+[group('development')]
+test-random: spec-build
+    ./bin/noir_spec --order random
+
+# Re-run the suite in one specific order: `just test-seed 12345`.
+[group('development')]
+test-seed SEED: spec-build
+    ./bin/noir_spec --order {{SEED}}
 
 # Run unit tests only.
 [group('development')]
@@ -113,10 +136,11 @@ test-func:
 test-uncovered:
     crystal spec spec/uncovered_test
 
-# The fastest feedback loop while working on a single analyzer — ~8.5s
-# against ~16.5s for the whole suite. Almost all of that is compiling src/,
-# not running the test (the run itself is ~0.06s), so narrowing further
-# buys nothing.
+# The fastest feedback loop while working on a single analyzer: ~8.5s, against
+# ~38s for a full `just test` (a ~20s build plus an 18s run). Almost all of the
+# 8.5s is compiling src/, not running the test (the run itself is ~0.06s), so
+# narrowing further buys nothing. Once bin/noir_spec is built, though,
+# `./bin/noir_spec -e hono` is cheaper still, because it skips the compiler.
 #
 # Run one functional tester, e.g. `just test-func-one javascript/hono`.
 [group('development')]

--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ check:
 # Compiling src/ is nearly the whole cost of a spec run, and that cost does not
 # grow when both suites go into one program: unit alone compiles in ~20s and
 # unit+functional together compiles in the same ~20s. Building once gives a
-# binary that runs all 30,356 examples in 18s on 0.3GB, so re-running in
+# binary that runs all 30,357 examples in 18s on 0.3GB, so re-running in
 # randomized order or under a filter costs nothing more.
 #
 # Build the whole suite as one binary at bin/noir_spec.
@@ -104,14 +104,32 @@ spec-build:
     mkdir -p bin
     crystal build spec/suite.cr -o bin/noir_spec
 
-# Run all tests.
+# Run all tests, as two processes split on the `functional` tag. The run is
+# single-threaded and takes only ~0.3GB, so the halves are ~18s together and
+# ~10s in parallel. Each writes to its own log because two spec runners sharing
+# a terminal interleave their progress dots and their failure reports.
 [group('development')]
 test: spec-build
-    ./bin/noir_spec
+    #!/usr/bin/env bash
+    set -uo pipefail
+    logs=$(mktemp -d)
+    trap 'rm -rf "$logs"' EXIT
+    ./bin/noir_spec --tag '~functional' > "$logs/unit.log" 2>&1 & unit_pid=$!
+    ./bin/noir_spec --tag functional > "$logs/functional.log" 2>&1 & functional_pid=$!
+    failed=0
+    wait $unit_pid || failed=1
+    wait $functional_pid || failed=1
+    for half in unit functional; do
+      echo "--- $half half ---"
+      cat "$logs/$half.log"
+    done
+    exit $failed
 
 # Re-run the already-built suite in a randomized example order, which is how an
-# accidental order dependency between examples surfaces. The seed is printed on
-# failure; reproduce it with `just test-seed <seed>`.
+# accidental order dependency between examples surfaces. Deliberately one
+# process over the whole suite rather than the tagged halves, so it can also
+# catch a unit example that depends on a functional one, or the reverse. The
+# seed is printed at the end; reproduce it with `just test-seed <seed>`.
 [group('development')]
 test-random: spec-build
     ./bin/noir_spec --order random
@@ -137,10 +155,10 @@ test-uncovered:
     crystal spec spec/uncovered_test
 
 # The fastest feedback loop while working on a single analyzer: ~8.5s, against
-# ~38s for a full `just test` (a ~20s build plus an 18s run). Almost all of the
-# 8.5s is compiling src/, not running the test (the run itself is ~0.06s), so
-# narrowing further buys nothing. Once bin/noir_spec is built, though,
-# `./bin/noir_spec -e hono` is cheaper still, because it skips the compiler.
+# ~21s for a full `just test` (a ~12s build plus a ~10s parallel run). Almost
+# all of the 8.5s is compiling src/, not running the test (the run itself is
+# ~0.06s), so narrowing further buys nothing. Once bin/noir_spec is built,
+# though, `./bin/noir_spec -e hono` is cheaper still: it skips the compiler.
 #
 # Run one functional tester, e.g. `just test-func-one javascript/hono`.
 [group('development')]

--- a/spec/AGENTS.md
+++ b/spec/AGENTS.md
@@ -48,7 +48,7 @@ A staging area for test cases that are **not yet fully covered** or are **expect
 
 ```bash
 just spec-build        # Build the whole suite as bin/noir_spec
-just test              # spec-build, then run every CI example once
+just test              # spec-build, then run both halves in parallel
 just test-random       # Re-run the built binary in randomized example order
 just test-seed 12345   # Re-run it in one specific order
 just test-unit         # Run unit tests only (compiles just that directory)
@@ -57,8 +57,8 @@ just test-uncovered    # Run uncovered tests only (not in CI)
 ```
 
 `spec/suite.cr` requires `unit_test/**` plus `functional_test/testers/**` and
-nothing else, so `bin/noir_spec` holds exactly the 30,356 examples CI runs
-(5,697 unit and 24,659 functional). `uncovered_test/` is deliberately outside
+nothing else, so `bin/noir_spec` holds exactly the 30,357 examples CI runs
+(5,698 unit and 24,659 functional). `uncovered_test/` is deliberately outside
 it, which is also why `crystal spec` with no arguments is the wrong command
 here: its default glob sweeps up `uncovered_test/` too, and those examples are
 expected to fail.
@@ -71,10 +71,33 @@ Two constraints come with the binary:
   `unknown argument`. Narrow a run with a filter instead:
 
 ```bash
-./bin/noir_spec -e hono                                   # ~49 examples
-./bin/noir_spec --location spec/unit_test/foo_spec.cr:42   # one example
-./bin/noir_spec --dry-run                                  # list without running
+./bin/noir_spec -e hono                                    # ~49 examples
+./bin/noir_spec --location spec/unit_test/foo_spec.cr:42    # one example
+./bin/noir_spec --tag functional                            # functional half only
+./bin/noir_spec --tag '~functional'                         # unit half only
+./bin/noir_spec --dry-run                                   # list without running
 ```
+
+### Tags
+
+`functional` marks every example that drives a real scan over a fixture: the
+24,659 registered under `spec/functional_test/testers/`. The remaining 5,698
+are the unit half. `just test` runs the two as parallel processes, which is
+why the run drops from 18.6s to 9.7s.
+
+`FunctionalTester` tags what it registers. **A hand-written `describe`,
+`context` or `it` in a tester file has to spell the tag itself:**
+
+```crystal
+describe "TanStack Router source attribution", tags: "functional" do
+```
+
+Only top-level blocks need it, because Crystal merges a parent's tags into its
+children (`Spec::Item#all_tags`).
+`spec/unit_test/functional_tag_coverage_spec.cr` fails, naming the file and
+line, if one is missed. That guard exists because a missing tag breaks nothing
+visibly: the example simply joins the unit half and drags a full fixture scan
+into it, so the split quietly stops being a split.
 
 ### Why one binary
 
@@ -87,13 +110,14 @@ grow when the suites are combined. Measured locally on a warm compiler cache:
 | `crystal spec spec/functional_test` (24,659 ex) | 23.5s | 8.3s | 5.2 GB |
 | both suites compiled together | 20.9s | - | 6.1 GB |
 | `crystal build spec/suite.cr -o bin/noir_spec` | 20.0s | - | 6.6 GB |
-| `./bin/noir_spec` (30,356 ex) | 18.9s | 18.0s | 0.3 GB |
+| `./bin/noir_spec` (30,357 ex) | 18.9s | 18.0s | 0.3 GB |
 
-So the compile is paid once and every re-run after that is 18s on 0.3GB. Two
-runs of the binary in parallel finish in 19s wall against 36s sequential, which
-is what CI does with the default and randomized orders. CI previously compiled
-the same program four times (unit, functional, and both again randomized) for
-about 90s each.
+So the compile is paid once and every re-run after that is 18s on 0.3GB. Runs
+of the binary are single-threaded and cheap enough in memory to go in parallel:
+two at once finish in 19s wall against 36s sequential. CI builds once and then
+launches four (default order, randomized order, and each tag half on its own),
+where it previously compiled the same program four times, for about 90s each,
+to run unit, functional, and both again randomized.
 
 ### While working on one analyzer
 
@@ -130,7 +154,7 @@ reach past `perform_tests` for a one-off assertion, do the lookup in the `it`
 block:
 
 ```crystal
-it "keeps a single path param" do
+it "keeps a single path param", tags: "functional" do
   endpoint = tester.endpoints.find { |ep| ep.url == "/users/:id" }   # scans here
   ...
 end

--- a/spec/AGENTS.md
+++ b/spec/AGENTS.md
@@ -7,7 +7,7 @@ This document explains the test directory structure and how to add new test case
 ```
 spec/
 ├── spec_helper.cr              # Shared test helpers
-├── noir_spec.cr                # Main spec entry point
+├── suite.cr                    # Entry point: both CI suites in one binary
 ├── unit_test/                  # Unit tests (included in CI)
 ├── functional_test/            # Functional/integration tests (included in CI)
 │   ├── func_spec.cr            # FunctionalTester class
@@ -47,11 +47,53 @@ A staging area for test cases that are **not yet fully covered** or are **expect
 ## How to Run Tests
 
 ```bash
-just test              # Run all CI tests (unit + functional)
-just test-unit         # Run unit tests only
-just test-func         # Run functional tests only
+just spec-build        # Build the whole suite as bin/noir_spec
+just test              # spec-build, then run every CI example once
+just test-random       # Re-run the built binary in randomized example order
+just test-seed 12345   # Re-run it in one specific order
+just test-unit         # Run unit tests only (compiles just that directory)
+just test-func         # Run functional tests only (compiles just that directory)
 just test-uncovered    # Run uncovered tests only (not in CI)
 ```
+
+`spec/suite.cr` requires `unit_test/**` plus `functional_test/testers/**` and
+nothing else, so `bin/noir_spec` holds exactly the 30,356 examples CI runs
+(5,697 unit and 24,659 functional). `uncovered_test/` is deliberately outside
+it, which is also why `crystal spec` with no arguments is the wrong command
+here: its default glob sweeps up `uncovered_test/` too, and those examples are
+expected to fail.
+
+Two constraints come with the binary:
+
+- **Run it from the repository root.** `FunctionalTester` resolves fixtures
+  through a relative `./spec/functional_test/...` path.
+- **It takes no positional paths.** `bin/noir_spec spec/unit_test` fails with
+  `unknown argument`. Narrow a run with a filter instead:
+
+```bash
+./bin/noir_spec -e hono                                   # ~49 examples
+./bin/noir_spec --location spec/unit_test/foo_spec.cr:42   # one example
+./bin/noir_spec --dry-run                                  # list without running
+```
+
+### Why one binary
+
+Compiling `src/` is essentially the whole cost of a spec run, and it does not
+grow when the suites are combined. Measured locally on a warm compiler cache:
+
+| Command | wall | running examples | peak RSS |
+|---|---|---|---|
+| `crystal spec spec/unit_test` (5,697 ex) | 28.7s | 9.1s | 6.1 GB |
+| `crystal spec spec/functional_test` (24,659 ex) | 23.5s | 8.3s | 5.2 GB |
+| both suites compiled together | 20.9s | - | 6.1 GB |
+| `crystal build spec/suite.cr -o bin/noir_spec` | 20.0s | - | 6.6 GB |
+| `./bin/noir_spec` (30,356 ex) | 18.9s | 18.0s | 0.3 GB |
+
+So the compile is paid once and every re-run after that is 18s on 0.3GB. Two
+runs of the binary in parallel finish in 19s wall against 36s sequential, which
+is what CI does with the default and randomized orders. CI previously compiled
+the same program four times (unit, functional, and both again randomized) for
+about 90s each.
 
 ### While working on one analyzer
 
@@ -62,22 +104,24 @@ just test-func-one javascript/hono    # crystal spec spec/functional_test/tester
 just test-func-lang python            # every tester under testers/python/
 ```
 
-Measured on this repo: one tester **~8.5s**, one language directory ~10.5s,
-the whole functional suite ~16.5s.
+Measured on this repo: one tester **~8.5s**, one language directory ~10.5s.
+Compiling one file is still ~10s cheaper than compiling the suite, so these
+recipes stay on `crystal spec`. If `bin/noir_spec` is already built and your
+change is in a spec rather than in `src/`, `./bin/noir_spec -e hono` beats both.
 
 Two things worth knowing before you try to make that faster:
 
 - **Compiling `src/` is essentially the whole cost.** The single-tester run
   above executes its 78 examples in ~0.06s; the other ~8.5s is the compiler.
-  The number of spec files barely matters — 55 python testers compile in about
-  the same time as all 576. So narrowing the target below one file, or
-  sharding the suite across jobs, buys nothing.
+  The number of spec files barely matters: 55 python testers compile in about
+  the same time as all 576. So narrowing the target below one file, or sharding
+  the suite across jobs, buys nothing.
 - **`--example` works too, and is cheap.** `FunctionalTester` scans lazily: the
   first example to run triggers its tester's scan, so a filter only pays for the
   testers it selects. `--example hono` costs ~0.2s of run time against ~6.9s
   before the scans moved out of collection time. It still pays the ~8.5s
-  compile, so a path and a filter cost about the same — use whichever names what
-  you want.
+  compile, so a path and a filter cost about the same with `crystal spec`; use
+  whichever names what you want.
 
 ### Assertions go inside the example
 

--- a/spec/AGENTS.md
+++ b/spec/AGENTS.md
@@ -57,8 +57,8 @@ just test-uncovered    # Run uncovered tests only (not in CI)
 ```
 
 `spec/suite.cr` requires `unit_test/**` plus `functional_test/testers/**` and
-nothing else, so `bin/noir_spec` holds exactly the 30,357 examples CI runs
-(5,698 unit and 24,659 functional). `uncovered_test/` is deliberately outside
+nothing else, so `bin/noir_spec` holds exactly the 20,807 examples CI runs
+(5,698 unit and 15,109 functional). `uncovered_test/` is deliberately outside
 it, which is also why `crystal spec` with no arguments is the wrong command
 here: its default glob sweeps up `uncovered_test/` too, and those examples are
 expected to fail.
@@ -81,9 +81,9 @@ Two constraints come with the binary:
 ### Tags
 
 `functional` marks every example that drives a real scan over a fixture: the
-24,659 registered under `spec/functional_test/testers/`. The remaining 5,698
+15,109 registered under `spec/functional_test/testers/`. The remaining 5,698
 are the unit half. `just test` runs the two as parallel processes, which is
-why the run drops from 18.6s to 9.7s.
+why the run drops from 17.5s to 9.7s.
 
 `FunctionalTester` tags what it registers. **A hand-written `describe`,
 `context` or `it` in a tester file has to spell the tag itself:**
@@ -106,11 +106,16 @@ grow when the suites are combined. Measured locally on a warm compiler cache:
 
 | Command | wall | running examples | peak RSS |
 |---|---|---|---|
-| `crystal spec spec/unit_test` (5,697 ex) | 28.7s | 9.1s | 6.1 GB |
-| `crystal spec spec/functional_test` (24,659 ex) | 23.5s | 8.3s | 5.2 GB |
+| `crystal spec spec/unit_test` | 28.7s | 9.1s | 6.1 GB |
+| `crystal spec spec/functional_test` | 23.5s | 8.3s | 5.2 GB |
 | both suites compiled together | 20.9s | - | 6.1 GB |
 | `crystal build spec/suite.cr -o bin/noir_spec` | 20.0s | - | 6.6 GB |
-| `./bin/noir_spec` (30,357 ex) | 18.9s | 18.0s | 0.3 GB |
+| `./bin/noir_spec` (20,807 ex) | 17.5s | 17.4s | 0.3 GB |
+
+The two `crystal spec` rows were timed before the tautological url/method/name
+examples came out, when the same work registered 30,357 examples rather than
+20,807. The wall times did not move: the fixture scans dominate, and dropping
+9,550 examples took ~0.3s off the functional half.
 
 So the compile is paid once and every re-run after that is 18s on 0.3GB. Runs
 of the binary are single-threaded and cheap enough in memory to go in parallel:

--- a/spec/functional_test/func_spec.cr
+++ b/spec/functional_test/func_spec.cr
@@ -122,10 +122,13 @@ class FunctionalTester
   # failure inside the example rather than a branch taken while registering
   # examples.
   #
-  # Every example for a missing endpoint fails with the same greppable line, so
-  # one absent endpoint is noisy (~1 failure per detail checked) but always names
-  # the tester and the endpoint. The previous shape produced exactly one failure
-  # here — and zero for a raising analyzer, which is the trade this makes.
+  # Every example in the endpoint's group calls through here, so one absent
+  # endpoint still fails once per detail the tester declared, all of them with
+  # the same greppable `MISSING ENDPOINT [...]` line naming the tester and the
+  # endpoint. Registering examples for details that are not asserted anywhere
+  # else is what this trades away: the group carries one presence example plus
+  # the examples for the protocol, params, values and callees the tester
+  # actually declared, and nothing that only restates the lookup key.
   private def actual_endpoint(expected : Endpoint) : Endpoint
     key = "#{expected.method}::#{expected.url}"
     endpoints.find { |e| e.method == expected.method && e.url == expected.url } ||
@@ -184,12 +187,13 @@ class FunctionalTester
       key = expected.method.to_s + "::" + expected.url.to_s
 
       describe "endpoint check [#{key}]", tags: "functional" do
-        it "check - url [K: #{key}]" do
-          actual_endpoint(expected).url.should eq expected.url
-        end
-
-        it "check - method [K: #{key}]" do
-          actual_endpoint(expected).method.should eq expected.method
+        # `actual_endpoint` looks the endpoint up *by* method and url, so
+        # asserting those two back is a tautology: the only way either could
+        # fail was the `MISSING ENDPOINT` path, which every other example in
+        # this group takes as well. Two examples per endpoint said nothing that
+        # this one does not.
+        it "is detected [K: #{key}]" do
+          actual_endpoint(expected)
         end
 
         if expected.protocol != "http"
@@ -201,10 +205,10 @@ class FunctionalTester
         if expected.params.size > 0
           describe "check - params" do
             expected.params.each do |param|
-              it "check '#{param.name}' name " do
-                actual_params(expected, param.name)[0].name.should eq param.name
-              end
-
+              # No separate name check, for the same reason: `actual_params`
+              # selects by name and fails with `MISSING PARAM` when nothing
+              # matches, so the param_type example below already forces the
+              # param to be present under the expected name.
               it "check '#{param.name}' param_type '#{param.param_type}'" do
                 actual_params(expected, param.name)
                   .any? { |found| found.param_type == param.param_type }

--- a/spec/functional_test/func_spec.cr
+++ b/spec/functional_test/func_spec.cr
@@ -157,17 +157,25 @@ class FunctionalTester
     nil
   end
 
+  # Everything this class registers carries the `functional` tag, and so does
+  # every hand-written `describe` in a tester file (see
+  # `spec/unit_test/functional_tag_coverage_spec.cr`, which fails if one does
+  # not). The whole suite lives in one binary now, so the tag is what lets
+  # `bin/noir_spec --tag functional` and `bin/noir_spec --tag '~functional'`
+  # split it into two processes that run in parallel. Crystal merges a parent's
+  # tags into its children (`Spec::Item#all_tags`), so tagging the `describe`
+  # below covers the examples inside it.
   def test_detect
     return unless @expected_count.has_key?(:techs)
 
-    it "test detect using count check [#{@path}]" do
+    it "test detect using count check [#{@path}]", tags: "functional" do
       app.techs.size.should eq @expected_count[:techs]
     end
   end
 
   def test_analyze
     if @expected_count.has_key?(:endpoints)
-      it "test analyze using count check [#{@path}]" do
+      it "test analyze using count check [#{@path}]", tags: "functional" do
         endpoints.size.should eq @expected_count[:endpoints]
       end
     end
@@ -175,7 +183,7 @@ class FunctionalTester
     @expected_endpoints.each do |expected|
       key = expected.method.to_s + "::" + expected.url.to_s
 
-      describe "endpoint check [#{key}]" do
+      describe "endpoint check [#{key}]", tags: "functional" do
         it "check - url [K: #{key}]" do
           actual_endpoint(expected).url.should eq expected.url
         end

--- a/spec/functional_test/testers/cpp/crow_routes_spec.cr
+++ b/spec/functional_test/testers/cpp/crow_routes_spec.cr
@@ -43,7 +43,7 @@ tester = FunctionalTester.new("fixtures/cpp/crow_routes/", {
 
 tester.perform_tests
 
-describe "Crow route discovery edge cases" do
+describe "Crow route discovery edge cases", tags: "functional" do
   it "does not leak route_dynamic params into the preceding static route" do
     static = tester.app.endpoints.find { |e| e.url == "/static" && e.method == "GET" }
     static.should_not be_nil

--- a/spec/functional_test/testers/cpp/drogon_controllers_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_controllers_spec.cr
@@ -48,7 +48,7 @@ tester = FunctionalTester.new("fixtures/cpp/drogon_controllers/", {
 
 tester.perform_tests
 
-describe "Drogon controller routing edge cases" do
+describe "Drogon controller routing edge cases", tags: "functional" do
   it "ignores macros inside block comments" do
     tester.app.endpoints.any? { |e| e.url == "/ghost" }.should be_false
   end

--- a/spec/functional_test/testers/cpp/drogon_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_spec.cr
@@ -44,7 +44,7 @@ tester = FunctionalTester.new("fixtures/cpp/drogon/", {
 
 tester.perform_tests
 
-describe "Drogon analyzer edge cases" do
+describe "Drogon analyzer edge cases", tags: "functional" do
   it "does not leak registerHandler params across sibling lambdas" do
     ping = tester.app.endpoints.find { |e| e.url == "/ping" && e.method == "GET" }
     ping.should_not be_nil

--- a/spec/functional_test/testers/cpp/httplib_spec.cr
+++ b/spec/functional_test/testers/cpp/httplib_spec.cr
@@ -46,7 +46,7 @@ tester = FunctionalTester.new("fixtures/cpp/httplib/", {
 
 tester.perform_tests
 
-describe "cpp-httplib route discovery edge cases" do
+describe "cpp-httplib route discovery edge cases", tags: "functional" do
   it "does not treat a Client verb call as a route" do
     tester.app.endpoints.any? { |e| e.url == "/external" }.should be_false
   end

--- a/spec/functional_test/testers/cpp/oatpp_spec.cr
+++ b/spec/functional_test/testers/cpp/oatpp_spec.cr
@@ -39,7 +39,7 @@ tester = FunctionalTester.new("fixtures/cpp/oatpp/", {
 
 tester.perform_tests
 
-describe "oat++ ENDPOINT macro edge cases" do
+describe "oat++ ENDPOINT macro edge cases", tags: "functional" do
   it "ignores ENDPOINT_INFO metadata macros" do
     # getUserById appears in both ENDPOINT_INFO and ENDPOINT; only one route.
     tester.app.endpoints.count { |e| e.url == "/users/{userId}" && e.method == "GET" }.should eq 1

--- a/spec/functional_test/testers/crystal/amber_callees_spec.cr
+++ b/spec/functional_test/testers/crystal/amber_callees_spec.cr
@@ -49,7 +49,7 @@ tester = FunctionalTester.new("fixtures/crystal/amber_callees/", {
 })
 tester.perform_tests
 
-describe "Amber callee extraction" do
+describe "Amber callee extraction", tags: "functional" do
   it "keeps controller-less fallback routes callee-empty" do
     health_endpoint = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/health" }
     health_endpoint.should_not be_nil

--- a/spec/functional_test/testers/crystal/cli_monorepo_shards_spec.cr
+++ b/spec/functional_test/testers/crystal/cli_monorepo_shards_spec.cr
@@ -23,7 +23,7 @@ tester = FunctionalTester.new("fixtures/crystal/cli_monorepo_shards/", {
 })
 tester.perform_tests
 
-it "does not merge two shards that infer the same binary name" do
+it "does not merge two shards that infer the same binary name", tags: "functional" do
   svc_a = tester.endpoints.find! { |endpoint| endpoint.url == "cli://svc-a/tool" }
   svc_a.params.map(&.name).should_not contain("only-b")
   svc_a.details.code_paths.map(&.path).each(&.should(contain("svc-a")))

--- a/spec/functional_test/testers/crystal/cli_monorepo_spec.cr
+++ b/spec/functional_test/testers/crystal/cli_monorepo_spec.cr
@@ -23,7 +23,7 @@ tester = FunctionalTester.new("fixtures/crystal/cli_monorepo/", {
 })
 tester.perform_tests
 
-it "keeps each binary's flags on its own command" do
+it "keeps each binary's flags on its own command", tags: "functional" do
   alpha = tester.endpoints.find! { |endpoint| endpoint.url == "cli://alpha" }
   alpha.params.map(&.name).should_not contain("beta-only")
 

--- a/spec/functional_test/testers/crystal/kemal_ai_context_spec.cr
+++ b/spec/functional_test/testers/crystal/kemal_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Kemal auth fixtures" do
+describe "--ai-context on Kemal auth fixtures", tags: "functional" do
   fixture_path = "fixtures/crystal/kemal_auth/"
   app_suffix = "spec/functional_test/fixtures/crystal/kemal_auth/app.cr"
 

--- a/spec/functional_test/testers/csharp/aspnet_ai_context_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on ASP.NET auth fixtures" do
+describe "--ai-context on ASP.NET auth fixtures", tags: "functional" do
   fixture_path = "fixtures/csharp/aspnet_auth/"
   controller_suffix = "spec/functional_test/fixtures/csharp/aspnet_auth/Controllers/PostsController.cs"
 

--- a/spec/functional_test/testers/csharp/aspnet_core_minimal_api_methodgroup_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_minimal_api_methodgroup_spec.cr
@@ -53,7 +53,7 @@ tester = FunctionalTester.new("fixtures/csharp/aspnet_core_minimal_api_methodgro
 
 tester.perform_tests
 
-describe "ASP.NET Core Minimal API method-group analyzer edge cases" do
+describe "ASP.NET Core Minimal API method-group analyzer edge cases", tags: "functional" do
   it "drops DI services injected into a lambda handler" do
     inv = tester.app.endpoints.find { |e| e.url == "/inventory" && e.method == "GET" }
     inv.should_not be_nil

--- a/spec/functional_test/testers/csharp/aspnet_core_minimal_api_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_minimal_api_spec.cr
@@ -54,7 +54,7 @@ tester = FunctionalTester.new("fixtures/csharp/aspnet_core_minimal_api/", {
 
 tester.perform_tests
 
-describe "ASP.NET Core Minimal API analyzer edge cases" do
+describe "ASP.NET Core Minimal API analyzer edge cases", tags: "functional" do
   it "does not register routes written inside comments" do
     tester.app.endpoints.any?(&.url.includes?("doc-only")).should be_false
     tester.app.endpoints.any?(&.url.includes?("commented-out")).should be_false

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_modern_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_modern_spec.cr
@@ -84,7 +84,7 @@ tester = FunctionalTester.new("fixtures/csharp/aspnet_core_mvc_modern/", {
 
 tester.perform_tests
 
-describe "ASP.NET Core MVC modern controller edge cases" do
+describe "ASP.NET Core MVC modern controller edge cases", tags: "functional" do
   it "resolves actions on a primary-constructor controller" do
     list = tester.app.endpoints.find { |e| e.url == "/articles" && e.method == "GET" }
     list.should_not be_nil

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_solution_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_solution_spec.cr
@@ -20,7 +20,7 @@ tester = FunctionalTester.new("fixtures/csharp/aspnet_core_mvc_solution/", {
 
 tester.perform_tests
 
-describe "ASP.NET Core MVC conventional-route project scoping" do
+describe "ASP.NET Core MVC conventional-route project scoping", tags: "functional" do
   it "does not apply one project's route template to another project's controller" do
     tester.app.endpoints.any? { |e| e.url == "/a/Beta/Show" }.should be_false
     tester.app.endpoints.any? { |e| e.url == "/b/Alpha/Index" }.should be_false

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
@@ -124,7 +124,7 @@ tester = FunctionalTester.new("fixtures/csharp/aspnet_core_mvc/", {
 
 tester.perform_tests
 
-describe "ASP.NET Core MVC analyzer edge cases" do
+describe "ASP.NET Core MVC analyzer edge cases", tags: "functional" do
   it "extracts expression-bodied MapGet endpoints without leaking params" do
     ping = tester.app.endpoints.find { |e| e.url == "/mapped/ping" && e.method == "GET" }
     ping.should_not be_nil

--- a/spec/functional_test/testers/csharp/carter_spec.cr
+++ b/spec/functional_test/testers/csharp/carter_spec.cr
@@ -51,7 +51,7 @@ tester = FunctionalTester.new("fixtures/csharp/carter/", {
 
 tester.perform_tests
 
-describe "Carter analyzer edge cases" do
+describe "Carter analyzer edge cases", tags: "functional" do
   it "does not surface routes from /test/ fixtures" do
     tester.app.endpoints.any?(&.url.includes?("test-only")).should be_false
   end

--- a/spec/functional_test/testers/csharp/fastendpoints_multi_base_spec.cr
+++ b/spec/functional_test/testers/csharp/fastendpoints_multi_base_spec.cr
@@ -24,7 +24,7 @@ tester = FunctionalTester.new("fixtures/csharp/fastendpoints_multi_base/", {
 
 tester.perform_tests
 
-describe "FastEndpoints multi-base DTO scoping" do
+describe "FastEndpoints multi-base DTO scoping", tags: "functional" do
   it "keeps request DTO params inside the endpoint's base path" do
     service_a = tester.app.endpoints.find! { |endpoint| endpoint.method == "POST" && endpoint.url == "/a/users" }
     service_a.params.map(&.name).sort!.should eq(["Name"])

--- a/spec/functional_test/testers/csharp/fastendpoints_spec.cr
+++ b/spec/functional_test/testers/csharp/fastendpoints_spec.cr
@@ -44,7 +44,7 @@ tester = FunctionalTester.new("fixtures/csharp/fastendpoints/", {
 
 tester.perform_tests
 
-describe "FastEndpoints analyzer edge cases" do
+describe "FastEndpoints analyzer edge cases", tags: "functional" do
   it "treats EndpointWithoutRequest<TResponse> as response-only — no DTO leakage" do
     status = tester.app.endpoints.find { |e| e.url == "/status" && e.method == "GET" }
     status.should_not be_nil
@@ -64,7 +64,7 @@ describe "FastEndpoints analyzer edge cases" do
   end
 end
 
-describe "FastEndpoints auth tagger" do
+describe "FastEndpoints auth tagger", tags: "functional" do
   fixture_path = "fixtures/csharp/fastendpoints/"
 
   it "tags endpoints behind Roles/Permissions and skips AllowAnonymous ones" do

--- a/spec/functional_test/testers/csharp/httplistener_multi_service_spec.cr
+++ b/spec/functional_test/testers/csharp/httplistener_multi_service_spec.cr
@@ -17,7 +17,7 @@ tester = FunctionalTester.new("fixtures/csharp/httplistener_multi_service/", {
 
 tester.perform_tests
 
-describe "C# HttpListener analyzer across two services" do
+describe "C# HttpListener analyzer across two services", tags: "functional" do
   it "keeps a code path for every file that serves the route" do
     health = tester.app.endpoints.find { |e| e.url == "/health" && e.method == "GET" }
     health.should_not be_nil

--- a/spec/functional_test/testers/csharp/httplistener_spec.cr
+++ b/spec/functional_test/testers/csharp/httplistener_spec.cr
@@ -32,7 +32,7 @@ tester = FunctionalTester.new("fixtures/csharp/httplistener/", {
 
 tester.perform_tests
 
-describe "C# HttpListener analyzer edge cases" do
+describe "C# HttpListener analyzer edge cases", tags: "functional" do
   it "marks endpoints with the dedicated technology" do
     health = tester.app.endpoints.find { |e| e.url == "/health" && e.method == "GET" }
     health.should_not be_nil

--- a/spec/functional_test/testers/csharp/servicestack_spec.cr
+++ b/spec/functional_test/testers/csharp/servicestack_spec.cr
@@ -61,7 +61,7 @@ tester = FunctionalTester.new("fixtures/csharp/servicestack/", {
 
 tester.perform_tests
 
-describe "ServiceStack analyzer edge cases" do
+describe "ServiceStack analyzer edge cases", tags: "functional" do
   it "does not surface routes from /test/ fixtures" do
     tester.app.endpoints.any?(&.url.includes?("test-only")).should be_false
   end

--- a/spec/functional_test/testers/csharp/signalr_spec.cr
+++ b/spec/functional_test/testers/csharp/signalr_spec.cr
@@ -43,7 +43,7 @@ signalr_tester.perform_tests
 # Regression: the trailing CancellationToken on StreamData is a framework
 # type, not a client-supplied message field, so it must not surface as a
 # param on the analyzed endpoint.
-it "drops framework/DI params (CancellationToken) from SignalR events" do
+it "drops framework/DI params (CancellationToken) from SignalR events", tags: "functional" do
   stream = signalr_tester.app.endpoints.find { |e| e.url == "ws://chat/StreamData" }
   stream.should_not be_nil
   if stream

--- a/spec/functional_test/testers/dart/alfred_spec.cr
+++ b/spec/functional_test/testers/dart/alfred_spec.cr
@@ -53,7 +53,7 @@ tester = FunctionalTester.new("fixtures/dart/alfred/", {
 })
 tester.perform_tests
 
-it "extracts callees from an Alfred lambda handler body" do
+it "extracts callees from an Alfred lambda handler body", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/users" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -64,7 +64,7 @@ it "extracts callees from an Alfred lambda handler body" do
   end
 end
 
-it "skips the handler's trailing middleware argument when scanning callees" do
+it "skips the handler's trailing middleware argument when scanning callees", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/users/{id}" && found.method == "DELETE" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -72,7 +72,7 @@ it "skips the handler's trailing middleware argument when scanning callees" do
   end
 end
 
-it "composes Alfred nested route() base paths with cascade sub-paths" do
+it "composes Alfred nested route() base paths with cascade sub-paths", tags: "functional" do
   urls = tester.app.endpoints.map(&.url).to_set
   urls.should contain("/admin/")
   urls.should contain("/admin/users")

--- a/spec/functional_test/testers/dart/angel3_spec.cr
+++ b/spec/functional_test/testers/dart/angel3_spec.cr
@@ -38,11 +38,11 @@ tester = FunctionalTester.new("fixtures/dart/angel3/", {
 })
 tester.perform_tests
 
-it "composes nested Angel3 group() prefixes" do
+it "composes nested Angel3 group() prefixes", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/api/v2/widgets" && found.method == "POST" }
   endpoint.should_not be_nil
 end
 
-it "does not treat a package:http client get() as a route" do
+it "does not treat a package:http client get() as a route", tags: "functional" do
   tester.app.endpoints.any?(&.url.includes?("example.com")).should be_false
 end

--- a/spec/functional_test/testers/dart/dart_frog_callees_spec.cr
+++ b/spec/functional_test/testers/dart/dart_frog_callees_spec.cr
@@ -58,7 +58,7 @@ tester = FunctionalTester.new("fixtures/dart/dart_frog_callees/", {
 })
 tester.perform_tests
 
-it "reports the exact Dart Frog callee list for method-routed files" do
+it "reports the exact Dart Frog callee list for method-routed files", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/users/{id}" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|

--- a/spec/functional_test/testers/dart/dart_frog_spec.cr
+++ b/spec/functional_test/testers/dart/dart_frog_spec.cr
@@ -47,13 +47,13 @@ tester.perform_tests
 # `routes/dashboard_route.dart` is a Flutter UI widget (no `onRequest`
 # handler) that happens to live under `routes/`. It must not be reported
 # as an HTTP endpoint.
-it "ignores routes/ files without an onRequest handler" do
+it "ignores routes/ files without an onRequest handler", tags: "functional" do
   tester.app.endpoints.any? { |e| e.url == "/dashboard_route" }.should be_false
 end
 
 # A `webSocketHandler` route is a single GET with the `ws` protocol, not a
 # 5-verb fall-back.
-it "narrows a WebSocket route to GET and marks the ws protocol" do
+it "narrows a WebSocket route to GET and marks the ws protocol", tags: "functional" do
   ws = tester.app.endpoints.select { |e| e.url == "/ws" }
   ws.map(&.method).should eq(["GET"])
   ws.first.protocol.should eq("ws")

--- a/spec/functional_test/testers/dart/get_server_spec.cr
+++ b/spec/functional_test/testers/dart/get_server_spec.cr
@@ -37,10 +37,10 @@ tester = FunctionalTester.new("fixtures/dart/get_server/", {
 })
 tester.perform_tests
 
-it "resolves GetPage name constants declared in a separate file" do
+it "resolves GetPage name constants declared in a separate file", tags: "functional" do
   tester.app.endpoints.any? { |e| e.url == "/user/{id}" }.should be_true
 end
 
-it "skips GetPage entries declared under test/" do
+it "skips GetPage entries declared under test/", tags: "functional" do
   tester.app.endpoints.any? { |e| e.url == "/test-only" }.should be_false
 end

--- a/spec/functional_test/testers/dart/http_spec.cr
+++ b/spec/functional_test/testers/dart/http_spec.cr
@@ -27,7 +27,7 @@ tester = FunctionalTester.new("fixtures/dart/http/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "does not leak pre-route body reads into previous endpoints" do
+it "does not leak pre-route body reads into previous endpoints", tags: "functional" do
   reports = tester.app.endpoints.find { |found| found.url == "/reports" && found.method == "DELETE" }
   reports.should_not be_nil
   reports.try do |endpoint|

--- a/spec/functional_test/testers/dart/serverpod_callees_spec.cr
+++ b/spec/functional_test/testers/dart/serverpod_callees_spec.cr
@@ -39,7 +39,7 @@ tester = FunctionalTester.new("fixtures/dart/serverpod_callees/", {
 })
 tester.perform_tests
 
-it "reports the exact Serverpod callees after comments before endpoint classes" do
+it "reports the exact Serverpod callees after comments before endpoint classes", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/example/hello" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|

--- a/spec/functional_test/testers/dart/serverpod_multi_base_spec.cr
+++ b/spec/functional_test/testers/dart/serverpod_multi_base_spec.cr
@@ -19,7 +19,7 @@ tester = FunctionalTester.new("fixtures/dart/serverpod_multi_base/", {
 })
 tester.perform_tests
 
-it "keeps Serverpod web route classes inside each base path" do
+it "keeps Serverpod web route classes inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.url == "/a-web" }
   service_a.method.should eq("GET")
 

--- a/spec/functional_test/testers/dart/serverpod_spec.cr
+++ b/spec/functional_test/testers/dart/serverpod_spec.cr
@@ -35,7 +35,7 @@ serverpod_tester = FunctionalTester.new("fixtures/dart/serverpod/", {
 })
 serverpod_tester.perform_tests
 
-it "extracts callees from a Serverpod web-route handler body" do
+it "extracts callees from a Serverpod web-route handler body", tags: "functional" do
   endpoint = serverpod_tester.app.endpoints.find { |found| found.url == "/webhook" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|

--- a/spec/functional_test/testers/dart/shelf_multi_base_spec.cr
+++ b/spec/functional_test/testers/dart/shelf_multi_base_spec.cr
@@ -19,7 +19,7 @@ tester = FunctionalTester.new("fixtures/dart/shelf_multi_base/", {
 })
 tester.perform_tests
 
-it "keeps Shelf router mounts inside each base path" do
+it "keeps Shelf router mounts inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.url == "/a/shared" }
   service_a.method.should eq("GET")
 

--- a/spec/functional_test/testers/dart/shelf_spec.cr
+++ b/spec/functional_test/testers/dart/shelf_spec.cr
@@ -53,7 +53,7 @@ callee_tester = FunctionalTester.new("fixtures/dart/shelf/", {} of Symbol => Int
 })
 callee_tester.perform_tests
 
-it "records bare function-reference handlers as callees" do
+it "records bare function-reference handlers as callees", tags: "functional" do
   endpoint = callee_tester.app.endpoints.find { |found| found.url == "/users" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -61,7 +61,7 @@ it "records bare function-reference handlers as callees" do
   end
 end
 
-it "extracts callees from @Route-annotated handler bodies" do
+it "extracts callees from @Route-annotated handler bodies", tags: "functional" do
   endpoint = callee_tester.app.endpoints.find { |found| found.url == "/tasks/{id}/done" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|

--- a/spec/functional_test/testers/elixir/phoenix_ai_context_spec.cr
+++ b/spec/functional_test/testers/elixir/phoenix_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Phoenix auth fixtures" do
+describe "--ai-context on Phoenix auth fixtures", tags: "functional" do
   fixture_path = "fixtures/elixir/phoenix_auth/"
   post_suffix = "spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/controllers/post_controller.ex"
   public_suffix = "spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/controllers/public_controller.ex"

--- a/spec/functional_test/testers/elixir/phoenix_channel_spec.cr
+++ b/spec/functional_test/testers/elixir/phoenix_channel_spec.cr
@@ -30,7 +30,7 @@ phoenix_channel_tester.perform_tests
 
 # Regression: the catch-all handle_in clause carries no literal event name
 # and must not surface as an endpoint.
-it "does not emit an endpoint for a catch-all handle_in clause" do
+it "does not emit an endpoint for a catch-all handle_in clause", tags: "functional" do
   urls = phoenix_channel_tester.app.endpoints.map(&.url)
   urls.count(&.starts_with?("ws://room:*/")).should eq 2
 end

--- a/spec/functional_test/testers/elixir/phoenix_multi_base_spec.cr
+++ b/spec/functional_test/testers/elixir/phoenix_multi_base_spec.cr
@@ -24,7 +24,7 @@ tester = FunctionalTester.new("fixtures/elixir/phoenix_multi_base/", {
 
 tester.perform_tests
 
-it "keeps Phoenix controller params scoped to each configured base" do
+it "keeps Phoenix controller params scoped to each configured base", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.method == "GET" && endpoint.url == "/service-a/shared" }
   service_b = tester.app.endpoints.find! { |endpoint| endpoint.method == "GET" && endpoint.url == "/service-b/shared" }
 

--- a/spec/functional_test/testers/fsharp/giraffe_callees_spec.cr
+++ b/spec/functional_test/testers/fsharp/giraffe_callees_spec.cr
@@ -59,7 +59,7 @@ tester = FunctionalTester.new("fixtures/fsharp/giraffe_callees/", {
 })
 tester.perform_tests
 
-it "reports exact Giraffe callees for multiline inline handlers" do
+it "reports exact Giraffe callees for multiline inline handlers", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/profile" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -67,7 +67,7 @@ it "reports exact Giraffe callees for multiline inline handlers" do
   end
 end
 
-it "recovers the handler callee for a constant-path route" do
+it "recovers the handler callee for a constant-path route", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/dashboard" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -75,7 +75,7 @@ it "recovers the handler callee for a constant-path route" do
   end
 end
 
-it "does not leak sibling Giraffe route callees into routef handlers" do
+it "does not leak sibling Giraffe route callees into routef handlers", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/users/:int" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -85,7 +85,7 @@ it "does not leak sibling Giraffe route callees into routef handlers" do
   end
 end
 
-it "populates Giraffe callee source paths" do
+it "populates Giraffe callee source paths", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/profile" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -97,7 +97,7 @@ it "populates Giraffe callee source paths" do
   end
 end
 
-it "does not stop multiline Giraffe handlers at inner list delimiters" do
+it "does not stop multiline Giraffe handlers at inner list delimiters", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/pipeline" && found.method == "PATCH" }
   endpoint.should_not be_nil
   endpoint.try do |actual|

--- a/spec/functional_test/testers/go/chi_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/chi_hunt_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context Hunt signals on Chi fixtures" do
+describe "--ai-context Hunt signals on Chi fixtures", tags: "functional" do
   fixture_path = "fixtures/go/chi/"
 
   before_each do

--- a/spec/functional_test/testers/go/cli_monorepo_spec.cr
+++ b/spec/functional_test/testers/go/cli_monorepo_spec.cr
@@ -26,12 +26,12 @@ tester = FunctionalTester.new("fixtures/go/cli_monorepo/", {
 })
 tester.perform_tests
 
-it "keeps each command's flags on its own binary" do
+it "keeps each command's flags on its own binary", tags: "functional" do
   alpha = tester.endpoints.find! { |endpoint| endpoint.url == "cli://alpha" }
   alpha.params.map(&.name).should_not contain("beta-only-flag")
 end
 
-it "records every file that contributed to a command" do
+it "records every file that contributed to a command", tags: "functional" do
   alpha = tester.endpoints.find! { |endpoint| endpoint.url == "cli://alpha" }
   paths = alpha.details.code_paths.map { |code_path| File.basename(code_path.path) }
   paths.should contain("main.go")

--- a/spec/functional_test/testers/go/cli_spec.cr
+++ b/spec/functional_test/testers/go/cli_spec.cr
@@ -191,7 +191,7 @@ FunctionalTester.new("fixtures/go/cli_mitchellh_fp/", {
 # blocks above even on the old buggy code. Assert the exact negative
 # directly so these regressions truly fail on the old fallback/sticky-cursor
 # behavior and pass only once the leak is gone.
-describe "go CLI attribution false-positive guards" do
+describe "go CLI attribution false-positive guards", tags: "functional" do
   it "does not leak an unrelated envconfig-tagged struct's fields onto the kong root command" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/go/cli_kong_fp/")])

--- a/spec/functional_test/testers/go/connect_rpc_multi_base_spec.cr
+++ b/spec/functional_test/testers/go/connect_rpc_multi_base_spec.cr
@@ -22,7 +22,7 @@ tester = FunctionalTester.new("fixtures/go/connect_rpc_multi_base/", {
 })
 tester.perform_tests
 
-it "keeps Connect RPC service mounts inside each base path" do
+it "keeps Connect RPC service mounts inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.url == "/servicea.v1.UserService/Get" }
   service_b = tester.app.endpoints.find! { |endpoint| endpoint.url == "/serviceb.v1.UserService/Get" }
 

--- a/spec/functional_test/testers/go/echo_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/echo_hunt_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context Hunt signals on Echo fixtures" do
+describe "--ai-context Hunt signals on Echo fixtures", tags: "functional" do
   fixture_path = "fixtures/go/echo/"
 
   before_each do

--- a/spec/functional_test/testers/go/gin_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/gin_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Gin auth fixtures" do
+describe "--ai-context on Gin auth fixtures", tags: "functional" do
   fixture_path = "fixtures/go/gin_auth/"
   main_suffix = "spec/functional_test/fixtures/go/gin_auth/main.go"
 

--- a/spec/functional_test/testers/go/goyave_exclude_path_spec.cr
+++ b/spec/functional_test/testers/go/goyave_exclude_path_spec.cr
@@ -13,7 +13,7 @@ overrides["exclude_path"] = YAML::Any.new("index.html")
 baseline = FunctionalTester.new("fixtures/go/goyave/", empty_count, no_endpoints)
 excluded = FunctionalTester.new("fixtures/go/goyave/", empty_count, no_endpoints, overrides)
 
-describe "Go static directories with --exclude-path" do
+describe "Go static directories with --exclude-path", tags: "functional" do
   it "reports files under a registered static directory" do
     baseline.endpoints.map(&.url).should contain("/static/index.html")
   end

--- a/spec/functional_test/testers/go/mux_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/mux_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Mux fixtures" do
+describe "--ai-context on Mux fixtures", tags: "functional" do
   fixture_path = "fixtures/go/mux/"
 
   before_each do

--- a/spec/functional_test/testers/groovy/grails_callees_spec.cr
+++ b/spec/functional_test/testers/groovy/grails_callees_spec.cr
@@ -64,7 +64,7 @@ tester = FunctionalTester.new("fixtures/groovy/grails_callees/", {
 })
 tester.perform_tests
 
-it "reports exact Grails callees for allowedMethods fan-out" do
+it "reports exact Grails callees for allowedMethods fan-out", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/book/update" && found.method == "PUT" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -72,7 +72,7 @@ it "reports exact Grails callees for allowedMethods fan-out" do
   end
 end
 
-it "handles Groovy literals and safe navigation in Grails action bodies" do
+it "handles Groovy literals and safe navigation in Grails action bodies", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/book/show" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -80,7 +80,7 @@ it "handles Groovy literals and safe navigation in Grails action bodies" do
   end
 end
 
-it "does not attach callees to scaffold-generated Grails actions" do
+it "does not attach callees to scaffold-generated Grails actions", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/product/save" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -88,7 +88,7 @@ it "does not attach callees to scaffold-generated Grails actions" do
   end
 end
 
-it "populates Grails callee source paths" do
+it "populates Grails callee source paths", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/book/index" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|

--- a/spec/functional_test/testers/haskell/cli_spec.cr
+++ b/spec/functional_test/testers/haskell/cli_spec.cr
@@ -49,7 +49,7 @@ turtle_fp_endpoints = [
 turtle_fp_tester = FunctionalTester.new("fixtures/haskell/cli_turtle_fp/", {:techs => 1, :endpoints => turtle_fp_endpoints.size}, turtle_fp_endpoints)
 turtle_fp_tester.perform_tests
 
-it "does not leak bogus params from adjacent non-Turtle code into the Turtle CLI endpoint" do
+it "does not leak bogus params from adjacent non-Turtle code into the Turtle CLI endpoint", tags: "functional" do
   endpoint = turtle_fp_tester.app.endpoints.find! { |e| e.method == "CLI" && e.url == "cli://tool" }
   endpoint.params.map(&.name).sort!.should eq ["GREETING_TOKEN", "count", "name", "retries", "target", "verbose"]
 end

--- a/spec/functional_test/testers/haskell/scotty_multi_base_callees_spec.cr
+++ b/spec/functional_test/testers/haskell/scotty_multi_base_callees_spec.cr
@@ -20,7 +20,7 @@ tester = FunctionalTester.new("fixtures/haskell/scotty_multi_base_callees/", {
 })
 tester.perform_tests
 
-it "keeps Scotty handler bodies inside each base path" do
+it "keeps Scotty handler bodies inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.url == "/a" && endpoint.method == "GET" }
   service_a.callees.map(&.name).should contain("serviceA")
 

--- a/spec/functional_test/testers/haskell/servant_callees_applied_spec.cr
+++ b/spec/functional_test/testers/haskell/servant_callees_applied_spec.cr
@@ -37,7 +37,7 @@ tester = FunctionalTester.new("fixtures/haskell/servant_callees_applied/", {
 })
 tester.perform_tests
 
-it "resolves Servant callees through a non-conventional server name and applied leaves" do
+it "resolves Servant callees through a non-conventional server name and applied leaves", tags: "functional" do
   info = tester.app.endpoints.find { |found| found.url == "/info" && found.method == "GET" }
   info.should_not be_nil
   info.try do |actual|

--- a/spec/functional_test/testers/haskell/servant_callees_spec.cr
+++ b/spec/functional_test/testers/haskell/servant_callees_spec.cr
@@ -36,7 +36,7 @@ tester = FunctionalTester.new("fixtures/haskell/servant_callees/", {
 })
 tester.perform_tests
 
-it "reports exact Servant callees by flattened server order" do
+it "reports exact Servant callees by flattened server order", tags: "functional" do
   list_endpoint = tester.app.endpoints.find { |found| found.url == "/v1/users" && found.method == "GET" }
   list_endpoint.should_not be_nil
   list_endpoint.try do |actual|
@@ -56,7 +56,7 @@ it "reports exact Servant callees by flattened server order" do
   end
 end
 
-it "populates Servant callee source paths" do
+it "populates Servant callee source paths", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/health" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -81,7 +81,7 @@ mismatch_tester = FunctionalTester.new("fixtures/haskell/servant_callees_mismatc
 })
 mismatch_tester.perform_tests
 
-it "leaves Servant callees empty when server leaf count mismatches endpoint count" do
+it "leaves Servant callees empty when server leaf count mismatches endpoint count", tags: "functional" do
   mismatch_tester.app.endpoints.each do |endpoint|
     endpoint.callees.should be_empty
   end
@@ -103,7 +103,7 @@ multi_api_tester = FunctionalTester.new("fixtures/haskell/servant_callees_multi_
 })
 multi_api_tester.perform_tests
 
-it "does not reuse a same-file generic Servant server for a different API alias" do
+it "does not reuse a same-file generic Servant server for a different API alias", tags: "functional" do
   admin = multi_api_tester.app.endpoints.find { |found| found.url == "/admin" && found.method == "GET" }
   admin.should_not be_nil
   admin.try do |endpoint|
@@ -124,7 +124,7 @@ cross_alias_tester = FunctionalTester.new("fixtures/haskell/servant_callees_cros
 })
 cross_alias_tester.perform_tests
 
-it "does not expand nested Servant server aliases from another file" do
+it "does not expand nested Servant server aliases from another file", tags: "functional" do
   cross_alias_tester.app.endpoints.each do |endpoint|
     endpoint.callees.should be_empty
   end

--- a/spec/functional_test/testers/haskell/servant_multi_base_callees_spec.cr
+++ b/spec/functional_test/testers/haskell/servant_multi_base_callees_spec.cr
@@ -20,7 +20,7 @@ tester = FunctionalTester.new("fixtures/haskell/servant_multi_base_callees/", {
 })
 tester.perform_tests
 
-it "keeps Servant handler bodies inside each base path" do
+it "keeps Servant handler bodies inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.url == "/a" && endpoint.method == "GET" }
   service_a.callees.map(&.name).should contain("serviceA")
 

--- a/spec/functional_test/testers/haskell/yesod_callees_spec.cr
+++ b/spec/functional_test/testers/haskell/yesod_callees_spec.cr
@@ -62,7 +62,7 @@ tester = FunctionalTester.new("fixtures/haskell/yesod_callees/", {
 })
 tester.perform_tests
 
-it "reports exact Yesod callees by handler convention" do
+it "reports exact Yesod callees by handler convention", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -70,7 +70,7 @@ it "reports exact Yesod callees by handler convention" do
   end
 end
 
-it "uses handle-prefixed Yesod handlers for methodless routes" do
+it "uses handle-prefixed Yesod handlers for methodless routes", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/faq" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -78,7 +78,7 @@ it "uses handle-prefixed Yesod handlers for methodless routes" do
   end
 end
 
-it "does not attach unrelated top-level functions to Yesod endpoints" do
+it "does not attach unrelated top-level functions to Yesod endpoints", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/api/health" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -86,7 +86,7 @@ it "does not attach unrelated top-level functions to Yesod endpoints" do
   end
 end
 
-it "populates Yesod callee source paths" do
+it "populates Yesod callee source paths", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/blog/:text" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|

--- a/spec/functional_test/testers/haskell/yesod_multi_base_callees_spec.cr
+++ b/spec/functional_test/testers/haskell/yesod_multi_base_callees_spec.cr
@@ -20,7 +20,7 @@ tester = FunctionalTester.new("fixtures/haskell/yesod_multi_base_callees/", {
 })
 tester.perform_tests
 
-it "keeps Yesod handler bodies inside each base path" do
+it "keeps Yesod handler bodies inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.url == "/a" && endpoint.method == "GET" }
   service_a.callees.map(&.name).should contain("serviceA")
 

--- a/spec/functional_test/testers/java/dropwizard_exclude_path_spec.cr
+++ b/spec/functional_test/testers/java/dropwizard_exclude_path_spec.cr
@@ -15,7 +15,7 @@ overrides["exclude_path"] = YAML::Any.new("config.yml")
 baseline = FunctionalTester.new("fixtures/java/dropwizard/", empty_count, no_endpoints)
 excluded = FunctionalTester.new("fixtures/java/dropwizard/", empty_count, no_endpoints, overrides)
 
-describe "Dropwizard config discovery with --exclude-path" do
+describe "Dropwizard config discovery with --exclude-path", tags: "functional" do
   it "applies the server config when nothing is excluded" do
     baseline.endpoints.map(&.url).should contain("/service/api/hello")
   end

--- a/spec/functional_test/testers/java/httpserver_spec.cr
+++ b/spec/functional_test/testers/java/httpserver_spec.cr
@@ -40,7 +40,7 @@ tester = FunctionalTester.new("fixtures/java/httpserver/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "does not surface a body param on the GET branch of a method-dispatching handler" do
+it "does not surface a body param on the GET branch of a method-dispatching handler", tags: "functional" do
   users_get = tester.app.endpoints.find { |e| e.url == "/users" && e.method == "GET" }
   users_get.should_not be_nil
   users_get.try do |endpoint|
@@ -48,6 +48,6 @@ it "does not surface a body param on the GET branch of a method-dispatching hand
   end
 end
 
-it "excludes createContext routes declared under src/test/" do
+it "excludes createContext routes declared under src/test/", tags: "functional" do
   tester.app.endpoints.any? { |e| e.url == "/should-not-appear" }.should be_false
 end

--- a/spec/functional_test/testers/java/httpserver_switch_spec.cr
+++ b/spec/functional_test/testers/java/httpserver_switch_spec.cr
@@ -24,6 +24,6 @@ tester = FunctionalTester.new("fixtures/java/httpserver_switch/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "does not leak unrelated switch case labels as HTTP verbs" do
+it "does not leak unrelated switch case labels as HTTP verbs", tags: "functional" do
   tester.app.endpoints.any? { |e| e.url == "/actions" && (e.method == "DELETE" || e.method == "PUT") }.should be_false
 end

--- a/spec/functional_test/testers/java/jsp_servlet_multi_base_spec.cr
+++ b/spec/functional_test/testers/java/jsp_servlet_multi_base_spec.cr
@@ -20,7 +20,7 @@ tester = FunctionalTester.new("fixtures/java/jsp_servlet_multi_base/", {
 
 tester.perform_tests
 
-describe "JSP servlet multi-base scoping" do
+describe "JSP servlet multi-base scoping", tags: "functional" do
   it "keeps servlet params inside the web.xml base path" do
     service_a = tester.app.endpoints.find! { |endpoint| endpoint.method == "GET" && endpoint.url == "/a-servlet" }
     service_a.params.map(&.name).sort!.should eq(["a"])

--- a/spec/functional_test/testers/java/quarkus_exclude_path_spec.cr
+++ b/spec/functional_test/testers/java/quarkus_exclude_path_spec.cr
@@ -15,7 +15,7 @@ overrides["exclude_path"] = YAML::Any.new("app.js")
 baseline = FunctionalTester.new("fixtures/java/quarkus/", empty_count, no_endpoints)
 excluded = FunctionalTester.new("fixtures/java/quarkus/", empty_count, no_endpoints, overrides)
 
-describe "Quarkus static resources with --exclude-path" do
+describe "Quarkus static resources with --exclude-path", tags: "functional" do
   it "reports a META-INF/resources file when nothing is excluded" do
     baseline.endpoints.map(&.url).should contain("/platform/assets/app.js")
   end

--- a/spec/functional_test/testers/java/spring_ai_context_spec.cr
+++ b/spec/functional_test/testers/java/spring_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Spring auth fixtures" do
+describe "--ai-context on Spring auth fixtures", tags: "functional" do
   fixture_path = "fixtures/java/spring_auth/"
 
   before_each do

--- a/spec/functional_test/testers/java/spring_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/java/spring_hunt_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context Hunt signals on Spring fixtures" do
+describe "--ai-context Hunt signals on Spring fixtures", tags: "functional" do
   fixture_path = "fixtures/java/spring/"
 
   before_each do

--- a/spec/functional_test/testers/javascript/astro_spec.cr
+++ b/spec/functional_test/testers/javascript/astro_spec.cr
@@ -34,7 +34,7 @@ FunctionalTester.new("fixtures/javascript/astro/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "Astro route source attribution" do
+describe "Astro route source attribution", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/javascript/cli_spec.cr
+++ b/spec/functional_test/testers/javascript/cli_spec.cr
@@ -119,7 +119,7 @@ FunctionalTester.new("fixtures/javascript/cli_command_line_args_fp/", {
   :endpoints => cla_fp_endpoints.size,
 }, cla_fp_endpoints).perform_tests
 
-describe "command-line-args scoping keeps unrelated fields out" do
+describe "command-line-args scoping keeps unrelated fields out", tags: "functional" do
   tester = FunctionalTester.new("fixtures/javascript/cli_command_line_args_fp/", {
     :techs => 1,
   }, [] of Endpoint)
@@ -167,7 +167,7 @@ FunctionalTester.new("fixtures/javascript/cli_getopts_fp/", {
   :endpoints => getopts_fp_endpoints.size,
 }, getopts_fp_endpoints).perform_tests
 
-describe "bare 'getopts' substring does not grant CLI evidence" do
+describe "bare 'getopts' substring does not grant CLI evidence", tags: "functional" do
   tester = FunctionalTester.new("fixtures/javascript/cli_getopts_fp/", {
     :techs => 1,
   }, [] of Endpoint)

--- a/spec/functional_test/testers/javascript/express_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/express_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Express auth fixtures" do
+describe "--ai-context on Express auth fixtures", tags: "functional" do
   fixture_path = "fixtures/javascript/express_auth/"
 
   before_each do

--- a/spec/functional_test/testers/javascript/express_hono_foreign_spec.cr
+++ b/spec/functional_test/testers/javascript/express_hono_foreign_spec.cr
@@ -17,13 +17,13 @@ tester = FunctionalTester.new("fixtures/javascript/express_hono_foreign/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "tags Hono handler-file routes js_hono, not js_express" do
+it "tags Hono handler-file routes js_hono, not js_express", tags: "functional" do
   hono_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/hono-items" && endpoint.method == "POST" }
   hono_route.should_not be_nil
   hono_route.try(&.details.technology).should eq("js_hono")
 end
 
-it "still tags Express's own routes js_express" do
+it "still tags Express's own routes js_express", tags: "functional" do
   express_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/express-home" && endpoint.method == "GET" }
   express_route.should_not be_nil
   express_route.try(&.details.technology).should eq("js_express")

--- a/spec/functional_test/testers/javascript/express_koa_foreign_mount_spec.cr
+++ b/spec/functional_test/testers/javascript/express_koa_foreign_mount_spec.cr
@@ -26,12 +26,12 @@ tester = FunctionalTester.new("fixtures/javascript/express_koa_foreign_mount/", 
 }, expected_endpoints)
 tester.perform_tests
 
-it "does not report koa routes at the un-prefixed path" do
+it "does not report koa routes at the un-prefixed path", tags: "functional" do
   phantom = tester.app.endpoints.select { |endpoint| endpoint.url == "/users" || endpoint.url == "/users/login" }
   phantom.should be_empty
 end
 
-it "keeps the koa mount prefix on the koa analyzer's endpoints" do
+it "keeps the koa mount prefix on the koa analyzer's endpoints", tags: "functional" do
   koa_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/api/users" && endpoint.method == "GET" }
   koa_route.should_not be_nil
   koa_route.try(&.details.technology).should eq("js_koa")

--- a/spec/functional_test/testers/javascript/fastify_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Fastify auth fixtures" do
+describe "--ai-context on Fastify auth fixtures", tags: "functional" do
   fixture_path = "fixtures/javascript/fastify_auth/"
 
   before_each do

--- a/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context Hunt signals on Fastify fixtures" do
+describe "--ai-context Hunt signals on Fastify fixtures", tags: "functional" do
   fixture_path = "fixtures/javascript/fastify/"
 
   before_each do

--- a/spec/functional_test/testers/javascript/fastify_two_services_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_two_services_spec.cr
@@ -21,7 +21,7 @@ tester = FunctionalTester.new("fixtures/javascript/fastify_two_services/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "keeps both services as code paths of the shared route" do
+it "keeps both services as code paths of the shared route", tags: "functional" do
   shared = tester.app.endpoints.find { |endpoint| endpoint.url == "/items/:id" && endpoint.method == "GET" }
   shared.should_not be_nil
   paths = shared.try(&.details.code_paths.map { |code_path| File.basename(File.dirname(code_path.path)) }) || [] of String

--- a/spec/functional_test/testers/javascript/js_ai_context_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/js_ai_context_callees_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context JS framework callee coverage" do
+describe "--ai-context JS framework callee coverage", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/javascript/koa_source_lines_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_source_lines_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "Koa route source attribution" do
+describe "Koa route source attribution", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/javascript/nestjs_multi_app_spec.cr
+++ b/spec/functional_test/testers/javascript/nestjs_multi_app_spec.cr
@@ -16,7 +16,7 @@ tester = FunctionalTester.new("fixtures/javascript/nestjs_multi_app/", {
 
 tester.perform_tests
 
-describe "NestJS analyzer across two applications" do
+describe "NestJS analyzer across two applications", tags: "functional" do
   it "gives each application its own global prefix" do
     urls = tester.app.endpoints.map(&.url).sort!
     urls.should eq ["/apiv1/alpha/ping", "/internal/beta/ping"]

--- a/spec/functional_test/testers/javascript/nextjs_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/nextjs_callees_spec.cr
@@ -75,7 +75,7 @@ FunctionalTester.new("fixtures/javascript/nextjs_callees/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "Next.js callee source attribution" do
+describe "Next.js callee source attribution", tags: "functional" do
   it "uses aliased route handlers and server-action export lines" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/nextjs_callees/")])

--- a/spec/functional_test/testers/javascript/nextjs_spec.cr
+++ b/spec/functional_test/testers/javascript/nextjs_spec.cr
@@ -143,7 +143,7 @@ FunctionalTester.new("fixtures/javascript/nextjs/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "Next.js variable header keys" do
+describe "Next.js variable header keys", tags: "functional" do
   it "surfaces identifier names for req.headers[CONST] and request.headers.get(CONST)" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/nextjs/")])
@@ -162,7 +162,7 @@ describe "Next.js variable header keys" do
   end
 end
 
-describe "Next.js comment filtering" do
+describe "Next.js comment filtering", tags: "functional" do
   it "does not emit endpoints for commented-out exports (// and /* */)" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/nextjs/")])
@@ -178,7 +178,7 @@ describe "Next.js comment filtering" do
   end
 end
 
-describe "Next.js App Router method-local params" do
+describe "Next.js App Router method-local params", tags: "functional" do
   it "does not leak GET query params onto POST handlers in the same route file" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/nextjs/")])
@@ -195,7 +195,7 @@ describe "Next.js App Router method-local params" do
   end
 end
 
-describe "Next.js source attribution" do
+describe "Next.js source attribution", tags: "functional" do
   it "uses handler and server-action lines instead of the file start" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/nextjs/")])

--- a/spec/functional_test/testers/javascript/nuxtjs_monorepo_spec.cr
+++ b/spec/functional_test/testers/javascript/nuxtjs_monorepo_spec.cr
@@ -33,7 +33,7 @@ tester = FunctionalTester.new("fixtures/javascript/nuxtjs_monorepo/", {
 
 tester.perform_tests
 
-describe "nuxtjs monorepo route folding" do
+describe "nuxtjs monorepo route folding", tags: "functional" do
   it "keeps every contributing file in code_paths" do
     fixture = "./spec/functional_test/fixtures/javascript/nuxtjs_monorepo"
 

--- a/spec/functional_test/testers/javascript/remix_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/remix_callees_spec.cr
@@ -54,7 +54,7 @@ FunctionalTester.new("fixtures/javascript/remix_callees/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "Remix callee source attribution" do
+describe "Remix callee source attribution", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/javascript/remix_spec.cr
+++ b/spec/functional_test/testers/javascript/remix_spec.cr
@@ -28,7 +28,7 @@ FunctionalTester.new("fixtures/javascript/remix/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "Remix route source attribution" do
+describe "Remix route source attribution", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/javascript/restify_source_lines_spec.cr
+++ b/spec/functional_test/testers/javascript/restify_source_lines_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "Restify route source attribution" do
+describe "Restify route source attribution", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/javascript/socketio_spec.cr
+++ b/spec/functional_test/testers/javascript/socketio_spec.cr
@@ -29,7 +29,7 @@ socketio_tester.perform_tests
 # calls, and `.on` handlers on non-socket receivers (`httpServer.on("error")`,
 # `process.on("SIGTERM")`) are not inbound attack surface and must not be
 # emitted.
-it "excludes reserved events, outbound emits and non-socket .on handlers" do
+it "excludes reserved events, outbound emits and non-socket .on handlers", tags: "functional" do
   urls = socketio_tester.app.endpoints.map(&.url)
   urls.should_not contain("ws://disconnect")
   urls.should_not contain("ws://banned")

--- a/spec/functional_test/testers/javascript/sveltekit_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/sveltekit_callees_spec.cr
@@ -39,7 +39,7 @@ FunctionalTester.new("fixtures/javascript/sveltekit_callees/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "SvelteKit callee source attribution" do
+describe "SvelteKit callee source attribution", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/javascript/sveltekit_nonascii_spec.cr
+++ b/spec/functional_test/testers/javascript/sveltekit_nonascii_spec.cr
@@ -22,7 +22,7 @@ FunctionalTester.new("fixtures/javascript/sveltekit_nonascii/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "SvelteKit line numbers with multi-byte source" do
+describe "SvelteKit line numbers with multi-byte source", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/javascript/sveltekit_spec.cr
+++ b/spec/functional_test/testers/javascript/sveltekit_spec.cr
@@ -36,7 +36,7 @@ FunctionalTester.new("fixtures/javascript/sveltekit/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "SvelteKit route source attribution" do
+describe "SvelteKit route source attribution", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/kotlin/ktor_ai_context_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Ktor auth fixtures" do
+describe "--ai-context on Ktor auth fixtures", tags: "functional" do
   fixture_path = "fixtures/kotlin/ktor_auth/"
   app_suffix = "spec/functional_test/fixtures/kotlin/ktor_auth/src/Application.kt"
 

--- a/spec/functional_test/testers/kotlin/spring_callees_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_callees_spec.cr
@@ -119,7 +119,7 @@ FunctionalTester.new("fixtures/kotlin/spring_callees/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "--ai-context on Kotlin Spring constructor-injected callee expansion" do
+describe "--ai-context on Kotlin Spring constructor-injected callee expansion", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/kotlin/spring_functional_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_functional_spec.cr
@@ -62,7 +62,7 @@ FunctionalTester.new("fixtures/kotlin/spring_functional/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "--ai-context on Kotlin Spring functional router fixtures" do
+describe "--ai-context on Kotlin Spring functional router fixtures", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/kotlin/spring_interface_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_interface_spec.cr
@@ -22,7 +22,7 @@ FunctionalTester.new("fixtures/kotlin/spring_interface/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "--ai-context on Kotlin Spring interface controller fixtures" do
+describe "--ai-context on Kotlin Spring interface controller fixtures", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/kotlin/spring_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_spec.cr
@@ -40,7 +40,7 @@ FunctionalTester.new("fixtures/kotlin/spring/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "--ai-context on Kotlin Spring security annotations" do
+describe "--ai-context on Kotlin Spring security annotations", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/kotlin/spring_static_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_static_spec.cr
@@ -27,7 +27,7 @@ baseline = FunctionalTester.new("fixtures/kotlin/spring_static/", empty_count, n
 file_excluded = FunctionalTester.new("fixtures/kotlin/spring_static/", empty_count, no_endpoints, file_overrides)
 dir_excluded = FunctionalTester.new("fixtures/kotlin/spring_static/", empty_count, no_endpoints, dir_overrides)
 
-describe "Spring static-locations" do
+describe "Spring static-locations", tags: "functional" do
   it "serves classpath: and in-base file: locations" do
     urls = baseline.endpoints.map(&.url)
     urls.should contain("/index.html")

--- a/spec/functional_test/testers/kotlin/spring_websocket_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_websocket_spec.cr
@@ -51,7 +51,7 @@ FunctionalTester.new("fixtures/kotlin/spring_websocket/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "--ai-context on Kotlin Spring websocket fixtures" do
+describe "--ai-context on Kotlin Spring websocket fixtures", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/lua/lapis_callees_spec.cr
+++ b/spec/functional_test/testers/lua/lapis_callees_spec.cr
@@ -87,7 +87,7 @@ tester = FunctionalTester.new("fixtures/lua/lapis_callees/", {
 })
 tester.perform_tests
 
-it "reports exact Lapis callees for inline Lua handlers" do
+it "reports exact Lapis callees for inline Lua handlers", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/users" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -95,7 +95,7 @@ it "reports exact Lapis callees for inline Lua handlers" do
   end
 end
 
-it "reuses same Lapis callees for app:match fallback methods" do
+it "reuses same Lapis callees for app:match fallback methods", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/health" && found.method == "PATCH" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -103,7 +103,7 @@ it "reuses same Lapis callees for app:match fallback methods" do
   end
 end
 
-it "resolves same-file string action handlers for Lapis table routes" do
+it "resolves same-file string action handlers for Lapis table routes", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/admin/dashboard" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -111,7 +111,7 @@ it "resolves same-file string action handlers for Lapis table routes" do
   end
 end
 
-it "extracts MoonScript action callees without leaking adjacent routes" do
+it "extracts MoonScript action callees without leaking adjacent routes", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/moon/users/:id" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -119,7 +119,7 @@ it "extracts MoonScript action callees without leaking adjacent routes" do
   end
 end
 
-it "ignores fake calls in Lua strings and comments" do
+it "ignores fake calls in Lua strings and comments", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/string-noise" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -127,7 +127,7 @@ it "ignores fake calls in Lua strings and comments" do
   end
 end
 
-it "resolves identifier handler variables for Lapis routes" do
+it "resolves identifier handler variables for Lapis routes", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/identifier" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -135,7 +135,7 @@ it "resolves identifier handler variables for Lapis routes" do
   end
 end
 
-it "populates Lapis callee source paths" do
+it "populates Lapis callee source paths", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/named" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|

--- a/spec/functional_test/testers/mobile/android_exclude_path_spec.cr
+++ b/spec/functional_test/testers/mobile/android_exclude_path_spec.cr
@@ -22,7 +22,7 @@ buildsrc_baseline = FunctionalTester.new("fixtures/mobile/android_gradle_const/"
 buildsrc_excluded = FunctionalTester.new("fixtures/mobile/android_gradle_const/",
   empty_count, no_endpoints, buildsrc_overrides)
 
-describe "Android resource walks with --exclude-path" do
+describe "Android resource walks with --exclude-path", tags: "functional" do
   it "reads navigation graphs and every values file by default" do
     urls = baseline.endpoints.map(&.url)
     urls.should contain("myapp://users/:userId") # res/navigation/nav_graph.xml

--- a/spec/functional_test/testers/perl/catalyst_multi_base_spec.cr
+++ b/spec/functional_test/testers/perl/catalyst_multi_base_spec.cr
@@ -23,7 +23,7 @@ tester = FunctionalTester.new("fixtures/perl/catalyst_multi_base/", {
 })
 tester.perform_tests
 
-it "keeps Catalyst chained actions inside each base path" do
+it "keeps Catalyst chained actions inside each base path", tags: "functional" do
   tester.app.endpoints.any? { |endpoint| endpoint.url == "/a/:root_capture/item" }.should be_true
   tester.app.endpoints.any? { |endpoint| endpoint.url == "/b/:root_capture/item" }.should be_true
 end

--- a/spec/functional_test/testers/perl/dancer2_ai_context_spec.cr
+++ b/spec/functional_test/testers/perl/dancer2_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Dancer2 auth fixtures" do
+describe "--ai-context on Dancer2 auth fixtures", tags: "functional" do
   fixture_path = "fixtures/perl/dancer2_auth/"
 
   before_each do

--- a/spec/functional_test/testers/perl/dancer2_callees_spec.cr
+++ b/spec/functional_test/testers/perl/dancer2_callees_spec.cr
@@ -39,7 +39,7 @@ tester = FunctionalTester.new("fixtures/perl/dancer2_callees/", {
 })
 tester.perform_tests
 
-it "reports exact Dancer2 inline-handler callees" do
+it "reports exact Dancer2 inline-handler callees", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/hello" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -47,7 +47,7 @@ it "reports exact Dancer2 inline-handler callees" do
   end
 end
 
-it "resolves Dancer2 code-ref (`=> \\&handler`) callees via the named-sub index" do
+it "resolves Dancer2 code-ref (`=> \\&handler`) callees via the named-sub index", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/status" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -55,7 +55,7 @@ it "resolves Dancer2 code-ref (`=> \\&handler`) callees via the named-sub index"
   end
 end
 
-it "attaches callees to prefix-nested Dancer2 routes" do
+it "attaches callees to prefix-nested Dancer2 routes", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/api/login" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -63,7 +63,7 @@ it "attaches callees to prefix-nested Dancer2 routes" do
   end
 end
 
-it "populates Dancer2 callee source paths" do
+it "populates Dancer2 callee source paths", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/hello" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -75,7 +75,7 @@ it "populates Dancer2 callee source paths" do
   end
 end
 
-it "does not populate Dancer2 callees by default" do
+it "does not populate Dancer2 callees by default", tags: "functional" do
   config_init = ConfigInitializer.new
   noir_options = config_init.default_options
   noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/perl/dancer2_callees/")])

--- a/spec/functional_test/testers/perl/mojolicious_callees_multi_base_spec.cr
+++ b/spec/functional_test/testers/perl/mojolicious_callees_multi_base_spec.cr
@@ -35,7 +35,7 @@ tester = FunctionalTester.new("fixtures/perl/mojolicious_callees_multi_base/", {
 })
 tester.perform_tests
 
-it "keeps Mojolicious controller callees inside each base path" do
+it "keeps Mojolicious controller callees inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.url == "/a/status" && endpoint.method == "GET" }
   service_a.callees.map(&.name).should contain("AService.call")
   service_a.callees.map(&.name).should_not contain("BService.call")

--- a/spec/functional_test/testers/perl/mojolicious_callees_spec.cr
+++ b/spec/functional_test/testers/perl/mojolicious_callees_spec.cr
@@ -76,7 +76,7 @@ tester = FunctionalTester.new("fixtures/perl/mojolicious_callees/", {
 })
 tester.perform_tests
 
-it "reports exact Mojolicious::Lite callees for inline handlers" do
+it "reports exact Mojolicious::Lite callees for inline handlers", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/hello" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -84,7 +84,7 @@ it "reports exact Mojolicious::Lite callees for inline handlers" do
   end
 end
 
-it "reuses Mojolicious any-handler callees for every emitted method" do
+it "reuses Mojolicious any-handler callees for every emitted method", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/multi" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -92,7 +92,7 @@ it "reuses Mojolicious any-handler callees for every emitted method" do
   end
 end
 
-it "keeps nested websocket callback callees out of the route body" do
+it "keeps nested websocket callback callees out of the route body", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/echo" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -102,7 +102,7 @@ it "keeps nested websocket callback callees out of the route body" do
   end
 end
 
-it "attaches Mojolicious full-app controller action callees" do
+it "attaches Mojolicious full-app controller action callees", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/api/login" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -110,7 +110,7 @@ it "attaches Mojolicious full-app controller action callees" do
   end
 end
 
-it "attaches nested Mojolicious controller action callees" do
+it "attaches nested Mojolicious controller action callees", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/admin/users/:id" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -118,7 +118,7 @@ it "attaches nested Mojolicious controller action callees" do
   end
 end
 
-it "attaches named Mojolicious controller/action callees" do
+it "attaches named Mojolicious controller/action callees", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/admin/users" && found.method == "POST" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -126,7 +126,7 @@ it "attaches named Mojolicious controller/action callees" do
   end
 end
 
-it "populates Mojolicious callee source paths" do
+it "populates Mojolicious callee source paths", tags: "functional" do
   endpoint = tester.app.endpoints.find { |found| found.url == "/api/status" && found.method == "GET" }
   endpoint.should_not be_nil
   endpoint.try do |actual|
@@ -138,7 +138,7 @@ it "populates Mojolicious callee source paths" do
   end
 end
 
-it "does not populate Mojolicious callees by default" do
+it "does not populate Mojolicious callees by default", tags: "functional" do
   config_init = ConfigInitializer.new
   noir_options = config_init.default_options
   noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/perl/mojolicious_callees/")])

--- a/spec/functional_test/testers/perl/mojolicious_scoping_spec.cr
+++ b/spec/functional_test/testers/perl/mojolicious_scoping_spec.cr
@@ -21,7 +21,7 @@ tester = FunctionalTester.new("fixtures/perl/mojolicious_scoping/", {
 })
 tester.perform_tests
 
-it "does not read the neighbouring Dancer2 app as Mojolicious routes" do
+it "does not read the neighbouring Dancer2 app as Mojolicious routes", tags: "functional" do
   paths = tester.endpoints.flat_map { |endpoint| endpoint.details.code_paths.map(&.path) }
   paths.any?(&.includes?("dancer2app")).should be_false
 
@@ -31,7 +31,7 @@ it "does not read the neighbouring Dancer2 app as Mojolicious routes" do
   end
 end
 
-it "does not report data accessors spelled ->get('literal') as routes" do
+it "does not report data accessors spelled ->get('literal') as routes", tags: "functional" do
   urls = tester.endpoints.map(&.url)
   urls.should_not contain("/session_timeout")
   urls.should_not contain("/current_user")

--- a/spec/functional_test/testers/php/cakephp_callees_spec.cr
+++ b/spec/functional_test/testers/php/cakephp_callees_spec.cr
@@ -84,7 +84,7 @@ tester = FunctionalTester.new("fixtures/php/cakephp_callees/", {
 })
 tester.perform_tests
 
-describe "CakePHP callee extraction" do
+describe "CakePHP callee extraction", tags: "functional" do
   it "keeps unsupported route targets callee-empty" do
     legacy_endpoint = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/legacy" }
     computed_endpoint = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/computed" }

--- a/spec/functional_test/testers/php/cli_spec.cr
+++ b/spec/functional_test/testers/php/cli_spec.cr
@@ -47,7 +47,7 @@ robo_tester = FunctionalTester.new("fixtures/php/cli_robo_fp/", {
 }, robo_endpoints)
 robo_tester.perform_tests
 
-it "does not attach the constructor's or the untagged helper's params to the Robo command" do
+it "does not attach the constructor's or the untagged helper's params to the Robo command", tags: "functional" do
   ep = robo_tester.app.endpoints.find { |e| e.url == "cli://cli_robo_fp/foo:bar" }
   ep.should_not be_nil
   ep.try(&.params.map(&.name)).should eq(["arg"])
@@ -78,7 +78,7 @@ wp_cli_tester = FunctionalTester.new("fixtures/php/cli_wp_cli_fp/", {
 }, wp_cli_endpoints)
 wp_cli_tester.perform_tests
 
-it "does not leak the unrelated helper's $args[7] into the WP-CLI command's params" do
+it "does not leak the unrelated helper's $args[7] into the WP-CLI command's params", tags: "functional" do
   ep = wp_cli_tester.app.endpoints.find { |e| e.url == "cli://cli_wp_cli_fp/foo bar" }
   ep.should_not be_nil
   ep.try(&.params.map(&.name).sort!).should eq(["arg0", "format"])
@@ -106,7 +106,7 @@ artisan_tester = FunctionalTester.new("fixtures/php/cli_artisan_fp/", {
 }, artisan_endpoints)
 artisan_tester.perform_tests
 
-it "strips the ' : description' suffix from described Artisan signature tokens" do
+it "strips the ' : description' suffix from described Artisan signature tokens", tags: "functional" do
   ep = artisan_tester.app.endpoints.find { |e| e.url == "cli://cli_artisan_fp/mail:send" }
   ep.should_not be_nil
   names = ep.try(&.params.map(&.name)).not_nil!

--- a/spec/functional_test/testers/php/codeigniter_callees_spec.cr
+++ b/spec/functional_test/testers/php/codeigniter_callees_spec.cr
@@ -62,7 +62,7 @@ tester = FunctionalTester.new("fixtures/php/codeigniter_callees/", {
 })
 tester.perform_tests
 
-describe "CodeIgniter callee extraction" do
+describe "CodeIgniter callee extraction", tags: "functional" do
   it "keeps resource convention routes callee-empty in the first pass" do
     photos = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/photos" }
     photos.should_not be_nil

--- a/spec/functional_test/testers/php/laravel_ai_context_spec.cr
+++ b/spec/functional_test/testers/php/laravel_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Laravel auth fixtures" do
+describe "--ai-context on Laravel auth fixtures", tags: "functional" do
   fixture_path = "fixtures/php/laravel_auth/"
   routes_suffix = "spec/functional_test/fixtures/php/laravel_auth/routes/web.php"
 

--- a/spec/functional_test/testers/php/laravel_callees_spec.cr
+++ b/spec/functional_test/testers/php/laravel_callees_spec.cr
@@ -64,7 +64,7 @@ tester = FunctionalTester.new("fixtures/php/laravel_callees/", {
 })
 tester.perform_tests
 
-describe "Laravel callee extraction" do
+describe "Laravel callee extraction", tags: "functional" do
   it "resolves callees for controller-array handlers from the controller file" do
     reports_endpoint = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/reports" }
 

--- a/spec/functional_test/testers/php/laravel_html_template_spec.cr
+++ b/spec/functional_test/testers/php/laravel_html_template_spec.cr
@@ -28,7 +28,7 @@ tester.perform_tests
 # Blanking the HTML has to preserve its newlines: analyzers report `code_path`
 # lines from these offsets, so collapsing a 20-line header would slide every
 # reported line in the file.
-it "reports source lines below a 20-line HTML header unshifted" do
+it "reports source lines below a 20-line HTML header unshifted", tags: "functional" do
   endpoints = tester.app.endpoints
   endpoints.find! { |e| e.url == "/from-first-block" }.details.code_paths.first.line.should eq(25)
   endpoints.find! { |e| e.url == "/after-html" }.details.code_paths.first.line.should eq(33)

--- a/spec/functional_test/testers/php/laravel_nested_handlers_spec.cr
+++ b/spec/functional_test/testers/php/laravel_nested_handlers_spec.cr
@@ -34,7 +34,7 @@ FunctionalTester.new("fixtures/php/laravel_nested_handlers/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "Laravel routes nested in a handler body" do
+describe "Laravel routes nested in a handler body", tags: "functional" do
   before_each do
     CodeLocator.instance.clear_all
   end

--- a/spec/functional_test/testers/php/lumen_callees_spec.cr
+++ b/spec/functional_test/testers/php/lumen_callees_spec.cr
@@ -48,7 +48,7 @@ tester = FunctionalTester.new("fixtures/php/lumen_callees/", {
 })
 tester.perform_tests
 
-describe "Lumen callee extraction" do
+describe "Lumen callee extraction", tags: "functional" do
   it "leaves controller string handlers callee-empty until ImportGraph resolves them" do
     reports_endpoint = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/reports" }
     reports_endpoint.should_not be_nil

--- a/spec/functional_test/testers/php/lumen_spec.cr
+++ b/spec/functional_test/testers/php/lumen_spec.cr
@@ -24,7 +24,7 @@ FunctionalTester.new("fixtures/php/lumen/", {
   :endpoints => 13, # Analysis drops the redundant Laravel run and php_pure file endpoint
 }, expected_endpoints).perform_tests
 
-describe "Lumen analyzer filter" do
+describe "Lumen analyzer filter", tags: "functional" do
   it "drops php_laravel when php_lumen is detected so the redundant pass is skipped" do
     techs = ["php_lumen", "php_laravel", "php_pure"]
     # php_pure is deliberately kept: it resolves URLs against the document

--- a/spec/functional_test/testers/php/php_callees_spec.cr
+++ b/spec/functional_test/testers/php/php_callees_spec.cr
@@ -37,7 +37,7 @@ tester = FunctionalTester.new("fixtures/php/php_callees/", {
 })
 tester.perform_tests
 
-describe "Pure PHP callee extraction" do
+describe "Pure PHP callee extraction", tags: "functional" do
   it "keeps file-level callees to top-level calls" do
     endpoint = tester.app.endpoints.find { |e| e.method == "POST" && e.url == "/create.php" }
     endpoint.should_not be_nil

--- a/spec/functional_test/testers/php/pure_webroot_spec.cr
+++ b/spec/functional_test/testers/php/pure_webroot_spec.cr
@@ -33,7 +33,7 @@ tester = FunctionalTester.new("fixtures/php/pure_webroot/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "does not emit files outside the document root" do
+it "does not emit files outside the document root", tags: "functional" do
   urls = tester.app.endpoints.map(&.url)
 
   # Both carry superglobals; neither is servable.

--- a/spec/functional_test/testers/php/symfony_callees_spec.cr
+++ b/spec/functional_test/testers/php/symfony_callees_spec.cr
@@ -88,7 +88,7 @@ FunctionalTester.new("fixtures/php/symfony/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "Symfony YAML route callees" do
+describe "Symfony YAML route callees", tags: "functional" do
   it "keeps YAML-only routes callee-empty" do
     config_init = ConfigInitializer.new
     noir_options = config_init.default_options

--- a/spec/functional_test/testers/php/yii_callees_spec.cr
+++ b/spec/functional_test/testers/php/yii_callees_spec.cr
@@ -67,7 +67,7 @@ FunctionalTester.new("fixtures/php/yii/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "Yii config route callees" do
+describe "Yii config route callees", tags: "functional" do
   it "keeps urlManager-only routes callee-empty" do
     config_init = ConfigInitializer.new
     noir_options = config_init.default_options

--- a/spec/functional_test/testers/python/aiohttp_spec.cr
+++ b/spec/functional_test/testers/python/aiohttp_spec.cr
@@ -108,7 +108,7 @@ tester = FunctionalTester.new("fixtures/python/aiohttp/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "marks aiohttp WebSocketResponse handlers with ws protocol" do
+it "marks aiohttp WebSocketResponse handlers with ws protocol", tags: "functional" do
   feed = tester.app.endpoints.find { |endpoint| endpoint.url == "/feed/{channel}" }
   feed.should_not be_nil
   feed.try(&.protocol).should eq("ws")

--- a/spec/functional_test/testers/python/bottle_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/bottle_multivalue_spec.cr
@@ -14,7 +14,7 @@ FunctionalTester.new("fixtures/python/bottle_multivalue/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "Bottle multi-value accessor negatives" do
+describe "Bottle multi-value accessor negatives", tags: "functional" do
   it "does not report dict-API methods as params" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/bottle_multivalue/")])

--- a/spec/functional_test/testers/python/django_ai_context_spec.cr
+++ b/spec/functional_test/testers/python/django_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Django auth fixtures" do
+describe "--ai-context on Django auth fixtures", tags: "functional" do
   fixture_path = "fixtures/python/django_auth/"
   views_suffix = "spec/functional_test/fixtures/python/django_auth/blog/views.py"
 

--- a/spec/functional_test/testers/python/django_callees_spec.cr
+++ b/spec/functional_test/testers/python/django_callees_spec.cr
@@ -59,7 +59,7 @@ tester = FunctionalTester.new("fixtures/python/django_callees/", {
 })
 tester.perform_tests
 
-it "keeps Django class-based view callees scoped to each HTTP method" do
+it "keeps Django class-based view callees scoped to each HTTP method", tags: "functional" do
   get_endpoint = tester.app.endpoints.find { |endpoint| endpoint.url == "/profile" && endpoint.method == "GET" }
   post_endpoint = tester.app.endpoints.find { |endpoint| endpoint.url == "/profile" && endpoint.method == "POST" }
 

--- a/spec/functional_test/testers/python/django_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/django_multivalue_spec.cr
@@ -14,7 +14,7 @@ FunctionalTester.new("fixtures/python/django_multivalue/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "Django multi-value accessor negatives" do
+describe "Django multi-value accessor negatives", tags: "functional" do
   it "does not report dynamic keys as params" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/django_multivalue/")])

--- a/spec/functional_test/testers/python/django_optional_slash_spec.cr
+++ b/spec/functional_test/testers/python/django_optional_slash_spec.cr
@@ -28,6 +28,6 @@ tester = FunctionalTester.new("fixtures/python/django_optional_slash/", {
 }, extracted_endpoints)
 tester.perform_tests
 
-it "leaves no regex quantifier in the emitted paths" do
+it "leaves no regex quantifier in the emitted paths", tags: "functional" do
   tester.app.endpoints.map(&.url).select(&.includes?('?')).should be_empty
 end

--- a/spec/functional_test/testers/python/fastapi_ai_context_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on FastAPI auth fixtures" do
+describe "--ai-context on FastAPI auth fixtures", tags: "functional" do
   fixture_path = "fixtures/python/fastapi_auth/"
 
   before_each do

--- a/spec/functional_test/testers/python/fastapi_callees_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_callees_spec.cr
@@ -84,7 +84,7 @@ FunctionalTester.new("fixtures/python/fastapi_callees/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-describe "FastAPI programmatic route callees" do
+describe "FastAPI programmatic route callees", tags: "functional" do
   it "does not emit handler references unless callee context is requested" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/fastapi_callees/")])
@@ -100,7 +100,7 @@ describe "FastAPI programmatic route callees" do
   end
 end
 
-describe "FastAPI multi-line decorator callee scope" do
+describe "FastAPI multi-line decorator callee scope", tags: "functional" do
   it "does not treat decorator dependency calls as handler callees" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/fastapi_callees/")])

--- a/spec/functional_test/testers/python/fastapi_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_spec.cr
@@ -75,7 +75,7 @@ tester = FunctionalTester.new("fixtures/python/fastapi/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "marks FastAPI websocket endpoints with ws protocol" do
+it "marks FastAPI websocket endpoints with ws protocol", tags: "functional" do
   websocket_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/api/ws/{room_id}" }
   websocket_route.should_not be_nil
   websocket_route.try(&.protocol).should eq("ws")

--- a/spec/functional_test/testers/python/flask_foreign_spec.cr
+++ b/spec/functional_test/testers/python/flask_foreign_spec.cr
@@ -16,7 +16,7 @@ tester = FunctionalTester.new("fixtures/python/flask_foreign/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "tags FastAPI handler-file routes python_fastapi, not python_flask" do
+it "tags FastAPI handler-file routes python_fastapi, not python_flask", tags: "functional" do
   fastapi_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/fastapi-items" && endpoint.method == "POST" }
   fastapi_route.should_not be_nil
   fastapi_route.try(&.details.technology).should eq("python_fastapi")

--- a/spec/functional_test/testers/python/flask_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/flask_multivalue_spec.cr
@@ -18,7 +18,7 @@ FunctionalTester.new("fixtures/python/flask_multivalue/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "Flask multi-value accessor negatives" do
+describe "Flask multi-value accessor negatives", tags: "functional" do
   it "does not report dynamic keys or dict-API methods as params" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/flask_multivalue/")])

--- a/spec/functional_test/testers/python/litestar_spec.cr
+++ b/spec/functional_test/testers/python/litestar_spec.cr
@@ -43,13 +43,13 @@ tester = FunctionalTester.new("fixtures/python/litestar/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "marks Litestar websocket endpoints with ws protocol" do
+it "marks Litestar websocket endpoints with ws protocol", tags: "functional" do
   websocket_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws/{room_id}" }
   websocket_route.should_not be_nil
   websocket_route.try(&.protocol).should eq("ws")
 end
 
-it "detects @websocket_listener handlers as ws endpoints" do
+it "detects @websocket_listener handlers as ws endpoints", tags: "functional" do
   listener_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws-listener" }
   listener_route.should_not be_nil
   listener_route.try(&.protocol).should eq("ws")

--- a/spec/functional_test/testers/python/pyramid_multi_base_spec.cr
+++ b/spec/functional_test/testers/python/pyramid_multi_base_spec.cr
@@ -23,7 +23,7 @@ tester = FunctionalTester.new("fixtures/python/pyramid_multi_base/", {
 })
 tester.perform_tests
 
-it "keeps Pyramid route names inside each base path" do
+it "keeps Pyramid route names inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.method == "GET" && endpoint.url == "/a-home" }
   service_a.params.map(&.name).sort!.should eq(["a"])
 

--- a/spec/functional_test/testers/python/sanic_spec.cr
+++ b/spec/functional_test/testers/python/sanic_spec.cr
@@ -60,7 +60,7 @@ tester = FunctionalTester.new("fixtures/python/sanic/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "marks Sanic websocket endpoints with ws protocol" do
+it "marks Sanic websocket endpoints with ws protocol", tags: "functional" do
   feed = tester.app.endpoints.find { |endpoint| endpoint.url == "/feed/{channel}" }
   feed.should_not be_nil
   feed.try(&.protocol).should eq("ws")

--- a/spec/functional_test/testers/python/starlette_spec.cr
+++ b/spec/functional_test/testers/python/starlette_spec.cr
@@ -75,7 +75,7 @@ tester = FunctionalTester.new("fixtures/python/starlette/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "marks Starlette WebSocketRoute endpoints with ws protocol" do
+it "marks Starlette WebSocketRoute endpoints with ws protocol", tags: "functional" do
   chat = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws/{room}" }
   chat.should_not be_nil
   chat.try(&.protocol).should eq("ws")

--- a/spec/functional_test/testers/python/tornado_spec.cr
+++ b/spec/functional_test/testers/python/tornado_spec.cr
@@ -52,7 +52,7 @@ tester = FunctionalTester.new("fixtures/python/tornado/", {
 }, expected_endpoints)
 tester.perform_tests
 
-it "marks Tornado WebSocketHandler endpoints with ws protocol" do
+it "marks Tornado WebSocketHandler endpoints with ws protocol", tags: "functional" do
   websocket_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws/([^/]+)" }
   websocket_route.should_not be_nil
   websocket_route.try(&.protocol).should eq("ws")

--- a/spec/functional_test/testers/ruby/actioncable_spec.cr
+++ b/spec/functional_test/testers/ruby/actioncable_spec.cr
@@ -33,7 +33,7 @@ actioncable_tester.perform_tests
 
 # Regression: lifecycle callbacks and private helpers must not surface as
 # actions.
-it "excludes Action Cable lifecycle callbacks and private helpers" do
+it "excludes Action Cable lifecycle callbacks and private helpers", tags: "functional" do
   urls = actioncable_tester.app.endpoints.map(&.url)
   urls.should_not contain("ws://cable/ChatChannel/subscribed")
   urls.should_not contain("ws://cable/ChatChannel/unsubscribed")

--- a/spec/functional_test/testers/ruby/cli_spec.cr
+++ b/spec/functional_test/testers/ruby/cli_spec.cr
@@ -78,7 +78,7 @@ clamp_tester.perform_tests
 # bare word "option" followed eventually by a quoted "--flag"-looking string
 # as a DSL declaration, or it would attribute a phantom "json"/"text" flag
 # to the root command.
-it "does not attribute a bogus flag from a stray 'option' local variable (Clamp FP regression)" do
+it "does not attribute a bogus flag from a stray 'option' local variable (Clamp FP regression)", tags: "functional" do
   root = clamp_tester.app.endpoints.find { |e| e.url == "cli://clamp_app" }
   root.should_not be_nil
   if root

--- a/spec/functional_test/testers/ruby/padrino_spec.cr
+++ b/spec/functional_test/testers/ruby/padrino_spec.cr
@@ -41,7 +41,7 @@ FunctionalTester.new("fixtures/ruby/padrino/", {
   :endpoints => 8,
 }, expected_endpoints).perform_tests
 
-describe "Padrino analyzer filter" do
+describe "Padrino analyzer filter", tags: "functional" do
   it "drops ruby_sinatra when ruby_padrino is detected so the redundant pass is skipped" do
     filter_redundant_generic_techs(["ruby_padrino", "ruby_sinatra"]).should eq ["ruby_padrino"]
   end

--- a/spec/functional_test/testers/ruby/rails_ai_context_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_ai_context_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "--ai-context on Rails auth fixtures" do
+describe "--ai-context on Rails auth fixtures", tags: "functional" do
   fixture_path = "fixtures/ruby/rails_auth/"
   controller_suffix = "spec/functional_test/fixtures/ruby/rails_auth/app/controllers/posts_controller.rb"
 

--- a/spec/functional_test/testers/rust/actix_builder_local_shadow_spec.cr
+++ b/spec/functional_test/testers/rust/actix_builder_local_shadow_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "actix builder local handler shadowing" do
+describe "actix builder local handler shadowing", tags: "functional" do
   it "does not attach params from a same-named handler in another file" do
     config_init = ConfigInitializer.new
     options = config_init.default_options

--- a/spec/functional_test/testers/scala/cli_spec.cr
+++ b/spec/functional_test/testers/scala/cli_spec.cr
@@ -36,7 +36,7 @@ scallop_endpoints = [
 scallop_tester = FunctionalTester.new("fixtures/scala/cli_scallop/", {:techs => 1, :endpoints => scallop_endpoints.size}, scallop_endpoints)
 scallop_tester.perform_tests
 
-describe "scala scallop: subcommand-only opts must not leak onto the root endpoint" do
+describe "scala scallop: subcommand-only opts must not leak onto the root endpoint", tags: "functional" do
   it "cli://tool does not contain the subcommand-scoped 'port'/'file' params" do
     root = scallop_tester.app.endpoints.find { |e| e.url == "cli://tool" }
     root.should_not be_nil
@@ -67,7 +67,7 @@ scallop_object_endpoints = [
 scallop_object_tester = FunctionalTester.new("fixtures/scala/cli_scallop_object_fp/", {:techs => 1, :endpoints => scallop_object_endpoints.size}, scallop_object_endpoints)
 scallop_object_tester.perform_tests
 
-describe "scala scallop: 'object x extends Subcommand(...)' idiom creates a scoped subcommand endpoint" do
+describe "scala scallop: 'object x extends Subcommand(...)' idiom creates a scoped subcommand endpoint", tags: "functional" do
   it "cli://tool/serve exists and cli://tool does not contain its params" do
     endpoints_found = scallop_object_tester.app.endpoints
     serve = endpoints_found.find { |e| e.url == "cli://tool/serve" }

--- a/spec/functional_test/testers/typescript/nestjs_param_dedupe_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_param_dedupe_spec.cr
@@ -1,6 +1,6 @@
 require "../../func_spec.cr"
 
-describe "nestjs param dedupe" do
+describe "nestjs param dedupe", tags: "functional" do
   tester = FunctionalTester.new("fixtures/typescript/nestjs/", {
     :techs => 1,
   }, [] of Endpoint)

--- a/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
@@ -16,7 +16,7 @@ FunctionalTester.new("fixtures/typescript/tanstack_router/", {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
 
-it "does not attach callees from unrelated objects after empty file routes" do
+it "does not attach callees from unrelated objects after empty file routes", tags: "functional" do
   config_init = ConfigInitializer.new
   noir_options = config_init.default_options
   noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/typescript/tanstack_router/")])

--- a/spec/functional_test/testers/typescript/tanstack_router_i18n_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_i18n_spec.cr
@@ -9,7 +9,7 @@ FunctionalTester.new("fixtures/typescript/tanstack_router_i18n/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "TanStack Router non-ASCII source attribution" do
+describe "TanStack Router non-ASCII source attribution", tags: "functional" do
   it "byte-counts line numbers and masks template-literal fakes past multi-byte chars" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/typescript/tanstack_router_i18n/")])

--- a/spec/functional_test/testers/typescript/tanstack_router_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_spec.cr
@@ -56,7 +56,7 @@ FunctionalTester.new("fixtures/typescript/tanstack_router/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "TanStack Router source attribution" do
+describe "TanStack Router source attribution", tags: "functional" do
   it "keeps createFileRoute line numbers and skips test/string fixtures" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/typescript/tanstack_router/")])

--- a/spec/functional_test/testers/typescript/trpc_multi_base_spec.cr
+++ b/spec/functional_test/testers/typescript/trpc_multi_base_spec.cr
@@ -19,7 +19,7 @@ tester = FunctionalTester.new("fixtures/typescript/trpc_multi_base/", {
 })
 tester.perform_tests
 
-it "keeps tRPC routers and prefixes inside each base path" do
+it "keeps tRPC routers and prefixes inside each base path", tags: "functional" do
   service_a = tester.app.endpoints.find! { |endpoint| endpoint.url == "/a/trpc/user.list" }
   service_a.method.should eq("GET")
 

--- a/spec/functional_test/testers/typescript/trpc_spec.cr
+++ b/spec/functional_test/testers/typescript/trpc_spec.cr
@@ -26,7 +26,7 @@ FunctionalTester.new("fixtures/typescript/trpc/", {
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
 
-describe "tRPC source filtering" do
+describe "tRPC source filtering", tags: "functional" do
   it "skips test route fixtures and route-like docs strings" do
     options = ConfigInitializer.new.default_options
     options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/typescript/trpc/")])

--- a/spec/noir_spec.cr
+++ b/spec/noir_spec.cr
@@ -1,1 +1,0 @@
-require "./spec_helper"

--- a/spec/suite.cr
+++ b/spec/suite.cr
@@ -9,7 +9,7 @@
 # randomized and functional randomized.
 #
 # Built as a binary instead, one 20s compile produces something that runs all
-# 30,356 examples in 18s using 0.3GB of RSS, so a second run in randomized
+# 30,357 examples in 18s using 0.3GB of RSS, so a second run in randomized
 # order, or a filtered re-run while debugging, is free of the compiler
 # entirely. Two runs in parallel finish in 19s wall against 36s sequential.
 #

--- a/spec/suite.cr
+++ b/spec/suite.cr
@@ -9,7 +9,7 @@
 # randomized and functional randomized.
 #
 # Built as a binary instead, one 20s compile produces something that runs all
-# 30,357 examples in 18s using 0.3GB of RSS, so a second run in randomized
+# 20,807 examples in 17.5s using 0.3GB of RSS, so a second run in randomized
 # order, or a filtered re-run while debugging, is free of the compiler
 # entirely. Two runs in parallel finish in 19s wall against 36s sequential.
 #

--- a/spec/suite.cr
+++ b/spec/suite.cr
@@ -1,0 +1,27 @@
+# The whole test suite as one program, built once and re-run as a binary.
+#
+# Compiling `src/` is essentially the entire cost of running specs, and it does
+# not grow when the suites are combined: measured locally on a warm compiler
+# cache, `crystal spec spec/unit_test` takes 28.7s (9.1s of it running examples,
+# the rest compiling) and `crystal spec spec/functional_test` another 23.5s,
+# while compiling both together costs the same 20.9s as unit alone. CI was
+# paying that compile four times over, once for each of unit, functional, unit
+# randomized and functional randomized.
+#
+# Built as a binary instead, one 20s compile produces something that runs all
+# 30,356 examples in 18s using 0.3GB of RSS, so a second run in randomized
+# order, or a filtered re-run while debugging, is free of the compiler
+# entirely. Two runs in parallel finish in 19s wall against 36s sequential.
+#
+# The file is deliberately not named `*_spec.cr`: `crystal spec` with no
+# arguments globs those, and picking this up as well would compile every
+# example twice into the same program.
+#
+# One thing the binary does not inherit from `crystal spec` is positional path
+# arguments (`bin/noir_spec spec/unit_test` fails with `unknown argument`).
+# Narrow a run with `-e SUBSTRING`, `--location file:line` or `--tag`.
+# `FunctionalTester` also resolves its fixtures through relative paths, so run
+# the binary from the repository root.
+require "spec"
+require "./unit_test/**"
+require "./functional_test/testers/**"

--- a/spec/uncovered_test/func_spec.cr
+++ b/spec/uncovered_test/func_spec.cr
@@ -127,10 +127,13 @@ class UncoveredFunctionalTester
   # failure inside the example rather than a branch taken while registering
   # examples.
   #
-  # Every example for a missing endpoint fails with the same greppable line, so
-  # one absent endpoint is noisy (~1 failure per detail checked) but always names
-  # the tester and the endpoint. The previous shape produced exactly one failure
-  # here — and zero for a raising analyzer, which is the trade this makes.
+  # Every example in the endpoint's group calls through here, so one absent
+  # endpoint still fails once per detail the tester declared, all of them with
+  # the same greppable `MISSING ENDPOINT [...]` line naming the tester and the
+  # endpoint. Registering examples for details that are not asserted anywhere
+  # else is what this trades away: the group carries one presence example plus
+  # the examples for the protocol, params and callees the tester actually
+  # declared, and nothing that only restates the lookup key.
   private def actual_endpoint(expected : Endpoint) : Endpoint
     key = "#{expected.method}::#{expected.url}"
     endpoints.find { |e| e.method == expected.method && e.url == expected.url } ||
@@ -181,12 +184,13 @@ class UncoveredFunctionalTester
       key = expected.method.to_s + "::" + expected.url.to_s
 
       describe "endpoint check [#{key}]" do
-        it "check - url [K: #{key}]" do
-          actual_endpoint(expected).url.should eq expected.url
-        end
-
-        it "check - method [K: #{key}]" do
-          actual_endpoint(expected).method.should eq expected.method
+        # `actual_endpoint` looks the endpoint up *by* method and url, so
+        # asserting those two back is a tautology: the only way either could
+        # fail was the `MISSING ENDPOINT` path, which every other example in
+        # this group takes as well. Two examples per endpoint said nothing that
+        # this one does not.
+        it "is detected [K: #{key}]" do
+          actual_endpoint(expected)
         end
 
         if expected.protocol != "http"
@@ -198,10 +202,10 @@ class UncoveredFunctionalTester
         if expected.params.size > 0
           describe "check - params" do
             expected.params.each do |param|
-              it "check '#{param.name}' name " do
-                actual_params(expected, param.name)[0].name.should eq param.name
-              end
-
+              # No separate name check, for the same reason: `actual_params`
+              # selects by name and fails with `MISSING PARAM` when nothing
+              # matches, so the param_type example below already forces the
+              # param to be present under the expected name.
               it "check '#{param.name}' param_type '#{param.param_type}'" do
                 actual_params(expected, param.name)
                   .any? { |found| found.param_type == param.param_type }

--- a/spec/unit_test/functional_tag_coverage_spec.cr
+++ b/spec/unit_test/functional_tag_coverage_spec.cr
@@ -1,0 +1,45 @@
+require "../spec_helper"
+
+# Every example under spec/functional_test/testers/ must carry the `functional`
+# tag, and this spec is the ratchet that keeps it true.
+#
+# `bin/noir_spec` holds both suites, and CI splits it into a
+# `--tag functional` process and a `--tag '~functional'` one so they run in
+# parallel. An untagged example in a tester file does not fail anything: it
+# just silently joins the unit half, where it drags a full fixture scan along
+# with it. So the split quietly stops being a split, and the only symptom is
+# the unit half getting slower for no visible reason.
+#
+# `FunctionalTester` tags what it registers itself. What it cannot reach are the
+# hand-written `describe` and `it` blocks a tester file adds around it, which is
+# what this checks. Only top-level blocks are checked, because Crystal merges a
+# parent's tags into its children (`Spec::Item#all_tags`), so a nested block
+# inherits from the one that encloses it.
+#
+# This reads the spec sources rather than the registered example tree because
+# `Spec::RootContext` exposes no public way to walk it. The glob is relative, so
+# like the functional testers themselves this expects to run from the repository
+# root.
+TOP_LEVEL_BLOCK = /^(?:describe|context|it)[\s(]/
+
+describe "functional tester tagging" do
+  it "tags every top-level block in spec/functional_test/testers" do
+    files = Dir.glob("spec/functional_test/testers/**/*.cr").sort
+    files.should_not be_empty
+
+    untagged = [] of String
+    files.each do |path|
+      File.read_lines(path).each_with_index do |line, index|
+        next unless line.matches?(TOP_LEVEL_BLOCK)
+        # Both halves matter: `tags:` alone would accept `tags: "slow"`, which
+        # lands the block in the unit half just as an absent tag does.
+        next if line.includes?("tags:") && line.includes?("functional")
+        untagged << "#{path}:#{index + 1}: #{line}"
+      end
+    end
+
+    unless untagged.empty?
+      fail "top-level spec blocks missing `tags: \"functional\"`:\n#{untagged.join("\n")}"
+    end
+  end
+end


### PR DESCRIPTION
## Why

The test suite's cost was almost entirely Crystal compile time, and the same program was being compiled over and over. The CI `tests` job spent ~390s running four `crystal spec` steps of ~90s each (unit, functional, then both again in randomized order); inside each step the examples themselves ran for 18–21s and the remaining ~70s compiled the identical program again. Locally `just test` compiled twice (52s, two 6GB peaks) for 17s of actual test execution.

Compiling the unit and functional suites together costs the same as the unit suite alone (measured: 20.9s / 6.1GB vs 20s / 6.1GB), because `src/` is what the compiler is chewing on, not the spec files.

## What

Six commits, each independently revertable:

1. **`spec/suite.cr` single spec binary.** `just test` now runs `crystal build spec/suite.cr -o bin/noir_spec` once and executes the binary. CI builds once (with `--stats` so compile phases are visible in the log) and runs the binary in parallel processes instead of compiling four times. `spec/noir_spec.cr` (dead entry file) is removed. `spec/AGENTS.md` documents the new commands; note the prebuilt binary takes no positional paths, use `-e`, `--location file:line` or `--tag`.
2. **`tags: "functional"` on FunctionalTester examples** and every custom `describe` in tester files, so the unit and functional halves run as two parallel processes. A guard spec (`spec/unit_test/functional_tag_coverage_spec.cr`) fails, naming file and line, if a tester file grows an untagged top-level block, which would otherwise silently move that scan into the unit half.
3. **Drop tautological examples.** `check - url`, `check - method` and `check '<param>' name` could only fail through the same `MISSING ...` path as every sibling example, since `actual_endpoint`/`actual_params` look up by exactly those keys. They are replaced by one `is detected` example per endpoint. Functional examples go from 24,659 to 15,109 with identical coverage; a missing endpoint now produces fewer duplicate failures. The uncovered-test twin gets the same change to stay structurally identical.
4. **CI compiler cache key on `src/**/*.cr` only.** Spec files change on every PR and made the primary key miss every time; Crystal's cache is content-fingerprinted so a partially stale restore only recompiles the entries that changed.
5. **`--no-debug` for the CI spec build.** 14–17% less compile time on the combined binary (23.2s → 19.9s cold, 10.1s → 8.4s warm locally). The cost is file:line in backtraces when an analyzer raises mid-scan; spec assertion failures are unaffected. `just spec-build` keeps debug info for local reproduction. Kept as its own commit so it can be reverted alone if full backtraces in CI are preferred.
6. **Cache the compiled ameba binary in the lint job.** 126s of the lint job's 155s was compiling ameba from source on every run; `bin/ameba` is now cached on `shard.lock`. `just check`/`just fix` use the binary when present and fall back to `crystal run`.

## Measured (local, M-series, warm cache)

| | before | after |
|---|---|---|
| `just test` wall | 52.2s (two compiles) | 22–23s (one compile + 9.7s parallel run) |
| example run wall | 18.6s | 9.7s |
| functional examples | 24,659 | 15,109 |
| total examples | 30,356 | 20,807 |

CI numbers are what this PR's own run will show; the previous `tests` job baseline is 388s / 397s on the last two main pushes.

## Verified

`just test`, `just test-random` (seed reproduces with `bin/noir_spec --order <seed>`), `bin/noir_spec -e hono` (49 examples), `crystal tool format --check`, ameba (0 issues), exit-code propagation of the parallel shell steps.
