### PR TITLE
ci: stop the spec binary exporting every Crystal symbol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,13 +175,10 @@ jobs:
           # Crystal fingerprints its own cache entries by content, so a
           # partially-stale restore is safe — it only ever means some entries
           # get recompiled. Hence the loose restore-keys ladder.
-          # The ladder stops at the `-build-` prefix: the bare
-          # `crystal-<os>-<version>-` prefix reaches the spec and lint jobs'
-          # caches, which are compilations of different programs. See the spec
-          # job's cache step for what that produced.
-          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-v2-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
           restore-keys: |
-            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-v2-
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-
       - name: Install dependencies
         run: shards install
       - name: Build
@@ -399,22 +396,10 @@ jobs:
           # hit the primary key instead. Note that a primary-key hit also means
           # actions/cache does not re-save, so the entry ages until src/ moves.
           # Watch the `--stats` lines on the build step for the effect.
-          #
-          # The ladder stops at the `-spec-` prefix on purpose. It used to end
-          # with the bare `crystal-<os>-<version>-` prefix, which reaches the
-          # *other* jobs' caches: `-build-` is a different program (the noir
-          # binary, not the spec suite) and `-lint-` is Ameba, whose own comment
-          # says its entries are disjoint from these. Restoring those produced a
-          # spec binary that linked but died on exec with
-          # `symbol lookup error: undefined symbol: <libc symbol>, version
-          # <a Crystal method signature>` — a corrupted dynamic symbol table,
-          # naming a different pair of symbols on each branch. It reproduced on
-          # main as well as on pull requests, and because a primary-key hit does
-          # not re-save, a poisoned entry then persisted under that key until
-          # src/ moved. The `-v2-` salt abandons the entries already poisoned.
-          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-v2-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
           restore-keys: |
-            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-v2-
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-
       - name: Install dependencies
         run: shards install
       # This job used to run four `crystal spec` steps (unit, functional, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,33 +424,34 @@ jobs:
       # the spec DSL passes its own file and line. Reproduce such a failure with
       # `just spec-build`, which keeps debug info on purpose.
       - name: Build the spec binary
+        # `--no-export-dynamic` is load-bearing, not tidiness. Crystal passes
+        # `-rdynamic` so backtraces can symbolize, which exports every Crystal
+        # symbol into `.dynsym`. For this binary that was 133,142 entries in
+        # `.gnu.version` over a 4.9 MB `.dynstr`, and at that size the loader
+        # read an out-of-range version index and dereferenced into `.dynstr`,
+        # which is full of Crystal names:
+        #
+        #   ./bin/noir_spec: symbol lookup error: ./bin/noir_spec:
+        #     undefined symbol: xmlFree, version Hash(K, V)#fetch<String, Nil>:(JSON::Any | Nil)
+        #
+        # A libc/libxml2 symbol carrying a Crystal method signature as its ELF
+        # symbol version is that read, not a corrupt binary. `ld` takes the last
+        # of `--export-dynamic` / `--no-export-dynamic`, so appending it here
+        # cancels the one Crystal adds. Nothing dlopens this binary.
         run: |
           mkdir -p bin
-          crystal build spec/suite.cr -o bin/noir_spec --stats
-      # DIAGNOSTIC, not a permanent step. `bin/noir_spec` has been linking
-      # successfully and then dying on exec with
-      # `symbol lookup error: undefined symbol: xmlFree, version
-      # Hash(K, V)#fetch<String, Nil>:(JSON::Any | Nil)` — a libxml2 or libc
-      # symbol carrying a Crystal method signature as its ELF symbol version,
-      # which is a corrupted dynamic symbol table. It reproduces on main, and
-      # a fully cold build (no Crystal cache, every tree-sitter grammar
-      # recompiled) fails the same way, so it is neither stale objects nor the
-      # source. This prints what the loader is actually being handed.
-      - name: Inspect the spec binary
-        if: always()
+          crystal build spec/suite.cr -o bin/noir_spec --stats --no-debug \
+            --link-flags="-Wl,--no-export-dynamic"
+      # Guards the above: if `.dynsym` grows back, the suite starts failing at
+      # exec with a message that looks like anything but its cause.
+      - name: Check the spec binary's dynamic symbol count
         run: |
