### PR TITLE
fix(lua_lapis): report the HTTP methods a Lapis route table actually declares

### DIFF
--- a/spec/functional_test/fixtures/lua/lapis_verb_tables/descriptor.lua
+++ b/spec/functional_test/fixtures/lua/lapis_verb_tables/descriptor.lua
@@ -1,0 +1,14 @@
+-- Descriptor form: the route entry carries a schema alongside the verb
+-- table, so the methods live one level down under `methods`.
+local kong = kong
+
+return {
+  ["/clustering/data-planes"] = {
+    schema = kong.db.clustering_data_planes.schema,
+    methods = {
+      GET = function(self, dao, helpers)
+        return dao.clustering_data_planes:page()
+      end,
+    },
+  },
+}

--- a/spec/functional_test/fixtures/lua/lapis_verb_tables/lapis-fixture-1.0-1.rockspec
+++ b/spec/functional_test/fixtures/lua/lapis_verb_tables/lapis-fixture-1.0-1.rockspec
@@ -1,0 +1,9 @@
+package = "lapis-verb-tables-fixture"
+version = "1.0-1"
+source = { url = "git+https://example.com/lapis-verb-tables-fixture.git" }
+description = { summary = "Lapis application tables keyed by HTTP verb" }
+dependencies = {
+  "lua >= 5.1",
+  "lapis",
+}
+build = { type = "builtin" }

--- a/spec/functional_test/fixtures/lua/lapis_verb_tables/mixed.lua
+++ b/spec/functional_test/fixtures/lua/lapis_verb_tables/mixed.lua
@@ -1,0 +1,29 @@
+-- Value shapes that carry no method evidence, and the one wrapper form
+-- that does.
+local lapis = require("lapis")
+local respond_to = require("lapis.application").respond_to
+
+-- A URL-keyed lookup table is not a route table: a boolean can never be
+-- a Lapis handler, so `/fallback/lookup` is not an endpoint at all.
+local ACCEPTS_YAML = {
+  ["/fallback/lookup"] = true,
+}
+
+return lapis.Application:extend({
+  -- Filter-only table: says nothing about which methods are served.
+  ["/fallback/filtered"] = {
+    before = function(self) return ACCEPTS_YAML[self.req.parsed_url.path] end,
+  },
+
+  -- A bare function and a named string handler both answer any method.
+  ["/fallback/inline"] = function(self) return "inline" end,
+  ["/fallback/named"] = "named_handler",
+
+  named_handler = function(self) return "named" end,
+
+  -- The explicit Lapis wrapper limits the route to the verbs it names.
+  ["/wrapped"] = respond_to({
+    GET = function(self) return "get" end,
+    POST = function(self) return "post" end,
+  }),
+})

--- a/spec/functional_test/fixtures/lua/lapis_verb_tables/routes.lua
+++ b/spec/functional_test/fixtures/lua/lapis_verb_tables/routes.lua
@@ -1,0 +1,59 @@
+-- Application-table routes whose value is keyed by the verbs the path
+-- implements. Lapis dispatches such a table through `respond_to`, which
+-- answers 405 for every verb the table does not name, so the keys are the
+-- method set -- not a starting point for an all-verbs fan-out.
+local kong = kong
+
+local endpoints = {
+  disable = {
+    before = function() return kong.response.exit(404) end,
+  },
+}
+
+local function shared_handler(self)
+  return kong.response.exit(200, { message = "shared" })
+end
+
+return {
+  -- Exactly one declared verb.
+  ["/cache"] = {
+    DELETE = function()
+      kong.cache:purge()
+      return kong.response.exit(204)
+    end,
+  },
+
+  -- Two verbs, with handler bodies that declare their own locals at the
+  -- same brace depth as the verb keys (Lua function bodies are not
+  -- brace-delimited) and nest tables that are not method keys.
+  ["/cache/:key"] = {
+    GET = function(self)
+      local ttl, err, value = kong.cache:probe(self.params.key)
+      if err then
+        return kong.response.exit(500, { message = "probe failed" })
+      end
+      return kong.response.exit(200, { ttl = ttl, value = value })
+    end,
+
+    DELETE = function(self)
+      kong.cache:invalidate_local(self.params.key)
+      return kong.response.exit(204)
+    end,
+  },
+
+  -- One handler shared by several verbs.
+  ["/shared"] = {
+    GET = shared_handler,
+    HEAD = shared_handler,
+  },
+
+  -- Bracketed string keys are the same declaration in different syntax.
+  ["/bracket-keys"] = {
+    ["GET"] = function() return kong.response.exit(200) end,
+    ["OPTIONS"] = function() return kong.response.exit(204) end,
+  },
+
+  -- A shared table reached through a module reference names no verb, so
+  -- the route keeps the all-methods fallback.
+  ["/disabled"] = endpoints.disable,
+}

