### PR TITLE
fix(go_chi,javascript): report gitea's API routes at the paths it actually serves

### DIFF
--- a/spec/functional_test/fixtures/go/chi_combo_wrapper/go.mod
+++ b/spec/functional_test/fixtures/go/chi_combo_wrapper/go.mod
@@ -1,0 +1,5 @@
+module example.com/combo
+
+go 1.22
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/spec/functional_test/fixtures/go/chi_combo_wrapper/modules/web/router.go
+++ b/spec/functional_test/fixtures/go/chi_combo_wrapper/modules/web/router.go
@@ -1,0 +1,37 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Router is a thin wrapper over chi in the style of gitea's modules/web:
+// it adds Combo (one path, chained verbs) and Methods (a comma-separated
+// method list) on top of the chi verbs.
+type Router struct {
+	chiRouter chi.Router
+}
+
+func NewRouter() *Router {
+	return &Router{chiRouter: chi.NewRouter()}
+}
+
+func (r *Router) Get(pattern string, h ...any)    {}
+func (r *Router) Post(pattern string, h ...any)   {}
+func (r *Router) Put(pattern string, h ...any)    {}
+func (r *Router) Delete(pattern string, h ...any) {}
+func (r *Router) Methods(methods, pattern string, h ...any) {}
+func (r *Router) Group(pattern string, fn func(), middlewares ...any) {}
+
+type Combo struct{}
+
+func (r *Router) Combo(pattern string, h ...any) *Combo { return &Combo{} }
+func (c *Combo) Get(h ...any) *Combo                    { return c }
+func (c *Combo) Post(h ...any) *Combo                   { return c }
+func (c *Combo) Put(h ...any) *Combo                    { return c }
+func (c *Combo) Delete(h ...any) *Combo                 { return c }
+
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.chiRouter.ServeHTTP(w, req)
+}

--- a/spec/functional_test/fixtures/go/chi_combo_wrapper/routers/api.go
+++ b/spec/functional_test/fixtures/go/chi_combo_wrapper/routers/api.go
@@ -1,0 +1,46 @@
+package routers
+
+import (
+	"net/http"
+
+	chi_middleware "github.com/go-chi/chi/v5/middleware"
+
+	"example.com/combo/modules/web"
+)
+
+func reqToken() any { return nil }
+
+func getToken(w http.ResponseWriter, r *http.Request)    {}
+func deleteToken(w http.ResponseWriter, r *http.Request) {}
+func getSecret(w http.ResponseWriter, r *http.Request)   {}
+func putSecret(w http.ResponseWriter, r *http.Request)   {}
+func delSecret(w http.ResponseWriter, r *http.Request)   {}
+func listSecrets(w http.ResponseWriter, r *http.Request) {}
+func robots(w http.ResponseWriter, r *http.Request)      {}
+func assets(w http.ResponseWriter, r *http.Request)      {}
+
+// Routes registers the API in gitea's style: Combo chains for one path
+// with several verbs, and Methods for an explicit method list.
+func Routes() *web.Router {
+	m := web.NewRouter()
+	_ = chi_middleware.GetHead
+
+	m.Methods("GET, HEAD", "/robots.txt", robots)
+	m.Methods("GET,HEAD,OPTIONS", "/assets/*", assets)
+
+	m.Group("/user", func() {
+		// Token introspection and deletion endpoint
+		m.Combo("/token").
+			Get(reqToken(), getToken).
+			Delete(reqToken(), deleteToken)
+
+		m.Group("/actions/secrets", func() {
+			m.Get("", reqToken(), listSecrets)
+			m.Combo("/{secretname}").
+				Get(reqToken(), getSecret).
+				Put(reqToken(), putSecret).
+				Delete(reqToken(), delSecret)
+		})
+	})
+	return m
+}

--- a/spec/functional_test/fixtures/go/chi_crosspkg_mount/go.mod
+++ b/spec/functional_test/fixtures/go/chi_crosspkg_mount/go.mod
@@ -1,0 +1,5 @@
+module example.com/crosspkg
+
+go 1.22
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/spec/functional_test/fixtures/go/chi_crosspkg_mount/main.go
+++ b/spec/functional_test/fixtures/go/chi_crosspkg_mount/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	apiv1 "example.com/crosspkg/routers/api/v1"
+	"example.com/crosspkg/routers/web"
+)
+
+func main() {
+	r := chi.NewRouter()
+
+	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+
+	// Sub-routers built in other packages: the mount prefix must land on
+	// every route they register, and the root mount must not double the
+	// slash.
+	r.Mount("/", web.Routes())
+	r.Mount("/api/v1", apiv1.Routes())
+
+	http.ListenAndServe(":3000", r)
+}

--- a/spec/functional_test/fixtures/go/chi_crosspkg_mount/routers/api/v1/admin.go
+++ b/spec/functional_test/fixtures/go/chi_crosspkg_mount/routers/api/v1/admin.go
@@ -1,0 +1,16 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func adminRouter() http.Handler {
+	r := chi.NewRouter()
+	r.Delete("/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		_ = id
+	})
+	return r
+}

--- a/spec/functional_test/fixtures/go/chi_crosspkg_mount/routers/api/v1/api.go
+++ b/spec/functional_test/fixtures/go/chi_crosspkg_mount/routers/api/v1/api.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Routes builds the API router that main mounts at "/api/v1".
+func Routes() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/users", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		_ = page
+	})
+	r.Route("/repos", func(r chi.Router) {
+		r.Get("/{owner}/{repo}", func(w http.ResponseWriter, r *http.Request) {
+			owner := chi.URLParam(r, "owner")
+			_ = owner
+		})
+		r.Post("/{owner}/{repo}/issues", func(w http.ResponseWriter, r *http.Request) {
+			title := r.FormValue("title")
+			_ = title
+		})
+	})
+	// A nested mount inside a mounted router composes both prefixes.
+	r.Mount("/admin", adminRouter())
+	return r
+}

--- a/spec/functional_test/fixtures/go/chi_crosspkg_mount/routers/web/web.go
+++ b/spec/functional_test/fixtures/go/chi_crosspkg_mount/routers/web/web.go
@@ -1,0 +1,16 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Routes builds the web router that main mounts at "/".
+func Routes() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("metrics"))
+	})
+	return r
+}

--- a/spec/functional_test/fixtures/go/chi_route_helpers/go.mod
+++ b/spec/functional_test/fixtures/go/chi_route_helpers/go.mod
@@ -1,0 +1,5 @@
+module example.com/helpers
+
+go 1.22
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/spec/functional_test/fixtures/go/chi_route_helpers/main.go
+++ b/spec/functional_test/fixtures/go/chi_route_helpers/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func listProjects(w http.ResponseWriter, r *http.Request)  {}
+func getProject(w http.ResponseWriter, r *http.Request)    {}
+func deleteProject(w http.ResponseWriter, r *http.Request) {}
+func listSecrets(w http.ResponseWriter, r *http.Request)   {}
+func home(w http.ResponseWriter, r *http.Request)          {}
+func orphan(w http.ResponseWriter, r *http.Request)        {}
+
+// addProjectRoutes registers one scope's project tree on the router it
+// is handed. It is called from two groups, so its routes exist under
+// both prefixes — and under neither on their own.
+func addProjectRoutes(r chi.Router) {
+	r.Get("/projects", listProjects)
+	r.Route("/projects/{id}", func(r chi.Router) {
+		r.Get("/", getProject)
+		r.Delete("/", deleteProject)
+	})
+}
+
+// neverCalled takes a router too, but nothing calls it: its routes keep
+// their prefix-less path exactly as before.
+func neverCalled(r chi.Router) {
+	r.Get("/orphan", orphan)
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Get("/", home)
+
+	// A closure helper bound to a variable is expanded the same way.
+	addSecretRoutes := func(m chi.Router) {
+		m.Get("/secrets", listSecrets)
+	}
+
+	r.Route("/orgs/{org}", func(r chi.Router) {
+		addProjectRoutes(r)
+		addSecretRoutes(r)
+	})
+	r.Route("/repos/{owner}/{repo}", func(r chi.Router) {
+		addProjectRoutes(r)
+	})
+
+	http.ListenAndServe(":3000", r)
+}

