### PR TITLE
feat(optimizer): keep every contributing technology on a merged endpoint

### DIFF
--- a/docs/content/usage/output_formats/json/index.ko.md
+++ b/docs/content/usage/output_formats/json/index.ko.md
@@ -25,6 +25,19 @@ noir scan . -f json --no-log
 
 결과는 `endpoints`, `passive_results`, `errors` 배열을 담은 객체입니다. 각 엔드포인트에는 URL, HTTP 메서드, 파라미터(타입: `cookie`, `form`, `header`, `json` 등), 소스 코드 위치(`details.code_paths`), 해당 엔드포인트를 만든 분석기(`details.technology`), 그리고 Tagger가 붙인 보안 태그가 들어갑니다. 아래 예시는 태거를 켠 상태(`-T`)로 만든 것이며, `tags` 배열이 채워진 이유도 그 때문입니다.
 
+같은 엔드포인트를 여러 분석기가 찾으면(예: Go 라우터와 프로젝트의 OpenAPI 문서) Noir는 하나의 항목으로 합칩니다. `details.technology`는 병합에서 이긴 분석기이고, `details.technologies`는 기여한 모든 분석기를 정렬·중복 제거해 담은 목록입니다. 이 목록은 항목이 둘 이상일 때만 출력되므로, 분석기 하나만 본 엔드포인트는 이전과 똑같은 모양입니다. 모든 출처가 필요한 소비자는 `technologies`가 있으면 그것을 읽고, 없으면 `[technology]`로 대체하면 됩니다.
+
+```json
+"details": {
+  "code_paths": [
+    { "path": "routers/router.go", "line": 42 },
+    { "path": "swagger/swagger.json", "line": 1300 }
+  ],
+  "technology": "go_beego",
+  "technologies": ["go_beego", "oas2"]
+}
+```
+
 ```json
 {
   "endpoints": [

--- a/docs/content/usage/output_formats/json/index.md
+++ b/docs/content/usage/output_formats/json/index.md
@@ -25,6 +25,19 @@ noir scan . -f json --no-log
 
 The result is an object with an `endpoints` array, a `passive_results` array, and an `errors` array. Each endpoint has the URL, HTTP method, parameters (typed as `cookie`, `form`, `header`, `json`, etc.), source code location in `details.code_paths`, the analyzer that produced it in `details.technology`, and any security tags from taggers. The sample below was produced with taggers enabled (`-T`), which is what fills the `tags` arrays.
 
+When more than one analyzer finds the same endpoint, for example a Go router and the project's OpenAPI document, Noir merges them into one entry. `details.technology` names the analyzer that won the merge, and `details.technologies` lists every analyzer that contributed, sorted and deduplicated. The list is only emitted when it holds two or more entries, so an endpoint seen by a single analyzer looks exactly as it did before. A consumer that wants every source should read `technologies` when present and fall back to `[technology]` when it is absent.
+
+```json
+"details": {
+  "code_paths": [
+    { "path": "routers/router.go", "line": 42 },
+    { "path": "swagger/swagger.json", "line": 1300 }
+  ],
+  "technology": "go_beego",
+  "technologies": ["go_beego", "oas2"]
+}
+```
+
 ```json
 {
   "endpoints": [

--- a/spec/unit_test/models/endpoint_spec.cr
+++ b/spec/unit_test/models/endpoint_spec.cr
@@ -178,6 +178,72 @@ describe "Endpoint equality" do
   end
 end
 
+describe "Details contributing technologies" do
+  it "adds technologies once each, sorted, ignoring nil and blank" do
+    details = Details.new
+    details.add_technology("oas3")
+    details.add_technology("go_gin")
+    details.add_technology(nil)
+    details.add_technology("")
+    details.add_technology("oas3")
+    details.technologies.should eq(["go_gin", "oas3"])
+  end
+
+  it "copies the list on detached_copy without sharing it" do
+    details = Details.new
+    details.add_technology("go_gin")
+    copy = details.detached_copy
+    copy.add_technology("oas3")
+    details.technologies.should eq(["go_gin"])
+    copy.technologies.should eq(["go_gin", "oas3"])
+  end
+
+  # Serialized only when two or more technologies contributed, so the
+  # unmerged majority of endpoints keep their pre-existing JSON/YAML shape.
+  it "omits the list from JSON and YAML when it holds fewer than two entries" do
+    details = Details.new(PathInfo.new("router.go", 3))
+    details.technology = "go_gin"
+    details.add_technology("go_gin")
+    endpoint = Endpoint.new("/users", "GET", details)
+
+    json = JSON.parse(endpoint.to_json)
+    json["details"]["technology"].as_s.should eq("go_gin")
+    json["details"]["technologies"]?.should be_nil
+
+    yaml = YAML.parse(endpoint.to_yaml)
+    yaml["details"]["technology"].as_s.should eq("go_gin")
+    yaml["details"]["technologies"]?.should be_nil
+  end
+
+  it "round-trips a multi-technology list through JSON and YAML" do
+    details = Details.new(PathInfo.new("router.go", 3))
+    details.technology = "go_gin"
+    details.add_technology("go_gin")
+    details.add_technology("oas3")
+    endpoint = Endpoint.new("/users", "GET", details)
+
+    json = JSON.parse(endpoint.to_json)
+    json["details"]["technology"].as_s.should eq("go_gin")
+    json["details"]["technologies"].as_a.map(&.as_s).should eq(["go_gin", "oas3"])
+    from_json = Endpoint.from_json(endpoint.to_json)
+    from_json.details.technology.should eq("go_gin")
+    from_json.details.technologies.should eq(["go_gin", "oas3"])
+
+    yaml = YAML.parse(endpoint.to_yaml)
+    yaml["details"]["technologies"].as_a.map(&.as_s).should eq(["go_gin", "oas3"])
+    from_yaml = Endpoint.from_yaml(endpoint.to_yaml)
+    from_yaml.details.technology.should eq("go_gin")
+    from_yaml.details.technologies.should eq(["go_gin", "oas3"])
+  end
+
+  it "parses documents written before the field existed as an empty list" do
+    legacy = %({"url":"/users","method":"GET","params":[],"details":{"code_paths":[{"path":"router.go","line":3}],"technology":"go_gin"},"protocol":"http","kind":"","tags":[],"callees":[],"internal":false})
+    endpoint = Endpoint.from_json(legacy)
+    endpoint.details.technology.should eq("go_gin")
+    endpoint.details.technologies.should eq([] of String)
+  end
+end
+
 describe AIContext do
   it "is empty by default" do
     AIContext.new.empty?.should be_true

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -4,6 +4,12 @@ require "../../../src/optimizer/optimizer"
 require "../../../src/models/endpoint"
 require "../../../src/models/logger"
 
+private def tech_endpoint(url : String, method : String, technology : String, path : String, line : Int32 = 1) : Endpoint
+  details = Details.new(PathInfo.new(path, line))
+  details.technology = technology
+  Endpoint.new(url, method, [] of Param, details)
+end
+
 describe "EndpointOptimizer" do
   options = create_test_options
   logger = NoirLogger.new(false, false, false, false)
@@ -709,6 +715,152 @@ describe "EndpointOptimizer" do
 
       result.size.should eq(1)
       result[0].internal.should be_true
+    end
+
+    # The dedup kept the winner's `technology` and discarded the loser's, so
+    # a route declared by both a Go router and the project's swagger document
+    # was reported as Go only. `code_paths` proved a second file existed, but
+    # nothing said which analyzer read it; scanning casdoor whole attributed
+    # 9 endpoints to `oas2` when its `swagger/` directory alone yields 235.
+    describe "contributing technologies" do
+      it "lists only the endpoint's own technology when nothing merged into it" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        result = optimizer.optimize_endpoints([tech_endpoint("/api/users", "GET", "go_gin", "router.go")])
+
+        result.size.should eq(1)
+        result[0].details.technology.should eq("go_gin")
+        result[0].details.technologies.should eq(["go_gin"])
+      end
+
+      it "keeps both technologies when two analyzers report the same endpoint" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        # "routers/" sorts before "swagger/", so the Go route wins and the
+        # spec's technology is the one that used to be lost.
+        go = tech_endpoint("/api/users", "GET", "go_beego", "routers/router.go", 42)
+        spec = tech_endpoint("/api/users", "GET", "oas2", "swagger/swagger.json", 1300)
+
+        result = optimizer.optimize_endpoints([go, spec])
+
+        result.size.should eq(1)
+        result[0].details.technology.should eq("go_beego")
+        result[0].details.technologies.should eq(["go_beego", "oas2"])
+        result[0].details.code_paths.map(&.path).should eq(["routers/router.go", "swagger/swagger.json"])
+      end
+
+      it "accumulates every technology when an endpoint absorbs three duplicates" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        endpoints = [
+          tech_endpoint("/api/users", "GET", "oas3", "d_openapi.yaml"),
+          tech_endpoint("/api/users", "GET", "go_beego", "a_router.go"),
+          tech_endpoint("/api/users", "GET", "k8s_ingress", "c_ingress.yaml"),
+          tech_endpoint("/api/users", "GET", "har", "b_capture.har"),
+        ]
+
+        result = optimizer.optimize_endpoints(endpoints)
+
+        result.size.should eq(1)
+        result[0].details.technology.should eq("go_beego")
+        result[0].details.technologies.should eq(["go_beego", "har", "k8s_ingress", "oas3"])
+      end
+
+      it "does not repeat a technology two files of the same framework share" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        endpoints = [
+          tech_endpoint("/health", "GET", "go_gin", "a.go"),
+          tech_endpoint("/health", "GET", "go_gin", "b.go"),
+        ]
+
+        result = optimizer.optimize_endpoints(endpoints)
+
+        result.size.should eq(1)
+        result[0].details.technologies.should eq(["go_gin"])
+      end
+
+      it "keeps distinct endpoints' technology lists apart" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        endpoints = [
+          tech_endpoint("/a", "GET", "go_gin", "a.go"),
+          tech_endpoint("/a", "GET", "oas3", "openapi.yaml"),
+          tech_endpoint("/b", "GET", "oas3", "openapi.yaml", 2),
+        ]
+
+        result = optimizer.optimize_endpoints(endpoints)
+
+        result.size.should eq(2)
+        by_url = result.to_h { |endpoint| {endpoint.url, endpoint.details.technologies} }
+        by_url["/a"].should eq(["go_gin", "oas3"])
+        by_url["/b"].should eq(["oas3"])
+      end
+
+      # `promote_source_context` replaces a collection winner's `technology`
+      # with the framework's. Both belong in the list: the promotion changes
+      # which one is "the" technology, not which ones contributed.
+      it "lists the collection technology after a source promotion replaced it" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        collection = tech_endpoint("/api/users", "GET", "postman", "a_collection.json")
+        source = tech_endpoint("/api/users", "GET", "kotlin_spring", "b_controller.kt")
+
+        result = optimizer.optimize_endpoints([collection, source])
+
+        result.size.should eq(1)
+        result[0].details.technology.should eq("kotlin_spring")
+        result[0].details.technologies.should eq(["kotlin_spring", "postman"])
+      end
+
+      # Same for the GraphQL SDL promotion in `merge_graphql_params`.
+      it "lists the runtime technology after the SDL promotion replaced it" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        runtime = tech_endpoint("/graphql#Query.user", "POST", "javascript_graphql_yoga", "app.js")
+        runtime.params << Param.new("graphql_query", "query { user { id } }", "json")
+        sdl = tech_endpoint("/graphql#Query.user", "POST", "graphql_sdl", "schema.graphqls")
+        sdl.params << Param.new("graphql_query", "query Q($id: ID!) { user(id: $id) { id } }", "json")
+
+        result = optimizer.optimize_endpoints([runtime, sdl])
+
+        result.size.should eq(1)
+        result[0].details.technology.should eq("graphql_sdl")
+        result[0].details.technologies.should eq(["graphql_sdl", "javascript_graphql_yoga"])
+      end
+
+      # Collection concrete examples merge into templates in a second pass
+      # (`merge_concrete_example_endpoints`), not the main dedup loop.
+      it "records the collection technology when a concrete example folds into a template" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        template = tech_endpoint("/api/users/{id}", "GET", "kotlin_spring", "a_controller.kt")
+        example = tech_endpoint("/api/users/42", "GET", "postman", "b_collection.json")
+
+        result = optimizer.optimize_endpoints([template, example])
+
+        result.size.should eq(1)
+        result[0].url.should eq("/api/users/{id}")
+        result[0].details.technology.should eq("kotlin_spring")
+        result[0].details.technologies.should eq(["kotlin_spring", "postman"])
+      end
+
+      it "orders the list the same way whichever duplicate sorts first" do
+        optimizer = EndpointOptimizer.new(logger, options)
+
+        forward = optimizer.optimize_endpoints([
+          tech_endpoint("/x", "GET", "oas3", "a.yaml"),
+          tech_endpoint("/x", "GET", "go_gin", "b.go"),
+        ])
+        reverse = optimizer.optimize_endpoints([
+          tech_endpoint("/x", "GET", "go_gin", "a.go"),
+          tech_endpoint("/x", "GET", "oas3", "b.yaml"),
+        ])
+
+        forward[0].details.technology.should eq("oas3")
+        reverse[0].details.technology.should eq("go_gin")
+        forward[0].details.technologies.should eq(reverse[0].details.technologies)
+      end
     end
 
     it "still merges Kotlin Spring GraphQL endpoints with SDL when the controller is under a build module" do

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -280,7 +280,7 @@ struct Details
     if technology = @technology
       copy.technology = technology
     end
-    @technologies.each { |technology| copy.add_technology(technology) }
+    @technologies.each { |contributor| copy.add_technology(contributor) }
     copy
   end
 

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -240,6 +240,27 @@ struct Details
   property status_code : Int32?
   property technology : String?
 
+  # Every technology that produced this endpoint, sorted, deduplicated.
+  #
+  # The optimizer collapses endpoints on `(method, url, scope)`, and the
+  # winning duplicate keeps `technology` while the loser's is discarded —
+  # `code_paths` records that a second file also declared the route, but
+  # nothing records which analyzer read that file. Scanning casdoor whole
+  # therefore attributed 9 endpoints to `oas2` when its swagger document
+  # alone yields 235: the fact was destroyed at the merge, in proportion to
+  # how well the sources agreed. This list keeps it. `technology` is
+  # unchanged (still the winner) and is always a member of this list.
+  #
+  # Serialized only when two or more technologies contributed. A single
+  # entry would repeat `technology` on every endpoint of every report, so
+  # suppressing it keeps the JSON/YAML/TOML documents byte-identical for the
+  # unmerged majority; a consumer reads `technologies` when present and
+  # falls back to `[technology]` when absent — the same fallback it needs
+  # for output from a Noir that predates the field.
+  @[JSON::Field(ignore_serialize: technologies.size < 2)]
+  @[YAML::Field(ignore_serialize: technologies.size < 2)]
+  property technologies : Array(String) = [] of String
+
   # New details types can be added in the future.
 
   def initialize(code_path : PathInfo? = nil)
@@ -259,7 +280,18 @@ struct Details
     if technology = @technology
       copy.technology = technology
     end
+    @technologies.each { |technology| copy.add_technology(technology) }
     copy
+  end
+
+  # Record a contributing technology. Idempotent; keeps the list sorted so
+  # the emitted order does not depend on which duplicate the optimizer saw
+  # first.
+  def add_technology(technology : String?) : Nil
+    return if technology.nil? || technology.empty?
+    return if @technologies.includes?(technology)
+    @technologies << technology
+    @technologies.sort!
   end
 
   def status_code=(status_code : Int32)

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -159,6 +159,11 @@ class EndpointOptimizer
         next
       end
 
+      # Seed the contributing-technology list with the endpoint's own
+      # analyzer, so the list is complete whether or not a duplicate ever
+      # merges into it.
+      tiny_tmp = record_own_technology(tiny_tmp)
+
       # Duplicate check
       absolute_url = tiny_tmp.url.matches?(ABSOLUTE_URL_RE)
 
@@ -199,6 +204,7 @@ class EndpointOptimizer
         end
         dup = promote_source_context(dup, tiny_tmp)
         dup = promote_scalar_context(dup, tiny_tmp)
+        dup = absorb_technologies(dup, tiny_tmp)
         final_map[key] = dup
       else
         final_map[key] = tiny_tmp
@@ -335,7 +341,35 @@ class EndpointOptimizer
       target.details.add_path(path_info) unless target.details.code_paths.any? { |existing| existing == path_info }
     end
     target = promote_source_context(target, source)
+    target = absorb_technologies(target, source)
 
+    target
+  end
+
+  private def record_own_technology(endpoint : Endpoint) : Endpoint
+    details = endpoint.details
+    details.add_technology(details.technology)
+    endpoint.details = details
+    endpoint
+  end
+
+  # Keep every technology that contributed to a merged endpoint.
+  #
+  # The dedup keeps the winner's `technology` and, until this list existed,
+  # discarded the loser's — so an endpoint declared by both a Go router and
+  # the project's swagger document was reported as Go only, and a consumer
+  # asking "which sources know this route" had to run one scan per
+  # technology to find out. Runs after the promotions above on purpose: a
+  # promotion may have replaced `technology`, and both the old and the new
+  # value belong in the list.
+  #
+  # Returns the endpoint for the same reason `promote_scalar_context` does.
+  private def absorb_technologies(target : Endpoint, source : Endpoint) : Endpoint
+    details = target.details
+    details.add_technology(details.technology)
+    details.add_technology(source.details.technology)
+    source.details.technologies.each { |technology| details.add_technology(technology) }
+    target.details = details
     target
   end
 


### PR DESCRIPTION
## Problem

`Optimizer#optimize_endpoints` deduplicates endpoints on `(method, url, scope)`. When two analyzers find the same route — a Go router in `routers/router.go` and the same path in `swagger/swagger.json` — the winner keeps the whole `Details` struct and the loser's `details.technology` is discarded. `code_paths` records that a second file declared the route, but nothing records which analyzer read it.

The information is destroyed in proportion to how well the sources agree. Scanning casdoor whole attributes **9** endpoints to `oas2`; scanning its `swagger/` directory alone yields **235**. The same loss happens inside one language: netbox `python_django` 921 vs 1210, superset `python_flask` 140 vs 281, kong `lua_lapis` 316 vs 330.

A consumer that wants to know which sources describe a route has to run one scan per technology with `--only-techs` to find out.

## Change

A new `Details#technologies` field records every technology that contributed to a merged endpoint: sorted, deduplicated, seeded with the endpoint's own analyzer and unioned at each merge point (the duplicate branch, the collection and GraphQL SDL promotions, and the second-pass concrete-example fold).

`details.technology` is unchanged — still the winner, and always a member of the list.

The field is serialized in json, jsonl, yaml and toml **only when it holds two or more entries**, so every unmerged endpoint's document is byte-identical to before. Consumers read `technologies` when present and fall back to `[technology]` when absent, which is the same fallback they need for output from an older Noir.

## Verification

Release builds on both sides, `main` as the baseline.

**Set equality against per-technology scans.** For each of twelve OSS repositories (casdoor, netbox, directus, argo-cd, authentik, flipt, gitea, superset, minio, NodeBB, kong, hoppscotch), group a full scan by every entry of `technologies`, then run `--only-techs T` separately for each T and compare the sets. **71 of 77 (repo, technology) pairs are exactly set-equal**, including casdoor `oas2` 235, netbox `python_django` 1210, superset `python_flask` 281, kong `lua_lapis` 330. No pair has an endpoint carrying a technology that technology's own scan does not know.

The six residuals are all the same pre-existing endpoint: hoppscotch's `POST /graphql`, emitted by the GraphQL operation-file analyzer with `technology: null` and outside the `--only-techs` filter. It behaves identically on 1.3.1, on main and here; it is not caused by this change.

**Nothing else moved.** All 717 depth-2 fixture directories scanned one at a time: endpoint counts identical, and the JSON byte-identical once the new key is removed — 717 of 717. The key appears in exactly four fixture directories (`etc/multi_techs`, `go/connect_rpc`, `go/connect_rpc_multi_base`, `rust/rust_security`). Same result across all twelve OSS repos.

**No regression.** Endpoint counts identical on all twelve repos; largest timing delta 0.05 s on superset, within noise.

`crystal spec` green: 5,743 unit + 15,109 functional examples, 0 failures, including 14 new examples covering two-, three- and four-way merges, promotion paths, ordering independence, and the JSON/YAML round trip in both directions.

## Notes

`sarif`, `oas3`, `postman`, `markdown-table` and plain output are unchanged by design.