-          ls -l bin/noir_spec
-          file bin/noir_spec
-          echo "--- ldd ---"
-          ldd bin/noir_spec || true
-          echo "--- dynamic section ---"
-          readelf -d bin/noir_spec | head -30 || true
-          echo "--- version requirements (.gnu.version_r) ---"
-          readelf -V bin/noir_spec | head -60 || true
-          echo "--- xmlFree / stderr in dynsym ---"
-          readelf --dyn-syms bin/noir_spec | grep -E 'xmlFree|stderr' || true
-          echo "--- libxml2 on this image ---"
-          dpkg -l | grep -i libxml2 || true
+          count=$(readelf --dyn-syms bin/noir_spec | grep -c '^ *[0-9]*:' || true)
+          echo "dynamic symbols: $count"
+          if [ "$count" -gt 2000 ]; then
+            echo "::error::bin/noir_spec exports $count dynamic symbols; --no-export-dynamic is not taking effect"
+            exit 1
+          fi
       # Spec files load in directory order, which differs between macOS and
       # Linux, so an example that depends on state another example left behind
       # passes locally and fails here, on an unrelated PR. Four such couplings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,16 @@ jobs:
           path: |
             src/ext/tree_sitter/runtime/lib.o
             src/ext/tree_sitter/grammars/*/*.o
-          key: treesitter-${{ runner.os }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
+          # The runner image is part of the key. These are compiled object
+          # files, and `runs-on: ubuntu-latest` is a rotating label: objects built
+          # against one image's glibc and libxml2 were being restored onto a
+          # later image and linked into the spec binary, which then died on exec
+          # with `symbol lookup error: undefined symbol: xmlFree` (and `stderr`),
+          # each naming a Crystal method signature as its ELF symbol version.
+          # The entry that caused it was compiled on 2026-08-13 and was still
+          # being restored a month later, because `runner.os` is only "Linux"
+          # and nothing else in the key described the toolchain.
+          key: treesitter-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
       - name: Refresh restored object mtimes
         if: steps.ts-cache.outputs.cache-hit == 'true'
         # `build.sh` decides staleness by mtime (`[ "$SRC" -nt "$OBJ" ]`), and
@@ -378,7 +387,16 @@ jobs:
           path: |
             src/ext/tree_sitter/runtime/lib.o
             src/ext/tree_sitter/grammars/*/*.o