--- a/spec/functional_test/testers/lua/lapis_verb_tables_spec.cr
+++ b/spec/functional_test/testers/lua/lapis_verb_tables_spec.cr
@@ -1,0 +1,43 @@
+require "../../func_spec.cr"
+
+fallback_methods = ["GET", "POST", "PUT", "DELETE", "PATCH"]
+
+expected_endpoints = [] of Endpoint
+
+# A verb-keyed application table declares its whole method set: Lapis
+# answers 405 for anything it does not name, so a single-verb table is a
+# single endpoint, not a five-verb fan-out.
+expected_endpoints << Endpoint.new("/cache", "DELETE")
+expected_endpoints << Endpoint.new("/cache/:key", "GET", [Param.new("key", "", "path")])
+expected_endpoints << Endpoint.new("/cache/:key", "DELETE", [Param.new("key", "", "path")])
+
+# One handler bound to several verbs.
+expected_endpoints << Endpoint.new("/shared", "GET")
+expected_endpoints << Endpoint.new("/shared", "HEAD")
+
+# Bracketed string keys are the same declaration.
+expected_endpoints << Endpoint.new("/bracket-keys", "GET")
+expected_endpoints << Endpoint.new("/bracket-keys", "OPTIONS")
+
+# Descriptor form — the verbs live under a `methods` sub-table.
+expected_endpoints << Endpoint.new("/clustering/data-planes", "GET")
+
+# `respond_to({ ... })` names its verbs explicitly.
+expected_endpoints << Endpoint.new("/wrapped", "GET")
+expected_endpoints << Endpoint.new("/wrapped", "POST")
+
+# Values that carry no method evidence keep the all-verbs fallback: a
+# module reference, a filter-only table, a bare function, a named string
+# handler.
+fallback_methods.each { |m| expected_endpoints << Endpoint.new("/disabled", m) }
+fallback_methods.each { |m| expected_endpoints << Endpoint.new("/fallback/filtered", m) }
+fallback_methods.each { |m| expected_endpoints << Endpoint.new("/fallback/inline", m) }
+fallback_methods.each { |m| expected_endpoints << Endpoint.new("/fallback/named", m) }
+
+# `["/fallback/lookup"] = true` is a URL-keyed lookup table, not a route,
+# and is deliberately absent from the expectations above.
+
+FunctionalTester.new("fixtures/lua/lapis_verb_tables/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -449,7 +449,7 @@ module Analyzer::Lua
           next
         end
 
-        if depth == 1
+        if depth == 1 && table_key_position?(chars, index, open_index)
           if char == '['
             # `["GET"] = ...` — bracketed string key.
             quote_index = skip_ws_chars(chars, index + 1)
@@ -465,8 +465,7 @@ module Analyzer::Lua
                 end
               end
             end
-          elsif identifier_start?(char) && !identifier_part?(index > 0 ? chars[index - 1] : '\0') &&
-                (index == 0 || (chars[index - 1] != '.' && chars[index - 1] != ':'))
+          elsif identifier_start?(char)
             name_end = index
             while name_end < close_index && identifier_part?(chars[name_end])
               name_end += 1
@@ -488,6 +487,22 @@ module Analyzer::Lua
       end
 
       keys
+    end
+
+    # A key in a Lua table constructor can only follow the opening brace
+    # or a `,` / `;` separator. Requiring that keeps the scan off tokens
+    # that merely look like keys inside a handler body — `local POST = 1`,
+    # `t.PUT = 2`, `obj:DELETE` — which sit at the same brace depth
+    # because Lua function bodies are delimited by `function`/`end`, not
+    # by braces.
+    private def table_key_position?(chars : Array(Char), index : Int32, floor : Int32) : Bool
+      cursor = index - 1
+      while cursor > floor && chars[cursor].whitespace?
+        cursor -= 1
+      end
+      return true if cursor == floor
+      char = chars[cursor]
+      char == '{' || char == ',' || char == ';'
     end
 
     private def table_key_of_interest?(name : String) : Bool

--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -11,8 +11,11 @@ module Analyzer::Lua
   #   * Generic `app:match(path, handler)` and the named
   #     `app:match("name", "/path", handler)` form, both of which
   #     dispatch on any HTTP method.
-  #   * Application-table style: `["/path"] = "handler_name"` or
-  #     `["/path"] = function(self) ... end`.
+  #   * Application-table style: `["/path"] = "handler_name"`,
+  #     `["/path"] = function(self) ... end`, or a table keyed by the
+  #     verbs the path implements — `["/path"] = { GET = ..., DELETE = ... }`,
+  #     which Lapis dispatches through `respond_to` and which answers 405
+  #     for every verb it does not name.
   #   * MoonScript class actions: `"/path": =>` and the named form
   #     `[name: "/path"]: =>`.
   #
@@ -42,6 +45,11 @@ module Analyzer::Lua
     # one precompiled union so the boolean gate costs a single PCRE2 match
     # instead of up to two naive substring scans.
     MOON_ACTION_MARKER_RE = Regex.union("=>", "respond_to")
+    # `["/path"] = ` application-table route key.
+    TABLE_ROUTE_RE = /\[\s*(['"])([^'"]+)\1\s*\]\s*=/
+    RESPOND_TO     = "respond_to"
+    # Literal values a Lapis route entry can never hold.
+    NON_HANDLER_KEYWORDS = %w[true false nil]
 
     def analyze
       include_callee = callees_needed?
@@ -275,24 +283,250 @@ module Analyzer::Lua
       verbs
     end
 
-    # `["/path"] = "handler"` and `["/path"] = function(self) ... end`
-    # — application-table style.
+    # `["/path"] = "handler"`, `["/path"] = function(self) ... end` and
+    # `["/path"] = { GET = ..., DELETE = ... }` — application-table style.
+    # The method set comes from the value when the value declares one
+    # (see `table_route_methods`), and falls back to all verbs otherwise.
     private def emit_table_routes(path : String,
                                   content : String,
                                   cleaned : String,
                                   include_callee : Bool,
                                   handler_bodies : Hash(String, Noir::LuaCalleeExtractor::FunctionBody))
       return unless cleaned.includes?("]") && cleaned.includes?("=")
-      pattern = /\[\s*(['"])([^'"]+)\1\s*\]\s*=/
-      cleaned.scan(pattern) do |match|
+      # Materialised once per file and shared by every route in it —
+      # `String#[]` re-walks from byte 0 on multi-byte content, so a
+      # per-route `cleaned.chars` would be O(n^2) on route-dense files.
+      cleaned_chars : Array(Char)? = nil
+      cleaned.scan(TABLE_ROUTE_RE) do |match|
         url = match[2]
         next unless url.starts_with?("/")
 
         route_offset = match.begin(0) || 0
         after_assignment = match.end(0) || route_offset
+        chars = (cleaned_chars ||= cleaned.chars)
+        next if non_handler_literal?(chars, skip_ws_chars(chars, after_assignment))
+        methods = table_route_methods(chars, after_assignment) || FALLBACK_METHODS
         callees = include_callee ? table_route_callees(path, content, after_assignment, handler_bodies) : [] of Noir::LuaCalleeExtractor::Entry
-        emit_endpoint(path, content, route_offset, url, FALLBACK_METHODS, callees)
+        emit_endpoint(path, content, route_offset, url, methods, callees)
       end
+    end
+
+    # A Lapis application-table value is a handler: a function, a
+    # `respond_to` table, or the string name of one. A boolean, `nil` or
+    # a number never is, so `["/path"] = <literal>` is a lookup table
+    # keyed by URL, not a route — Kong's
+    # `ACCEPTS_YAML = { ["/config"] = true }` is the canonical example,
+    # and it was fanning `/config` out to five methods.
+    private def non_handler_literal?(chars : Array(Char), value_start : Int32) : Bool
+      return false unless value_start < chars.size
+      char = chars[value_start]
+      return true if char.ascii_number?
+      if (char == '-' || char == '.') && chars[value_start + 1]?.try(&.ascii_number?)
+        return true
+      end
+      NON_HANDLER_KEYWORDS.any? { |keyword| keyword_at?(chars, value_start, keyword) }
+    end
+
+    private def keyword_at?(chars : Array(Char), index : Int32, keyword : String) : Bool
+      return false unless index + keyword.size <= chars.size
+      keyword.each_char_with_index do |char, offset|
+        return false unless chars[index + offset] == char
+      end
+      !identifier_part?(chars[index + keyword.size]? || '\0')
+    end
+
+    # The HTTP verbs a `["/path"] = <value>` entry actually serves, or
+    # `nil` when the value carries no method evidence and the caller
+    # should keep the all-verbs fallback.
+    #
+    # Lapis dispatches a verb-keyed handler table through `respond_to`,
+    # which answers 405 for every verb the table does not name, so the
+    # keys *are* the method set. Kong's Admin API is written entirely in
+    # this style — `["/cache"] = { DELETE = function(self) ... end }`
+    # serves DELETE and nothing else — and fanning it out to five verbs
+    # invents four requests that cannot exist.
+    #
+    # Three value shapes carry verbs:
+    #
+    #   ["/p"] = { GET = ..., DELETE = ... }        -- top-level keys
+    #   ["/p"] = { schema = s, methods = { GET = ... } }  -- Kong new-DB descriptor
+    #   ["/p"] = respond_to({ GET = ... })          -- explicit Lapis wrapper
+    #
+    # Everything else keeps the fallback: a bare `function(self)` and a
+    # `"handler_name"` string both answer any method, and a table that
+    # names no verb at all (a `before`-only filter table, an
+    # `endpoints.disable` reference) says nothing about methods.
+    #
+    # Caveat, deliberately not special-cased: Kong merges the route
+    # files named after a DAO schema into its auto-generated CRUD
+    # endpoints, so a partial table there (`{ before = ..., GET = ...,
+    # PATCH = ... }` in `certificates.lua`) is an override of a larger
+    # generated set rather than the whole route. That merge is invisible
+    # in the file, and reading it would need Kong-specific knowledge; a
+    # plain Lapis reading of the source is what we report.
+    private def table_route_methods(chars : Array(Char), after_assignment : Int32) : Array(String)?
+      value_start = skip_ws_chars(chars, after_assignment)
+      return unless value_start < chars.size
+
+      if respond_to_at?(chars, value_start)
+        return respond_to_verbs(chars, value_start)
+      end
+
+      return unless chars[value_start] == '{'
+      close_index = Noir::LuaCalleeExtractor.find_matching_delimiter(chars, value_start, '{', '}')
+      return unless close_index
+
+      keys = table_verb_keys(chars, value_start, close_index)
+      verbs = keys.compact_map { |name, _| HTTP_METHODS.includes?(name) ? name : nil }
+      return verbs unless verbs.empty?
+
+      # `{ schema = ..., methods = { GET = ... } }` — Kong's "new DB
+      # routes" descriptor keeps the verbs one level down.
+      if methods_at = keys.find { |name, _| name == "methods" }
+        nested_start = skip_ws_chars(chars, methods_at[1])
+        if nested_start < chars.size && chars[nested_start] == '{'
+          if nested_close = Noir::LuaCalleeExtractor.find_matching_delimiter(chars, nested_start, '{', '}')
+            nested = table_verb_keys(chars, nested_start, nested_close)
+              .compact_map { |name, _| HTTP_METHODS.includes?(name) ? name : nil }
+            return nested unless nested.empty?
+          end
+        end
+      end
+
+      nil
+    end
+
+    private def respond_to_at?(chars : Array(Char), index : Int32) : Bool
+      return false unless index + RESPOND_TO.size <= chars.size
+      RESPOND_TO.each_char_with_index do |char, offset|
+        return false unless chars[index + offset] == char
+      end
+      before = index > 0 ? chars[index - 1] : '\0'
+      !identifier_part?(before)
+    end
+
+    # `respond_to({ GET = ... })` / `respond_to { GET = ... }` — read the
+    # verbs out of the wrapped table. An empty result means the table is
+    # built elsewhere (`respond_to(handlers)`), which carries no evidence.
+    private def respond_to_verbs(chars : Array(Char), value_start : Int32) : Array(String)?
+      cursor = skip_ws_chars(chars, value_start + RESPOND_TO.size)
+      cursor = skip_ws_chars(chars, cursor + 1) if cursor < chars.size && chars[cursor] == '('
+      return unless cursor < chars.size && chars[cursor] == '{'
+      close_index = Noir::LuaCalleeExtractor.find_matching_delimiter(chars, cursor, '{', '}')
+      return unless close_index
+
+      verbs = table_verb_keys(chars, cursor, close_index)
+        .compact_map { |name, _| HTTP_METHODS.includes?(name) ? name : nil }
+      verbs.empty? ? nil : verbs
+    end
+
+    # Collect the `NAME =` / `["NAME"] =` keys written directly inside the
+    # table that opens at `open_index`, as `{name, index just past the =}`.
+    # Only verb names and `methods` are kept — everything else in a Lapis
+    # route table is a handler body, and Lua function bodies are *not*
+    # brace-delimited, so a handler's own statements sit at the same brace
+    # depth as the table's keys. Restricting the vocabulary keeps that
+    # noise out; a `local GET = ...` or a `t.GET = ...` inside a body is
+    # still rejected by the preceding-character check.
+    private def table_verb_keys(chars : Array(Char), open_index : Int32, close_index : Int32) : Array(Tuple(String, Int32))
+      keys = [] of Tuple(String, Int32)
+      depth = 0
+      index = open_index
+
+      while index < close_index && index < chars.size
+        char = chars[index]
+        case char
+        when '"', '\''
+          index = skip_short_string_chars(chars, index, close_index)
+          next
+        when '{'
+          depth += 1
+          index += 1
+          next
+        when '}'
+          depth -= 1
+          index += 1
+          next
+        end
+
+        if depth == 1
+          if char == '['
+            # `["GET"] = ...` — bracketed string key.
+            quote_index = skip_ws_chars(chars, index + 1)
+            if quote_index < close_index && (chars[quote_index] == '"' || chars[quote_index] == '\'')
+              name_end = skip_short_string_chars(chars, quote_index, close_index)
+              name = chars[(quote_index + 1)...(name_end - 1)].join
+              bracket = skip_ws_chars(chars, name_end)
+              if bracket < close_index && chars[bracket] == ']'
+                if assign = assignment_after(chars, bracket + 1, close_index)
+                  keys << {name, assign} if table_key_of_interest?(name)
+                  index = assign
+                  next
+                end
+              end
+            end
+          elsif identifier_start?(char) && !identifier_part?(index > 0 ? chars[index - 1] : '\0') &&
+                (index == 0 || (chars[index - 1] != '.' && chars[index - 1] != ':'))
+            name_end = index
+            while name_end < close_index && identifier_part?(chars[name_end])
+              name_end += 1
+            end
+            name = chars[index...name_end].join
+            if table_key_of_interest?(name)
+              if assign = assignment_after(chars, name_end, close_index)
+                keys << {name, assign}
+                index = assign
+                next
+              end
+            end
+            index = name_end
+            next
+          end
+        end
+
+        index += 1
+      end
+
+      keys
+    end
+
+    private def table_key_of_interest?(name : String) : Bool
+      name == "methods" || HTTP_METHODS.includes?(name)
+    end
+
+    # Index just past a `=` that is an assignment (not `==`), skipping
+    # whitespace from `index`; `nil` when the next token is anything else.
+    private def assignment_after(chars : Array(Char), index : Int32, limit : Int32) : Int32?
+      cursor = skip_ws_chars(chars, index)
+      return unless cursor < limit && chars[cursor] == '='
+      return if chars[cursor + 1]? == '='
+      cursor + 1
+    end
+
+    private def skip_ws_chars(chars : Array(Char), index : Int32) : Int32
+      cursor = index
+      while cursor < chars.size && chars[cursor].whitespace?
+        cursor += 1
+      end
+      cursor
+    end
+
+    # Index just past the closing quote of the short string that opens at
+    # `index`, honouring backslash escapes.
+    private def skip_short_string_chars(chars : Array(Char), index : Int32, limit : Int32) : Int32
+      quote = chars[index]
+      cursor = index + 1
+      while cursor < chars.size
+        char = chars[cursor]
+        if char == '\\'
+          cursor += 2
+          next
+        end
+        return cursor + 1 if char == quote
+        break if char == '\n'
+        cursor += 1
+      end
+      cursor
     end
 
     # MoonScript class actions come in several shapes, all keyed by the


### PR DESCRIPTION
## The defect

`Analyzer::Lua::Lapis#emit_table_routes` emitted every `["/path"] = <value>` application-table route with a hard-coded five-verb fallback, regardless of what the value said. Kong's entire Admin API is written in that style, with the value being a table keyed by the verbs the path actually implements:

```lua
return {
  ["/cache"]      = { DELETE = function(self) ... end },
  ["/cache/:key"] = { GET = ..., DELETE = ... },
}
```

Kong attaches these with `app_helpers.respond_to` (`kong/api/api_helpers.lua:478`), and Lapis's `respond_to` answers **405** for any method the table does not name. So noir was reporting requests the server refuses.

The before-distribution is its own proof: **66 paths × 5 verbs = 330 endpoints, exactly 66 of each method.** Not one verb in Kong's output was ever read from source.

Found by hand-checking twenty of alibi's kong findings against the source: ten were a real path carrying a fabricated method.

## The fix

Read the verbs out of the value when the value declares them — top-level keys, keys under a `methods` sub-table, or an explicit `respond_to({...})` wrapper — and keep the fallback for every shape that carries no method evidence. Also drop the entry entirely when the value is a boolean, number or `nil`, because a URL-keyed lookup table (`ACCEPTS_YAML = { ["/config"] = true }`) is not a route.

| shape | example in Kong | decision |
| --- | --- | --- |
| verb-keyed table | `["/cache"] = { DELETE = ... }` | narrow to declared verbs |
| verbs under `methods` | `{ schema = ..., methods = { GET = ... } }` | narrow, one level down |
| `respond_to({...})` wrapper | vanilla Lapis idiom | narrow |
| shared handler on several verbs | `GET = h, HEAD = h` | narrow to both |
| `before`-only filter table | `["/filter-chains"] = { before = ... }` | keep fallback — names no verb |
| module reference | `["/targets"] = endpoints.disable` | keep fallback — not a table |
| bare function / string handler | `["/p"] = function(self) ... end` | keep fallback — answers any method |
| boolean/number literal | `ACCEPTS_YAML = { ["/config"] = true }` | not a route at all |

A Lua function body is delimited by `function`/`end`, not braces, so a handler's own statements sit at the *same brace depth* as the table's keys. A key is therefore only read when it follows the opening brace or a `,`/`;` separator — the only positions a key can occupy in a Lua table constructor — which is what rejects `local POST = 1`, `t.PUT = 2` and `obj:DELETE` inside a handler body. A hostile fixture covers it.

## Measurement

```
noir -b ~/oss-corpus/kong --only-techs lua_lapis
before  330 endpoints, 66 unique paths   GET 66  POST 66  PUT 66  PATCH 66  DELETE 66
after   142 endpoints, 66 unique paths   GET 46  POST 27  PUT 24  PATCH 23  DELETE 22
188 (path, method) pairs removed, 0 added, 0 paths lost
```

The full Kong scan moves 513 → 325 unique `(url, method)` over the same 224 paths, removing set-identically the same 188 pairs. No non-Lua endpoint moved. Every other corpus repository is unchanged, including argo-cd, the only other one carrying Lua (437 files).

The report on the branch carries a per-path ledger naming, for all 41 paths that changed, every kept and dropped verb with the source table and line. Sixteen paths keep all five verbs and are correct to: `/` and `/metrics` come from genuine any-method `app:match` registrations, and the rest are the `before`-only and `endpoints.disable` shapes with no method evidence.

### The honest false-negative ledger

Kong merges route files **named after a DAO schema** into an auto-generated CRUD set (`kong/api/init.lua:59-104`), where a partial verb table is an *override* of a larger generated route rather than the whole route. That merge is invisible in the file being read, so **24 of the 188 removed pairs are methods Kong's runtime would still answer** — `/plugins` GET, `/tags/:tags` PUT PATCH DELETE, and ten more, all listed in the report.

So 164 of 188 (87%) are unambiguously fabricated and 24 are collateral. The trade is worth taking: those 24 belong to Kong's generated Admin API, of which noir already emits none of the paths, so they are part of an existing blind spot rather than a new one — and every affected path survives with at least one method. Reading the merge would mean teaching a general Lapis analyzer to parse `kong/db/schema/entities/*.lua`.

## Scope

This was the only place in the Lua analyzers where a concretely declared handler shape got fanned out to a guessed verb set. `emit_match_calls` (`app:match` really is any-method in Lapis), `moonscript_methods`, and `lua_lor`'s `ALL_VERBS` (which fires only for `router:all`, an explicit catch-all declaration) are all correct readings and are unchanged.

## Verification

**Fixture A/B**, all 717 depth-2 directories scanned one at a time: **the diff is empty.** Zero existing fixtures moved — which is also the finding, because no existing Lua fixture used the verb-keyed shape at all. That is why this bug was green in CI, and the gap is now closed by a new fixture directory emitting 30 endpoints across nine shapes, including a table declaring exactly one verb, a handler bound to several verbs, bracketed-key syntax, `methods` nesting, a `respond_to` wrapper, and the three fallback shapes.

`just test` 5743 + 15143 examples, 0 failures. `crystal tool format --check` clean. `ameba` 2296 inspected, 0 failures.
