### PR TITLE
fix(directus): stop reading test-suite schema snapshots as application routes

### DIFF
--- a/spec/functional_test/fixtures/specification/directus/tests/e2e/snapshot.json
+++ b/spec/functional_test/fixtures/specification/directus/tests/e2e/snapshot.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "directus": "10.13.0",
+  "vendor": "postgres",
+  "collections": [
+    {
+      "collection": "test_articles_1234",
+      "meta": {
+        "collection": "test_articles_1234",
+        "singleton": false,
+        "hidden": false
+      },
+      "schema": {
+        "name": "test_articles_1234"
+      }
+    }
+  ],
+  "fields": [
+    {
+      "collection": "test_articles_1234",
+      "field": "id",
+      "type": "integer",
+      "meta": {
+        "readonly": true
+      },
+      "schema": {
+        "has_auto_increment": true
+      }
+    },
+    {
+      "collection": "test_articles_1234",
+      "field": "title",
+      "type": "string",
+      "meta": {
+        "readonly": false
+      }
+    }
+  ]
+}

--- a/spec/unit_test/detector/specification/directus_spec.cr
+++ b/spec/unit_test/detector/specification/directus_spec.cr
@@ -87,6 +87,25 @@ describe "Detect Directus snapshot" do
     instance.detect("snapshot.yaml", "directus: 10\ncollections:\n  - : :\n\t bad").should be_false
   end
 
+  it "ignores snapshots inside test directories" do
+    instance.detect("tests/e2e/snapshot.json", snapshot).should be_false
+    instance.detect("tests/sandbox/snapshot.json", snapshot).should be_false
+    instance.detect("test/fixtures/snapshot.yaml", snapshot).should be_false
+    instance.detect("__tests__/snapshot.json", snapshot).should be_false
+    instance.detect("e2e/snapshot.json", snapshot).should be_false
+    instance.detect("cypress/snapshot.json", snapshot).should be_false
+    instance.detect("playwright/snapshot.json", snapshot).should be_false
+    instance.detect("spec/fixtures/snapshot.yaml", snapshot).should be_false
+    instance.detect("fixtures/snapshot.json", snapshot).should be_false
+  end
+
+  it "ignores snapshots with test file suffixes" do
+    instance.detect("snapshot.test.json", snapshot).should be_false
+    instance.detect("snapshot.spec.yaml", snapshot).should be_false
+    instance.detect("snapshot-test.json", snapshot).should be_false
+    instance.detect("snapshot_test.json", snapshot).should be_false
+  end
+
   it "registers the path in the code locator" do
     locator = CodeLocator.instance
     locator.clear Noir::LocatorKeys::DIRECTUS_SNAPSHOT

--- a/src/detector/detectors/specification/directus.cr
+++ b/src/detector/detectors/specification/directus.cr
@@ -22,6 +22,37 @@ module Detector::Specification
     # chained String#includes? on Crystal (see analyzers/php/php.cr).
     SNAPSHOT_MARKER = /^\s*directus\s*:|"directus"\s*:/m
 
+    # Test directories, mocks, and fixtures that contain temporary/generated schema snapshots
+    # for test suites rather than the project's production schema.
+    TEST_DIR_MARKERS = [
+      "/tests/",
+      "/test/",
+      "/__tests__/",
+      "/e2e/",
+      "/e2e-tests/",
+      "/cypress/",
+      "/playwright/",
+      "/__mocks__/",
+      "/__fixtures__/",
+      "/fixtures/",
+      "/fixture/",
+      "/spec/",
+      "/specs/",
+    ]
+
+    TEST_DIR_MARKER = Regex.union(TEST_DIR_MARKERS)
+
+    TEST_FILENAME_MARKERS = [
+      ".test.",
+      ".spec.",
+      "-test.",
+      "-spec.",
+      "_test.",
+      "_spec.",
+    ]
+
+    TEST_FILENAME_MARKER = Regex.union(TEST_FILENAME_MARKERS)
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
       return false unless content_matches?(file_contents, SNAPSHOT_MARKER)
@@ -51,9 +82,23 @@ module Detector::Specification
       return false unless SNAPSHOT_EXTENSIONS.includes?(File.extname(filename).downcase)
 
       path = filename.includes?('\\') ? filename.gsub('\\', '/') : filename
+      return false if test_path?(path)
+
+      relative = base_relative_path(path)
+      relative_path = relative.starts_with?('/') ? relative : "/#{relative}"
+
       File.basename(path).downcase.starts_with?("snapshot") ||