-          key: treesitter-${{ runner.os }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
+          # The runner image is part of the key. These are compiled object
+          # files, and `runs-on: ubuntu-latest` is a rotating label: objects built
+          # against one image's glibc and libxml2 were being restored onto a
+          # later image and linked into the spec binary, which then died on exec
+          # with `symbol lookup error: undefined symbol: xmlFree` (and `stderr`),
+          # each naming a Crystal method signature as its ELF symbol version.
+          # The entry that caused it was compiled on 2026-08-13 and was still
+          # being restored a month later, because `runner.os` is only "Linux"
+          # and nothing else in the key described the toolchain.
+          key: treesitter-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
       - name: Refresh restored object mtimes
         if: steps.ts-cache.outputs.cache-hit == 'true'
         # See the identical step in build-crystal for why this is needed and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,7 +426,31 @@ jobs:
       - name: Build the spec binary
         run: |
           mkdir -p bin
-          crystal build spec/suite.cr -o bin/noir_spec --stats --no-debug
+          crystal build spec/suite.cr -o bin/noir_spec --stats
+      # DIAGNOSTIC, not a permanent step. `bin/noir_spec` has been linking
+      # successfully and then dying on exec with
+      # `symbol lookup error: undefined symbol: xmlFree, version
+      # Hash(K, V)#fetch<String, Nil>:(JSON::Any | Nil)` — a libxml2 or libc
+      # symbol carrying a Crystal method signature as its ELF symbol version,
+      # which is a corrupted dynamic symbol table. It reproduces on main, and
+      # a fully cold build (no Crystal cache, every tree-sitter grammar
+      # recompiled) fails the same way, so it is neither stale objects nor the
+      # source. This prints what the loader is actually being handed.
+      - name: Inspect the spec binary
+        if: always()
+        run: |
+          ls -l bin/noir_spec
+          file bin/noir_spec
+          echo "--- ldd ---"
+          ldd bin/noir_spec || true
+          echo "--- dynamic section ---"
+          readelf -d bin/noir_spec | head -30 || true
+          echo "--- version requirements (.gnu.version_r) ---"
+          readelf -V bin/noir_spec | head -60 || true
+          echo "--- xmlFree / stderr in dynsym ---"
+          readelf --dyn-syms bin/noir_spec | grep -E 'xmlFree|stderr' || true
+          echo "--- libxml2 on this image ---"
+          dpkg -l | grep -i libxml2 || true
       # Spec files load in directory order, which differs between macOS and
       # Linux, so an example that depends on state another example left behind
       # passes locally and fails here, on an unrelated PR. Four such couplings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,16 +157,7 @@ jobs:
           path: |
             src/ext/tree_sitter/runtime/lib.o
             src/ext/tree_sitter/grammars/*/*.o
-          # The runner image is part of the key. These are compiled object
-          # files, and `runs-on: ubuntu-latest` is a rotating label: objects built
-          # against one image's glibc and libxml2 were being restored onto a
-          # later image and linked into the spec binary, which then died on exec
-          # with `symbol lookup error: undefined symbol: xmlFree` (and `stderr`),
-          # each naming a Crystal method signature as its ELF symbol version.
-          # The entry that caused it was compiled on 2026-08-13 and was still
-          # being restored a month later, because `runner.os` is only "Linux"
-          # and nothing else in the key described the toolchain.
-          key: treesitter-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
+          key: treesitter-${{ runner.os }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
       - name: Refresh restored object mtimes
         if: steps.ts-cache.outputs.cache-hit == 'true'
         # `build.sh` decides staleness by mtime (`[ "$SRC" -nt "$OBJ" ]`), and
@@ -387,16 +378,7 @@ jobs:
           path: |
             src/ext/tree_sitter/runtime/lib.o
             src/ext/tree_sitter/grammars/*/*.o
-          # The runner image is part of the key. These are compiled object
-          # files, and `runs-on: ubuntu-latest` is a rotating label: objects built
-          # against one image's glibc and libxml2 were being restored onto a
-          # later image and linked into the spec binary, which then died on exec
-          # with `symbol lookup error: undefined symbol: xmlFree` (and `stderr`),
-          # each naming a Crystal method signature as its ELF symbol version.
-          # The entry that caused it was compiled on 2026-08-13 and was still
-          # being restored a month later, because `runner.os` is only "Linux"
-          # and nothing else in the key described the toolchain.
-          key: treesitter-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
+          key: treesitter-${{ runner.os }}-${{ hashFiles('src/ext/tree_sitter/build.sh', 'src/ext/tree_sitter/runtime/src/**', 'src/ext/tree_sitter/runtime/include/**', 'src/ext/tree_sitter/grammars/*/*.c', 'src/ext/tree_sitter/grammars/*/tree_sitter/*.h') }}
       - name: Refresh restored object mtimes
         if: steps.ts-cache.outputs.cache-hit == 'true'
         # See the identical step in build-crystal for why this is needed and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,10 +175,13 @@ jobs:
           # Crystal fingerprints its own cache entries by content, so a
           # partially-stale restore is safe — it only ever means some entries
           # get recompiled. Hence the loose restore-keys ladder.
-          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
+          # The ladder stops at the `-build-` prefix: the bare
+          # `crystal-<os>-<version>-` prefix reaches the spec and lint jobs'
+          # caches, which are compilations of different programs. See the spec
+          # job's cache step for what that produced.
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-v2-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
           restore-keys: |
-            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-
-            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-build-v2-
       - name: Install dependencies
         run: shards install
       - name: Build
@@ -396,10 +399,22 @@ jobs:
           # hit the primary key instead. Note that a primary-key hit also means
           # actions/cache does not re-save, so the entry ages until src/ moves.
           # Watch the `--stats` lines on the build step for the effect.
-          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
+          #
+          # The ladder stops at the `-spec-` prefix on purpose. It used to end
+          # with the bare `crystal-<os>-<version>-` prefix, which reaches the
+          # *other* jobs' caches: `-build-` is a different program (the noir
+          # binary, not the spec suite) and `-lint-` is Ameba, whose own comment
+          # says its entries are disjoint from these. Restoring those produced a
+          # spec binary that linked but died on exec with
+          # `symbol lookup error: undefined symbol: <libc symbol>, version
+          # <a Crystal method signature>` — a corrupted dynamic symbol table,
+          # naming a different pair of symbols on each branch. It reproduced on
+          # main as well as on pull requests, and because a primary-key hit does
+          # not re-save, a poisoned entry then persisted under that key until
+          # src/ moved. The `-v2-` salt abandons the entries already poisoned.
+          key: crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-v2-${{ hashFiles('shard.lock', 'src/**/*.cr') }}
           restore-keys: |
-            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-
-            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-
+            crystal-${{ runner.os }}-${{ matrix.crystal-version }}-spec-v2-
       - name: Install dependencies
         run: shards install
       # This job used to run four `crystal spec` steps (unit, functional, and


### PR DESCRIPTION
`bin/noir_spec` was linking successfully and then dying the moment it was executed:

```
./bin/noir_spec: symbol lookup error: ./bin/noir_spec:
  undefined symbol: xmlFree, version Hash(K, V)#fetch<String, Nil>:(JSON::Any | Nil)
```

## The message is not a corrupt binary

Crystal passes `-rdynamic` so backtraces can symbolize, which exports **every** Crystal symbol into `.dynsym`. For this binary, `readelf` reports:

```
Version symbols section '.gnu.version' contains 133142 entries
STRTAB (.dynstr)                4,921,242 bytes
```

`.gnu.version` entries are 16-bit indices into the version table. At this size the loader read an out-of-range index and dereferenced into `.dynstr` — which is 4.9 MB of Crystal mangled names. So a libc or libxml2 symbol came out carrying a *Crystal method signature* as its ELF symbol version, and the pair differed per build (`stderr` with `Hash(K, V)#entries_full?:Bool` on one branch, `xmlFree` with `Hash(K, V)#fetch` on another and on main).

Two more readings from the same diagnostic run confirm the scale: `readelf -V` took **13 minutes** on this binary, and `readelf --dyn-syms | grep -E 'xmlFree|stderr'` took another 13 and matched **nothing** — the symbols the loader named are not in the table it was reading.

`ldd` resolves every library including `libxml2.so.2` (2.9.14), so nothing was missing from the image.

## The change

`ld` takes the last of `--export-dynamic` / `--no-export-dynamic`, so appending the latter through `--link-flags` cancels the one Crystal adds. Nothing dlopens this binary.

A guard step fails the job if the count grows back above 2,000, because the symptom points nowhere near the cause and cost several rounds to find.

## Why not split the binary instead

Halving the symbol count by building unit and functional separately would work, but #2699 established that compiling `src/` is essentially the entire cost and does not grow when the suites are combined — unit alone and unit-plus-functional both compile in 20.9 s. Splitting would pay that twice and undo a measured optimization to work around a linker flag.

## Eliminated on the way here, each by measurement

1. **Not any one pull request** — it reproduced on `main`: one of four runs of the `fix(lua_lapis)` merge commit failed this way.
2. **Not the Crystal compiler cache** — a run logging `Cache not found for input keys: crystal-Linux-1.21.0-spec-v2-…` failed identically; deleting every `crystal-*` entry by hand did not help.
3. **Not the tree-sitter object cache** — after deleting the entry and keying on the runner image, the run rebuilt every grammar from source and reported `no previous .o files were reused`. A fully cold build failed the same way.
4. **Not `--no-debug`** — dropping it changed nothing, which is expected: debug info does not live in `.dynsym`.
5. **Not a race between the four concurrent invocations** — all four failed identically.
6. **Not the source** — `just test` on a merge of current main passes on each blocked branch: ~5,730 unit + ~15,240 functional examples, 0 failures.

Those first three attempts are reverted on this branch; the diff against main is the build flag and the guard.

## Unblocks

#2707, #2708 and #2709, each green on every check except this job.