--- a/spec/functional_test/fixtures/js/express_client_receiver/app.js
+++ b/spec/functional_test/fixtures/js/express_client_receiver/app.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const express = require('express');
+const app = express();
+const router = express.Router();
+
+router.get('/users/:uid', (req, res) => res.json({}));
+router.post('/users', (req, res) => res.json({}));
+
+app.use('/api', router);
+app.listen(3000);

--- a/spec/functional_test/fixtures/js/express_client_receiver/package.json
+++ b/spec/functional_test/fixtures/js/express_client_receiver/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "express-client-receiver",
+  "version": "1.0.0",
+  "main": "app.js",
+  "dependencies": { "express": "^4.19.2" }
+}

--- a/spec/functional_test/fixtures/js/express_client_receiver/test/api.js
+++ b/spec/functional_test/fixtures/js/express_client_receiver/test/api.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// HTTP client calls in a test file. `request.get(url, opts)` has the same
+// token shape as `router.get(path, handler)`, so these used to be
+// reported as routes of this application.
+const request = require('../lib/request');
+const assert = require('assert');
+
+describe('api', () => {
+	it('reads a user', async () => {
+		const { response } = await request.get(`${base}/api/users/1`, opts);
+		assert(response);
+	});
+
+	it('creates a user', async () => {
+		const { response } = await request.post(`${base}/api/users`, { name: 'x' });
+		assert(response);
+	});
+
+	it('deletes a user', async () => {
+		await request.delete(`${base}/api/users/1`, opts);
+	});
+
+	it('replaces a user', async () => {
+		await request.put(`${base}/api/users/1`, { name: 'y' });
+	});
+});