-        path.includes?("/directus/") ||
-        path.includes?("/snapshots/")
+        relative_path.includes?("/directus/") ||
+        relative_path.includes?("/snapshots/")
+    end
+
+    private def test_path?(path : String) : Bool
+      relative = base_relative_path(path)
+      relative_path = relative.starts_with?('/') ? relative : "/#{relative}"
+      return true if relative_path.matches?(TEST_DIR_MARKER)
+      return true if File.basename(path).downcase.matches?(TEST_FILENAME_MARKER)
+
+      false
     end
 
     private def collections_present?(root : Hash(YAML::Any, YAML::Any)) : Bool


### PR DESCRIPTION
## The defect

noir mined collection names out of `tests/e2e/**/snapshot.json` in the Directus repository — database schema snapshots belonging to the end-to-end test suite, with generated collection names — and emitted them as endpoints: `/items/articles_1234`, `/items/trains_1234_operators_1234`, `/items/tests_fields_1234`. **137 endpoints, all false**, each a fabricated instance of the real dynamic route `/items/{collection}`.

Found by hand-checking twenty of alibi's directus findings against the source: seven had this single cause.

## Two problems, one of them broader than Directus

**1. Test snapshots were indistinguishable from application schema.** `applicable?` accepted any `.json`/`.yaml`/`.yml` whose basename starts with `snapshot`, wherever it sat. Fifteen such files live under `tests/e2e/` and `tests/sandbox/`.

**2. The path checks read the absolute path.** `path.includes?("/directus/")` was evaluated against the full filesystem path, so scanning a checkout that happens to be named `directus` — which is exactly what you get from `git clone https://github.com/directus/directus` — made **every** `.json` and `.yaml` in the tree applicable, leaving only the content marker as a gate. The same held for `/snapshots/`. Results depended on where the repository sat on disk. Both checks now use `base_relative_path`.

Test paths are matched slash-delimited (`/tests/`, `/e2e/`, `/cypress/`, `/__mocks__/`, `/fixtures/`, …) so a directory named `contest` or a path containing `latest` is unaffected, plus filename markers (`.test.`, `.spec.`, `-test.`, `_spec.`).

## Verification

**Directus repository:**

| | before | after |
| --- | ---: | ---: |
| `--only-techs directus` | 137 | **0** |
| all technologies | 562 | 425 |
| `js_express` / `js_cli` / `oas3` / `js_fastify` | 266 / 43 / 115 / 1 | unchanged |

The net change is exactly −137. The Directus repository is the engine monorepo and holds no production application schema, so zero is the right answer for it; the analyzer still emits per-collection endpoints for a real `snapshot.yaml` (the existing fixture yields 9 both before and after).

**alibi near-misses on directus: 137 → 4.** Those were the highest near-miss count in a twelve-repository corpus, and the 133 that went away were all a generated test collection clashing with `/items/{collection}`. The remaining 4 are unrelated (Express versus OpenAPI path differences on auth/oauth).

**Controls unchanged:** hoppscotch 71, superset 550, NodeBB 522, all delta 0.

**Fixture A/B**, every depth-2 directory under `spec/functional_test/fixtures` scanned on its own: 716 of 717 identical. The one that moves is `specification/directus`, which this PR extends with a `tests/e2e/snapshot.json` — 16 endpoints on `main` (9 real plus 7 mined from the new test file) versus 9 on this branch. The pre-existing 9 are untouched.

`crystal spec`: 20,854 examples, 0 failures. `just check`: 2,295 files, 0 failures.

## Deliberately not done

**Dropping per-collection endpoints entirely** in favour of only the parameterised `/items/{collection}`. A real Directus project declares its collections and fields in `snapshot.yaml`, and discovering the concrete routes with their field filters (`filter[title][_eq]`) and writable body fields is the point of the analyzer. The bug was the source of the collection names, not the emission.

**Adding `/test/` and `/tests/` to the shared `JSRouteExtractor::TEST_STUB_PATH_MARKERS`.** That list is used across many JS frameworks where integration harnesses import server modules; widening it carries cross-framework regression risk and needs its own A/B. Not needed for a specification-format bug.

## Risk

A project could store its production schema under a directory named `test/` or `tests/`. Directus snapshots are produced by `directus schema snapshot` and applied by `directus schema apply`, conventionally at the project root or in `snapshots/` / `directus/` / `schema/`, so this is unlikely; and because the markers are now evaluated against the scan-relative path, a parent directory outside the scan root cannot trigger the exclusion.