--- a/spec/functional_test/testers/go/chi_combo_wrapper_spec.cr
+++ b/spec/functional_test/testers/go/chi_combo_wrapper_spec.cr
@@ -1,0 +1,25 @@
+require "../../func_spec.cr"
+
+# gitea's `modules/web` wrapper registers one path with several verbs
+# through a `Combo` chain (`m.Combo("/token").Get(h).Delete(h)`) and an
+# explicit method list through `Methods("GET, HEAD", "/x", h)`. Neither
+# shape is a chi verb call, so before this fixture the 93 Combo chains in
+# gitea's API router contributed nothing.
+expected_endpoints = [
+  Endpoint.new("/robots.txt", "GET"),
+  Endpoint.new("/robots.txt", "HEAD"),
+  Endpoint.new("/assets/*", "GET"),
+  Endpoint.new("/assets/*", "HEAD"),
+  Endpoint.new("/assets/*", "OPTIONS"),
+  Endpoint.new("/user/token", "GET"),
+  Endpoint.new("/user/token", "DELETE"),
+  Endpoint.new("/user/actions/secrets", "GET"),
+  Endpoint.new("/user/actions/secrets/{secretname}", "GET"),
+  Endpoint.new("/user/actions/secrets/{secretname}", "PUT"),
+  Endpoint.new("/user/actions/secrets/{secretname}", "DELETE"),
+]
+
+FunctionalTester.new("fixtures/go/chi_combo_wrapper/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/chi_crosspkg_mount_spec.cr
+++ b/spec/functional_test/testers/go/chi_crosspkg_mount_spec.cr
@@ -1,0 +1,20 @@
+require "../../func_spec.cr"
+
+# `r.Mount("/api/v1", apiv1.Routes())` where `Routes` is declared in
+# another package: the mount prefix must reach every route the target
+# registers (including a nested `Mount` inside it), and a root mount
+# (`r.Mount("/", web.Routes())`) must not double the slash. Before this
+# fixture every gitea API route was reported without its `/api/v1`.
+expected_endpoints = [
+  Endpoint.new("/healthz", "GET"),
+  Endpoint.new("/metrics", "GET"),
+  Endpoint.new("/api/v1/users", "GET", [Param.new("page", "", "query")]),
+  Endpoint.new("/api/v1/repos/{owner}/{repo}", "GET", [Param.new("owner", "", "path")]),
+  Endpoint.new("/api/v1/repos/{owner}/{repo}/issues", "POST", [Param.new("title", "", "form")]),
+  Endpoint.new("/api/v1/admin/users/{id}", "DELETE", [Param.new("id", "", "path")]),
+]
+
+FunctionalTester.new("fixtures/go/chi_crosspkg_mount/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/chi_route_helpers_spec.cr
+++ b/spec/functional_test/testers/go/chi_route_helpers_spec.cr
@@ -1,0 +1,24 @@
+require "../../func_spec.cr"
+
+# A same-file function (or closure variable) that takes the router as a
+# parameter registers its routes wherever it is called, under the
+# caller's prefix. Before this fixture gitea's `addProjectRoutes(m, ...)`
+# — called from the user, org and repo groups — was reported once, at
+# the prefix-less `/{id}/columns`, which is a path nothing serves.
+# A helper nobody calls keeps its historical prefix-less routes.
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/orgs/{org}/projects", "GET"),
+  Endpoint.new("/orgs/{org}/projects/{id}/", "GET"),
+  Endpoint.new("/orgs/{org}/projects/{id}/", "DELETE"),
+  Endpoint.new("/orgs/{org}/secrets", "GET"),
+  Endpoint.new("/repos/{owner}/{repo}/projects", "GET"),
+  Endpoint.new("/repos/{owner}/{repo}/projects/{id}/", "GET"),
+  Endpoint.new("/repos/{owner}/{repo}/projects/{id}/", "DELETE"),
+  Endpoint.new("/orphan", "GET"),
+]
+
+FunctionalTester.new("fixtures/go/chi_route_helpers/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/express_client_receiver_spec.cr
+++ b/spec/functional_test/testers/javascript/express_client_receiver_spec.cr
@@ -1,0 +1,17 @@
+require "../../func_spec.cr"
+
+# An HTTP *client* receiver is not a router. `request.get(url, opts)` in
+# a test file carries the same tokens as `router.get(path, handler)` — an
+# identifier, a verb, a path and a second argument — so the handler-shape
+# heuristic keeps it. The receiver name is what separates them: nothing
+# in these files builds a router called `request`. On NodeBB this shape
+# put 11 endpoints that no server serves into the report.
+expected_endpoints = [
+  Endpoint.new("/api/users/:uid", "GET"),
+  Endpoint.new("/api/users", "POST"),
+]
+
+FunctionalTester.new("fixtures/js/express_client_receiver/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -536,7 +536,8 @@ module Analyzer::Go
             # is empty because any nested func literal inside is the inline
             # handler which the walker already ignores by convention.
             collected = [] of Noir::TreeSitterGoRouteExtractor::Route
-            Noir::TreeSitterGoRouteExtractor.walk_chi_public(body, content, collected, string_values)
+            helpers = Noir::TreeSitterGoRouteExtractor.collect_route_helpers(root, content)
+            Noir::TreeSitterGoRouteExtractor.walk_chi_public(body, content, collected, string_values, helpers)
             # Capture routes' original line numbers on the endpoint details.
             # `attach_router_function_params` uses those to bind parameter
             # lines to the correct endpoint instead of counting verb calls,

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -12,6 +12,14 @@ module Analyzer::Go
   class Chi < Analyzer
     analyzer_for "go_chi"
 
+    # Import path -> package directory, from the tree's go.mod files.
+    @import_dirs = Hash(String, String).new
+    # Per-file `{alias => import path}`, filled lazily for files that
+    # mount a package-qualified router.
+    @import_aliases_cache = Hash(String, Hash(String, String)).new
+    # Per-directory string constants, shared with the Mount expansion.
+    @package_string_values = Hash(String, Hash(String, String)).new
+
     # Go enforces per-file imports, so any file using chi's router
     # types must mention the package path. Filter on this marker
     # to avoid touching the bulk of files in projects whose
@@ -37,6 +45,12 @@ module Analyzer::Go
       # constants (`const tokenPath = "/api/v2/token"`) are resolved only
       # for these so unrelated packages don't pay for an extra parse.
       chi_dirs = Set(String).new
+      mount_files = [] of String
+      # Files whose `.Mount(...)` lines resolve to a router the expander
+      # can walk. They are visited even without the chi import marker:
+      # gitea's `routers/init.go` mounts `apiv1.Routes()` through its own
+      # `modules/web` wrapper and never names chi itself.
+      expandable_mount_files = Set(String).new
 
       get_files_by_extension(".go").each do |scan_path|
         dir = File.dirname(scan_path)
@@ -54,23 +68,10 @@ module Analyzer::Go
         file_contents_cache[scan_path] = content
         file_lines_cache[scan_path] = content.lines
 
-        # Mount targets still need a regex sweep — the name that appears
-        # in `r.Mount("/admin", adminRouter())` is a *symbol*, not a
-        # route, and it determines which function bodies to exclude from
-        # the free-floating TS extraction pass below. The target may be
-        # a plain function (`adminRouter()`) or a struct value-method
-        # (`todosResource{}.Routes()`); each contributes a *skip key*
-        # (qualified by receiver type for methods, so a same-named
-        # `Routes()` on another type — or a top-level router builder
-        # also named `Routes()` — is not skipped by accident).
-        next unless content_matches?(content, MOUNT_CALL_RE)
-        content.each_line do |scan_line|
-          next unless scan_line.includes?(".Mount(")
-          if target = parse_mount_target(scan_line)
-            package_mounted_functions[dir] ||= Set(String).new
-            package_mounted_functions[dir] << mount_skip_key(target)
-          end
-        end
+        # Mount targets are resolved after this loop (see below): the
+        # target of `r.Mount("/api/v1", apiv1.Routes())` may live in a
+        # package that has not been read yet.
+        mount_files << scan_path if content_matches?(content, MOUNT_CALL_RE)
       rescue IO::Error
         # skip
       end
@@ -115,12 +116,59 @@ module Analyzer::Go
         end
         package_string_values[dir] = merged unless merged.empty?
       end
+      @package_string_values = package_string_values
+
+      # Import-path -> directory index for every package in the tree, so
+      # a Mount target qualified by a package alias resolves to the
+      # directory that declares it. Built once; gitea-style apps mount
+      # a handful of routers from `routers/init.go` whose bodies live in
+      # `routers/api/v1`, `routers/web`, `routers/private`, ...
+      modules = collect_go_modules
+      package_files.each_key do |dir|
+        next if modules.empty?
+        if import_path = import_path_for_dir(dir, modules)
+          @import_dirs[import_path] = dir
+        end
+      end
+
+      # Mount targets need a regex sweep — the name that appears in
+      # `r.Mount("/admin", adminRouter())` is a *symbol*, not a route,
+      # and it determines which function bodies to exclude from the
+      # free-floating TS extraction pass below. The target may be a
+      # plain function (`adminRouter()`), a struct value-method
+      # (`todosResource{}.Routes()`) or a function in another package
+      # (`apiv1.Routes()`); each contributes a *skip key* to the
+      # directory that declares it (qualified by receiver type for
+      # methods, so a same-named `Routes()` on another type — or a
+      # top-level router builder also named `Routes()` — is not skipped
+      # by accident). A target that cannot be resolved contributes
+      # nothing: its routes then keep surfacing through the free pass,
+      # unprefixed, exactly as before.
+      mount_files.each do |scan_path|
+        content = file_contents_cache[scan_path]? || next
+        dir = File.dirname(scan_path)
+        content.each_line do |scan_line|
+          next unless scan_line.includes?(".Mount(")
+          target = parse_mount_target(scan_line, string_values_for(dir))
+          next unless target
+          target_dir = resolve_mount_dir(scan_path, dir, target, file_contents_cache)
+          next unless target_dir
+          expandable_mount_files << scan_path
+          package_mounted_functions[target_dir] ||= Set(String).new
+          package_mounted_functions[target_dir] << mount_skip_key(target)
+        end
+      end
 
       parallel_analyze(get_files_by_extension(".go")) do |path|
         next if GoEngine.go_test_file?(base_relative_path(path))
         next unless File.exists?(path)
         content = file_contents_cache[path]? || read_file_content(path)
-        next unless content_matches?(content, IMPORT_MARKER_RE)
+        # A file without the chi import marker takes part only through
+        # its resolvable `.Mount(...)` lines: the free-floating route
+        # pass below stays gated on the marker so another framework's
+        # verb calls cannot surface as chi routes.
+        chi_file = content_matches?(content, IMPORT_MARKER_RE)
+        next unless chi_file || expandable_mount_files.includes?(path)
         lines = file_lines_cache[path]? || content.lines
 
         dir = File.dirname(path)
@@ -130,9 +178,13 @@ module Analyzer::Go
         # / `r.Group(...)` resolved with the correct prefix, skipping
         # bodies of functions that are expanded via Mount (those
         # are handled below to get their `/admin` prefix).
-        ts_routes = Noir::TreeSitterGoRouteExtractor
-          .extract_chi_routes(content, mounted_functions,
-            package_string_values[dir]? || Hash(String, String).new)
+        ts_routes = if chi_file
+                      Noir::TreeSitterGoRouteExtractor
+                        .extract_chi_routes(content, mounted_functions,
+                          package_string_values[dir]? || Hash(String, String).new)
+                    else
+                      [] of Noir::TreeSitterGoRouteExtractor::Route
+                    end
         routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
         ts_routes.each do |r|
           routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
@@ -197,15 +249,18 @@ module Analyzer::Go
           details = Details.new(PathInfo.new(path, index + 1))
 
           if line.includes?(".Mount(")
-            if target = parse_mount_target(line)
-              endpoints = analyze_router_function(path, target[:func_name], package_files, file_contents_cache, file_lines_cache, target[:recv_type])
+            if (target = parse_mount_target(line, string_values_for(dir))) &&
+               (target_dir = resolve_mount_dir(path, dir, target, file_contents_cache))
+              endpoints = expand_mounted_router(target_dir, target[:func_name], target[:recv_type],
+                package_files, file_contents_cache, file_lines_cache, [] of String)
               endpoints.each do |ep|
-                ep.url = target[:prefix] + ep.url
+                ep.url = mount_join(target[:prefix], ep.url)
                 result << ep
               end
             end
             next
           end
+          next unless chi_file
 
           # Emit any route whose declaration begins on this line,
           # and seed inline-handler tracking so the param extractor
@@ -333,41 +388,59 @@ module Analyzer::Go
     end
 
     # Parses a `.Mount("/prefix", target())` line into its mount prefix
-    # and the declaration that builds the sub-router. Two target shapes
-    # are recognized:
+    # and the declaration that builds the sub-router. The prefix is a
+    # string literal or an identifier `string_values` can pin down
+    # (`prefix := "/api/actions"; r.Mount(prefix, ...)`). Four target
+    # shapes are recognized:
     #   * plain function   — `r.Mount("/admin", adminRouter())`
-    #     -> {func_name: "adminRouter", recv_type: nil}
+    #     -> {func_name: "adminRouter", recv_type: nil, pkg_alias: nil}
+    #   * package-qualified function — `r.Mount("/api/v1", apiv1.Routes())`
+    #     -> {func_name: "Routes", recv_type: nil, pkg_alias: "apiv1"}
+    #     (resolved to a directory by `resolve_mount_dir`)
     #   * struct value-method (chi's idiomatic REST "resource" pattern) —
     #     `r.Mount("/todos", todosResource{}.Routes())`
     #     -> {func_name: "Routes", recv_type: "todosResource"}
+    #   * pointer-receiver method — `r.Mount("/x", (&Type{}).Routes())`
     # The receiver type is kept so two resources that both expose a
     # `Routes()` method resolve to their own bodies, not the first one
-    # found. Returns nil for unsupported targets (e.g. a bare variable
-    # receiver `s.Routes()` whose concrete type can't be read locally).
-    private def parse_mount_target(line : String) : NamedTuple(prefix: String, func_name: String, recv_type: String?)?
-      # Value-receiver method: `Mount("/x", Type{}.Routes())` /
-      # `pkg.Type{...}.Routes()`.
-      if m = line.match(/\.Mount\(\s*"([^"]+)"\s*,\s*([\w.]+)\s*\{[^{}]*\}\s*\.\s*(\w+)\s*\(\s*\)/)
-        return {prefix: m[1], func_name: m[3], recv_type: m[2].split('.').last}
+    # found. Call arguments are allowed (`actions.Routes(prefix)`) —
+    # the body is what matters. Returns nil for unsupported targets
+    # (a bare variable `r.Mount("/x", sub)`, or a prefix that cannot be
+    # resolved to one string).
+    private def parse_mount_target(line : String, string_values : Hash(String, String) = Hash(String, String).new) : MountTarget?
+      m = line.match(/\.Mount\(\s*(?:"([^"]*)"|([A-Za-z_]\w*))\s*,\s*(.*)$/)
+      return unless m
+      prefix = m[1]?
+      if prefix.nil?
+        prefix = string_values[m[2]]?
+        return unless prefix
       end
-      # Pointer-receiver method: `Mount("/x", (&Type{}).Routes())` — the
-      # only valid Go syntax for a pointer-receiver resource (`.` binds
-      # tighter than `&`, so the parens are required).
-      if m = line.match(/\.Mount\(\s*"([^"]+)"\s*,\s*\(\s*&\s*([\w.]+)\s*\{[^{}]*\}\s*\)\s*\.\s*(\w+)\s*\(\s*\)/)
-        return {prefix: m[1], func_name: m[3], recv_type: m[2].split('.').last}
+      rest = m[3]
+      # Value-receiver method: `Type{}.Routes()` / `pkg.Type{...}.Routes()`.
+      if t = rest.match(/^([\w.]+)\s*\{[^{}]*\}\s*\.\s*(\w+)\s*\(/)
+        return {prefix: prefix, func_name: t[2], recv_type: t[1].split('.').last, pkg_alias: nil}
       end
-      # Plain function symbol: `Mount("/x", adminRouter())`.
-      if m = line.match(/\.Mount\(\s*"([^"]+)"\s*,\s*(\w+)\s*\(\s*\)/)
-        return {prefix: m[1], func_name: m[2], recv_type: nil}
+      # Pointer-receiver method: `(&Type{}).Routes()` — the only valid Go
+      # syntax for a pointer-receiver resource (`.` binds tighter than
+      # `&`, so the parens are required).
+      if t = rest.match(/^\(\s*&\s*([\w.]+)\s*\{[^{}]*\}\s*\)\s*\.\s*(\w+)\s*\(/)
+        return {prefix: prefix, func_name: t[2], recv_type: t[1].split('.').last, pkg_alias: nil}
+      end
+      # Plain or package-qualified function: `adminRouter()`,
+      # `apiv1.Routes()`, `actions.Routes(prefix)`.
+      if t = rest.match(/^(?:(\w+)\.)?(\w+)\s*\(/)
+        return {prefix: prefix, func_name: t[2], recv_type: nil, pkg_alias: t[1]?}
       end
       nil
     end
+
+    alias MountTarget = NamedTuple(prefix: String, func_name: String, recv_type: String?, pkg_alias: String?)
 
     # Skip key for a parsed mount target: a method target is keyed by
     # `Receiver.Method` so the free pass skips only the exact mounted
     # method body, while a plain-function target is keyed by its bare
     # name. Mirrors the keys produced when scanning declarations.
-    private def mount_skip_key(target : NamedTuple(prefix: String, func_name: String, recv_type: String?)) : String
+    private def mount_skip_key(target : MountTarget) : String
       if rt = target[:recv_type]
         "#{rt}.#{target[:func_name]}"
       else
@@ -375,80 +448,167 @@ module Analyzer::Go
       end
     end
 
-    # Extracts endpoints from a router function definition, searching across
-    # all .go files in the same directory (Go package) if not found in the
-    # given file.
-    #
-    # Uses the tree-sitter walker too, but scoped down to just the target
-    # function's declaration so the returned routes are relative to the
-    # function body — caller slaps on the Mount prefix. When `recv_type`
-    # is given, the target is a method (`func (r Type) Name()`) and only
-    # the declaration on that receiver type is matched.
-    def analyze_router_function(file_path : String, func_name : String,
-                                package_files : Hash(String, Array(String))? = nil,
-                                file_contents_cache : Hash(String, String)? = nil,
-                                file_lines_cache : Hash(String, Array(String))? = nil,
-                                recv_type : String? = nil) : Array(Endpoint)
-      endpoints = [] of Endpoint
-
-      # Search: given file first, then other files in the same directory.
-      dir = File.dirname(file_path)
-      search_files = [file_path]
-      if package_files && package_files.has_key?(dir)
-        package_files[dir].each do |other_path|
-          search_files << other_path unless other_path == file_path
-        end
+    # Directory whose package declares the mount target. A plain or
+    # receiver target is declared in the mounting file's own package; a
+    # package-qualified one goes through the file's import block and the
+    # go.mod-backed import-path index. Nil when the alias is not a local
+    # package (`middleware.Profiler()` from chi itself, `http.StripPrefix`).
+    private def resolve_mount_dir(file_path : String, dir : String, target : MountTarget,
+                                  file_contents_cache : Hash(String, String)) : String?
+      alias_name = target[:pkg_alias]
+      return dir unless alias_name
+      return if @import_dirs.empty?
+      aliases = @import_aliases_cache[file_path]? || begin
+        content = file_contents_cache[file_path]? || read_file_content(file_path)
+        @import_aliases_cache[file_path] = Noir::GoCalleeExtractor.extract_import_aliases(content)
       end
+      import_path = aliases[alias_name]?
+      return unless import_path
+      @import_dirs[import_path]?
+    end
 
-      search_files.each do |search_path|
+    # Route paths from the walker always start with `/` (or are empty for
+    # a `m.Get("", h)` at the router root), so joining is a matter of not
+    # doubling the slash when the mount prefix is `/` or `` — gitea mounts
+    # its web router at `/` and `r.Mount("/", web.Routes())` must not
+    # turn `/metrics` into `//metrics`.
+    private def mount_join(prefix : String, url : String) : String
+      base = prefix.rstrip('/')
+      if base.empty?
+        return url.empty? ? "/" : url
+      end
+      return base if url.empty?
+      url.starts_with?("/") ? "#{base}#{url}" : "#{base}/#{url}"
+    end
+
+    private def string_values_for(dir : String) : Hash(String, String)
+      @package_string_values[dir]? || EMPTY_STRING_VALUES
+    end
+
+    EMPTY_STRING_VALUES = Hash(String, String).new
+
+    # Nested `Mount` calls inside a mounted router are followed to this
+    # depth; deeper trees are almost certainly a cycle through a symbol
+    # the resolver could not tell apart.
+    MAX_MOUNT_DEPTH = 8
+
+    # Extracts endpoints from a router function definition declared in
+    # the Go package at `dir`, searching every `.go` file there.
+    #
+    # Uses the tree-sitter walker, scoped down to just the target
+    # function's declaration so the returned routes are relative to the
+    # function body — the caller slaps on the Mount prefix. When
+    # `recv_type` is given, the target is a method (`func (r Type) Name()`)
+    # and only the declaration on that receiver type is matched.
+    #
+    # `.Mount(...)` calls inside the body are expanded recursively with
+    # their own prefix, so `apiRouter()` mounting `usersRouter()` at
+    # `/users` yields `/users/...` relative to `apiRouter`'s root. The
+    # `ancestors` list guards against a router that (transitively)
+    # mounts itself.
+    def expand_mounted_router(dir : String, func_name : String, recv_type : String?,
+                              package_files : Hash(String, Array(String)),
+                              file_contents_cache : Hash(String, String),
+                              file_lines_cache : Hash(String, Array(String)),
+                              ancestors : Array(String)) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      key = "#{dir}|#{recv_type}.#{func_name}"
+      return endpoints if ancestors.includes?(key) || ancestors.size >= MAX_MOUNT_DEPTH
+      files = package_files[dir]?
+      return endpoints unless files
+
+      files.each do |search_path|
         content =
-          (file_contents_cache.try &.[search_path]?) ||
+          file_contents_cache[search_path]? ||
             begin
               read_file_content(search_path)
             rescue IO::Error
               next
             end
 
-        routes = extract_router_function_routes(content, func_name, recv_type)
-        next if routes.empty?
+        found = false
+        nested = [] of Endpoint
+        string_values = string_values_for(dir)
+        Noir::TreeSitter.parse_go(content) do |root|
+          find_func_declaration(root, content, func_name, recv_type) do |body|
+            found = true
+            # Re-run the chi walker against the isolated body. skip_functions
+            # is empty because any nested func literal inside is the inline
+            # handler which the walker already ignores by convention.
+            collected = [] of Noir::TreeSitterGoRouteExtractor::Route
+            Noir::TreeSitterGoRouteExtractor.walk_chi_public(body, content, collected, string_values)
+            # Capture routes' original line numbers on the endpoint details.
+            # `attach_router_function_params` uses those to bind parameter
+            # lines to the correct endpoint instead of counting verb calls,
+            # which would false-positive on `r.Header.Get(...)` / `Query().Get(...)`
+            # accessor calls inside inline handlers.
+            collected.each do |route|
+              details = Details.new(PathInfo.new(search_path, route.line + 1))
+              Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                endpoints << Endpoint.new(route.path, verb, details)
+              end
+            end
 
-        # Capture routes' original line numbers on the endpoint details.
-        # `attach_router_function_params` uses those to bind parameter
-        # lines to the correct endpoint instead of counting verb calls,
-        # which would false-positive on `r.Header.Get(...)` / `Query().Get(...)`
-        # accessor calls inside inline handlers.
-        routes.each do |route|
-          details = Details.new(PathInfo.new(search_path, route.line + 1))
-          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-            endpoints << Endpoint.new(route.path, verb, details)
+            lines = file_lines_cache[search_path]? || content.lines
+            first_row = Noir::TreeSitter.node_start_row(body)
+            last_row = Noir::TreeSitter.node_end_row(body)
+            row = first_row
+            while row <= last_row && row < lines.size
+              line = lines[row]
+              row += 1
+              next unless line.includes?(".Mount(")
+              target = parse_mount_target(line, string_values)
+              next unless target
+              target_dir = resolve_mount_dir(search_path, dir, target, file_contents_cache)
+              next unless target_dir
+              expand_mounted_router(target_dir, target[:func_name], target[:recv_type],
+                package_files, file_contents_cache, file_lines_cache, ancestors + [key]).each do |ep|
+                ep.url = mount_join(target[:prefix], ep.url)
+                nested << ep
+              end
+            end
           end
         end
+        next unless found
 
-        lines = (file_lines_cache.try &.[search_path]?) || content.lines
+        lines = file_lines_cache[search_path]? || content.lines
         attach_router_function_params(endpoints, lines)
+        endpoints.concat(nested)
         break
       end
 
       endpoints
     end
 
-    # Walks the full tree-sitter tree for `source`, isolating the body of
-    # `func <func_name>(...)` (or method `func (r <recv_type>) <func_name>()`
-    # when `recv_type` is given) and returning only the routes registered
-    # there.
-    private def extract_router_function_routes(source : String, func_name : String, recv_type : String? = nil) : Array(Noir::TreeSitterGoRouteExtractor::Route)
-      hits = [] of Noir::TreeSitterGoRouteExtractor::Route
-      Noir::TreeSitter.parse_go(source) do |root|
-        find_func_declaration(root, source, func_name, recv_type) do |body|
-          # Re-run the chi walker against the isolated body. skip_functions
-          # is empty because any nested func literal inside is the inline
-          # handler which the walker already ignores by convention.
-          collected = [] of Noir::TreeSitterGoRouteExtractor::Route
-          Noir::TreeSitterGoRouteExtractor.walk_chi_public(body, source, collected)
-          collected.each { |c| hits << c }
+    # Twin of `GoEngine#collect_go_modules`; chi extends `Analyzer`
+    # directly so it cannot inherit it. `{module path, directory}` per
+    # `go.mod` in the tree, deepest directory first so a nested module
+    # wins over the one that contains it.
+    private def collect_go_modules : Array(Tuple(String, String))
+      modules = [] of Tuple(String, String)
+      get_files_by_basename("go.mod").each do |path|
+        next if base_relative_path(path).includes?("/vendor/")
+        begin
+          content = read_file_content(path)
+        rescue IO::Error
+          next
         end
+        match = content.match(/^\s*module\s+(\S+)/m)
+        next unless match
+        modules << {match[1], File.expand_path(File.dirname(path))}
       end
-      hits
+      modules.sort_by! { |(_module_path, mod_dir)| -mod_dir.size }
+      modules
+    end
+
+    private def import_path_for_dir(dir : String, modules : Array(Tuple(String, String))) : String?
+      expanded_dir = File.expand_path(dir)
+      modules.each do |module_path, module_dir|
+        next unless expanded_dir == module_dir || expanded_dir.starts_with?("#{module_dir}/")
+        rel = expanded_dir[module_dir.size..].lstrip("/")
+        return rel.empty? ? module_path : "#{module_path}/#{rel}"
+      end
+      nil
     end
 
     private def find_func_declaration(node : LibTreeSitter::TSNode, source : String, name : String, recv_type : String? = nil, &block : LibTreeSitter::TSNode ->)

--- a/src/miniparsers/go_callee_extractor.cr
+++ b/src/miniparsers/go_callee_extractor.cr
@@ -752,7 +752,10 @@ module Noir::GoCalleeExtractor
     import_aliases[Noir::TreeSitter.node_text(operand, source)]?
   end
 
-  private def extract_import_aliases(source : String) : Hash(String, String)
+  # `{alias => import path}` for every import in `source`. Public so the
+  # chi analyzer can turn `apiv1.Routes()` in a `.Mount(...)` call into
+  # the package directory that declares `Routes`.
+  def extract_import_aliases(source : String) : Hash(String, String)
     aliases = Hash(String, String).new
     Noir::TreeSitter.parse_go(source) do |root|
       walk(root) do |node|

--- a/src/miniparsers/go_route_extractor_ts/chi.cr
+++ b/src/miniparsers/go_route_extractor_ts/chi.cr
@@ -101,6 +101,14 @@ module Noir
             return
           end
         when ChiCall::Verb
+          # `m.Combo("/x").Get(h).Post(h)` — one path, several verbs,
+          # each on its own chained call. The outermost call is the
+          # last verb; peel the chain down to `Combo` first, and only
+          # fall back to the single-verb decoder when there is none.
+          if combo = decode_chi_combo_chain(node, source, prefix_stack, local_groups, string_values)
+            routes.concat(combo)
+            return
+          end
           if route = decode_chi_verb_call(node, source, prefix_stack, local_groups, config, string_values)
             routes << route
           end
@@ -179,8 +187,10 @@ module Noir
       if config.net_http_methods?
         # `r.MethodFunc("GET", "/x", h)` — method as the first string
         # arg (the route path is the second). Also covers custom verbs
-        # registered via `chi.RegisterMethod`.
-        return ChiCall::MethodFunc if name == "MethodFunc"
+        # registered via `chi.RegisterMethod`. gitea's `modules/web`
+        # wrapper spells the same shape `m.Methods("GET, HEAD", "/x", h)`
+        # with a comma-separated method list.
+        return ChiCall::MethodFunc if name == "MethodFunc" || name == "Methods"
         # `r.HandleFunc("/x", h)` / `r.Handle("/x", h)` — match every
         # HTTP method (chi fans these over the full method set).
         return ChiCall::HandleAll if name == "HandleFunc" || name == "Handle"
@@ -258,6 +268,65 @@ module Noir
         return if NON_ROUTER_OPERANDS.includes?(Noir::TreeSitter.node_text(final_field, source))
         Noir::TreeSitter.node_text(operand, source)
       end
+    end
+
+    # Verb names a Combo chain may carry. `Combo` itself is chi's
+    # `chi.Router#Combo`-less cousin from gitea's `modules/web` (and
+    # macaron before it): `m.Combo("/path", mw...).Get(h).Post(h)`.
+    COMBO_VERBS = Set{"Get", "Post", "Put", "Delete", "Patch", "Head", "Options"}
+
+    # Decode `<router>.Combo("/path", ...).Get(h).Post(h)...` into one
+    # Route per chained verb. `call` is the outermost (last) verb call.
+    # Returns nil when the chain does not bottom out in a `Combo` call
+    # so the caller can try the single-verb decoder instead. Each route
+    # is attributed to the line its verb sits on, which for the usual
+    # one-verb-per-line layout is the line a reader would point at.
+    private def decode_chi_combo_chain(call : LibTreeSitter::TSNode,
+                                       source : String,
+                                       prefix_stack : Array(String),
+                                       local_groups : Hash(String, String),
+                                       string_values : Hash(String, String) = Hash(String, String).new) : Array(Route)?
+      verbs = [] of Tuple(String, String, Int32)
+      cursor = call
+      loop do
+        function = Noir::TreeSitter.field(cursor, "function")
+        return unless function
+        return unless Noir::TreeSitter.node_type(function) == "selector_expression"
+        field = Noir::TreeSitter.field(function, "field")
+        operand = Noir::TreeSitter.field(function, "operand")
+        return unless field && operand
+        name = Noir::TreeSitter.node_text(field, source)
+
+        if name == "Combo"
+          router_name = chi_router_operand_name(operand, source)
+          return unless router_name
+          raw_path = chi_first_string_arg(cursor, source, string_values)
+          return unless raw_path
+          return if verbs.empty?
+          base_prefix = local_groups[router_name]? || prefix_stack.join
+          resolved = base_prefix.empty? ? raw_path : "#{base_prefix}#{raw_path}"
+          return verbs.reverse.map do |verb, handler_text, row|
+            Route.new(router_name, verb, resolved, raw_path, handler_text, row)
+          end
+        end
+
+        return unless COMBO_VERBS.includes?(name)
+        verbs << {name.upcase, chi_last_arg_text(cursor, source), Noir::TreeSitter.node_start_row(field)}
+        return unless Noir::TreeSitter.node_type(operand) == "call_expression"
+        cursor = operand
+      end
+    end
+
+    # Text of a call's last argument — the handler in gitea's
+    # `Get(middleware..., handler)` convention.
+    private def chi_last_arg_text(call : LibTreeSitter::TSNode, source : String) : String
+      args = Noir::TreeSitter.field(call, "arguments")
+      return "" unless args
+      last = ""
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        last = Noir::TreeSitter.node_text(arg, source)
+      end
+      last
     end
 
     # Decode `r.MethodFunc("GET", "/path", handler)` — chi's net/http
@@ -506,7 +575,17 @@ module Noir
       # operand-type check above; this catches the bare-identifier
       # receivers (`genv`, `gmeta`, `r`) the operand check intentionally
       # allows through.
-      return unless raw_path.starts_with?("/")
+      #
+      # The one exception is the empty path: chi itself panics on it,
+      # but gitea's `modules/web` wrapper registers the group root as
+      # `m.Get("", handler)` inside `m.Group("/secrets", func(){...})`.
+      # It is accepted only when a group prefix is active and a handler
+      # is present, so a value getter (`r.Get("")`) still cannot mint a
+      # route.
+      base_prefix = local_groups[router_name]? || prefix_stack.join
+      unless raw_path.starts_with?("/")
+        return unless raw_path.empty? && path_was_literal && !base_prefix.empty? && !handler_text.empty?
+      end
 
       # Tighten the broadened cases (selector receiver or a path resolved
       # from a non-literal) so they can't surface noise: a real chi/gf
@@ -519,7 +598,6 @@ module Noir
       # Prefer the local binding (closure param / `v1 := group.Group(...)`)
       # when it exists, since Go scope rules say the nearest binding wins.
       # Otherwise fall back to the ambient prefix stack.
-      base_prefix = local_groups[router_name]? || prefix_stack.join
       resolved = String.build do |io|
         io << base_prefix
         io << chain_prefix

--- a/src/miniparsers/go_route_extractor_ts/chi.cr
+++ b/src/miniparsers/go_route_extractor_ts/chi.cr
@@ -757,7 +757,9 @@ module Noir
       # route.
       base_prefix = local_groups[router_name]? || prefix_stack.join
       unless raw_path.starts_with?("/")
-        return unless raw_path.empty? && path_was_literal && !base_prefix.empty? && !handler_text.empty?
+        group_root = raw_path.empty? && path_was_literal &&
+                     base_prefix.size > 0 && handler_text.size > 0
+        return unless group_root
       end
 
       # Tighten the broadened cases (selector receiver or a path resolved

--- a/src/miniparsers/go_route_extractor_ts/chi.cr
+++ b/src/miniparsers/go_route_extractor_ts/chi.cr
@@ -20,10 +20,155 @@ module Noir
     def walk_chi_public(node : LibTreeSitter::TSNode,
                         source : String,
                         sink : Array(Route),
-                        string_values : Hash(String, String) = Hash(String, String).new)
+                        string_values : Hash(String, String) = Hash(String, String).new,
+                        helpers : RouteHelperIndex = RouteHelperIndex.new)
       local_groups = Hash(String, String).new
       skip = Set(String).new
-      walk_chi(node, source, [] of String, local_groups, sink, skip, ScopedConfig.new(net_http_methods: true), string_values)
+      walk_chi(node, source, [] of String, local_groups, sink, skip, ScopedConfig.new(net_http_methods: true), string_values, helpers)
+    end
+
+    # A same-file function (or closure variable) that takes the router as
+    # a parameter and registers routes on it — gitea's
+    # `func addProjectRoutes(m *web.Router, ...)` called from three
+    # different groups, or `addActionsRoutes := func(m *web.Router, ...)`.
+    # Its body is walked at every call site with the caller's active
+    # prefix, and its declaration is skipped by the free-floating walk
+    # (which would otherwise report the routes at the helper's own,
+    # prefix-less, path).
+    class RouteHelper
+      getter body : LibTreeSitter::TSNode
+      getter router_param : String
+      getter router_index : Int32
+      property calls : Int32 = 0
+
+      def initialize(@body, @router_param, @router_index)
+      end
+    end
+
+    class RouteHelperIndex
+      getter helpers = Hash(String, RouteHelper).new
+      # Helpers whose bodies are being expanded right now (recursion guard).
+      getter active = Set(String).new
+
+      def empty? : Bool
+        helpers.empty?
+      end
+
+      def [](name : String) : RouteHelper?
+        helpers[name]?
+      end
+    end
+
+    # Router-typed parameter: `*web.Router`, `chi.Router`, `*chi.Mux`,
+    # `*Router`. `http.ServeMux` is deliberately not one (its `Mux` is not
+    # a whole segment) — helpers taking a stdlib mux register net/http
+    # handlers, not chi routes.
+    ROUTER_PARAM_TYPE_RE = /\A\*?(?:\w+\.)?(?:Router|Mux)\z/
+
+    # Scan a whole file for route helpers and count their call sites.
+    # Only a helper that is called at least once is skipped by the free
+    # walk; an uncalled one keeps its historical (prefix-less) routes so
+    # nothing that used to be reported disappears.
+    def collect_route_helpers(root : LibTreeSitter::TSNode, source : String) : RouteHelperIndex
+      index = RouteHelperIndex.new
+      walk(root) do |node|
+        case Noir::TreeSitter.node_type(node)
+        when "function_declaration"
+          name_node = Noir::TreeSitter.field(node, "name")
+          body = Noir::TreeSitter.field(node, "body")
+          next unless name_node && body
+          if param = router_parameter(node, source)
+            index.helpers[Noir::TreeSitter.node_text(name_node, source)] = RouteHelper.new(body, param[0], param[1])
+          end
+        when "short_var_declaration"
+          left = Noir::TreeSitter.field(node, "left")
+          right = Noir::TreeSitter.field(node, "right")
+          next unless left && right
+          name_node = first_named_child(left)
+          closure = first_named_child(right)
+          next unless name_node && closure
+          next unless Noir::TreeSitter.node_type(name_node) == "identifier"
+          next unless Noir::TreeSitter.node_type(closure) == "func_literal"
+          body = Noir::TreeSitter.field(closure, "body")
+          next unless body
+          if param = router_parameter(closure, source)
+            index.helpers[Noir::TreeSitter.node_text(name_node, source)] = RouteHelper.new(body, param[0], param[1])
+          end
+        end
+      end
+      return index if index.empty?
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "call_expression"
+        function = Noir::TreeSitter.field(node, "function")
+        next unless function && Noir::TreeSitter.node_type(function) == "identifier"
+        if helper = index[Noir::TreeSitter.node_text(function, source)]
+          helper.calls += 1
+        end
+      end
+      index
+    end
+
+    # `{name, position}` of the first router-typed parameter of a
+    # function declaration or func literal, or nil.
+    private def router_parameter(func : LibTreeSitter::TSNode, source : String) : Tuple(String, Int32)?
+      params = Noir::TreeSitter.field(func, "parameters")
+      return unless params
+      position = 0
+      Noir::TreeSitter.each_named_child(params) do |decl|
+        if Noir::TreeSitter.node_type(decl) == "parameter_declaration"
+          type_node = Noir::TreeSitter.field(decl, "type")
+          names = [] of String
+          Noir::TreeSitter.each_named_child(decl) do |child|
+            names << Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "identifier"
+          end
+          if type_node && !names.empty? && Noir::TreeSitter.node_text(type_node, source).matches?(ROUTER_PARAM_TYPE_RE)
+            return {names.first, position}
+          end
+          # `a, b *T` declares several names in one declaration.
+          position += names.empty? ? 1 : names.size
+        else
+          position += 1
+        end
+      end
+      nil
+    end
+
+    # Walk a helper's body as if its routes were registered at the call
+    # site: the router argument's active prefix becomes the base prefix
+    # and the helper's own parameter name resolves through the stack.
+    private def expand_route_helper(call : LibTreeSitter::TSNode,
+                                    helper : RouteHelper,
+                                    name : String,
+                                    source : String,
+                                    prefix_stack : Array(String),
+                                    local_groups : Hash(String, String),
+                                    routes : Array(Route),
+                                    skip_functions : Set(String),
+                                    config : ScopedConfig,
+                                    string_values : Hash(String, String),
+                                    helpers : RouteHelperIndex)
+      return if helpers.active.includes?(name) || helpers.active.size >= 8
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      router_arg = nil
+      position = 0
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        if position == helper.router_index
+          router_arg = arg
+          break
+        end
+        position += 1
+      end
+      return unless router_arg
+      return unless Noir::TreeSitter.node_type(router_arg) == "identifier"
+      router_name = Noir::TreeSitter.node_text(router_arg, source)
+      base_prefix = local_groups[router_name]? || prefix_stack.join
+
+      inner_groups = local_groups.dup
+      inner_groups.delete(helper.router_param)
+      helpers.active << name
+      walk_chi(helper.body, source, [base_prefix], inner_groups, routes, skip_functions, config, string_values, helpers)
+      helpers.active.delete(name)
     end
 
     private def walk_chi(node : LibTreeSitter::TSNode,
@@ -33,8 +178,36 @@ module Noir
                          routes : Array(Route),
                          skip_functions : Set(String),
                          config : ScopedConfig,
-                         string_values : Hash(String, String) = Hash(String, String).new)
+                         string_values : Hash(String, String) = Hash(String, String).new,
+                         helpers : RouteHelperIndex = RouteHelperIndex.new)
       ty = Noir::TreeSitter.node_type(node)
+
+      # A called route helper is expanded at its call sites, never at
+      # its declaration (see `RouteHelper`).
+      unless helpers.empty?
+        case ty
+        when "function_declaration"
+          if name_node = Noir::TreeSitter.field(node, "name")
+            if (helper = helpers[Noir::TreeSitter.node_text(name_node, source)]) && helper.calls > 0
+              return
+            end
+          end
+        when "short_var_declaration"
+          if (left = Noir::TreeSitter.field(node, "left")) && (name_node = first_named_child(left))
+            if (helper = helpers[Noir::TreeSitter.node_text(name_node, source)]) && helper.calls > 0
+              return
+            end
+          end
+        when "call_expression"
+          if (function = Noir::TreeSitter.field(node, "function")) && Noir::TreeSitter.node_type(function) == "identifier"
+            name = Noir::TreeSitter.node_text(function, source)
+            if helper = helpers[name]
+              expand_route_helper(node, helper, name, source, prefix_stack, local_groups, routes, skip_functions, config, string_values, helpers)
+              return
+            end
+          end
+        end
+      end
 
       # Skip `func <skipped>() { ... }` bodies entirely — their routes are
       # emitted by a separate analysis pass (e.g. Mount expansion). A plain
@@ -83,7 +256,7 @@ module Noir
             active_prefix = prefix_stack.join
             saved_binding = local_groups[param_name]? if param_name
             local_groups[param_name] = active_prefix if param_name
-            walk_chi(body, source, prefix_stack, local_groups, routes, skip_functions, config, string_values)
+            walk_chi(body, source, prefix_stack, local_groups, routes, skip_functions, config, string_values, helpers)
             if param_name
               if saved_binding.nil?
                 local_groups.delete(param_name)
@@ -97,7 +270,7 @@ module Noir
         when ChiCall::Group
           if info = unpack_chi_scope_call(node, source, string_values, expect_prefix: false)
             _, body, _ = info
-            walk_chi(body, source, prefix_stack, local_groups, routes, skip_functions, config, string_values)
+            walk_chi(body, source, prefix_stack, local_groups, routes, skip_functions, config, string_values, helpers)
             return
           end
         when ChiCall::Verb
@@ -132,7 +305,7 @@ module Noir
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk_chi(child, source, prefix_stack, local_groups, routes, skip_functions, config, string_values)
+        walk_chi(child, source, prefix_stack, local_groups, routes, skip_functions, config, string_values, helpers)
       end
     end
 

--- a/src/miniparsers/go_route_extractor_ts/core.cr
+++ b/src/miniparsers/go_route_extractor_ts/core.cr
@@ -42,7 +42,10 @@ module Noir
       when "ANY", "ALL"
         ANY_FAN_OUT_VERBS
       else
-        [verb]
+        # `Methods("GET, HEAD", ...)` carries a comma-separated list;
+        # a plain verb is a one-element list of itself.
+        return [verb] unless verb.includes?(',')
+        verb.split(',').map(&.strip.upcase).reject(&.empty?)
       end
     end
 

--- a/src/miniparsers/go_route_extractor_ts/core.cr
+++ b/src/miniparsers/go_route_extractor_ts/core.cr
@@ -643,7 +643,8 @@ module Noir
         # path is a constant resolves to its literal value.
         string_values = external_string_values.dup
         collect_string_values(root, source).each { |k, v| string_values[k] = v }
-        walk_chi(root, source, [] of String, local_groups, routes, skip_functions, config, string_values)
+        helpers = collect_route_helpers(root, source)
+        walk_chi(root, source, [] of String, local_groups, routes, skip_functions, config, string_values, helpers)
       end
       routes
     end

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -35,6 +35,11 @@ module Noir
     @current_route_start_pos : Int32? = nil
     @router_prefixes : Hash(String, Array(String)) = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
     @named_route_receivers = Set(String).new
+    # Receivers this file explicitly builds a router from (`x =
+    # express.Router()`, `x = new Router()`, `x = express()`), as opposed
+    # to the ones inferred from a verb call — every `request.get(...)`
+    # would otherwise vouch for itself as a router.
+    @explicit_router_vars = Set(String).new
     @supports_named_routes : Bool = false
 
     private struct PathEntry
@@ -104,6 +109,7 @@ module Noir
       # 1. Variables assigned from express.Router()
       # 2. Variables that have route methods called on them (.get, .post, etc.)
       @named_route_receivers.clear
+      @explicit_router_vars.clear
       identify_router_variables(router_variables)
       identify_named_route_receivers(router_variables)
       scan_router_constructor_prefixes(router_prefixes, router_variables)
@@ -657,6 +663,28 @@ module Noir
     # Routers are identified by:
     # 1. Assignment from express.Router(): const router = express.Router()
     # 2. Having route methods called on them: router.get(...)
+    # Receivers that are HTTP *clients*, never routers. `request.get(url,
+    # opts)` in a test file has the same token shape as `router.get(path,
+    # handler)` — an identifier, a verb, a path-ish first argument and a
+    # second argument — so `route_handler_arg?` cannot separate them and
+    # deliberately errs toward keeping the route. The receiver name can:
+    # none of these is ever assigned an Express/Koa/Fastify router, and
+    # NodeBB's `test/*.js` alone turns 385 such calls into routes that do
+    # not exist. Keep the list to library names that would be perverse to
+    # use for a router — a receiver named `api` or `client` may well be
+    # one, so neither is listed.
+    HTTP_CLIENT_RECEIVERS = Set{
+      "request", "axios", "superagent", "supertest", "got",
+      "needle", "unirest", "ky", "phin", "chai",
+    }
+
+    # A receiver is a client only when the file never builds a router
+    # from that name, so a project that genuinely names its router
+    # `request` keeps its routes.
+    private def http_client_receiver?(router_var : String) : Bool
+      HTTP_CLIENT_RECEIVERS.includes?(router_var) && !@explicit_router_vars.includes?(router_var)
+    end
+
     private def identify_router_variables(router_variables : Set(String))
       idx = 0
       while idx < @tokens.size - 4
@@ -668,6 +696,7 @@ module Noir
            idx + 3 < @tokens.size && @tokens[idx + 3].type == :dot &&
            idx + 4 < @tokens.size && @tokens[idx + 4].value == "Router"
           router_variables.add(@tokens[idx].value)
+          @explicit_router_vars.add(@tokens[idx].value)
         end
 
         # Pattern 2: identifier.get/post/put/delete/patch/all/head/options(
@@ -705,6 +734,7 @@ module Noir
              (@tokens[scan_idx].value == "Router" || @tokens[scan_idx].value.ends_with?("Router"))
             @named_route_receivers.add(receiver)
             router_variables.add(receiver)
+            @explicit_router_vars.add(receiver)
           end
         end
 
@@ -809,7 +839,7 @@ module Noir
            @tokens[idx + 1].type == :dot &&
            http_method?(@tokens[idx + 2]) &&
            @tokens[idx + 3].type == :lparen
-          unless route_handler_arg?(idx + 3)
+          if !route_handler_arg?(idx + 3) || http_client_receiver?(@tokens[idx].value)
             idx += 1
             next
           end
@@ -834,7 +864,7 @@ module Noir
            http_method_name?(@tokens[idx + 2].value) &&
            @tokens[idx + 3].type == :rbracket &&
            @tokens[idx + 4].type == :lparen
-          unless route_handler_arg?(idx + 4)
+          if !route_handler_arg?(idx + 4) || http_client_receiver?(@tokens[idx].value)
             idx += 1
             next
           end
@@ -1092,6 +1122,7 @@ module Noir
            path_idx + 1 < @tokens.size &&
            route_handler_arg?(path_idx)
           router_var = @tokens[idx - 1].type == :identifier ? @tokens[idx - 1].value : ""
+          return results if http_client_receiver?(router_var)
           path_entries = route_path_entries_from_args(path_idx + 1, allow_named_route: named_route_receiver?(router_var))
           @position = path_idx + 2 unless path_entries.empty?
 


### PR DESCRIPTION
Four fixes found by cross-checking noir's code view against the OpenAPI documents the same repositories ship. gitea is the headline: **every one of its API routes was reported at a path nothing serves.**

## gitea: the mount prefix was dropped (commits 1–3)

`routers/init.go:184` is `r.Mount("/api/v1", apiv1.Routes())`, where `Routes` is declared in another package at `routers/api/v1/api.go:1007`. noir ignored the mount and surfaced the target's routes through its free-floating pass, unprefixed. Not one gitea endpoint carried `/api/v1`.

| | before | after |
| --- | ---: | ---: |
| total endpoints | 1313 | **2065** |
| `go_chi` | 661 | 1413 |
| under `/api/v1/` | 0 | 546 |
| under `/api/packages/` | 0 | 170 |
| under `/api/internal/` | 0 | 21 |
| under `/v2/` (container registry) | 0 | 3 |
| overlap with gitea's own OpenAPI | **0 of 537** | **511 of 537** |

193 endpoints disappeared and 945 appeared; every removed one reappears under a mount prefix, so no route was lost — only relocated to the path gitea actually serves (`DELETE /admin/users/{username}/keys/{id}` → `DELETE /api/v1/admin/users/{username}/keys/{id}`).

Three general defects, none of them gitea quirks:

1. **A `Mount` whose target is built in another package.** `parse_mount_target` recognised only a bare same-package call. Fixed by resolving the package alias through the file's import block and a go.mod-backed import-path index. `routers/init.go` does not import chi at all — it mounts through gitea's own `modules/web` wrapper — so a file now takes part through its resolvable `Mount` lines even without the chi import marker, while the free-floating route pass stays gated on that marker so no other framework's verb calls can surface as chi routes.
2. **Wrapper registration forms.** `m.Combo("/{secretname}").Put(h).Delete(h)` puts the last verb outermost, so the walker saw a verb call on a call-expression receiver and dropped the whole chain — 93 chains in `routers/api/v1/api.go` alone. `m.Methods("GET, HEAD", "/robots.txt", h)` is a comma-separated verb list. `m.Get("", h)` inside `m.Group("/secrets", ...)` is the group root, rejected by the `/`-prefix guard because chi proper panics on an empty pattern — 187 such registrations. The empty path is accepted only when a group prefix is active *and* a handler is present, so a value getter still cannot mint a route.
3. **Route helpers.** `func addProjectRoutes(m *web.Router, ...)` is called from three different groups. The walker read the declaration instead, so one tree was reported at the wrong prefix and the three real ones were missing. Fixed by indexing same-file helpers on their first router-typed parameter and expanding the body at each call site under that argument's prefix. A helper nobody calls keeps its historical routes, so nothing that used to be reported disappears.

The residual 26 doc-only paths are a representation difference, not a miss: the code registers chi wildcards (`/branches/*`) where the generated spec writes `{branch}`.

## NodeBB: HTTP client calls read as routes (commit 4)

Eleven endpoints removed, none added — all `await request.<verb>(...)` calls in `test/*.js`, reported as routes like `DELETE /{url}/api/v3/topics/{tid}` from `test/topics.js:2717`.

`js_parser.cr` already documents this exact pair and concludes the handler argument is the discriminator. It is not sufficient — `adminApiOpts` is a bare identifier and counts as a handler. The receiver name works, but only after fixing a second problem: `identify_router_variables` treated any identifier with a verb call as a router, so `request.get(...)` vouched for `request` being a router. Explicitly constructed routers are now tracked separately, and a small list of client library names is rejected unless the file really does build a router with that name.

## Verification

**Corpus, twelve repositories, unique `(method, url)` before → after:** only two moved.

```
casdoor 382→382   netbox 2183→2183   directus 562→562   authentik 1522→1522
superset 550→550  minio 42→42        kong 513→513       hoppscotch 71→71
argo-cd 267→267   flipt 62→62        NodeBB 522→511     gitea 1313→2065
```

**Fixture A/B:** every depth-2 directory under `spec/functional_test/fixtures` scanned separately, recording endpoint count *and* an md5 of the sorted `method url` list so a same-count URL change cannot hide. 721 directories. The complete diff is the four fixtures this PR adds (`go/chi_crosspkg_mount`, `go/chi_combo_wrapper`, `go/chi_route_helpers`, `js/express_client_receiver`). No pre-existing fixture changed in count or URL set.

`crystal spec`: 20878 examples, 0 failures.

**Scan time**, release builds, median of three: gitea 0.70 → 0.72 s, NodeBB 0.57 → 0.58 s, casdoor 0.70 → 0.67 s. Within noise even where the output tripled.

## Triaged and deliberately not changed

flipt, argo-cd and minio looked like false negatives and are not. minio reports 42 (the minio/mux fork support is present and working). flipt's and argo-cd's HTTP surfaces are generated by grpc-gateway from `.proto` files that noir already reads. hoppscotch's NestJS surface is complete — every HTTP decorator under `packages/hoppscotch-backend/src` reconciles exactly against noir's 45 `ts_nestjs` endpoints; its real surface is 143 GraphQL operations assembled at runtime with `autoSchemaFile: true`, so there is no artifact to read.

NodeBB's write API (~400 endpoints behind `helpers.setupApiRoute`) is the same class of defect in the JavaScript analyzer, but the helpers are exported across files rather than same-file, so it needs its own change and is filed separately.
